### PR TITLE
Avoid multiple 'logged in' logs in security log when using Bolt

### DIFF
--- a/app/scripts/init/statusCheck.coffee
+++ b/app/scripts/init/statusCheck.coffee
@@ -29,12 +29,7 @@ angular.module('neo4jApp').run([
     timer = null
     $scope.check = ->
       $timeout.cancel(timer)
-      # There is something wrong with the XHR implementation in IE10:
-      # It will return 304 (not modified) even if the server goes down as long as
-      # the URL is the same. So we need a unique URL every time in order for it
-      # to detect request error
-      ts = (new Date()).getTime()
-      Server.addresses('?t='+ts).success(
+      Server.addresses().success(
         (r) ->
           $scope.offline = no
           timer = $timeout($scope.check, Settings.heartbeat * 1000)

--- a/app/scripts/services/Auth.coffee
+++ b/app/scripts/services/Auth.coffee
@@ -41,7 +41,7 @@ angular.module('neo4jApp.services')
         that = @
         @current_password = password
         setConnectionAuthData username, password
-        promise = @makeRequest(withoutCredentials = no, retainConnection = yes)
+        promise = @makeRequest(withoutCredentials = no)
         promise.then(
           (r) ->
             ConnectionStatusService.setConnected yes
@@ -56,7 +56,7 @@ angular.module('neo4jApp.services')
       authorizationRequired: ->
         #Make call without auth headers
         q = $q.defer()
-        p = @makeRequest(withoutCredentials = yes, retainConnection = yes)
+        p = @makeRequest(withoutCredentials = yes)
         p.then(
           (r) ->
             ##Success, no auth required
@@ -104,7 +104,7 @@ angular.module('neo4jApp.services')
       isConnected: (retainConnection = no) ->
         that = @
         q = $q.defer()
-        p = @makeRequest(withoutCredentials = no, retainConnection)
+        p = @makeRequest(withoutCredentials = no)
         p.then(
           (rr) ->
             ConnectionStatusService.setConnected yes
@@ -117,8 +117,8 @@ angular.module('neo4jApp.services')
         )
         q.promise
 
-      makeRequest: (withoutCredentials = no, retainConnection = no) ->
-        ProtocolFactory.utils().makeRequest(withoutCredentials, retainConnection)
+      makeRequest: (withoutCredentials = no) ->
+        ProtocolFactory.utils().makeRequest(withoutCredentials)
 
       forget: ->
         if @getCurrentUser()

--- a/app/scripts/services/Bolt.coffee
+++ b/app/scripts/services/Bolt.coffee
@@ -112,6 +112,7 @@ angular.module('neo4jApp.services')
           driver = driversObj.getDirectDriver()
           driver.onError = (e) ->
             driversObj.close()
+            _driversObj = null
             if e instanceof Event and e.type is 'error'
               q.reject getSocketErrorObj()
             else if e.code and e.message # until Neo4jError is in drivers public API

--- a/app/scripts/services/CypherTransactionBolt.coffee
+++ b/app/scripts/services/CypherTransactionBolt.coffee
@@ -70,7 +70,6 @@ angular.module('neo4jApp.services')
           @requests = []
           delegate = null
           @session = null
-          @tx = null
 
         _requestDone: (promise) ->
           that = @
@@ -86,7 +85,6 @@ angular.module('neo4jApp.services')
         _onError: () ->
 
         _reset: ->
-          @tx = null
           @session = null
 
         begin: () ->
@@ -104,8 +102,7 @@ angular.module('neo4jApp.services')
           params = Utils.findNumberInVal params, [transformFn]
           UDC.increment('cypher_attempts')
           q = $q.defer()
-          {tx, promise, session} = Bolt.routedWriteTransaction(query, params)
-          @tx = tx
+          { promise, session } = Bolt.routedWriteTransaction(query, params)
           @session = session
           promise.then((r) ->
             $rootScope.bolt_connection_failure = no

--- a/app/scripts/services/Server.coffee
+++ b/app/scripts/services/Server.coffee
@@ -164,7 +164,7 @@ angular.module('neo4jApp.services')
         status: (params = '')->
           # User a smaller timeout for status requests so IE10 detects when the
           # server goes down faster.
-          @options "#{Settings.endpoint.rest}/", { timeout: (Settings.heartbeat * 1000)}
+          @get "#{Settings.endpoint.discover}/", { skipAuthHeader: yes, timeout: (Settings.heartbeat * 1000)}
 
         log: (path) ->
           @get(path).then((r)-> console.log (r))

--- a/app/scripts/services/UtilityBolt.coffee
+++ b/app/scripts/services/UtilityBolt.coffee
@@ -172,11 +172,10 @@ angular.module('neo4jApp.services')
             .catch((e) -> q.reject Bolt.constructResult e)
           q.promise
 
-        makeRequest: (withoutCredentials, retainConnection) ->
+        makeRequest: (withoutCredentials) ->
           q = $q.defer()
           r = Bolt.testConnection withoutCredentials
           r.then((r) ->
-            Bolt.connect() if retainConnection
             if (r.credentials_expired)
               errObj = {data: {}}
               errObj.data.password_change = 'true'
@@ -184,7 +183,7 @@ angular.module('neo4jApp.services')
               q.reject errObj
             else
               $rootScope.bolt_connection_failure = no
-              return q.resolve({})
+              q.resolve({})
           ,(err) ->
             errObj = Bolt.constructResult err
             if errObj.data.errors[0].code is 'Socket.Error' || errObj.data.errors[0].message.indexOf('WebSocket connection failure') == 0


### PR DESCRIPTION
Use same driver for testing connections as well as for running queries. 