### PR TITLE
Read and present query timings from result when using Bolt

### DIFF
--- a/app/scripts/init/commandInterpreters.coffee
+++ b/app/scripts/init/commandInterpreters.coffee
@@ -491,7 +491,7 @@ angular.module('neo4jApp')
         pattern = new RegExp("^[^#{cmdchar}]")
         input.match(pattern)
       templateUrl: 'views/frame-cypher.html'
-      exec: ['Cypher', 'CypherGraphModel', 'CypherParser', (Cypher, CypherGraphModel, CypherParser) ->
+      exec: ['Cypher', 'CypherGraphModel', 'CypherParser', 'Utils', (Cypher, CypherGraphModel, CypherParser, Utils) ->
         # Return the function that handles the input
         (input, q) ->
           current_transaction = Cypher.transaction()
@@ -502,7 +502,7 @@ angular.module('neo4jApp')
                   response.displayedSize = Settings.maxRows
                 q.resolve(
                   raw: response.raw
-                  responseTime: response.raw.responseTime
+                  timings: response.raw.timings || Utils.buildTimingObject(response)
                   table: response
                   graph: extractGraphModel(response, CypherGraphModel)
                   notifications: response.notifications || [],

--- a/app/views/frame-cypher.jade
+++ b/app/views/frame-cypher.jade
@@ -88,10 +88,10 @@ div(ng-controller="CypherResultCtrl", fullscreen)
                   p(ng-show="getNonZeroStatisticsFields(frame).length")
                     {{formatStatisticsOutput(updatesStatistics(frame))}}
                   p(ng-show="!getNonZeroStatisticsFields(frame).length")
-                    | (no changes, no rows)
+                    | (no changes, no records)
                 article.help.no-data.has-status-bar(ng-show='!frame.response.table._response.data.length && frame.response.table._response.columns.length')
                   p
-                    | (no rows)
+                    | (no records)
                 neo-table(table-data='frame.response.table', ng-show='frame.response.table._response.data.length')
               .status-bar
                 .status

--- a/lib/helpers.coffee
+++ b/lib/helpers.coffee
@@ -229,3 +229,18 @@ class neo.helpers
         cluster.push tmp
       )
       cluster
+
+    @buildTimingObject = (result = {}) ->
+      obj = {
+        resultAvailableAfter: undefined,
+        resultConsumedAfter: undefined,
+        responseTime: result.raw?.responseTime || undefined,
+        type: 'client'
+      }
+      if result and result.summary and typeof result.summary.resultAvailableAfter isnt 'undefined'
+        obj.resultAvailableAfter = result.summary.resultAvailableAfter
+        obj.resultConsumedAfter = result.summary.resultConsumedAfter
+        obj.totalTime = obj.resultAvailableAfter + obj.resultConsumedAfter
+        obj.responseTime = undefined
+        obj.type = 'bolt'
+      obj


### PR DESCRIPTION
REST don't have access to this information so the old timer is kept there.

### Statusbar output examples

Read query:  
> Started streaming 25 records after 0 ms and completed after 1 ms.

Read query, no hits:  
> Completed after 0 ms.

Query without returns:  
> Completed after 0 ms.

Write query:  
> Set 250 properties, started streaming 250 records after 7 ms and completed after 19 ms.

Profile query (just showing the resultAvailableAfter timing):  
> Cypher version: CYPHER 3.1, planner: COST, runtime: INTERPRETED. 2 total db hits in 18 ms.

Raw / Code view:  
> Started streaming 25 records after 0 ms and completed after 1 ms.

### Frame output example

Updates, no returns:  
> Set 250 properties, statement completed in 4 ms.

No updates, no returns:  
> (no changes, no records)