### PR TITLE
Retrieve and present update statistics from bolt result

### DIFF
--- a/src/browser/modules/Stream/CypherFrame.jsx
+++ b/src/browser/modules/Stream/CypherFrame.jsx
@@ -137,7 +137,7 @@ class CypherFrame extends Component {
             this.changeView(viewTypes.TABLE)
           }}><TableIcon /></CypherFrameButton>
         </Visible>
-        <Visible if={!this.state.errors}>
+        <Visible if={this.resultHasNodes() && !this.state.errors}>
           <CypherFrameButton selected={this.state.openView === viewTypes.TEXT} onClick={() => {
             this.changeView(viewTypes.TEXT)
           }}><AsciiIcon /></CypherFrameButton>

--- a/src/browser/modules/Stream/CypherFrame.jsx
+++ b/src/browser/modules/Stream/CypherFrame.jsx
@@ -124,6 +124,10 @@ class CypherFrame extends Component {
     return (this.state.nodesAndRelationships) ? (this.state.nodesAndRelationships.nodes && this.state.nodesAndRelationships.nodes.length > 0) : false
   }
 
+  resultHasRows () {
+    return this.state.rows && this.state.rows.length > 0
+  }
+
   sidebar () {
     return (
       <FrameSidebar>
@@ -137,7 +141,7 @@ class CypherFrame extends Component {
             this.changeView(viewTypes.TABLE)
           }}><TableIcon /></CypherFrameButton>
         </Visible>
-        <Visible if={this.resultHasNodes() && !this.state.errors}>
+        <Visible if={this.resultHasRows() && !this.state.errors}>
           <CypherFrameButton selected={this.state.openView === viewTypes.TEXT} onClick={() => {
             this.changeView(viewTypes.TEXT)
           }}><AsciiIcon /></CypherFrameButton>

--- a/src/browser/modules/Stream/Views/AsciiView.jsx
+++ b/src/browser/modules/Stream/Views/AsciiView.jsx
@@ -19,12 +19,12 @@
  */
 
 import asciitable from 'ascii-data-table'
-import { PaddedDiv } from '../styled'
+import { PaddedDiv, StyledBodyMessage } from '../styled'
 
-const AsciiView = ({rows, style}) => {
+const AsciiView = ({rows, style, message}) => {
   const contents = rows
     ? <pre>{asciitable.table(rows, 70)}</pre>
-    : <div><em>No results found</em></div>
+    : <StyledBodyMessage>{message}</StyledBodyMessage>
   return <PaddedDiv style={style}>{contents}</PaddedDiv>
 }
 

--- a/src/browser/modules/Stream/Views/TableView.jsx
+++ b/src/browser/modules/Stream/Views/TableView.jsx
@@ -20,7 +20,7 @@
 
 import { Component } from 'preact'
 import { v4 } from 'uuid'
-import { PaddedDiv } from '../styled'
+import { PaddedDiv, StyledBodyMessage } from '../styled'
 
 class TableView extends Component {
   constructor (props) {
@@ -33,7 +33,7 @@ class TableView extends Component {
     }
   }
   render () {
-    if (!this.props.data) return (<div style={this.props.style}><em>No results found</em></div>)
+    if (!this.props.data) return (<PaddedDiv style={this.props.style}><StyledBodyMessage>{this.props.message}</StyledBodyMessage></PaddedDiv>)
     const tableHeader = this.state.columns.map((column, i) => (
       <th className='table-header' key={i}>{column}</th>)
     )

--- a/src/browser/modules/Stream/styled.jsx
+++ b/src/browser/modules/Stream/styled.jsx
@@ -220,3 +220,9 @@ export const StyledStatsBar = styled.div`
 export const StyledSchemaBody = styled(StyledPreformattedArea)`
   padding-top: 6px
 `
+export const StyledBodyMessage = styled.div`
+  padding-top: 20px;
+  line-height: 1.428;
+  font-size: 15px;
+  color: #666;
+`

--- a/src/shared/services/bolt/bolt.js
+++ b/src/shared/services/bolt/bolt.js
@@ -211,5 +211,6 @@ export default {
   extractPlan: (result) => {
     return mappings.extractPlan(result)
   },
+  retrieveFormattedUpdateStatistics: mappings.retrieveFormattedUpdateStatistics,
   neo4j: neo4j
 }

--- a/src/shared/services/bolt/boltMappings.js
+++ b/src/shared/services/bolt/boltMappings.js
@@ -18,6 +18,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import updateStatsFields from './updateStatisticsFields'
+
 export function toObjects (records, intChecker, intConverter) {
   const recordValues = records.map((record) => {
     let out = []
@@ -135,4 +137,12 @@ const extractNodesAndRelationshipsFromPath = (item, rawNodes, rawRels) => {
       rawRels.push(segment.relationship)
     })
   })
+}
+
+export const retrieveFormattedUpdateStatistics = (result) => {
+  if (result.summary.counters) {
+    const stats = result.summary.counters._stats
+    const statsMessages = updateStatsFields.filter(field => stats[field.field] > 0).map(field => `${field.verb} ${stats[field.field]} ${stats[field.field] === 1 ? field.singular : field.plural}`)
+    return statsMessages.join(', ')
+  } else return null
 }

--- a/src/shared/services/bolt/updateStatisticsFields.js
+++ b/src/shared/services/bolt/updateStatisticsFields.js
@@ -1,0 +1,14 @@
+export default [
+  { plural: 'constraints', singular: 'constraint', verb: 'added', field: 'constraintsAdded' },
+  { plural: 'constraints', singular: 'constraint', verb: 'removed', field: 'constraintsRemoved' },
+  { plural: 'indexes', singular: 'index', verb: 'added', field: 'indexesAdded' },
+  { plural: 'indexes', singular: 'index', verb: 'removed', field: 'indexesRemoved' },
+  { plural: 'labels', singular: 'label', verb: 'added', field: 'labelsAdded' },
+  { plural: 'labels', singular: 'label', verb: 'removed', field: 'labelsRemoved' },
+  { plural: 'nodes', singular: 'node', verb: 'created', field: 'nodesCreated' },
+  { plural: 'nodes', singular: 'node', verb: 'deleted', field: 'nodesDeleted' },
+  { plural: 'properties', singular: 'property', verb: 'set', field: 'propertiesSet' },
+  { plural: 'relationships', singular: 'relationship', verb: 'deleted', field: 'relationshipDeleted' },
+  { plural: 'relationships', singular: 'relationship', verb: 'deleted', field: 'relationshipsDeleted' },
+  { plural: 'relationships', singular: 'relationship', verb: 'created', field: 'relationshipsCreated' }
+]


### PR DESCRIPTION
- Retrieve query update statistics from bolt result (from summary.counters)
- Prepend update stats to streaming stats in Status Bar
- Present update stats in Body in Table & Ascii View if there are no rows