### PR TITLE
Connection feedback banners

### DIFF
--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -23,7 +23,7 @@ import { connect } from 'preact-redux'
 import { withBus } from 'preact-suber'
 import { ThemeProvider } from 'styled-components'
 import * as themes from 'browser/styles/themes'
-import { getTheme } from 'shared/modules/settings/settingsDuck'
+import { getTheme, getCmdChar } from 'shared/modules/settings/settingsDuck'
 import { FOCUS } from 'shared/modules/editor/editorDuck'
 import { StyledWrapper, StyledApp, StyledBody, StyledMainWrapper } from './styled'
 
@@ -45,16 +45,16 @@ class App extends Component {
     this.props.bus && this.props.bus.send(FOCUS)
   }
   render () {
-    const {drawer, handleNavClick, activeConnection, connectionState, theme} = this.props
+    const {drawer, cmdchar, handleNavClick, activeConnection, connectionState, theme} = this.props
     const themeData = themes[theme] || themes['normal']
     return (
       <ThemeProvider theme={themeData}>
         <StyledWrapper>
           <StyledApp>
             <StyledBody>
-              <Sidebar activeConnection={activeConnection} openDrawer={drawer} onNavClick={handleNavClick} connectionState={connectionState} />
+              <Sidebar openDrawer={drawer} onNavClick={handleNavClick} />
               <StyledMainWrapper>
-                <Main />
+                <Main cmdchar={cmdchar} activeConnection={activeConnection} connectionState={connectionState} />
               </StyledMainWrapper>
             </StyledBody>
           </StyledApp>
@@ -69,7 +69,8 @@ const mapStateToProps = (state) => {
     drawer: state.drawer,
     activeConnection: getActiveConnection(state),
     theme: getTheme(state),
-    connectionState: getConnectionState(state)
+    connectionState: getConnectionState(state),
+    cmdchar: getCmdChar(state)
   }
 }
 

--- a/src/browser/modules/ClickToCode/index.jsx
+++ b/src/browser/modules/ClickToCode/index.jsx
@@ -1,0 +1,12 @@
+
+import { withBus } from 'preact-suber'
+import { SET_CONTENT, setContent } from 'shared/modules/editor/editorDuck'
+import StyledCodeBlock from './styled'
+
+export const ClickToCode = ({CodeComponent = StyledCodeBlock, bus, code, children}) => {
+  if (!children || !children[0]) return null
+  code = code || children[0]
+  return <CodeComponent onClick={() => bus.send(SET_CONTENT, setContent(code))}>{children[0]}</CodeComponent>
+}
+
+export default withBus(ClickToCode)

--- a/src/browser/modules/ClickToCode/index.jsx
+++ b/src/browser/modules/ClickToCode/index.jsx
@@ -1,4 +1,22 @@
-
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 import { withBus } from 'preact-suber'
 import { SET_CONTENT, setContent } from 'shared/modules/editor/editorDuck'
 import StyledCodeBlock from './styled'

--- a/src/browser/modules/ClickToCode/styled.jsx
+++ b/src/browser/modules/ClickToCode/styled.jsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components'
+
+export const StyledCodeBlock = styled.code`
+  background-color: black;
+  color: white;
+  cursor: pointer;
+  border: none;
+  border-radius: 4px;
+  padding: 2px 4px;
+`

--- a/src/browser/modules/ClickToCode/styled.jsx
+++ b/src/browser/modules/ClickToCode/styled.jsx
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 import styled from 'styled-components'
 
 export const StyledCodeBlock = styled.code`

--- a/src/browser/modules/Main/Main.jsx
+++ b/src/browser/modules/Main/Main.jsx
@@ -18,14 +18,31 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { DISCONNECTED_STATE, PENDING_STATE } from 'shared/modules/connections/connectionsDuck'
 import Editor from '../Editor/Editor'
 import Stream from '../Stream/Stream'
-import { StyledMain } from './styled'
+import Visible from 'browser-components/Visible'
+import ClickToCode from '../ClickToCode'
+import { StyledMain, WarningBanner, NotAuthedBanner, StyledCodeBlockAuthBar } from './styled'
 
 const Main = (props) => {
   return (
     <StyledMain>
       <Editor />
+      <Visible if={props.connectionState === DISCONNECTED_STATE}>
+        <NotAuthedBanner>
+          Database access not available. Please use&nbsp;
+          <ClickToCode CodeComponent={StyledCodeBlockAuthBar}>
+            {props.cmdchar}server connect
+          </ClickToCode>&nbsp;
+          to establish connection. There's a graph waiting for you.
+        </NotAuthedBanner>
+      </Visible>
+      <Visible if={props.connectionState === PENDING_STATE}>
+        <WarningBanner>
+          Connection to server lost. Reconnecting...
+        </WarningBanner>
+      </Visible>
       <Stream />
     </StyledMain>
   )

--- a/src/browser/modules/Main/styled.jsx
+++ b/src/browser/modules/Main/styled.jsx
@@ -19,6 +19,7 @@
  */
 
 import styled from 'styled-components'
+import { StyledCodeBlock } from '../ClickToCode/styled'
 
 export const StyledMain = styled.div`
   flex: 0 0 auto;
@@ -27,4 +28,27 @@ export const StyledMain = styled.div`
   background-color: #D2D5DA;
   min-width: 0;
   position: relative;
+`
+
+export const Banner = styled.div`
+  height: 49px;
+  line-height: 49px;
+  width: 100%;
+  color: white;
+  padding: 0 24px;
+`
+
+export const ErrorBanner = styled(Banner)`
+  background-color: ${props => props.theme.error}
+`
+export const WarningBanner = styled(Banner)`
+  background-color: ${props => props.theme.warning}
+`
+export const NotAuthedBanner = styled(Banner)`
+  background-color: ${props => props.theme.auth}
+`
+
+export const StyledCodeBlockAuthBar = styled(StyledCodeBlock)`
+  background-color: white;
+  color: ${props => props.theme.auth};
 `

--- a/src/browser/modules/Sidebar/Sidebar.jsx
+++ b/src/browser/modules/Sidebar/Sidebar.jsx
@@ -19,13 +19,11 @@
  */
 
 import { Component } from 'preact'
-import { DISCONNECTED_STATE, CONNECTED_STATE, PENDING_STATE } from 'shared/modules/connections/connectionsDuck'
 import DatabaseInfo from '../DatabaseInfo/DatabaseInfo'
 import Favorites from './Favorites'
 import Documents from './Documents'
 import About from './About'
 import TabNavigation from 'browser-components/TabNavigation/Navigation'
-import Visible from 'browser-components/Visible'
 import Settings from './Settings'
 import BrowserSync from './../Sync/BrowserSync'
 import {
@@ -37,10 +35,6 @@ import {
   AboutIcon
 } from 'browser-components/icons/Icons'
 
-import MdFlashOn from 'react-icons/lib/md/flash-on'
-import MdFlashOff from 'react-icons/lib/md/flash-off'
-import Badge from 'browser-components/badge'
-
 class Sidebar extends Component {
   render () {
     const openDrawer = this.props.openDrawer
@@ -50,22 +44,8 @@ class Sidebar extends Component {
     const DocumentsDrawer = Documents
     const SettingsDrawer = Settings
     const AboutDrawer = About
-    const dbIcon = (isOpen) => (
-      <div style={{position: 'relative'}}>
-        <DatabaseIcon isOpen={isOpen} />
-        <Visible if={this.props.connectionState === DISCONNECTED_STATE}>
-          <Badge status='error'><MdFlashOff /></Badge>
-        </Visible>
-        <Visible if={this.props.connectionState === CONNECTED_STATE}>
-          <Badge status='ok'><MdFlashOn /></Badge>
-        </Visible>
-        <Visible if={this.props.connectionState === PENDING_STATE}>
-          <Badge status='warning'><MdFlashOff /></Badge>
-        </Visible>
-      </div>
-    )
     const topNavItemsList = [
-      {name: 'DB', icon: (isOpen) => dbIcon(isOpen), content: DatabaseDrawer},
+      {name: 'DB', icon: (isOpen) => <DatabaseIcon isOpen={isOpen} />, content: DatabaseDrawer},
       {name: 'Favorites', icon: (isOpen) => <FavoritesIcon isOpen={isOpen} />, content: FavoritesDrawer},
       {name: 'Documents', icon: (isOpen) => <DocumentsIcon isOpen={isOpen} />, content: DocumentsDrawer}
     ]

--- a/src/browser/styles/themes.js
+++ b/src/browser/styles/themes.js
@@ -43,7 +43,8 @@ export const base = {
   // User feedback colors
   success: '#70E9B1',
   error: '#E74C3C',
-  warning: '#ebf094',
+  warning: '#FD952C',
+  auth: '#428BCA',
 
   // Buttons
   primaryButtonText: '',

--- a/src/shared/modules/connections/connectionsDuck.js
+++ b/src/shared/modules/connections/connectionsDuck.js
@@ -199,7 +199,13 @@ const onLostConnection = (dispatch) => (e) => {
   dispatch({ type: LOST_CONNECTION, error: e })
 }
 
-export const connectionLossFilter = (action) => action.error.code !== 'Neo.ClientError.Security.Unauthorized'
+export const connectionLossFilter = (action) => {
+  const notLostCodes = [
+    'Neo.ClientError.Security.Unauthorized',
+    'Neo.ClientError.Security.AuthenticationRateLimit'
+  ]
+  return notLostCodes.indexOf(action.error.code) < 0
+}
 
 // Epics
 export const connectEpic = (action$, store) => {

--- a/src/shared/modules/settings/settingsDuck.js
+++ b/src/shared/modules/settings/settingsDuck.js
@@ -43,6 +43,7 @@ const browserSyncConfig = {
   }
 }
 export const getUseNewVisualization = (state) => state[NAME].useNewVis
+export const getCmdChar = (state) => state[NAME].cmdchar || initialState.cmdchar
 
 const initialState = {
   cmdchar: ':',


### PR DESCRIPTION
Add connection feedback banners below editor.

* Removed badge over DB icon in sidebar.
* Blue banner - Not connected to a database. Click on part of banner to populate editor with `:server connect`
* Orange banner - Connection lost, trying to reconnect.

<img width="887" alt="oskar4j 2017-04-10 at 20 56 14" src="https://cloud.githubusercontent.com/assets/570998/24878351/18e52b42-1e33-11e7-8764-ddceadd23653.png">
<img width="884" alt="oskar4j 2017-04-10 at 20 56 53" src="https://cloud.githubusercontent.com/assets/570998/24878350/18e49100-1e33-11e7-897e-b8d377fe2574.png">
