### PR TITLE
Fetch and store server config and info in redux

### DIFF
--- a/src/shared/modules/dbMeta/__snapshots__/dbMetaDuck.test.js.snap
+++ b/src/shared/modules/dbMeta/__snapshots__/dbMetaDuck.test.js.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`updating metadata can CLEAR to reset state 1`] = `
+Object {
+  "labels": Array [],
+  "properties": Array [],
+  "relationshipTypes": Array [],
+  "server": Object {
+    "edition": null,
+    "storeId": null,
+    "version": null,
+  },
+  "settings": Object {
+    "browser.allow_outgoing_connections": false,
+  },
+}
+`;
+
+exports[`updating metadata can update server info 1`] = `
+Object {
+  "hydrated": true,
+  "labels": Array [],
+  "properties": Array [],
+  "relationshipTypes": Array [],
+  "server": Object {
+    "edition": "enterprise",
+    "storeId": "xxxx",
+    "version": "3.2.0-RC2",
+  },
+  "settings": Object {
+    "browser.allow_outgoing_connections": false,
+  },
+  "shouldKeep": true,
+}
+`;
+
+exports[`updating metadata can update server settings 1`] = `
+Object {
+  "hydrated": true,
+  "labels": Array [],
+  "properties": Array [],
+  "relationshipTypes": Array [],
+  "server": Object {
+    "edition": null,
+    "storeId": null,
+    "version": null,
+  },
+  "settings": Object {
+    "browser.test": 1,
+  },
+  "shouldKeep": true,
+}
+`;

--- a/src/shared/modules/dbMeta/dbMetaDuck.test.js
+++ b/src/shared/modules/dbMeta/dbMetaDuck.test.js
@@ -46,28 +46,62 @@ describe('updating metadata', () => {
     expect(nextState.properties).toEqual([{val: 'prop1', context: 'mycontext'}, {val: 'prop2', context: 'mycontext'}])
   })
 
-  // test('should not update state when metadata has not changed', () => {
-  //   const returnedLabels = {
-  //     a: 'labels',
-  //     get: (val) => { return ['label1', 'label2'] }
-  //
-  //   }
-  //   const returnedRelationshipTypes = {
-  //     a: 'relationshipTypes',
-  //     get: (val) => { return ['rel1', 'rel2'] }
-  //
-  //   }
-  //   const returnedProperies = {
-  //     a: 'properties',
-  //     get: (val) => { return ['prop1', 'prop2'] }
-  //
-  //   }
-  //   const initialState = { labels: ['label1', 'label2'], relationshipTypes: ['rel1', 'rel2'], properties: ['prop1', 'prop2'] }
-  //   const action = {
-  //     type: dbInfo.actionTypes.UPDATE_META,
-  //     state: {meta: {records: [ returnedLabels, returnedRelationshipTypes, returnedProperies ]}}
-  //   }
-  //   const nextState = reducer(initialState, action)
-  //   expect(nextState).toEqual(initialState)
-  // })
+  test('can update server settings', () => {
+    // Given
+    const initState = {
+      shouldKeep: true
+    }
+    const action = {
+      type: meta.UPDATE_SETTINGS,
+      settings: {
+        'browser.test': 1
+      }
+    }
+
+    // When
+    const nextState = reducer(initState, action)
+
+    // Then
+    expect(nextState).toMatchSnapshot()
+  })
+
+  test('can update server info', () => {
+    // Given
+    const initState = {
+      shouldKeep: true
+    }
+    const action = {
+      type: meta.UPDATE_SERVER,
+      version: '3.2.0-RC2',
+      edition: 'enterprise',
+      storeId: 'xxxx'
+    }
+
+    // When
+    const nextState = reducer(initState, action)
+
+    // Then
+    expect(nextState).toMatchSnapshot()
+  })
+
+  test('can CLEAR to reset state', () => {
+    // Given
+    const initState = {
+      shouldKeep: false,
+      'server': {
+        edition: 'enterprise',
+        storeId: 'xxxx',
+        version: '3.2.0-RC2'
+      }
+    }
+    const action = {
+      type: meta.CLEAR
+    }
+
+    // When
+    const nextState = reducer(initState, action)
+
+    // Then
+    expect(nextState).toMatchSnapshot()
+  })
 })

--- a/src/shared/modules/dbMeta/dbMetaDuck.test.js
+++ b/src/shared/modules/dbMeta/dbMetaDuck.test.js
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* global test, expect */
+/* global describe, test, expect */
 import reducer, * as meta from './dbMetaDuck'
 
 describe('updating metadata', () => {
@@ -36,7 +36,7 @@ describe('updating metadata', () => {
       get: (val) => { return ['prop1', 'prop2'] }
     }
     const action = {
-      type: meta.UPDATE,
+      type: meta.UPDATE_META,
       meta: {records: [ returnedLabels, returnedRelationshipTypes, returnedProperies ]},
       context: 'mycontext'
     }

--- a/src/shared/services/bolt/bolt.js
+++ b/src/shared/services/bolt/bolt.js
@@ -212,5 +212,6 @@ export default {
     return mappings.extractPlan(result)
   },
   retrieveFormattedUpdateStatistics: mappings.retrieveFormattedUpdateStatistics,
+  itemIntToNumber: (item) => mappings.itemIntToString(item, neo4j.isInt, (val) => val.toNumber()),
   neo4j: neo4j
 }

--- a/src/shared/services/bolt/boltHelpers.js
+++ b/src/shared/services/bolt/boltHelpers.js
@@ -32,15 +32,38 @@ export const getDiscoveryEndpoint = () => {
   return `${info.protocol}//${info.host}/`
 }
 
-export const getServerConfig = () => {
+export const getServerConfig = (includePrefixes = []) => {
+  return getJmxValues([['Configuration']])
+    .then((confs) => {
+      const conf = confs[0]
+      let filtered
+      if (conf) {
+        Object.keys(conf)
+          .filter((key) => includePrefixes.length < 1 || includePrefixes.some((pfx) => key.startsWith(pfx)))
+          .forEach((key) => (filtered = {...filtered, [key]: bolt.itemIntToNumber(conf[key].value)}))
+      }
+      return filtered || conf
+    })
+}
+
+export const getJmxValues = (nameAttributePairs = []) => {
+  if (!nameAttributePairs.length) return Promise.reject(null)
   return bolt.directTransaction('CALL dbms.queryJmx("org.neo4j:*")')
     .then((res) => {
-      // Find kernel conf
-      let conf
-      res.records.forEach((record) => {
-        if (record.get('name').match(/Configuration$/)) conf = record.get('attributes')
+      let out = []
+      nameAttributePairs.forEach((pair) => {
+        const [name, attribute = null] = pair
+        if (!name) return out.push(null)
+        const part = res.records.filter((record) => record.get('name').match(new RegExp(name + '$')))
+        if (!part.length) return out.push(null)
+        const attributes = part[0].get('attributes')
+        if (!attribute) return out.push(attributes)
+        const key = attribute
+        if (typeof attributes[key] === 'undefined') return out.push(null)
+        const val = bolt.itemIntToNumber(attributes[key].value)
+        out.push({ [key]: val })
       })
-      return conf
+      return out
     }).catch((e) => {
       return null
     })


### PR DESCRIPTION
Store in `meta` reducer and update on every meta data update, since server con be restarted with new settings without the browser being reloaded.

The data stored is not used for anything with this PR, but will in future features.

![oskar4j 2017-04-26 at 21 01 17](https://cloud.githubusercontent.com/assets/570998/25451888/f95a6a56-2ac3-11e7-832b-266a3a571efd.png)

