### PR TITLE
[Bugfix] Show full children content in click to code

### DIFF
--- a/src/browser/modules/ClickToCode/index.jsx
+++ b/src/browser/modules/ClickToCode/index.jsx
@@ -22,9 +22,10 @@ import { SET_CONTENT, setContent } from 'shared/modules/editor/editorDuck'
 import StyledCodeBlock from './styled'
 
 export const ClickToCode = ({CodeComponent = StyledCodeBlock, bus, code, children}) => {
-  if (!children || !children[0]) return null
-  code = code || children[0]
-  return <CodeComponent onClick={() => bus.send(SET_CONTENT, setContent(code))}>{children[0]}</CodeComponent>
+  if (!children || children.length === 0) return
+  const text = children.join('')
+  code = code || text
+  return <CodeComponent onClick={() => bus.send(SET_CONTENT, setContent(code))}>{text}</CodeComponent>
 }
 
 export default withBus(ClickToCode)

--- a/src/browser/modules/NevadaVisualization/NevadaWrapper.jsx
+++ b/src/browser/modules/NevadaVisualization/NevadaWrapper.jsx
@@ -106,7 +106,7 @@ export class NevadaWrapper extends Component {
         updateRelStyle: this.updateRelationshipStyle.bind(this),
         getNodes: this.getNodes.bind(this),
         getRels: this.getRels.bind(this)
-//        clientData: 
+//        clientData:
       }
       require.ensure([], (require) => {
         const Nevada = require('neo4j-visualization').default


### PR DESCRIPTION
Instead of:

```
Database access not available. Please use `:`  to establish connection. There's a graph waiting for you.
```

It now shows:

```
Database access not available. Please use `:server connect`  to establish connection. There's a graph waiting for you.
```

