### PR TITLE
Fix docs links

### DIFF
--- a/src/browser/modules/Guides/html/concepts.html
+++ b/src/browser/modules/Guides/html/concepts.html
@@ -136,7 +136,7 @@
         <ul class="undecorated">
           <li><a play-topic="intro">Intro</a> - a guided tour</li>
           <li><a play-topic="cypher">Cypher</a> - query language</li>
-          <li><a target="_blank" href="http://neo4j.com/docs/developer-manual/">Neo4j Developer Manual</a></li>
+          <li><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/">Neo4j Developer Manual</a></li>
         </ul>
       </div>
       <div class="col-sm-4">

--- a/src/browser/modules/Guides/html/cypher.html
+++ b/src/browser/modules/Guides/html/cypher.html
@@ -159,9 +159,9 @@ RETURN DISTINCT surfer</pre>
       <div class="col-sm-4">
         <h3>Reference</h3>
         <ul class="undecorated">
-          <li><a target="_blank" href="http://neo4j.com/developer/guide-importing-data-and-etl/">Full Northwind import example</a></li>
-          <li><a target="_blank" href="http://neo4j.com/docs/cypher-refcard/">Cypher</a></li>
-          <li><a target="_blank" href="http://neo4j.com/docs/developer-manual/">Neo4j Developer Manual</a></li>
+          <li><a target="_blank" href="https://neo4j.com/developer/guide-importing-data-and-etl/">Full Northwind import example</a></li>
+          <li><a target="_blank" href="https://neo4j.com/docs/cypher-refcard/3.2/">Cypher Refcard</a></li>
+          <li><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/">The Cypher chapter</a> of the Neo4j Developer Manual</li>
         </ul>
       </div>
     </slide>

--- a/src/browser/modules/Guides/html/explore.html
+++ b/src/browser/modules/Guides/html/explore.html
@@ -29,7 +29,7 @@
   <section class="step">
     <h2>Read in-depth material</h2><img src="/content/help/guides/img/books.png">
     <ul>
-      <li><a target="_blank" href="http://neo4j.com/docs/developer-manual/" class="external">Neo4j Manual</a>- the official reference</li>
+      <li><a target="_blank" href="https://neo4j.com/docs/" class="external">Neo4j Documentation</a>- the official documentation library</li>
       <li><a target="_blank" href="http://graphdatabases.com/" class="external">Graph Databases</a>- the definitive book</li>
       <li><a target="_blank" href="http://www.manning.com/partner/" class="external">Neo4j in Action</a>- a practical approach</li>
     </ul>

--- a/src/browser/modules/Guides/html/learn.html
+++ b/src/browser/modules/Guides/html/learn.html
@@ -139,7 +139,7 @@
         <ul class="undecorated">
           <li><a play-topic="intro">Intro</a> - a guided tour</li>
           <li><a play-topic="cypher">Cypher</a> - query language</li>
-          <li><a target="_blank" href="http://neo4j.com/docs/developer-manual/">Neo4j Developer Manual</a></li>
+          <li><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/">Neo4j Developer Manual</a></li>
         </ul>
       </div>
       <div class="col-sm-4">

--- a/src/browser/modules/Guides/html/movie-graph.html
+++ b/src/browser/modules/Guides/html/movie-graph.html
@@ -718,8 +718,8 @@ RETURN tom, m, coActors, m2, cruise</pre>
       <div class="col-sm-4">
         <h3>Reference</h3>
         <ul class="undecorated">
-          <li><a target="_blank" href="http://neo4j.com/developer">Developer resources</a></li>
-          <li><a target="_blank" href="http://neo4j.com/docs/developer-manual/">Neo4j Developer Manual</a></li>
+          <li><a target="_blank" href="https://neo4j.com/developer/">Developer resources</a></li>
+          <li><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/">Neo4j Developer Manual</a></li>
         </ul>
       </div>
     </slide>

--- a/src/browser/modules/Guides/html/northwind-graph.html
+++ b/src/browser/modules/Guides/html/northwind-graph.html
@@ -199,9 +199,9 @@ RETURN DISTINCT cust.contactName as CustomerName, SUM(o.quantity) AS TotalProduc
       <div class="col-sm-4">
         <h3>Reference</h3>
         <ul class="undecorated">
-          <li><a target="_blank" href="http://neo4j.com/developer/guide-importing-data-and-etl/">Full Northwind import example</a></li>
-          <li><a target="_blank" href="http://neo4j.com/developer">Developer resources</a></li>
-          <li><a target="_blank" href="http://neo4j.com/docs/developer-manual/">Neo4j Developer Manual</a></li>
+          <li><a target="_blank" href="https://neo4j.com/developer/guide-importing-data-and-etl/">Full Northwind import example</a></li>
+          <li><a target="_blank" href="https://neo4j.com/developer/">Developer resources</a></li>
+          <li><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/">Neo4j Developer Manual</a></li>
         </ul>
       </div>
     </slide>

--- a/src/browser/modules/Help/html/contains.html
+++ b/src/browser/modules/Help/html/contains.html
@@ -10,7 +10,7 @@
         <div class="link">
           <p class="title">Reference</p>
           <p class="content">
-            <a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/#query-where">WHERE</a> manual page
+            <a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/clauses/where/#query-where-string">WHERE</a> manual page
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Help/html/create-index-on.html
+++ b/src/browser/modules/Help/html/create-index-on.html
@@ -10,7 +10,7 @@
         <div class="link">
           <p class="title">Reference</p>
           <p class="content">
-            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/#query-schema-index">schema indexes</code> manual page</a>
+            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/preview/cypher/schema/index/">schema indexes</code> manual page</a>
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Help/html/create-unique.html
+++ b/src/browser/modules/Help/html/create-unique.html
@@ -10,7 +10,7 @@
         <div class="link">
           <p class="title">Reference</p>
           <p class="content">
-            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/#query-create-unique">CREATE UNIQUE</code> manual page</a>
+            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/clauses/create-unique/">CREATE UNIQUE</code> manual page</a>
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Help/html/create.html
+++ b/src/browser/modules/Help/html/create.html
@@ -13,7 +13,7 @@
         <div class="link">
           <p class="title">Reference</p>
           <p class="content">
-            <a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/cypher/#query-create">CREATE</a> manual page
+            <a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/clauses/create/">CREATE</a> manual page
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Help/html/cypher.html
+++ b/src/browser/modules/Help/html/cypher.html
@@ -14,7 +14,7 @@
         <div class="link">
           <p class="title">Reference</p>
           <p class="content">
-            <a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/cypher/#cypher-intro">Cypher introduction</a>
+            <a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/">Cypher introduction</a>
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Help/html/delete.html
+++ b/src/browser/modules/Help/html/delete.html
@@ -10,7 +10,7 @@
         <div class="link">
           <p class="title">Reference</p>
           <p class="content">
-            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/cypher/#query-delete">DELETE</a> manual page</code>
+            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/clauses/delete/">DELETE</a> manual page</code>
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Help/html/detach-delete.html
+++ b/src/browser/modules/Help/html/detach-delete.html
@@ -10,7 +10,7 @@
         <div class="link">
           <p class="title">Reference</p>
           <p class="content">
-            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/cypher/#query-delete">DELETE</a> manual page</code>
+            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/clauses/delete/">DELETE</a> manual page</code>
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Help/html/drop-index-on.html
+++ b/src/browser/modules/Help/html/drop-index-on.html
@@ -10,7 +10,7 @@
         <div class="link">
           <p class="title">Reference</p>
           <p class="content">
-            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/cypher/#query-schema-index">schema indexes</a> manual page</code>
+            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/schema/index/">schema indexes</a> manual page</code>
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Help/html/ends-with.html
+++ b/src/browser/modules/Help/html/ends-with.html
@@ -10,7 +10,7 @@
         <div class="link">
           <p class="title">Reference</p>
           <p class="content">
-            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/cypher/#query-where">WHERE</a> manual page</code>
+            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/clauses/where/">WHERE</a> manual page</code>
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Help/html/foreach.html
+++ b/src/browser/modules/Help/html/foreach.html
@@ -10,7 +10,7 @@
         <div class="link">
           <p class="title">Reference</p>
           <p class="content">
-            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/cypher/#query-foreach">FOREACH</a> manual page</code>
+            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/clauses/foreach/">FOREACH</a> manual page</code>
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Help/html/load-csv.html
+++ b/src/browser/modules/Help/html/load-csv.html
@@ -10,8 +10,8 @@
         <div class="link">
           <p class="title">Reference</p>
           <p class="content">
-            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/cypher/#query-load-csv">LOAD CSV</a> manual page</code>
-            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/cypher/#query-periodic-commit">USING PERIODIC COMMIT</a> manual page</code>
+            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/clauses/load-csv/">LOAD CSV</a> manual page</code>
+            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/query-tuning/using/#query-using-periodic-commit-hint">USING PERIODIC COMMIT</a> manual page</code>
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Help/html/match.html
+++ b/src/browser/modules/Help/html/match.html
@@ -11,7 +11,7 @@
         <div class="link">
           <p class="title">Reference</p>
           <p class="content">
-            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/cypher/#query-match">MATCH</a> manual page</code>
+            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/clauses/match/">MATCH</a> manual page</code>
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Help/html/merge.html
+++ b/src/browser/modules/Help/html/merge.html
@@ -10,9 +10,9 @@
         <div class="link">
           <p class="title">Reference</p>
           <p class="content">
-            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/cypher/#query-merge">MERGE</a> manual page</code>
-            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/cypher/#merge-merge-with-on-create">ON CREATE</a> manual page</code>
-            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/cypher/#merge-merge-with-on-match">ON MATCH</a> manual page</code>
+            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/clauses/merge/">MERGE</a> manual page</code>
+            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/clauses/merge/#query-merge-on-create-on-match">ON CREATE</a> manual page</code>
+            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/clauses/merge/#query-merge-on-create-on-match">ON MATCH</a> manual page</code>
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Help/html/profile.html
+++ b/src/browser/modules/Help/html/profile.html
@@ -11,7 +11,7 @@
         <div class="link">
           <p class="title">Reference:</p>
           <p class="content">
-            <a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/#execution-plans">Execution Plans</a> manual page
+            <a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/execution-plans/">Execution Plans</a> manual page
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Help/html/query-plan.html
+++ b/src/browser/modules/Help/html/query-plan.html
@@ -24,7 +24,7 @@
         <h4>Operators</h4>
         <p>
           Each Operator is displayed as a rectangle with its name in
-          the top-left corner. See the&nbsp;<a target="_blank" href="http://neo4j.com/docs/developer-manual/#execution-plans">operators manual page</a> for a description of what each operator does.
+          the top-left corner. See the&nbsp;<a target="_blank" href="https://neo4j.com/docs/developer-manual/cypher/execution-plans/">operators manual page</a> for a description of what each operator does.
         </p>
         <h4>Pipes</h4>
         <p>
@@ -97,7 +97,7 @@
           <table class="table-condensed table-help">
             <tr>
               <th>Reference:</th>
-              <td><code><a target="_blank" href="http://neo4j.com/docs/developer-manual/#execution-plans">Execution Plans</a></code> manual page</td>
+              <td><code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/execution-plans/">Execution Plans</a></code> manual page</td>
             </tr>
             <tr>
               <th>Related:</th>

--- a/src/browser/modules/Help/html/remove.html
+++ b/src/browser/modules/Help/html/remove.html
@@ -10,7 +10,7 @@
         <div class="link">
           <p class="title">Reference</p>
           <p class="content">
-            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/cypher/#query-remove">REMOVE</a> manual page</code>
+            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/clauses/remove/">REMOVE</a> manual page</code>
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Help/html/return.html
+++ b/src/browser/modules/Help/html/return.html
@@ -10,7 +10,7 @@
         <div class="link">
           <p class="title">Reference</p>
           <p class="content">
-            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/cypher/#query-return">RETURN</a> manual page</code>
+            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/clauses/return/">RETURN</a> manual page</code>
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Help/html/schema.html
+++ b/src/browser/modules/Help/html/schema.html
@@ -10,7 +10,7 @@
         <div class="link">
           <p class="title">Reference</p>
           <p class="content">
-            <a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/#cypher-schema">Cypher Schema</a>
+            <a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/schema/">Cypher Schema</a>
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Help/html/set.html
+++ b/src/browser/modules/Help/html/set.html
@@ -10,7 +10,7 @@
         <div class="link">
           <p class="title">Reference</p>
           <p class="content">
-            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/cypher/#query-set">SET</a> manual page</code>
+            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/clauses/set/">SET</a> manual page</code>
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Help/html/start.html
+++ b/src/browser/modules/Help/html/start.html
@@ -11,7 +11,7 @@
         <div class="link">
           <p class="title">Reference</p>
           <p class="content">
-            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/cypher/#query-start">START</a> manual page</code>
+            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/clauses/start/">START</a> manual page</code>
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Help/html/starts-with.html
+++ b/src/browser/modules/Help/html/starts-with.html
@@ -10,7 +10,7 @@
         <div class="link">
           <p class="title">Reference</p>
           <p class="content">
-            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/cypher/#query-where">WHERE</a> manual page</code>
+            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/clauses/where/">WHERE</a> manual page</code>
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Help/html/template.html
+++ b/src/browser/modules/Help/html/template.html
@@ -14,7 +14,7 @@
         <div class="link">
           <p class="title">Reference</p>
           <p class="content">
-            <a target="_blank" href="http://neo4j.com/docs/developer-manual/#cypher-introduction">Cypher introduction</a>
+            <a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/">Cypher introduction</a>
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Help/html/unfound.html
+++ b/src/browser/modules/Help/html/unfound.html
@@ -18,7 +18,7 @@
               <ul>
                 <li><a help-topic="help">:help</a>&nbsp;- for general help about using Neo4j Browser</li>
                 <li><a help-topic="cypher">:help commands</a>&nbsp;- to see available commands</li>
-                <li><a href="http://neo4j.com/docs/">Neo4j Manual</a>&nbsp;- for detailed information about Neo4j</li>
+                <li><a href="https://neo4j.com/docs/">Neo4j Documentation</a>&nbsp;- for detailed information about Neo4j</li>
               </ul>
             </td>
           </tr>

--- a/src/browser/modules/Help/html/unknown.html
+++ b/src/browser/modules/Help/html/unknown.html
@@ -18,7 +18,7 @@
               <ul>
                 <li><a help-topic="help">:help</a>&nbsp;- for general help about using Neo4j Browser</li>
                 <li><a help-topic="cypher">:help commands</a>&nbsp;- to see available commands</li>
-                <li><a href="http://neo4j.com/docs/">Neo4j Manual</a>&nbsp;- for detailed information about Neo4j</li>
+                <li><a href="https://neo4j.com/docs/">Neo4j Documentation</a>&nbsp;- for detailed information about Neo4j</li>
               </ul>
             </td>
           </tr>

--- a/src/browser/modules/Help/html/unwind.html
+++ b/src/browser/modules/Help/html/unwind.html
@@ -10,7 +10,7 @@
         <div class="link">
           <p class="title">Reference</p>
           <p class="content">
-            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/cypher/#query-unwind">UNWIND</a> manual page</code>
+            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/clauses/unwind/">UNWIND</a> manual page</code>
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Help/html/where.html
+++ b/src/browser/modules/Help/html/where.html
@@ -11,7 +11,7 @@
         <div class="link">
           <p class="title">Reference</p>
           <p class="content">
-            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/cypher/#query-where">WHERE</a> manual page</code>
+            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/clauses/where/">WHERE</a> manual page</code>
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Help/html/with.html
+++ b/src/browser/modules/Help/html/with.html
@@ -10,7 +10,7 @@
         <div class="link">
           <p class="title">Reference</p>
           <p class="content">
-            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2-alpha/cypher/#query-with">WITH</a> manual page</code>
+            <code><a target="_blank" href="https://neo4j.com/docs/developer-manual/3.2/cypher/clauses/with/">WITH</a> manual page</code>
           </p>
         </div>
         <div class="link">

--- a/src/browser/modules/Sidebar/Documents.jsx
+++ b/src/browser/modules/Sidebar/Documents.jsx
@@ -34,11 +34,11 @@ const staticItems = {
     {name: 'Keyboard shortcuts', command: ':help keys', type: 'help'}
   ],
   reference: [
-    {name: 'Developer Manual', command: 'http://neo4j.com/docs/developer-manual/3.2-alpha/', type: 'link'},
-    {name: 'Operations Manual', command: 'http://neo4j.com/docs/operations-manual/3.2-alpha/', type: 'link'},
-    {name: 'Cypher Refcard', command: 'http://neo4j.com/docs/cypher-refcard/3.2-alpha/', type: 'link'},
-    {name: 'GraphGists', command: 'http://neo4j.com/graphgists/', type: 'link'},
-    {name: 'Developer Site', command: 'http://www.neo4j.com/developer', type: 'link'},
+    {name: 'Developer Manual', command: 'https://neo4j.com/docs/developer-manual/3.2/', type: 'link'},
+    {name: 'Operations Manual', command: 'https://neo4j.com/docs/operations-manual/3.2/', type: 'link'},
+    {name: 'Cypher Refcard', command: 'https://neo4j.com/docs/cypher-refcard/3.2/', type: 'link'},
+    {name: 'GraphGists', command: 'https://neo4j.com/graphgists/', type: 'link'},
+    {name: 'Developer Site', command: 'https://www.neo4j.com/developer/', type: 'link'},
     {name: 'Knowledge Base', command: 'https://neo4j.com/developer/kb/', type: 'link'}
   ]
 }


### PR DESCRIPTION
* Version docs links.
* Use literal version: `3.2` (breaks now, works for GA, update when can lookup version from server).
* Use HTTPS.
* Use full path for chunked pages.