### PR TITLE
Display index used in query plan

### DIFF
--- a/app/scripts/services/Bolt.coffee
+++ b/app/scripts/services/Bolt.coffee
@@ -354,6 +354,7 @@ angular.module('neo4jApp.services')
           Rows: plan.rows,
           EstimatedRows: plan.arguments.EstimatedRows,
           identifiers: plan.identifiers,
+          Index: plan.arguments.Index,
           children: plan.children.map boltPlanToRESTPlanShared
         }
 

--- a/lib/visualization/components/queryPlan.coffee
+++ b/lib/visualization/components/queryPlan.coffee
@@ -104,6 +104,10 @@ neo.queryPlan = (element)->
       wordWrap(identifiers.filter((d) -> not (/^  /.test(d))).join(', '), 'identifiers')
       details.push { className: 'padding' }
 
+    if index = operator.Index
+      wordWrap(index, 'index')
+      details.push { className: 'padding' }
+
     if expression = operator.LegacyExpression ? operator.ExpandExpression ? operator.LabelName
       wordWrap(expression, 'expression')
       details.push { className: 'padding' }


### PR DESCRIPTION
To test:

Prepare:
```
CREATE INDEX ON :Person(name)
CREATE (n:Person {name:"John", age: 25})
```

Try below query in current master. NodeIndexSeek used, but no index shown.
```
EXPLAIN MATCH (n:Person) WHERE n.name = 'John' RETURN n
```
Try in this branch, now shows the index used.
