### PR TITLE
Editor fixes - escape and newlines

### DIFF
--- a/src/browser/modules/Editor/Codemirror.jsx
+++ b/src/browser/modules/Editor/Codemirror.jsx
@@ -78,13 +78,6 @@ export default class CodeMirror extends Component {
     }
   }
 
-  componentWillUnmount () {
-    // TODO: is there a lighter-weight way to remove the cm instance?
-    if (this.codeMirror) {
-      this.codeMirror.toTextArea()
-    }
-  }
-
   componentWillReceiveProps (nextProps) {
     if (this.codeMirror &&
       nextProps.value !== undefined &&

--- a/src/shared/services/commandUtils.js
+++ b/src/shared/services/commandUtils.js
@@ -25,7 +25,11 @@ export function cleanCommand (cmd) {
 }
 
 export function stripEmptyCommandLines (str) {
-  return str.replace(/(^|\n)\s*/g, '')
+  const skipEmptyLines = (e) => !/^\s*$/.test(e)
+  return str
+    .split('\n')
+    .filter(skipEmptyLines)
+    .join('\n')
 }
 
 export function stripCommandComments (str) {

--- a/src/shared/services/commandUtils.test.js
+++ b/src/shared/services/commandUtils.test.js
@@ -36,11 +36,19 @@ describe('commandutils', () => {
   test('stripEmptyCommandLines should remove empty lines ', () => {
     const testStrs = [
       '\n\n     \nRETURN 1',
-      '   \n\nRETURN 1\n  \n\n',
-      'RETURN \n\n 1\n'
+      '   \n\nRETURN 1\n  \n\n'
     ]
     testStrs.forEach((str) => {
       expect(utils.stripEmptyCommandLines(str)).toEqual('RETURN 1')
+    })
+  })
+
+  test('stripEmptyCommandLines should preserve usual newlines ', () => {
+    const testStrs = [
+      'MATCH (n)\nRETURN n'
+    ]
+    testStrs.forEach((str) => {
+      expect(utils.stripEmptyCommandLines(str)).toEqual('MATCH (n)\nRETURN n')
     })
   })
 


### PR DESCRIPTION
### Escape

Unmount now is doing nothing. Basically when React component unmounts it removes element from DOM. When CM instance removed from DOM, it's no longer in use and will be GC'ed.

I took an memory snapshot while switching between fullscreen editor and usual one, and no leaks found.

### Newlines

Regexp that clean cypher query where incorrect. It also removed normal newlines.
Switched from pure regexp to mix of split/join + regexp, in order to solve issues with last newline.

Also removed one test case because it's incorrect. If user have for some reason placed `1` on next line, it should stay there.