### PR TITLE
Call destroy in sync object to avoid getting error message

### DIFF
--- a/app/scripts/services/CurrentUser.coffee
+++ b/app/scripts/services/CurrentUser.coffee
@@ -141,6 +141,7 @@ angular.module('neo4jApp.services')
       logout: ->
         $rootScope.currentUser = null
         NTN.logout()
+        @store.unauth()
         localStorageService.remove 'ntn_token'
         localStorageService.remove 'ntn_data_token'
         localStorageService.remove 'ntn_refresh_token'

--- a/app/scripts/services/NTN.coffee
+++ b/app/scripts/services/NTN.coffee
@@ -118,7 +118,7 @@ angular.module('neo4jApp.services')
       logout: ->
         auth.signout()
         _unbind()
-        _sync_object = {}
+        _sync_object.$destroy()
       authenticate: (profile, token) ->
         auth.authenticate(profile, token).then(-> _unbind())
       isAuthenticated: -> auth.isAuthenticated


### PR DESCRIPTION
when logging in a second time with different service