### PR TITLE
Avoid exceptions with null return values

### DIFF
--- a/src/shared/services/bolt/boltMappings.js
+++ b/src/shared/services/bolt/boltMappings.js
@@ -157,5 +157,5 @@ export const retrieveFormattedUpdateStatistics = (result) => {
 }
 
 export const flattenProperties = (rows) => {
-  return rows.map((row) => row.map((entry) => (entry.properties) ? entry.properties : entry))
+  return rows.map((row) => row.map((entry) => (entry && entry.properties) ? entry.properties : entry))
 }


### PR DESCRIPTION
Avoid ascii table throwing exception when return values are null, like RETURN NULL