### PR TITLE
Focus on the connection form only if it is used for the first time

### DIFF
--- a/src/browser/components/form/formKeyHandler.js
+++ b/src/browser/components/form/formKeyHandler.js
@@ -24,8 +24,8 @@ export default class FormKeyHandler {
     this.submitAction = submitAction
   }
 
-  initialize () {
-    this.elements[1] && this.elements[1].focus()
+  initialize (focus = true) {
+    focus && this.elements[1] && this.elements[1].focus()
   }
 
   registerInput (input, position) {

--- a/src/browser/modules/Main/styled.jsx
+++ b/src/browser/modules/Main/styled.jsx
@@ -44,6 +44,7 @@ export const StyledMain = styled.div`
 
 export const Banner = styled.div`
   line-height: 49px;
+  min-height: 49px;
   color: white;
   padding: 0 24px;
   margin: 0 24px;

--- a/src/browser/modules/Stream/Auth/ConnectForm.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectForm.jsx
@@ -40,7 +40,7 @@ export default class ConnectForm extends Component {
     this.formKeyHandler = new FormKeyHandler(this.onConnectClick.bind(this))
   }
   componentDidMount () {
-    this.formKeyHandler.initialize()
+    this.formKeyHandler.initialize(this.props.used === false)
   }
   onConnectClick () {
     this.setState({connecting: true}, () => {

--- a/src/browser/modules/Stream/Auth/ConnectionForm.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectionForm.jsx
@@ -36,12 +36,14 @@ export class ConnectionForm extends Component {
   constructor (props) {
     super(props)
     const connection = this.props.activeConnectionData || this.props.frame.connectionData
+    const isConnected = (!!props.activeConnection)
     this.state = {
       ...connection,
-      isConnected: (!!props.activeConnection),
+      isConnected: isConnected,
       passwordChangeNeeded: props.passwordChangeNeeded || false,
       forcePasswordChange: props.forcePasswordChange || false,
-      successCallback: props.onSuccess || (() => {})
+      successCallback: props.onSuccess || (() => {}),
+      used: isConnected
     }
   }
   connect (doneFn = () => {}) {
@@ -108,7 +110,7 @@ export class ConnectionForm extends Component {
     )
   }
   saveAndStart () {
-    this.setState({forcePasswordChange: false})
+    this.setState({forcePasswordChange: false, used: true})
     this.state.successCallback()
     this.updateRoutingSettings()
     this.saveCredentials()
@@ -159,6 +161,7 @@ export class ConnectionForm extends Component {
         host={this.state.hostInputVal || this.state.host}
         username={this.state.username}
         password={this.state.password}
+        used={this.state.used}
       />)
     }
     return view


### PR DESCRIPTION
Solves the problem of focusing on the bottom connection frame when disconnected and there are more than one connection frames in the stream. The solution is to avoid connection form request focus if it is used once or created in connected state.