### PR TITLE
Display link to show available procedures when a user executes an unknown procedure

### DIFF
--- a/src/browser/modules/Stream/Views/ErrorsView.jsx
+++ b/src/browser/modules/Stream/Views/ErrorsView.jsx
@@ -18,10 +18,25 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { StyledCypherErrorMessage, StyledHelpContent,
-  StyledH4, StyledPreformattedArea, StyledHelpDescription, StyledDiv, StyledHelpFrame} from '../styled'
+import { withBus } from 'preact-suber'
+import { executeCommand } from 'shared/modules/commands/commandsDuck'
+import { listAvailableProcedures } from 'shared/modules/cypher/procedureFactory'
+import { isUnknownProcedureError } from 'services/cypherErrorsHelper'
+import Visible from 'browser-components/Visible'
+import { PlayIcon } from 'browser-components/icons/Icons'
+import {
+  StyledCypherErrorMessage,
+  StyledHelpContent,
+  StyledH4,
+  StyledPreformattedArea,
+  StyledHelpDescription,
+  StyledDiv,
+  StyledLink,
+  StyledLinkContainer,
+  StyledHelpFrame
+} from '../styled'
 
-const WarningsView = ({error, style}) => {
+const ErrorsView = ({error, style, bus}) => {
   if (!error) {
     return null
   }
@@ -35,8 +50,18 @@ const WarningsView = ({error, style}) => {
         <StyledDiv>
           <StyledPreformattedArea>{error.message}</StyledPreformattedArea>
         </StyledDiv>
+        <Visible if={isUnknownProcedureError(error)}>
+          <StyledLinkContainer>
+            <StyledLink onClick={() => onItemClick(bus)}><PlayIcon />&nbsp;List available procedures</StyledLink>
+          </StyledLinkContainer>
+        </Visible>
       </StyledHelpContent>
     </StyledHelpFrame>)
 }
 
-export default WarningsView
+const onItemClick = (bus) => {
+  const action = executeCommand(listAvailableProcedures)
+  bus.send(action.type, action)
+}
+
+export default withBus(ErrorsView)

--- a/src/browser/modules/Stream/styled.jsx
+++ b/src/browser/modules/Stream/styled.jsx
@@ -161,6 +161,19 @@ export const StyledHelpDescription = styled.div`
 export const StyledDiv = styled.div`
 `
 
+export const StyledLink = styled.a`
+  cursor: pointer;
+  text-decoration: none;
+  &:hover {
+    color: #5dade2;
+    text-decoration: none;
+  }
+`
+
+export const StyledLinkContainer = styled.div`
+  margin: 16px 0;
+`
+
 export const StyledCypherMessage = styled.div`
   font-weight: bold
   line-height: 1em

--- a/src/browser/modules/Stream/styled.jsx
+++ b/src/browser/modules/Stream/styled.jsx
@@ -204,13 +204,14 @@ export const StyledBr = styled.br`
 `
 
 export const StyledPreformattedArea = styled.pre`
-  font-family: Monaco, "Courier New", Terminal, monospace
-  font-size: 14px
-  padding: 12px 16px
-  margin: 0
-  background: none
-  border: none
-  background-color: #f5f5f5
+  font-family: Monaco, "Courier New", Terminal, monospace;
+  font-size: 14px;
+  white-space: pre-line;
+  padding: 12px 16px;
+  margin: 0;
+  background: none;
+  border: none;
+  background-color: #f5f5f5;
 `
 
 export const ErrorText = styled.span`

--- a/src/shared/modules/cypher/procedureFactory.js
+++ b/src/shared/modules/cypher/procedureFactory.js
@@ -22,3 +22,5 @@ export const changeCurrentUsersPasswordQueryObj = (newPw) => ({
   query: 'CALL dbms.security.changePassword($password)',
   parameters: {password: newPw}
 })
+
+export const listAvailableProcedures = 'CALL dbms.procedures()'

--- a/src/shared/services/cypherErrorsHelper.js
+++ b/src/shared/services/cypherErrorsHelper.js
@@ -1,0 +1,2 @@
+export const isUnknownProcedureError = ({code}) =>
+  code === 'Neo.ClientError.Procedure.ProcedureNotFound'


### PR DESCRIPTION
Displays a helpful link in the cypher result frame whenever `Neo.ClientError.Propcedure.ProcedureNotFound` is returned
<img width="530" alt="screen shot 2017-04-25 at 18 34 35" src="https://cloud.githubusercontent.com/assets/849508/25399407/3aee3f3e-29e7-11e7-859f-e8c0b49feaf9.png">
