### PR TITLE
Fix string editor bug

### DIFF
--- a/app/scripts/codemirror-cypher.coffee
+++ b/app/scripts/codemirror-cypher.coffee
@@ -24,8 +24,11 @@ CodeMirror.defineMode "cypher", (config) ->
   tokenBase = (stream, state) ->
     ch = stream.next()
     curPunc = null
-    if ch is "\"" or ch is "'"
-      stream.match /.+?["']/
+    if ch is "\""
+      stream.match /.+?["]/
+      return "string"
+    if ch is "'"
+      stream.match /.+?[']/
       return "string"
     if /[{}\(\),\.;\[\]]/.test(ch)
       curPunc = ch


### PR DESCRIPTION
This updates the codemirror rules to only consider matching sets of \" and ' as a string
