### PR TITLE
<li> tag is not visible in dark theme

### DIFF
--- a/app/styles/themes/dark.styl
+++ b/app/styles/themes/dark.styl
@@ -213,6 +213,8 @@ body.theme-dark
       background-color: secondary-background-color
       p
         color: secondary-text-color
+      li
+        color: secondary-text-color
       pre.code
         color: tertiary-text-color
         background-color: tertiary-background-color


### PR DESCRIPTION
#Steps to reproduce

Login to the browser console on http://localhost:7474/browser/
Load the Northwind Graph database

The text is not visible in dark theme.

![screen shot 2017-02-26 at 8 11 11 am](https://cloud.githubusercontent.com/assets/638379/23339979/8443409a-fbfb-11e6-9f55-8a0ee1a41cb6.png)

It's because `li` tag is not included in the dark theme. 
