### PR TITLE
Cypher Editor - define list of commands with subcommands

### DIFF
--- a/src/browser/modules/Editor/Editor.jsx
+++ b/src/browser/modules/Editor/Editor.jsx
@@ -23,7 +23,6 @@ import { Component } from 'preact'
 import { connect } from 'preact-redux'
 import { withBus } from 'preact-suber'
 import { executeCommand, executeSystemCommand } from 'shared/modules/commands/commandsDuck'
-import commandHelper from 'services/commandInterpreterHelper'
 import * as favorites from 'shared/modules/favorites/favoritesDuck'
 import { SET_CONTENT, FOCUS, EXPAND } from 'shared/modules/editor/editorDuck'
 import { getHistory } from 'shared/modules/history/historyDuck'
@@ -36,6 +35,7 @@ import * as viewTypes from 'shared/modules/stream/frameViewTypes'
 import Codemirror from './Codemirror'
 import * as schemaConvert from './editorSchemaConverter'
 import cypherFunctions from './cypher/functions'
+import consoleCommands from './language/consoleCommands'
 
 export class Editor extends Component {
   constructor (props) {
@@ -331,7 +331,7 @@ const mapStateToProps = (state) => {
     history: getHistory(state),
     cmdchar: getSettings(state).cmdchar,
     schema: {
-      consoleCommands: commandHelper.commands.map(schemaConvert.toConsoleCommand),
+      consoleCommands: consoleCommands,
       labels: state.meta.labels.map(schemaConvert.toLabel),
       relationshipTypes: state.meta.relationshipTypes.map(schemaConvert.toRelationshipType),
       propertyKeys: state.meta.properties.map(schemaConvert.toPropertyKey),

--- a/src/browser/modules/Editor/editorSchemaConverter.js
+++ b/src/browser/modules/Editor/editorSchemaConverter.js
@@ -18,10 +18,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export function toConsoleCommand (command) {
-  return `:${command}`
-}
-
 export function toLabel (label) {
   return `:${label.val}`
 }

--- a/src/browser/modules/Editor/editorSchemaConverter.test.js
+++ b/src/browser/modules/Editor/editorSchemaConverter.test.js
@@ -22,10 +22,6 @@
 import * as convert from './editorSchemaConverter'
 
 describe('editor meta to schema conversion', () => {
-  test('convert console command', () => {
-    expect(convert.toConsoleCommand('play')).toEqual(':play')
-  })
-
   test('convert meta label', () => {
     expect(convert.toLabel({ val: 'label' })).toEqual(':label')
   })

--- a/src/browser/modules/Editor/language/consoleCommands.js
+++ b/src/browser/modules/Editor/language/consoleCommands.js
@@ -1,0 +1,150 @@
+export default [
+  {
+    name: ':help',
+    description: ' - learn about other topics',
+    commands: [
+      { name: 'help' },
+      { name: 'commands' },
+      { name: 'play' },
+      { name: 'server' },
+      { name: 'cypher' },
+      { name: 'param' },
+      { name: 'params' },
+      { name: 'queries' },
+      { name: 'keys' },
+      { name: 'clear' },
+      { name: 'bolt' },
+      { name: 'bolt-encryption' },
+      { name: 'bolt-routing' },
+      { name: 'server-user' },
+      { name: 'history' },
+      { name: 'explain' },
+      { name: 'profile' },
+      { name: 'match' },
+      { name: 'where' },
+      { name: 'return' },
+      { name: 'create' },
+      { name: 'merge' },
+      { name: 'delete' },
+      { name: 'detach-delete' },
+      { name: 'set' },
+      { name: 'foreach' },
+      { name: 'with' },
+      { name: 'load csv' },
+      { name: 'unwind' },
+      { name: 'start' },
+      { name: 'create-unique' },
+      { name: 'create-index-on' },
+      { name: 'starts-with' },
+      { name: 'ends-with' },
+      { name: 'contains' },
+      { name: 'rest' },
+      { name: 'rest-get' },
+      { name: 'rest-put' },
+      { name: 'rest-delete' },
+      { name: 'rest-post' }
+    ]
+  },
+  {
+    name: ':play',
+    description: ' - loads a mini-deck with either guide material or sample data',
+    commands: [
+      {
+        name: 'start',
+        description: ' - where graphs begins'
+      },
+      {
+        name: 'intro',
+        description: ' - getting started with Neo4j Browser'
+      },
+      {
+        name: 'concepts',
+        description: ' - basic concepts to get you going'
+      },
+      {
+        name: 'cypher',
+        description: " - graph query language introduction"
+      },
+      {
+        name: 'movie graph',
+        description: ' - pop-cultural connections between actors and movies'
+      },
+      {
+        name: 'northwind graph',
+        description: ' - from RDBMS to Graph, using a classic dataset'
+      }
+    ]
+  },
+  {
+    name: ':server',
+    description: ' - manage the connection to Neo4j',
+    commands: [
+      { name: 'status' },
+      { name: 'change-password' },
+      { name: 'connect' },
+      { name: 'disconnect' },
+      {
+        name: 'user',
+        description: ' - user management for administrators',
+        commands: [
+          { name: 'add' },
+          { name: 'list' }
+        ]
+      }
+    ]
+  },
+  {
+    name: ':param',
+    description: ' - define a parameter'
+  },
+  {
+    name: ':params',
+    description: ' - show you a list of all your current parameters'
+  },
+  {
+    name: ':queries',
+    description: ' - list your servers and clusters running queries'
+  },
+  {
+    name: ':sysinfo',
+    description: ' - system information'
+  },
+  {
+    name: ':clear',
+    description: ' - remove all frames from the stream'
+  },
+  {
+    name: ':config'
+  },
+  {
+    name: ':schema',
+    description: ' - display indexes and constraints'
+  },
+  {
+    name: ':history',
+    description: ' - display your most recent executed commands'
+  },
+  {
+    name: ':get',
+    description: " - send HTTP GET to Neo4j's REST interface"
+  },
+  {
+    name: ':post',
+    description: " - send HTTP POST to Neo4j's REST interface"
+  },
+  {
+    name: ':put',
+    description: " - send HTTP PUT to Neo4j's REST interface"
+  },
+  {
+    name: ':delete',
+    description: " - send HTTP DELETE to Neo4j's REST interface"
+  },
+  {
+    name: ':head',
+    description: " - send HTTP HEAD to Neo4j's REST interface"
+  },
+  {
+    name: ':style'
+  }
+]


### PR DESCRIPTION
PR should provide extensive list of all commands and their subcommands support by browser.

Picture:
![image](https://cloud.githubusercontent.com/assets/626772/25551456/f4864bd4-2c7c-11e7-8f02-d330b6547341.png)
