### PR TITLE
Terminate instead of rollback on frame close

### DIFF
--- a/app/scripts/services/Bolt.coffee
+++ b/app/scripts/services/Bolt.coffee
@@ -117,7 +117,7 @@ angular.module('neo4jApp.services')
             # reported a successful operation
             p = tx.run statement, parameters
             p.then((r) -> 
-              if tx # The tx might have been rolled back
+              if tx # The tx might have been terminated
                 tx.commit().then((txr) -> 
                   session.close()
                   q.resolve r

--- a/app/scripts/services/CypherTransactionBolt.coffee
+++ b/app/scripts/services/CypherTransactionBolt.coffee
@@ -123,14 +123,10 @@ angular.module('neo4jApp.services')
         rollback: ->
           q = $q.defer()
           that = @
-          if @tx
-            @tx.rollback().then((r) ->
-              that._reset()
-              q.resolve {original: r, remapped: Bolt.constructResult(r)}
-            ).catch((e)->
-              that._reset()
-              orig = {code: 'N/A', message: e.error}
-              q.reject {original: orig, remapped: Bolt.constructResult(orig)}
+          if @session and @tx
+            @session.close( ->
+              that.tx = null
+              q.resolve({original: {}, remapped: Bolt.constructResult({})})
             )
           else
             q.resolve({original: {}, remapped: Bolt.constructResult({})})


### PR DESCRIPTION
Terminate is more brutal and don't wait for the query to finish which rollback does.
