### PR TITLE
Add roles onselect without confirmation step

### DIFF
--- a/app/views/partials/user-roles.jade
+++ b/app/views/partials/user-roles.jade
@@ -2,10 +2,7 @@
   | {{ role }}
   a.sl.sl-minus-circle(ng-click="removeRole(role)", tooltip="Remove")
 .select
-  select(ng-show="isAddingRole", ng-model="selectedItem")
+  select(ng-show="isAddingRole", ng-model="selectedItem", ng-change="appendRole()")
     option(ng-repeat="role in listOfKnownRoles()", value="{{role}}" ) {{role}}
-  .select-actions
-    a.sl.sl-arrow-circle-right(ng-show="isAddingRole", ng-disabled="selectedItem == null", ng-click="appendRole()", tooltip="Assign")
-    a.sl.sl-delete-circle(ng-show="isAddingRole", ng-click="hideRole()", tooltip="Cancel")
 span
   a.sl.sl-add-circle(ng-hide="isAddingRole || listOfKnownRoles().length == 0", ng-click="showRole()", tooltip="Add")


### PR DESCRIPTION
Removes the misstake of adding no roles when adding users that keeps happening.

![roles](https://cloud.githubusercontent.com/assets/570998/18989950/2dd1a078-870f-11e6-95e4-06c213a8eaaa.gif)