### PR TITLE
Only show onboarding once

### DIFF
--- a/app/content/guides/neo4j-sync.jade
+++ b/app/content/guides/neo4j-sync.jade
@@ -49,3 +49,6 @@ article.guide(ng-controller="SyncSigninController")
           li
             i.sl.sl-bubble-comment.fa-lg
             | &nbsp; Get update notices, suggestions and help
+          li
+            i.sl.sl-question-mark.fa-lg  
+            a(href="http://neo4j.com/neo4j-sync") &nbsp;Learn More

--- a/app/scripts/settings.coffee
+++ b/app/scripts/settings.coffee
@@ -61,6 +61,7 @@ angular.module('neo4jApp.settings', ['neo4jApp.utils'])
     boltHost: "" # $location.host() is default
     shownTermsAndPrivacy: no
     acceptedTermsAndPrivacy: no
+    onboarding: yes
   })
 
 angular.module('neo4jApp.settings')

--- a/app/views/partials/drawer-profile.jade
+++ b/app/views/partials/drawer-profile.jade
@@ -28,7 +28,7 @@
   .local-data-holderdiv(ng-if="!currentUser")
     .local-data-confirm(ng-show="!clearSingleClicked")
       p
-        | This will clear your favourite scripts, grass, command history etc. locally.
+        | This will reset your local storage, clearing favorite scripts, grass, command history and settings.
       div
         button.btn.btn-popup(ng-click="updateClearSingleClicked(1)") Clear local data &nbsp;
           i.sl.sl-bin
@@ -75,13 +75,17 @@
 
   div(ng-if="!currentUser && syncService.hasConnection", ng-controller="SyncSigninController")
     p &nbsp;
-    p With Neo4j Sync you are able to always have fast access to your favorite scripts and styles.
+    h5 Sign In or Register
+    p Neo4j Sync is a companion cloud service for Neo4j Browser. Connect through a simple social sign-in
+      | to get started.
+    p 
+      a(play-topic="neo4j-sync") About Neo4j Sync
     alert.top-padded(ng-hide="goodBrowser") 
       | Neo4j Sync is currently only available for some versions of Internet Explorer.
       | If you have any trouble, we'd love to hear from you at&nbsp;
       a(href="mailto:feedback@neotechnology.com")
         | feedback@neotechnology.com
-    button.btn.btn-popup(ng-click="signInToSync()") Sign in to Neo4j Sync
+    button.btn.btn-popup(ng-click="signInToSync()") Sign In / Register
     .box-max
       .checkbox
         label.muted(for="acceptedTermsAndPrivacyCheckBox")


### PR DESCRIPTION
Once the onboarding has been viewed, it won't be shown again except by explicit user action to play the content. 
