### PR TITLE
remove dot check to allow syntax highlighting for properties

### DIFF
--- a/app/scripts/codemirror-cypher.coffee
+++ b/app/scripts/codemirror-cypher.coffee
@@ -30,7 +30,7 @@ CodeMirror.defineMode "cypher", (config) ->
     if ch is "'"
       stream.match /.+?[']/
       return "string"
-    if /[{}\(\),\.;\[\]]/.test(ch)
+    if /[{}\(\),;\[\]]/.test(ch)
       curPunc = ch
       "node"
     else if ch is "/" and stream.eat("/")


### PR DESCRIPTION

#119 

I think the dot check is not needed here, we can by pass it. Since the only place where we use dots is to get node's property and of course we have to allow the syntax highlighting.

P.S still at early days with graph db.