### PR TITLE
Fix issue where ascii view doesn't display properties correctly

### DIFF
--- a/src/browser/modules/Stream/Views/AsciiView.jsx
+++ b/src/browser/modules/Stream/Views/AsciiView.jsx
@@ -19,11 +19,13 @@
  */
 
 import asciitable from 'ascii-data-table'
+import { flattenProperties } from 'services/bolt/boltMappings'
+
 import { PaddedDiv, StyledBodyMessage } from '../styled'
 
 const AsciiView = ({rows, style, message}) => {
   const contents = rows
-    ? <pre>{asciitable.table(rows, 70)}</pre>
+    ? <pre>{asciitable.table(flattenProperties(rows), 70)}</pre>
     : <StyledBodyMessage>{message}</StyledBodyMessage>
   return <PaddedDiv style={style}>{contents}</PaddedDiv>
 }

--- a/src/shared/services/bolt/boltMappings.js
+++ b/src/shared/services/bolt/boltMappings.js
@@ -146,3 +146,7 @@ export const retrieveFormattedUpdateStatistics = (result) => {
     return statsMessages.join(', ')
   } else return null
 }
+
+export const flattenProperties = (rows) => {
+  return rows.map((row) => row.map((entry) => (entry.properties) ? entry.properties : entry))
+}

--- a/src/shared/services/bolt/boltMappings.test.js
+++ b/src/shared/services/bolt/boltMappings.test.js
@@ -20,7 +20,14 @@
 
 /* global test, expect */
 import { v1 as neo4j } from 'neo4j-driver-alias'
-import { itemIntToString, arrayIntToString, objIntToString, extractNodesAndRelationshipsFromRecords, extractPlan } from './boltMappings'
+import {
+  itemIntToString,
+  arrayIntToString,
+  objIntToString,
+  extractNodesAndRelationshipsFromRecords,
+  extractPlan,
+  flattenProperties
+} from './boltMappings'
 
 describe('boltMappings', () => {
   describe('itemIntToString', () => {
@@ -291,6 +298,35 @@ describe('boltMappings', () => {
         summary: {}
       }
       expect(extractPlan(result)).to.be.null
+    })
+  })
+  describe('flattenProperties', () => {
+    test('should map properties to object when properties exist', () => {
+      // Given
+      const result = [
+        [{properties: {foo: 'bar'}}]
+      ]
+      const expectedResult = [
+        [{foo: 'bar'}]
+      ]
+
+      // When
+      const flattenedProperties = flattenProperties(result)
+
+      // Then
+      expect(flattenedProperties).toEqual(expectedResult)
+    })
+    test('should not map properties to object when properties do not exist', () => {
+      // Given
+      const result = [
+        [{x: {foo: 'bar'}}]
+      ]
+
+      // When
+      const flattenedProperties = flattenProperties(result)
+
+      // Then
+      expect(flattenedProperties).toEqual(result)
     })
   })
 })


### PR DESCRIPTION
The mapping that is required for the ascii view to display results correctly is extracted out to the service layer in `boltMappings`.

I've attached screenshot to show the difference in the ascii view rendering.

Bug:
<img width="653" alt="screen shot 2017-04-26 at 09 27 39" src="https://cloud.githubusercontent.com/assets/849508/25425093/aad12af2-2a62-11e7-9e36-a8f77b8a2d4e.png">

Fix: 
<img width="457" alt="screen shot 2017-04-26 at 09 27 20" src="https://cloud.githubusercontent.com/assets/849508/25425105/b09d885e-2a62-11e7-9fd2-1cb874ace665.png">

