### PR TITLE
Set and read version from package.json and pom.xml

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neo4j-browser",
-  "version": "1.0.0",
+  "version": "3.0.1",
   "description": "Enjoy your data",
   "main": "index.js",
   "scripts": {
@@ -10,7 +10,9 @@
     "test": "npm run lint && jest",
     "dev": "jest --watch",
     "build": "rm -rf ./build && NODE_ENV=\"production\" webpack",
-    "jar": "yarn build && mvn package"
+    "jar": "yarn build && mvn package",
+    "version-pom": "node ./scripts/set-pom-version.js -f ./pom.xml -v $npm_package_version",
+    "version": "npm run version-pom && git add ./pom.xml"
   },
   "jest": {
     "testPathIgnorePatterns": [
@@ -135,6 +137,7 @@
     "styled-components": "^1.4.4",
     "suber": "^5.0.1",
     "swipe-js-iso": "^2.0.3",
-    "uuid": "^3.0.1"
+    "uuid": "^3.0.1",
+    "xml2js": "^0.4.17"
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.neo4j.client</groupId>
   <artifactId>neo4j-browser</artifactId>
@@ -8,7 +7,6 @@
   <name>Neo4j - Browser</name>
   <description>Graph database client.</description>
   <url>https://github.com/neo4j/neo4j</url>
-
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <license-text.header>GPL-3-header.txt</license-text.header>
@@ -17,7 +15,6 @@
     <attach-docs-phase>none</attach-docs-phase>
     <neo4j.java.version>1.8</neo4j.java.version>
   </properties>
-
   <developers>
     <developer>
       <id>neo4j</id>
@@ -27,14 +24,11 @@
       <organizationUrl>http://www.neotechnology.com/</organizationUrl>
     </developer>
   </developers>
-
   <scm>
     <connection>scm:git:git://github.com/neo4j/neo4j.git</connection>
     <developerConnection>scm:git:git@github.com:neo4j/neo4j.git</developerConnection>
     <url>https://github.com/neo4j/neo4j</url>
   </scm>
-
-
   <licenses>
     <license>
       <name>GNU General Public License, Version 3</name>
@@ -54,7 +48,6 @@
       </comments>
     </license>
   </licenses>
-
   <build>
     <resources>
       <resource>
@@ -72,9 +65,7 @@
         </excludes>
       </resource>
     </resources>
-
     <plugins>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -147,29 +138,8 @@
           </execution>
         </executions>
       </plugin>
-      <!-- <plugin>
-        <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.4</version>
-        <executions>
-          <execution>
-            <phase>process-resources</phase>
-            <configuration>
-              <tasks>
-                <copy file="target/classes/browser/index.html"
-                      toFile="dist/browser/index.html" overwrite="true"/>
-              </tasks>
-            </configuration>
-            <goals>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin> -->
-
     </plugins>
-
   </build>
-
   <distributionManagement>
     <repository>
       <id>releases@repo.neo4j.org</id>
@@ -179,5 +149,4 @@
       <layout>default</layout>
     </repository>
   </distributionManagement>
-
 </project>

--- a/scripts/set-pom-version.js
+++ b/scripts/set-pom-version.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const fs = require('fs')
+const path = require('path')
+const xml2js = require('xml2js')
+const parser = new xml2js.Parser()
+const builder = new xml2js.Builder()
+
+// Shallow validation
+if (process.argv.length !== 6) failExit()
+
+// Create obj from args
+const args = parseArgv(process.argv)
+main(args)
+
+function main (args) {
+  if (!args['-f'] || !args['-v']) return failExit() // Validate args
+
+  const file = path.join(__dirname, '../', args['-f'])
+
+  fs.readFile(file, function (err, data) {
+    if (err) return failExit()
+    parser.parseString(data, function (err, result) {
+      if (err) return failExit()
+      result.project.version = args['-v'] // Set new version in obj
+      const xml = builder.buildObject(result) // Create XML
+      fs.writeFile(file, xml, function (err) {
+        if (err) return failExit()
+        console.log('\nDone updating version in pom.xml\n')
+        process.exit(0) // All good
+      })
+    })
+  })
+}
+
+function parseArgv (argv) {
+  let out = {}
+  for (let i = 0; i < argv.length; i += 2) { // Pairs
+    out[argv[i]] = argv[i + 1]
+  }
+  return out
+}
+
+function failExit () {
+  console.log('Error. Usage: "node set-pom-version.js -f filepath/from/project/root/pom.xml -v new-version-semver"')
+  process.exit(1)
+}

--- a/src/browser/modules/Sidebar/About.jsx
+++ b/src/browser/modules/Sidebar/About.jsx
@@ -18,6 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { version } from '../../../../package.json'
 import {Drawer, DrawerBody, DrawerHeader, DrawerSubHeader, DrawerSection, DrawerSectionBody, DrawerFooter} from 'browser-components/drawer'
 
 const About = () => {
@@ -40,7 +41,7 @@ const About = () => {
             Neo4j Browser
           </DrawerSubHeader>
           <DrawerSectionBody>
-            You are running version 3.0.1
+            You are running version {version}
           </DrawerSectionBody>
         </DrawerSection>
         <DrawerSection>

--- a/src/browser/modules/Sidebar/About.jsx
+++ b/src/browser/modules/Sidebar/About.jsx
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { version } from '../../../../package.json'
+import { version } from 'project-root/package.json'
 import {Drawer, DrawerBody, DrawerHeader, DrawerSubHeader, DrawerSection, DrawerSectionBody, DrawerFooter} from 'browser-components/drawer'
 
 const About = () => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -235,6 +235,7 @@ module.exports = {
     alias: {
       'neo4j-driver-alias': 'neo4j-driver/lib/browser/neo4j-web.min.js',
       'src-root': path.resolve(__dirname, 'src'),
+      'project-root': path.resolve(__dirname),
       'services': path.resolve(__dirname, 'src/shared/services'),
       'browser-services': path.resolve(__dirname, 'src/browser/services'),
       'shared': path.resolve(__dirname, 'src/shared'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -5841,7 +5841,7 @@ save-as@^0.1.7:
   dependencies:
     chai "*"
 
-sax@^1.2.1, sax@~1.2.1:
+sax@>=0.6.0, sax@^1.2.1, sax@~1.2.1:
   version "1.2.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
 
@@ -6812,6 +6812,19 @@ xml-char-classes@^1.0.0:
 xml-name-validator@^2.0.1:
   version "2.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
+
+xml2js@^0.4.17:
+  version "0.4.17"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/xml2js/-/xml2js-0.4.17.tgz#17be93eaae3f3b779359c795b419705a8817e868"
+  dependencies:
+    sax ">=0.6.0"
+    xmlbuilder "^4.1.0"
+
+xmlbuilder@^4.1.0:
+  version "4.2.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/xmlbuilder/-/xmlbuilder-4.2.1.tgz#aa58a3041a066f90eaa16c2f5389ff19f3f461a5"
+  dependencies:
+    lodash "^4.0.0"
 
 xmlhttprequest-ssl@1.5.3:
   version "1.5.3"


### PR DESCRIPTION
Actions required on release is now to:

```
npm version 3.0.0-RC2
```

That command changes version in `package.json` and creates and tags a new commit with the new version.
Pushing to git repo is not part of this npm script.

This also updates `pom.xml` so we can remove a build step.