### PR TITLE
Add z-index to drawer so that content is hidden in safari

### DIFF
--- a/src/browser/components/TabNavigation/styled.jsx
+++ b/src/browser/components/TabNavigation/styled.jsx
@@ -35,6 +35,7 @@ export const StyledDrawer = styled.div`
   overflow: auto;
   width: ${props => props.open ? '300px' : '0px'};
   transition: .2s ease-out;
+  z-index: 1;
 `
 
 export const StyledTabsWrapper = styled.div`


### PR DESCRIPTION
Issue: 
![safari-meh](https://cloud.githubusercontent.com/assets/849508/25579686/c73fb60a-2e71-11e7-9d77-535d36eb8ce8.gif)

Fixed:
![safari-a](https://cloud.githubusercontent.com/assets/849508/25579690/cce94f1c-2e71-11e7-90c4-9b5f2d888148.gif)

