### PR TITLE
tweaked sidebar icon colors and state changes

### DIFF
--- a/src/browser/components/icons/Icons.jsx
+++ b/src/browser/components/icons/Icons.jsx
@@ -54,8 +54,7 @@ const StyledText = styled.div`
   padding: 0;
 `
 
-const databaseConnectionStateStyles =
-{
+const databaseConnectionStateStyles = {
   connected: {
     active: styles.green,
     inactive: styles.inactive,
@@ -67,7 +66,7 @@ const databaseConnectionStateStyles =
     classModifier: 'delete'
   },
   pending: {
-    active: styles.alertYello,
+    active: styles.alertYellow,
     inactive: styles.inactive,
     classModifier: 'alert'
   }
@@ -83,7 +82,7 @@ export const DocumentsIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activ
 
 export const CloudIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.successGreen} inactiveStyle={styles.inactive} className='sl sl-cloud-checked' />)
 export const CloudDisconnectedIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.warningRed} inactiveStyle={styles.warningRed} className='sl sl-cloud-delete' />)
-export const CloudSyncIcon = ({isOpen, connected}) => (<IconContainer isOpen={isOpen} activeStyle={connected ? styles.successGreen:styles.warningRed} inactiveStyle={connected ? styles.inactive:styles.warningRed} className={'sl sl-cloud' + (connected ? '-checked':'-delete')} />)
+export const CloudSyncIcon = ({isOpen, connected}) => (<IconContainer isOpen={isOpen} activeStyle={connected ? styles.successGreen : styles.warningRed} inactiveStyle={connected ? styles.inactive : styles.warningRed} className={'sl sl-cloud' + (connected ? '-checked' : '-delete')} />)
 
 export const SettingsIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.white} inactiveStyle={styles.inactive} className='sl sl-setting-gear' />)
 export const AboutIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.credits} inactiveStyle={styles.inactive} className='nw nw-neo4j-outline-32px' />)

--- a/src/browser/components/icons/Icons.jsx
+++ b/src/browser/components/icons/Icons.jsx
@@ -54,13 +54,38 @@ const StyledText = styled.div`
   padding: 0;
 `
 
-export const DatabaseIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.green} inactiveStyle={styles.inactive} className='sl sl-database' />)
-export const FavoritesIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.orange} inactiveStyle={styles.inactive} className='sl sl-star' />)
-export const DocumentsIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.blue} inactiveStyle={styles.inactive} className='sl sl-book' />)
+const databaseConnectionStateStyles =
+{
+  connected: {
+    active: styles.green,
+    inactive: styles.inactive,
+    classModifier: 'check'
+  },
+  disconnected: {
+    active: styles.warningRed,
+    inactive: styles.inactive,
+    classModifier: 'delete'
+  },
+  pending: {
+    active: styles.alertYello,
+    inactive: styles.inactive,
+    classModifier: 'alert'
+  }
+}
+
+export const DatabaseIcon = ({isOpen, connectionState}) => (<IconContainer isOpen={isOpen}
+  activeStyle={databaseConnectionStateStyles[connectionState].active}
+  inactiveStyle={databaseConnectionStateStyles[connectionState].inactive}
+  className={'sl sl-database-' + databaseConnectionStateStyles[connectionState].classModifier}
+/>)
+export const FavoritesIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.white} inactiveStyle={styles.inactive} className='sl sl-star' />)
+export const DocumentsIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.white} inactiveStyle={styles.inactive} className='sl sl-book' />)
 
 export const CloudIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.successGreen} inactiveStyle={styles.inactive} className='sl sl-cloud-checked' />)
 export const CloudDisconnectedIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.warningRed} inactiveStyle={styles.warningRed} className='sl sl-cloud-delete' />)
-export const SettingsIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.yellow} inactiveStyle={styles.inactive} className='sl sl-setting-gear' />)
+export const CloudSyncIcon = ({isOpen, connected}) => (<IconContainer isOpen={isOpen} activeStyle={connected ? styles.successGreen:styles.warningRed} inactiveStyle={connected ? styles.inactive:styles.warningRed} className={'sl sl-cloud' + (connected ? '-checked':'-delete')} />)
+
+export const SettingsIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.white} inactiveStyle={styles.inactive} className='sl sl-setting-gear' />)
 export const AboutIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.credits} inactiveStyle={styles.inactive} className='nw nw-neo4j-outline-32px' />)
 
 export const TableIcon = () => (<IconContainer className='fa fa-table' text='Table' />)

--- a/src/browser/components/icons/style.css
+++ b/src/browser/components/icons/style.css
@@ -2,10 +2,10 @@
   color: #797979;
 }
 .green {
-  color: #8DCC93;
+  color: #4cD950;
 }
 .successGreen {
-  color: #8DCC93;
+  color: #4cD950;
 }
 .orange {
   color: #F79868;
@@ -17,10 +17,13 @@
   color: #DB7295;
 }
 .yellow {
-  color: #FFE182;
+  color: #ffaf00;
+}
+.alertYellow {
+  color: #ffaf00;
 }
 .warningRed {
-  color: #F16667;
+  color: #df4D3b;
 }
 .white {
   color: #ffffff;
@@ -28,14 +31,17 @@
 .lightBlue {
   color: #5dade2
 }
-.credits
-  @keyframes neo4j-pulse {
-    0%, 100% {
-      color: #1bf621;
-    }
-    50% {
-      color: #00a3ff;
-    }
+
+@keyframes neo4j-pulse {
+  0%, 100% {
+    color: #1bf621;
   }
+  50% {
+    color: #00a3ff;
+  }
+}
+
+.credits {
   animation: neo4j-pulse 2s infinite;
-  animation-timing-function: ease-in-out;
+  animation-timing-function: ease-in-out
+}

--- a/src/browser/modules/Sidebar/Sidebar.jsx
+++ b/src/browser/modules/Sidebar/Sidebar.jsx
@@ -27,11 +27,13 @@ import About from './About'
 import TabNavigation from 'browser-components/TabNavigation/Navigation'
 import Settings from './Settings'
 import BrowserSync from './../Sync/BrowserSync'
+import { PENDING_STATE, CONNECTED_STATE, DISCONNECTED_STATE } from 'shared/modules/connections/connectionsDuck'
+
 import {
   DatabaseIcon,
   FavoritesIcon,
   DocumentsIcon,
-  CloudIcon,
+  CloudSyncIcon,
   CloudDisconnectedIcon,
   SettingsIcon,
   AboutIcon
@@ -46,14 +48,13 @@ class Sidebar extends Component {
     const DocumentsDrawer = Documents
     const SettingsDrawer = Settings
     const AboutDrawer = About
-    const SyncCloudIcon = this.props.syncConnected ? CloudIcon : CloudDisconnectedIcon
     const topNavItemsList = [
-      {name: 'DB', icon: (isOpen) => <DatabaseIcon isOpen={isOpen} />, content: DatabaseDrawer},
+      {name: 'DB', icon: (isOpen) => <DatabaseIcon isOpen={isOpen} connectionState={this.props.neo4jConnectionState}/>, content: DatabaseDrawer},
       {name: 'Favorites', icon: (isOpen) => <FavoritesIcon isOpen={isOpen} />, content: FavoritesDrawer},
       {name: 'Documents', icon: (isOpen) => <DocumentsIcon isOpen={isOpen} />, content: DocumentsDrawer}
     ]
     const bottomNavItemsList = [
-      {name: 'Sync', icon: (isOpen) => <SyncCloudIcon isOpen={isOpen} />, content: BrowserSync},
+      {name: 'Sync', icon: (isOpen) => <CloudSyncIcon isOpen={isOpen} connected={this.props.syncConnected} />, content: BrowserSync},
       {name: 'Settings', icon: (isOpen) => <SettingsIcon isOpen={isOpen} />, content: SettingsDrawer},
       {name: 'About', icon: (isOpen) => <AboutIcon isOpen={isOpen} />, content: AboutDrawer}
     ]
@@ -68,10 +69,24 @@ class Sidebar extends Component {
 }
 
 const mapStateToProps = (state) => {
+  let connectionState = 'disconnected'
+  if (state.connections) {
+    switch (state.connections.connectionState) {
+      case PENDING_STATE:
+        connectionState = 'pending'
+        break
+      case CONNECTED_STATE:
+        connectionState = 'connected'
+        break
+      case DISCONNECTED_STATE:
+        connectionState = 'disconnected'
+        break
+    }
+  }
   return {
-    syncConnected: state.sync && state.sync.authData
+    syncConnected: state.sync && state.sync.authData,
+    neo4jConnectionState: connectionState
   }
 }
 
 export default connect(mapStateToProps, null)(Sidebar)
-

--- a/src/browser/modules/Sidebar/Sidebar.jsx
+++ b/src/browser/modules/Sidebar/Sidebar.jsx
@@ -34,7 +34,6 @@ import {
   FavoritesIcon,
   DocumentsIcon,
   CloudSyncIcon,
-  CloudDisconnectedIcon,
   SettingsIcon,
   AboutIcon
 } from 'browser-components/icons/Icons'
@@ -49,7 +48,7 @@ class Sidebar extends Component {
     const SettingsDrawer = Settings
     const AboutDrawer = About
     const topNavItemsList = [
-      {name: 'DB', icon: (isOpen) => <DatabaseIcon isOpen={isOpen} connectionState={this.props.neo4jConnectionState}/>, content: DatabaseDrawer},
+      {name: 'DB', icon: (isOpen) => <DatabaseIcon isOpen={isOpen} connectionState={this.props.neo4jConnectionState} />, content: DatabaseDrawer},
       {name: 'Favorites', icon: (isOpen) => <FavoritesIcon isOpen={isOpen} />, content: FavoritesDrawer},
       {name: 'Documents', icon: (isOpen) => <DocumentsIcon isOpen={isOpen} />, content: DocumentsDrawer}
     ]


### PR DESCRIPTION
Colors are now used to indicate status. They're brighter again, but not quite as neon as in prior releases. Oh, except that the Neo4j icon has a pulsing green blue which only indicates that we are awesome. 