### PR TITLE
Handle unknown commands

### DIFF
--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -25,6 +25,7 @@ import { ThemeProvider } from 'styled-components'
 import * as themes from 'browser/styles/themes'
 import { getTheme, getCmdChar } from 'shared/modules/settings/settingsDuck'
 import { FOCUS } from 'shared/modules/editor/editorDuck'
+import { wasUnknownCommand } from 'shared/modules/commands/commandsDuck'
 import { StyledWrapper, StyledApp, StyledBody, StyledMainWrapper } from './styled'
 
 import Main from '../Main/Main'
@@ -45,7 +46,7 @@ class App extends Component {
     this.props.bus && this.props.bus.send(FOCUS)
   }
   render () {
-    const {drawer, cmdchar, handleNavClick, activeConnection, connectionState, theme} = this.props
+    const {drawer, cmdchar, handleNavClick, activeConnection, connectionState, theme, showUnknownCommandBanner} = this.props
     const themeData = themes[theme] || themes['normal']
     return (
       <ThemeProvider theme={themeData}>
@@ -54,7 +55,12 @@ class App extends Component {
             <StyledBody>
               <Sidebar openDrawer={drawer} onNavClick={handleNavClick} />
               <StyledMainWrapper>
-                <Main cmdchar={cmdchar} activeConnection={activeConnection} connectionState={connectionState} />
+                <Main
+                  cmdchar={cmdchar}
+                  activeConnection={activeConnection}
+                  connectionState={connectionState}
+                  showUnknownCommandBanner={showUnknownCommandBanner}
+                />
               </StyledMainWrapper>
             </StyledBody>
           </StyledApp>
@@ -70,7 +76,8 @@ const mapStateToProps = (state) => {
     activeConnection: getActiveConnection(state),
     theme: getTheme(state),
     connectionState: getConnectionState(state),
-    cmdchar: getCmdChar(state)
+    cmdchar: getCmdChar(state),
+    showUnknownCommandBanner: wasUnknownCommand(state)
   }
 }
 

--- a/src/browser/modules/Help/html/commands.html
+++ b/src/browser/modules/Help/html/commands.html
@@ -1,0 +1,37 @@
+<article class="help">
+  <section class="main">
+    <div class="headings">
+      <p class="title">Commands</p>
+      <p class="subtitle">Typing commands is 1337</p>
+    </div>
+    <div class="content">
+      <p>
+        In addition to composing and running Cypher queries, the editor bar up above &uarr;
+          understands a few client-side commands, which begin with a&nbsp;<code>:</code>. Without a colon, we'll assume you're trying to enter a Cypher query.
+      </p>
+      <table class="table-condensed table-help">
+        <tr>
+          <th>Information:</th>
+          <td><a help-topic="play">:help play</a></td>
+        </tr>
+        <tr>
+          <th>Server:</th>
+          <td><a help-topic="server">:help server</a>
+          </td>
+        </tr>
+        <tr>
+          <th>Cypher:</th>
+          <td><a help-topic="cypher">:help cypher</a></td>
+        </tr>
+        <tr>
+          <th>Params:</th>
+          <td><a help-topic="param">:help param</a><a help-topic="params">:help params</a></td>
+        </tr>
+        <tr>
+          <th>Query status:</th>
+          <td><a help-topic="queries">:help queries</a></td>
+        </tr>
+      </table>
+    </div>
+  </section>
+</article>

--- a/src/browser/modules/Help/html/index.js
+++ b/src/browser/modules/Help/html/index.js
@@ -18,6 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import _commands from './commands.html'
 import _contains from './contains.html'
 import _createIndexOn from './create-index-on.html'
 import _createUnique from './create-unique.html'
@@ -39,6 +40,8 @@ import _queries from './queries.html'
 import _queryPlan from './query-plan.html'
 import _remove from './remove.html'
 import _return from './return.html'
+import _server from './server.html'
+import _serverUser from './server-user.html'
 import _set from './set.html'
 import _start from './start.html'
 import _startsWith from './starts-with.html'
@@ -48,6 +51,7 @@ import _where from './where.html'
 import _with from './with.html'
 
 export default {
+  _commands,
   _contains,
   _createIndexOn,
   _createUnique,
@@ -69,6 +73,8 @@ export default {
   _queryPlan,
   _remove,
   _return,
+  _server,
+  _serverUser,
   _set,
   _start,
   _startsWith,

--- a/src/browser/modules/Main/Main.jsx
+++ b/src/browser/modules/Main/Main.jsx
@@ -23,12 +23,21 @@ import Editor from '../Editor/Editor'
 import Stream from '../Stream/Stream'
 import Visible from 'browser-components/Visible'
 import ClickToCode from '../ClickToCode'
-import { StyledMain, WarningBanner, NotAuthedBanner, StyledCodeBlockAuthBar } from './styled'
+import { StyledMain, WarningBanner, ErrorBanner, NotAuthedBanner, StyledCodeBlockAuthBar, StyledCodeBlockErrorBar } from './styled'
 
 const Main = (props) => {
   return (
     <StyledMain>
       <Editor />
+      <Visible if={props.showUnknownCommandBanner}>
+        <ErrorBanner>
+          Type&nbsp;
+          <ClickToCode CodeComponent={StyledCodeBlockErrorBar}>
+            {props.cmdchar}help commands
+          </ClickToCode>&nbsp;
+          for a list of available commands.
+        </ErrorBanner>
+      </Visible>
       <Visible if={props.connectionState === DISCONNECTED_STATE}>
         <NotAuthedBanner>
           Database access not available. Please use&nbsp;

--- a/src/browser/modules/Main/styled.jsx
+++ b/src/browser/modules/Main/styled.jsx
@@ -18,8 +18,19 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import styled from 'styled-components'
+import styled, { keyframes } from 'styled-components'
 import { StyledCodeBlock } from '../ClickToCode/styled'
+
+const grow = (height) => {
+  return keyframes`
+    0% {
+      max-height: 0px;
+    }
+    100% {
+      max-height: ${height};
+    }
+  `
+}
 
 export const StyledMain = styled.div`
   flex: 0 0 auto;
@@ -31,15 +42,16 @@ export const StyledMain = styled.div`
 `
 
 export const Banner = styled.div`
-  height: 49px;
   line-height: 49px;
   width: 100%;
   color: white;
   padding: 0 24px;
+  overflow: hidden;
+  animation: ${grow('49px')} .3s ease-in;
 `
 
 export const ErrorBanner = styled(Banner)`
-  background-color: ${props => props.theme.error}
+  background-color: ${props => props.theme.error};
 `
 export const WarningBanner = styled(Banner)`
   background-color: ${props => props.theme.warning}
@@ -51,4 +63,8 @@ export const NotAuthedBanner = styled(Banner)`
 export const StyledCodeBlockAuthBar = styled(StyledCodeBlock)`
   background-color: white;
   color: ${props => props.theme.auth};
+`
+export const StyledCodeBlockErrorBar = styled(StyledCodeBlock)`
+  background-color: white;
+  color: ${props => props.theme.error};
 `

--- a/src/shared/modules/commands/commandsDuck.js
+++ b/src/shared/modules/commands/commandsDuck.js
@@ -19,16 +19,37 @@
  */
 
 import bolt from 'services/bolt/bolt'
-import { cleanCommand } from 'services/commandUtils'
+import { getInterpreter, isNamedInterpreter } from 'services/commandUtils'
 import helper from 'services/commandInterpreterHelper'
 import { addHistory } from '../history/historyDuck'
-import { getSettings } from '../settings/settingsDuck'
+import { getCmdChar } from '../settings/settingsDuck'
 import { CONNECTION_SUCCESS } from '../connections/connectionsDuck'
+import { USER_CLEAR } from 'shared/modules/app/appDuck'
 import { fetchMetaData } from '../dbMeta/dbMetaDuck'
 
-const NAME = 'commands'
+export const NAME = 'commands'
 export const USER_COMMAND_QUEUED = NAME + '/USER_COMMAND_QUEUED'
 export const SYSTEM_COMMAND_QUEUED = NAME + '/SYSTEM_COMMAND_QUEUED'
+export const UNKNOWN_COMMAND = NAME + '/UNKNOWN_COMMAND'
+export const KNOWN_COMMAND = NAME + '/KNOWN_COMMAND'
+
+const initialState = {
+  lastCommandWasUnknown: false
+}
+export const wasUnknownCommand = (state) => state[NAME].lastCommandWasUnknown || initialState.lastCommandWasUnknown
+
+export default function reducer (state = initialState, action) {
+  switch (action.type) {
+    case UNKNOWN_COMMAND:
+      return { lastCommandWasUnknown: true }
+    case KNOWN_COMMAND:
+      return { lastCommandWasUnknown: false }
+    case USER_CLEAR:
+      return initialState
+    default:
+      return state
+  }
+}
 
 // Action creators
 export const executeCommand = (cmd, contextId, requestId = null) => {
@@ -49,20 +70,30 @@ export const executeSystemCommand = (cmd, contextId, requestId = null) => {
   }
 }
 
+export const unknownCommand = (cmd) => ({
+  type: UNKNOWN_COMMAND,
+  cmd
+})
+
 // Epics
 export const handleCommandsEpic = (action$, store) =>
   action$.ofType(USER_COMMAND_QUEUED)
-    .do((action) => store.dispatch(addHistory({cmd: action.cmd})))
     .merge(action$.ofType(SYSTEM_COMMAND_QUEUED))
-    .mergeMap((action) => {
-      const cleanCmd = cleanCommand(action.cmd)
-      const settingsState = getSettings(store.getState())
-      let interpreted = helper.interpret('cypher')// assume cypher
-      if (cleanCmd[0] === settingsState.cmdchar) { // :command
-        interpreted = helper.interpret(action.cmd.substr(settingsState.cmdchar.length))
+    .map((action) => {
+      const cmdchar = getCmdChar(store.getState())
+      const interpreted = getInterpreter(helper.interpret, action.cmd, cmdchar)
+      return {action, interpreted, cmdchar}
+    })
+    .do(({action, interpreted}) => {
+      if (action.type === SYSTEM_COMMAND_QUEUED) return
+      if (isNamedInterpreter(interpreted)) {
+        store.dispatch(addHistory({cmd: action.cmd})) // Only save valid commands to history
+        store.dispatch({ type: KNOWN_COMMAND }) // Clear any eventual unknown command notifications
       }
+    })
+    .mergeMap(({action, interpreted, cmdchar}) => {
       return new Promise((resolve, reject) => {
-        const res = interpreted.exec(action, settingsState.cmdchar, store.dispatch, store)
+        const res = interpreted.exec(action, cmdchar, store.dispatch, store)
         const noop = { type: 'NOOP' }
         if (!res || !res.then) {
           resolve(noop)
@@ -88,7 +119,7 @@ export const postConnectCmdEpic = (some$, store) =>
             if (record.get('name').match(/Configuration$/)) conf = record.get('attributes')
           })
           if (conf && conf['browser.post_connect_cmd'] && conf['browser.post_connect_cmd'].value) {
-            const cmdchar = getSettings(store.getState()).cmdchar
+            const cmdchar = getCmdChar(store.getState())
             store.dispatch(executeSystemCommand(`${cmdchar}${conf['browser.post_connect_cmd'].value}`))
           }
           return null

--- a/src/shared/modules/commands/commandsDuck.test.js
+++ b/src/shared/modules/commands/commandsDuck.test.js
@@ -68,6 +68,7 @@ describe('commandsDuck', () => {
         expect(store.getActions()).toEqual([
           action,
           addHistory({ cmd }),
+          { type: commands.KNOWN_COMMAND },
           helper.interpret(cmdString).exec(action, store.getState().settings.cmdchar, (a) => a, store),
           { type: 'NOOP' }
         ])
@@ -89,6 +90,7 @@ describe('commandsDuck', () => {
         expect(store.getActions()).toEqual([
           action,
           addHistory({cmd}),
+          { type: commands.KNOWN_COMMAND },
           send('cypher', requestId),
           frames.add({...action, type: 'cypher'}),
           updateQueryResult(requestId, createErrorObject(BoltConnectionError), 'error'),
@@ -114,6 +116,7 @@ describe('commandsDuck', () => {
         expect(store.getActions()).toEqual([
           action,
           addHistory({ cmd: cmdString }),
+          { type: commands.KNOWN_COMMAND },
           merge({x: 2}),
           frames.add({...action, success: true, type: 'param', params: {x: 2}}),
           { type: 'NOOP' }
@@ -138,6 +141,7 @@ describe('commandsDuck', () => {
         expect(store.getActions()).toEqual([
           action,
           addHistory({ cmd: cmdString }),
+          { type: commands.KNOWN_COMMAND },
           set({x: 2, y: 3}),
           frames.add({...action, success: true, type: 'params', params: {}}),
           { type: 'NOOP' }
@@ -161,6 +165,7 @@ describe('commandsDuck', () => {
         expect(store.getActions()).toEqual([
           action,
           addHistory({ cmd: cmdString }),
+          { type: commands.KNOWN_COMMAND },
           frames.add({...action, type: 'params', params: {}}),
           { type: 'NOOP' }
         ])
@@ -184,6 +189,7 @@ describe('commandsDuck', () => {
         expect(store.getActions()).toEqual([
           action,
           addHistory({ cmd: cmdString }),
+          { type: commands.KNOWN_COMMAND },
           updateSettings({x: 2}),
           frames.add({...action, type: 'pre', result: JSON.stringify({cmdchar: ':'}, null, 2)}),
           { type: 'NOOP' }
@@ -206,12 +212,33 @@ describe('commandsDuck', () => {
         expect(store.getActions()).toEqual([
           action,
           addHistory({ cmd }),
+          { type: commands.KNOWN_COMMAND },
           frames.add({ ...action, type: 'queries', result: "{res : 'QUERIES RESULT'}" }),
-            {type: 'NOOP'}
+          {type: 'NOOP'}
         ])
         done()
       })
 
+      store.dispatch(action)
+    })
+  })
+  describe(':unknown', () => {
+    test('unkown commands send out an UNKNOWN_COMMAND acation and not added to history', (done) => {
+      // Given
+      const cmd = store.getState().settings.cmdchar + 'unknown'
+      const id = 1
+      const action = commands.executeCommand(cmd, id)
+      bus.take('NOOP', (currentAction) => {
+        // Then
+        expect(store.getActions()).toEqual([
+          action,
+          commands.unknownCommand(cmd),
+          { type: 'NOOP' }
+        ])
+        done()
+      })
+
+      // When
       store.dispatch(action)
     })
   })
@@ -227,6 +254,7 @@ describe('commandsDuck', () => {
         expect(store.getActions()).toEqual([
           action,
           addHistory({cmd}),
+          { type: commands.KNOWN_COMMAND },
           frames.add({...action, type: 'disconnect'}),
           disconnectAction(null),
           { type: 'NOOP' }

--- a/src/shared/rootReducer.js
+++ b/src/shared/rootReducer.js
@@ -33,6 +33,7 @@ import visualizationReducer, { NAME as visualization } from 'shared/modules/visu
 import grassReducer, { NAME as grass } from 'shared/modules/grass/grassDuck'
 import { syncReducer, syncConsentReducer, NAME_CONSENT as syncConsent, NAME as sync } from 'shared/modules/sync/syncDuck'
 import foldersReducer, { NAME as folders } from 'shared/modules/favorites/foldersDuck'
+import commandsReducer, { NAME as commands } from 'shared/modules/commands/commandsDuck'
 
 export default {
   [connections]: connectionsReducer,
@@ -50,5 +51,6 @@ export default {
   [visualization]: visualizationReducer,
   [grass]: grassReducer,
   [sync]: syncReducer,
-  [syncConsent]: syncConsentReducer
+  [syncConsent]: syncConsentReducer,
+  [commands]: commandsReducer
 }

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -28,9 +28,10 @@ import remote from 'services/remote'
 import { getServerConfig } from 'services/bolt/boltHelpers'
 import { handleServerCommand } from 'shared/modules/commands/helpers/server'
 import { handleCypherCommand } from 'shared/modules/commands/helpers/cypher'
+import { unknownCommand } from 'shared/modules/commands/commandsDuck'
 import { handleParamCommand, handleParamsCommand } from 'shared/modules/commands/helpers/params'
 import { handleGetConfigCommand, handleUpdateConfigCommand } from 'shared/modules/commands/helpers/config'
-import { CouldNotFetchRemoteGuideError, UnknownCommandError, FetchURLError } from 'services/exceptions'
+import { CouldNotFetchRemoteGuideError, FetchURLError } from 'services/exceptions'
 import { parseHttpVerbCommand } from 'shared/modules/commands/helpers/http'
 
 const availableCommands = [{
@@ -180,7 +181,7 @@ const availableCommands = [{
   name: 'catch-all',
   match: () => true,
   exec: (action, cmdchar, put) => {
-    put(frames.add({...action, type: 'unknown', error: UnknownCommandError(action.cmd)}))
+    put(unknownCommand(action.cmd))
   }
 }]
 

--- a/src/shared/services/commandInterpreterHelper.test.js
+++ b/src/shared/services/commandInterpreterHelper.test.js
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* global test, expect */
+/* global describe, test, expect */
 import helper from './commandInterpreterHelper'
 
 describe('commandInterpreterHelper', () => {

--- a/src/shared/services/commandUtils.js
+++ b/src/shared/services/commandUtils.js
@@ -69,3 +69,15 @@ export function parseCommandJSON (cmd, input) {
   }
   return val
 }
+
+export const isCypherCommand = (cmd, cmdchar) => {
+  const cleanCmd = cleanCommand(cmd)
+  return cleanCmd[0] !== cmdchar
+}
+
+export const getInterpreter = (interpret, cmd, cmdchar) => {
+  if (isCypherCommand(cmd, cmdchar)) return interpret('cypher')
+  return interpret(cmd.substr(cmdchar.length))
+}
+
+export const isNamedInterpreter = (interpreter) => interpreter && interpreter.name !== 'catch-all'

--- a/src/shared/services/commandUtils.test.js
+++ b/src/shared/services/commandUtils.test.js
@@ -96,4 +96,15 @@ describe('commandutils', () => {
       expect(utils.parseCommandJSON(':config', obj.str)).toEqual(obj.expect)
     })
   })
+  test('isCypherCommand should treat everything not starting with : as cypher', () => {
+    const testStrs = [
+      {str: ':config {test: 10}', expect: false},
+      {str: 'return 1', expect: true},
+      {str: '//:hello\nRETURN 1', expect: true},
+      {str: '   RETURN 1', expect: true}
+    ]
+    testStrs.forEach((obj) => {
+      expect(obj.str + ': ' + utils.isCypherCommand(obj.str, ':')).toEqual(obj.str + ': ' + obj.expect)
+    })
+  })
 })


### PR DESCRIPTION
- Dispatch action of type UNKNOWN_COMMAND on unkown commands.
- Don't add it to history.
- Send action of type KNOWN_COMMAND on found commands.
- Show unknown command banner
- Add help doc `:help commands`, `:help server` and `:help server-user`.
- Animate all banners.

![unknown-banner](https://cloud.githubusercontent.com/assets/570998/25153394/ad208acc-248c-11e7-8e89-211bc2e085ba.gif)
