### PR TITLE
Don't focus on editor when current focus is an input field

### DIFF
--- a/app/scripts/controllers/Layout.coffee
+++ b/app/scripts/controllers/Layout.coffee
@@ -148,7 +148,7 @@ angular.module('neo4jApp.controllers')
           else
             Editor.maximize()
         else if e.keyCode is 191 # '/'
-          unless $scope.isEditorFocused()
+          unless $scope.isEditorFocused() || e.target.localName is 'input'
             e.preventDefault()
             $scope.focusEditor()
 


### PR DESCRIPTION
I've added a check to make sure that the current focus is not on a `<input/>` field. This will allow users to use the `/` character without losing focus on the current element.
