### PR TITLE
Fix mapping of procedure results in the sidebar (user details)

### DIFF
--- a/src/browser/modules/DatabaseInfo/UserDetails.jsx
+++ b/src/browser/modules/DatabaseInfo/UserDetails.jsx
@@ -38,10 +38,11 @@ export class UserDetails extends Component {
       (response) => {
         if (!response.success) return
         const result = response.result
+        const keys = result.records[0].keys
         this.setState({
           userDetails: {
-            username: result.records[0].get('username'),
-            roles: result.records[0].get('roles')
+            username: (keys.includes('username')) ? result.records[0].get('username') : '-',
+            roles: (keys.includes('roles')) ? result.records[0].get('roles') : ['admin']
           }
         })
       }


### PR DESCRIPTION
Handles mapping user details in the sidebar where 'roles' key is not available (usually in the community edition of the neo4j server) 