### PR TITLE
Fix cc mapping issue in :sysinfo

### DIFF
--- a/src/browser/modules/Stream/SysInfoFrame.jsx
+++ b/src/browser/modules/Stream/SysInfoFrame.jsx
@@ -58,7 +58,7 @@ export class SysInfoFrame extends Component {
           id: record.get('id'),
           addresses: record.get('addresses'),
           role: record.get('role'),
-          tags: record.get('tags')
+          groups: record.get('groups')
         }
       })
       const mappedTableHeader = <SysInfoTableEntry headers={['Roles', 'Addresses', 'Actions']} />


### PR DESCRIPTION
Fixes a bug when executing `:sysinfo` against a causal cluster (tags -> groups)
![screen shot 2017-04-28 at 14 04 39](https://cloud.githubusercontent.com/assets/849508/25529828/a9998124-2c1b-11e7-9b59-2cd9f1ad568d.png)
