### PR TITLE
Update editor content on code snippet click

### DIFF
--- a/src/browser/components/Directives.jsx
+++ b/src/browser/components/Directives.jsx
@@ -20,7 +20,7 @@
 
 import { connect } from 'preact-redux'
 import { withBus } from 'preact-suber'
-import { executeCommand } from 'shared/modules/commands/commandsDuck'
+import * as editor from 'shared/modules/editor/editorDuck'
 import { addClass, prependIcon } from 'shared/services/dom-helpers'
 
 const directives = [{
@@ -92,8 +92,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
   return {
     onItemClick: (cmd) => {
       if (!cmd.endsWith(' null') && !cmd.endsWith(':null')) {
-        const action = executeCommand(cmd)
-        ownProps.bus.send(action.type, action)
+        ownProps.bus.send(editor.SET_CONTENT, editor.setContent(cmd))
       }
     }
   }


### PR DESCRIPTION
Currently the browser _incorrectly_ executes the code snippet in a guide. This PR fixes this to only populate the editor. The user can then choose to execute the code snippet or not.