### PR TITLE
Change `:param` workflow to give user better feedback on errors

### DIFF
--- a/app/index.jade
+++ b/app/index.jade
@@ -222,4 +222,5 @@ html(class="no-js", lang="en", ng-app="neo4jApp", ng-controller="MainCtrl")
     script(src='lib/boltIntHelpers.js')
     script(src='lib/serializer.js')
     script(src='scripts/controllers/DatabaseDrawer.js')
+    script(src='scripts/controllers/Parameter.js')
     //endbuild

--- a/app/scripts/controllers/Parameter.coffee
+++ b/app/scripts/controllers/Parameter.coffee
@@ -1,0 +1,60 @@
+###!
+Copyright (c) 2002-2016 "Neo Technology,"
+Network Engine for Objects in Lund AB [http://neotechnology.com]
+
+This file is part of Neo4j.
+
+Neo4j is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+###
+
+'use strict'
+
+angular.module('neo4jApp.controllers')
+  .controller 'ParameterCtrl', ['Parameters', '$scope', 'Utils', (Parameters, $scope, Utils) ->
+    $scope.setParam = {}
+
+    setParamSet = (key, val) ->
+      $scope.setParam = (_obj = {}; _obj[key] = val; _obj)
+
+    setSuccessMessage = () ->
+      $scope.frame.successMessage = 'Parameter sucessfully set'
+
+    setParsingError = () ->
+      $scope.frame.setCustomError 'Could not interpret the input', null 
+
+    setNotFoundError = () ->
+      $scope.frame.setCustomError 'Could not find a defined parameter with that key', null
+
+    parseInput = (input) ->
+      matches = Utils.extractCommandParameters 'param', input
+      if (matches?)
+        [key, value] = matches
+        if (value isnt undefined and value isnt null)
+          value = try eval('(' + value + ')')
+          if typeof value isnt 'undefined'
+            Parameters[key] = value
+            setParamSet key, Parameters[key]
+            setSuccessMessage()
+          else
+            setParsingError()
+        else
+          setParamSet key, Parameters[key]
+          if typeof Parameters[key] is 'undefined'
+            setNotFoundError()
+      else
+        setParsingError()
+    
+    parseInput $scope.frame.response
+
+  ]

--- a/app/scripts/init/commandInterpreters.coffee
+++ b/app/scripts/init/commandInterpreters.coffee
@@ -228,25 +228,11 @@ angular.module('neo4jApp')
 
     FrameProvider.interpreters.push
       type: 'params'
-      templateUrl: 'views/frame-parameters.html'
+      templateUrl: 'views/frame-parameter.html'
       matches: ["#{cmdchar}param"]
-      exec: ['Parameters', 'Utils', (Parameters, Utils) ->
+      exec: [() ->
         (input, q) ->
-          matches = Utils.extractCommandParameters 'param', input
-          if (matches?)
-            [key, value] = matches
-            if (value isnt undefined and value isnt null)
-              value = try eval(value)
-              Parameters[key] = value if typeof value isnt 'undefined'
-              toResolve = angular.copy Parameters
-            else
-              toResolve = (_obj = {}; _obj[key] = Parameters[key]; _obj)
-              if typeof Parameters[key] is 'undefined'
-                toResolve = null
-
-            q.resolve toResolve
-          else
-            q.resolve angular.copy Parameters
+          q.resolve(input)
           q.promise
       ]
 

--- a/app/scripts/services/Frame.coffee
+++ b/app/scripts/services/Frame.coffee
@@ -143,6 +143,10 @@ angular.module('neo4jApp.services')
           setError: (response) =>
             @setErrorMessages response
             @hasErrors = yes
+          setCustomError: (code, details) =>
+            @errorText = "#{code}"
+            @detailedErrorText = details
+            @hasErrors = yes
           getDetailedErrorText: =>
             @detailedErrorText
 

--- a/app/views/frame-parameter.jade
+++ b/app/views/frame-parameter.jade
@@ -1,4 +1,4 @@
-div(fullscreen)
+div(ng-controller="ParameterCtrl", fullscreen)
   .outer
     include partials/frame-common-actions
     .inner
@@ -6,20 +6,21 @@ div(fullscreen)
         article.admin
           .view-result-table.result.no-min-height
             .table-holder.no-min-height
-              div(ng-hide="frame.response | isObjectEmpty")
+              div(ng-hide="frame.hasErrors")
                 table.table.table-condensed
                   tr
                     th.col-sm-2 Parameter name
                     th.col-sm-4 Value
-                  tr(ng-repeat="(key, value) in frame.response")
+                  tr(ng-repeat="(key, value) in setParam")
                     td 
                       span {{key}}
                     td 
                       span {{value}}
                 | Execute&nbsp;  
-                a(exec-topic="params {}") :params {}
-                | to clear all parameters.
-              div(ng-show="frame.response | isObjectEmpty")
-                p No parameters set. 
-                p Read about setting parameters:  
+                a(exec-topic="params") :params
+                | to display all defined parameters.
+              div(ng-show="frame.hasErrors")
+                p Read about defining parameters:  
                   a(help-topic="param") :help param
+      include partials/error-status-bar
+      include partials/success-status-bar


### PR DESCRIPTION
- Add a frame statusbar to give users feedback when defining parameters.
- Make sure that object litterals gets parsed correctly
  - Fixes #333 