### PR TITLE
Set default svg height for frame

### DIFF
--- a/app/styles/stream.styl
+++ b/app/styles/stream.styl
@@ -155,6 +155,7 @@
             min-height: frame-min-height
             svg
               width: 100%
+              height: (svg-start-height)
             &.one-legend-row
               svg
                 height: (svg-start-height - legend-row-height)


### PR DESCRIPTION
Fixes issue where frame will go fullscreen when removing all nodes for the graph visualisation
