### PR TITLE
renames 'String Store Size' to 'String Store', in sysinfo - Store Sizes table

### DIFF
--- a/app/content/guides/sysinfo.jade
+++ b/app/content/guides/sysinfo.jade
@@ -23,7 +23,7 @@ article.help(ng-controller="SysinfoController")
               th Relationship Store
               td {{sysinfo.kernel.RelationshipStoreSize | humanReadableBytes}}
             tr
-              th String Store Size
+              th String Store
               td {{sysinfo.kernel.StringStoreSize | humanReadableBytes}}
             tr
               th Total Store Size


### PR DESCRIPTION
No other store-related entries in that column have "Size" as suffix.
This commit simply makes naming of the String Store entry consistent with other store entries.