### PR TITLE
Change delete icon to minus (-), and keep (x) as cancel

### DIFF
--- a/app/views/frame-qs.jade
+++ b/app/views/frame-qs.jade
@@ -35,7 +35,7 @@ div(ng-controller="QueryStatusCtrl")
                       span {{query.elapsedTime}}
                     td.relative 
                       span 
-                        a.sl.sl-delete-circle(ng-hide="query.confirmKill", ng-click='query.confirmKill = true', tooltip="Kill query")
+                        a.sl.sl-minus-circle(ng-hide="query.confirmKill", ng-click='query.confirmKill = true', tooltip="Kill query")
                         a.sl.sl-arrow-circle-right(ng-show="query.confirmKill", ng-click='killQuery(query.clusterMember, query.queryId)', tooltip="Confirm Kill query")
                         a.sl.sl-delete-circle(ng-show="query.confirmKill", ng-click="query.confirmKill = false", tooltip="Cancel")
                       .fa.overflow-indicator.hover-pointer(

--- a/app/views/partials/frame-list-users.jade
+++ b/app/views/partials/frame-list-users.jade
@@ -32,7 +32,7 @@ table.table.table-condensed
         div(ng-if="!Features.canChangePassword") N/A
       td
         span(ng-show="notCurrentUser(user.username)")
-          a.sl.sl-delete-circle(ng-hide="user.confirmDelete", ng-click='user.confirmDelete = true', tooltip="Delete")
+          a.sl.sl-minus-circle(ng-hide="user.confirmDelete", ng-click='user.confirmDelete = true', tooltip="Delete")
           a.sl.sl-arrow-circle-right(ng-show="user.confirmDelete", ng-click='delete(user.username)', tooltip="Confirm Delete")
           a.sl.sl-delete-circle(ng-show="user.confirmDelete", ng-click="user.confirmDelete = false", tooltip="Cancel")
     tr


### PR DESCRIPTION
It's confusing to have the same icon for different actions.

Old:  
![old-delete](https://cloud.githubusercontent.com/assets/570998/18990287/27446ce8-8711-11e6-96d3-b6ebf8f0e795.gif)

New:  
![new-delete](https://cloud.githubusercontent.com/assets/570998/18990290/2befc99a-8711-11e6-8322-034fc3c53329.gif)
