### PR TITLE
Upgrade to Preact 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "neo4j-driver": "^1.2.0",
     "neo4j-visualization": "0.0.133",
     "node-noop": "^1.0.0",
-    "preact": "^7.2.0",
+    "preact": "^8.1.0",
     "preact-compat": "^3.13.1",
     "preact-redux": "^2.0.0",
     "preact-suber": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5530,9 +5530,9 @@ preact-transition-group@^1.1.0:
   version "1.1.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/preact-transition-group/-/preact-transition-group-1.1.0.tgz#97d0beff0790d721faecd2560c02cd30d5426f23"
 
-preact@^7.2.0:
-  version "7.2.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/preact/-/preact-7.2.1.tgz#159e1892f614985e49eb0a96fd6e6d8bdf8bbcc5"
+preact@^8.1.0:
+  version "8.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/preact/-/preact-8.1.0.tgz#f035b808eebb74e46d56246b02ca0f190b6d6574"
 
 precss@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
We are not affected by any of the breaking changes: https://gist.github.com/developit/89e0e6decb8fb5eb00def024b6fb7bd7

This should be a win for us:
- https://github.com/developit/preact/releases/tag/8.0.0
- https://github.com/developit/preact/releases/tag/8.1.0