### PR TITLE
Don't display the store directory

### DIFF
--- a/app/views/partials/drawer-database.jade
+++ b/app/views/partials/drawer-database.jade
@@ -29,8 +29,8 @@
       .key Version:
       .value {{ neo4j.version }}
     li.pair
-      .key Location:
-      .value {{kernel.StoreDirectory || '-'}}
+      .key Name:
+      .value {{kernel.DatabaseName || '-'}}
     li.pair
       .key Size:
       .value {{kernel.TotalStoreSize | humanReadableBytes}}


### PR DESCRIPTION
In 3.0 we are changing the way we tell Neo4j which database to
mount. Instead of providing a path we will give a name. So we should
mirror that in what the Browser displays.
