### PR TITLE
Expose URL param API to populate editor

### DIFF
--- a/app/scripts/controllers/Main.coffee
+++ b/app/scripts/controllers/Main.coffee
@@ -170,6 +170,17 @@ angular.module('neo4jApp.controllers')
 
   .run([
     '$rootScope'
-    ($scope) ->
+    'Utils'
+    'Settings'
+    'Editor'
+    ($scope, Utils, Settings, Editor) ->
       $scope.unauthorized = yes
+
+      if cmdParam = Utils.getUrlParam('cmd', window.location.href)
+        if cmdParam[0] is 'cypher'
+          cmdCommand = ''
+        else
+          cmdCommand = "#{Settings.cmdchar}#{cmdParam[0]} "
+        cmdArgs = Utils.getUrlParam('arg', decodeURIComponent(window.location.href)) || []
+        Editor.setContent(cmdCommand + cmdArgs.join(' '))
   ])

--- a/app/scripts/controllers/Main.coffee
+++ b/app/scripts/controllers/Main.coffee
@@ -177,10 +177,8 @@ angular.module('neo4jApp.controllers')
       $scope.unauthorized = yes
 
       if cmdParam = Utils.getUrlParam('cmd', window.location.href)
-        if cmdParam[0] is 'cypher'
-          cmdCommand = ''
-        else
-          cmdCommand = "#{Settings.cmdchar}#{cmdParam[0]} "
+        return unless cmdParam[0] is 'play'
+        cmdCommand = "#{Settings.cmdchar}#{cmdParam[0]} "
         cmdArgs = Utils.getUrlParam('arg', decodeURIComponent(window.location.href)) || []
         Editor.setContent(cmdCommand + cmdArgs.join(' '))
   ])

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -168,3 +168,11 @@ class neo.helpers
         flat
       , [])
         
+    @getUrlParam = (name, theLocation) ->
+      return no unless theLocation
+      out = []
+      re = new RegExp('[\\?&]' + name + '=([^&#]*)', 'g')
+      while (results = re.exec(theLocation)) isnt null
+        out.push(results[1]) if results and results[1]
+      return undefined if not out.length
+      out

--- a/test/spec/other/utils.coffee
+++ b/test/spec/other/utils.coffee
@@ -151,3 +151,24 @@ describe 'Utils', () ->
   it 'should flatten nested arrays', ->
     t1 = [1, [2], [[3], 'hello', {k: 1}]]
     expect(JSON.stringify(Utils.flattenArray(t1))).toBe(JSON.stringify([1, 2, 3, 'hello', {k: 1}]))
+
+  it 'should read URL params correctly', ->
+    urls = [
+      {location: 'http://neo4j.com/?param=1', paramName: 'param', expect: '1'},
+      {location: 'http://neo4j.com/?param2=2&param=1', paramName: 'param', expect: '1'},
+      {location: 'http://neo4j.com/?param=', paramName: 'param', expect: undefined},
+      {location: 'http://neo4j.com/', paramName: 'param', expect: undefined}
+    ]
+    urls.forEach((tCase) -> 
+      res = Utils.getUrlParam tCase.paramName, tCase.location
+      val = if res then res[0] else res
+      expect(val).toBe(tCase.expect)
+    )
+
+  it 'should read URL array params correctly', ->
+    single = 'http://neo4j.com/?cmd=play&arg=cypher'
+    expect(Utils.getUrlParam('arg', single)[0]).toBe('cypher')
+
+    multi = 'http://neo4j.com/?cmd=play&arg=cypher&arg=hello'
+    expect(Utils.getUrlParam('arg', multi)[0]).toBe('cypher')
+    expect(Utils.getUrlParam('arg', multi)[1]).toBe('hello')


### PR DESCRIPTION
This change exposes an API though URL params making it easier to publish links to prepopulate the editor.

The URL param API looks like this:
`cmd` - the command to use. Could be `play` or `help` or anything we decide to support.
`arg` - Zero or more of these args. 

Current implementation:   
 - `cmd` - This command will be prefixed by the current users config `cmdchar` (which defaults
to `:`). The special case here being `cmd=cypher`. In that case, the command is stripped and not prefixed by anything.  

- `arg` - They will be inserted in the order they appear in the URI and separated by a space.

This does **NOT** execute the command automatically. It adds content to the editor, the user must execute the command manually.

Examples:
Link to external guide: `http://localhost:7474/?cmd=play&arg=http://guides.neo4j.com/reco`
Link to cypher query: `http://localhost:7474/?cmd=cypher&arg=RETURN&arg=1`
