### PR TITLE
Help: case-insensitive guide lookup

### DIFF
--- a/src/browser/modules/Stream/HelpFrame.jsx
+++ b/src/browser/modules/Stream/HelpFrame.jsx
@@ -30,7 +30,7 @@ const HelpFrame = ({frame}) => {
   if (frame.result) {
     help = <Slide html={frame.result} />
   } else {
-    const helpTopic = snakeToCamel('_' + frame.cmd.replace(':help', '').trim())
+    const helpTopic = snakeToCamel('_' + frame.cmd.replace(':help', '').trim().toLowerCase())
     if (helpTopic !== '') {
       const content = html.default[helpTopic]
       if (content !== undefined) {


### PR DESCRIPTION
Small fix.

Now all variations will work properly:
```
:help match
:help MATCH
:help Match
```