### PR TITLE
Add tests for ClickToCode

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,9 @@
     "moduleNameMapper": {
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|html)$": "<rootDir>/__mocks__/fileMock.js",
       "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js",
-      "neo4j": "<rootDir>/__mocks__/neo4j.js"
+      "neo4j": "<rootDir>/__mocks__/neo4j.js",
+      "^react$": "preact-compat",
+      "^react-dom$": "preact-compat"
     },
     "modulePaths": [
       "<rootDir>/src",
@@ -78,6 +80,7 @@
     "postcss": "^5.0.21",
     "postcss-cssnext": "^2.6.0",
     "postcss-loader": "^1.3.3",
+    "preact-render-to-string": "^3.6.0",
     "precss": "^1.4.0",
     "react-addons-test-utils": "^15.0.2",
     "react-hot-loader": "^1.3.0",

--- a/src/browser/modules/ClickToCode/__snapshots__/index.test.js.snap
+++ b/src/browser/modules/ClickToCode/__snapshots__/index.test.js.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ClickToCode does not render if no children 1`] = `""`;
+
+exports[`ClickToCode renders all children 1`] = `"<code><div><span>hello</span>hi!</div></code>"`;
+
+exports[`ClickToCode renders children as code if no code is provided 1`] = `"<code>hellohi!</code>"`;
+
+exports[`ClickToCode renders code as the code when code is available 1`] = `"<code>yo</code>"`;
+
+exports[`ClickToCode renders if no CodeComponent is provided 1`] = `"<code class=\\"kOlXwI\\">my code</code>"`;

--- a/src/browser/modules/ClickToCode/index.jsx
+++ b/src/browser/modules/ClickToCode/index.jsx
@@ -19,13 +19,12 @@
  */
 import { withBus } from 'preact-suber'
 import { SET_CONTENT, setContent } from 'shared/modules/editor/editorDuck'
-import StyledCodeBlock from './styled'
+import { StyledCodeBlock } from './styled'
 
 export const ClickToCode = ({CodeComponent = StyledCodeBlock, bus, code, children}) => {
-  if (!children || children.length === 0) return
-  const text = children.join('')
-  code = code || text
-  return <CodeComponent onClick={() => bus.send(SET_CONTENT, setContent(code))}>{text}</CodeComponent>
+  if (!children || children.length === 0) return null
+  code = code || children.join('')
+  return <CodeComponent onClick={() => bus.send(SET_CONTENT, setContent(code))}>{children}</CodeComponent>
 }
 
 export default withBus(ClickToCode)

--- a/src/browser/modules/ClickToCode/index.test.js
+++ b/src/browser/modules/ClickToCode/index.test.js
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* global describe, beforeEach, afterEach, test, expect, jest */
+import render from 'preact-render-to-string'
+import { createBus } from 'suber'
+
+import { ClickToCode } from './index'
+import { SET_CONTENT } from 'shared/modules/editor/editorDuck'
+
+describe('ClickToCode', () => {
+  let MyComp
+  let bus
+  beforeEach(() => {
+    MyComp = ({onClick, children}) => {
+      onClick()
+      return <code>{children}</code>
+    }
+    bus = createBus()
+  })
+  afterEach(() => {
+    bus.reset()
+  })
+  test('does not render if no children', () => {
+    // Given
+    const myFn = jest.fn()
+
+    // When
+    bus.take(SET_CONTENT, myFn)
+    const component = render(<ClickToCode CodeComponent={MyComp} bus={bus} />)
+
+    // Then
+    expect(component).toMatchSnapshot()
+    expect(myFn).toHaveBeenCalledTimes(0)
+  })
+  test('renders if no CodeComponent is provided', () => {
+    // Given
+    // When
+    const component = render(<ClickToCode>my code</ClickToCode>)
+
+    // Then
+    expect(component).toMatchSnapshot()
+  })
+  test('renders code as the code when code is available', () => {
+    // Given
+    const myFn = jest.fn()
+    const code = 'my code'
+
+    // When
+    bus.take(SET_CONTENT, myFn)
+    const component = render(<ClickToCode CodeComponent={MyComp} code={code} bus={bus}>yo</ClickToCode>)
+
+    // Then
+    expect(component).toMatchSnapshot()
+    expect(myFn).toHaveBeenCalledTimes(1)
+    expect(myFn).toHaveBeenCalledWith({message: code, type: SET_CONTENT})
+  })
+  test('renders children as code if no code is provided', () => {
+    // Given
+    const myFn = jest.fn()
+    const hello = 'hello'
+    const childrenString = 'hellohi!'
+
+    // When
+    bus.take(SET_CONTENT, myFn)
+    const component = render(<ClickToCode CodeComponent={MyComp} bus={bus}>{hello}hi!</ClickToCode>)
+
+    // Then
+    expect(component).toMatchSnapshot()
+    expect(myFn).toHaveBeenCalledTimes(1)
+    expect(myFn).toHaveBeenCalledWith({message: childrenString, type: SET_CONTENT})
+  })
+  test('renders all children', () => {
+    // Given
+    const myFn = jest.fn()
+    const code = 'my code'
+    const children = <div><span>hello</span>hi!</div>
+
+    // When
+    bus.take(SET_CONTENT, myFn)
+    const component = render(<ClickToCode CodeComponent={MyComp} code={code} bus={bus}>{children}</ClickToCode>)
+
+    // Then
+    expect(component).toMatchSnapshot()
+    expect(myFn).toHaveBeenCalledTimes(1)
+    expect(myFn).toHaveBeenCalledWith({message: code, type: SET_CONTENT})
+  })
+})


### PR DESCRIPTION
The main issue is that react bevaiour changed when interpolating strings in JSX.

In Preact 7.2.1 these are the same (`:server connect` in `children[0]`)
```
<div>
  {props.cmdchar}server connect
</div>
// and
<div>
  {props.cmdchar + 'server connect'}
</div>
```

where in Preact 8 the first example actually created an array of two children.

In this PR I also introduce our first component render tests using `preact-render-to-string` and Jest snapshots.