### PR TITLE
Adapt to server config browser.credential_timeout

### DIFF
--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -30,6 +30,7 @@ import { StyledWrapper, StyledApp, StyledBody, StyledMainWrapper } from './style
 
 import Main from '../Main/Main'
 import Sidebar from '../Sidebar/Sidebar'
+import UserInteraction from '../UserInteraction'
 import { toggle } from 'shared/modules/sidebar/sidebarDuck'
 import { getActiveConnection, getConnectionState } from 'shared/modules/connections/connectionsDuck'
 
@@ -57,6 +58,7 @@ class App extends Component {
     return (
       <ThemeProvider theme={themeData}>
         <StyledWrapper>
+          <UserInteraction />
           <StyledApp>
             <StyledBody>
               <Sidebar openDrawer={drawer} onNavClick={handleNavClick} />

--- a/src/browser/modules/UserInteraction/index.jsx
+++ b/src/browser/modules/UserInteraction/index.jsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Component } from 'preact'
+import { withBus } from 'preact-suber'
+import { throttle } from 'services/utils'
+import { USER_INTERACTION } from 'shared/modules/userInteraction/userInteractionDuck'
+
+const reportInteraction = (bus) => {
+  if (!bus) return
+  bus.send(USER_INTERACTION)
+}
+const throttledReportInteraction = throttle(reportInteraction, 5000)
+
+export class UserInteraction extends Component {
+  componentDidMount () {
+    document.addEventListener('keyup', () => throttledReportInteraction(this.props.bus))
+    document.addEventListener('click', () => throttledReportInteraction(this.props.bus))
+  }
+  componentWillUnmount () {
+    document.removeEventListener('keyup', () => throttledReportInteraction(this.props.bus))
+    document.removeEventListener('click', () => throttledReportInteraction(this.props.bus))
+  }
+}
+
+export default withBus(UserInteraction)

--- a/src/shared/modules/credentialsPolicy/credentialsPolicyDuck.js
+++ b/src/shared/modules/credentialsPolicy/credentialsPolicyDuck.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { USER_INTERACTION } from 'shared/modules/userInteraction/userInteractionDuck'
+import { credentialsTimeout } from 'shared/modules/dbMeta/dbMetaDuck'
+import { disconnectAction, getActiveConnection } from 'shared/modules/connections/connectionsDuck'
+
+// Local variables (used in epics)
+let timer = null
+
+// Epics
+export const credentialsTimeoutEpic = (action$, store) =>
+  action$.ofType(USER_INTERACTION)
+    .do((action) => {
+      const cTimeout = credentialsTimeout(store.getState())
+      if (!cTimeout) return clearTimeout(timer)
+      clearTimeout(timer)
+      timer = setTimeout(() => {
+        const activeConnection = getActiveConnection(store.getState())
+        if (activeConnection) {
+          store.dispatch(disconnectAction(activeConnection))
+        }
+      }, cTimeout)
+    })
+    .mapTo({type: 'NOOP'})

--- a/src/shared/modules/dbMeta/dbMetaDuck.js
+++ b/src/shared/modules/dbMeta/dbMetaDuck.js
@@ -82,6 +82,7 @@ export const getStoreId = (state) => state[NAME].server.storeId
 
 export const getAvailableSettings = (state) => (state[NAME] || initialState).settings
 export const allowOutgoingConnections = (state) => getAvailableSettings(state)['browser.allow_outgoing_connections']
+export const credentialsTimeout = (state) => getAvailableSettings(state)['browser.credential_timeout'] || 0
 
 /**
  * Helpers

--- a/src/shared/modules/userInteraction/userInteractionDuck.js
+++ b/src/shared/modules/userInteraction/userInteractionDuck.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// Constants
+export const NAME = 'userInteraction'
+export const USER_INTERACTION = `${NAME}/USER_INTERACTION`

--- a/src/shared/rootEpic.js
+++ b/src/shared/rootEpic.js
@@ -29,6 +29,7 @@ import { populateEditorFromUrlEpic } from './modules/editor/editorDuck'
 import { adHocCypherRequestEpic, cypherRequestEpic, clusterCypherRequestEpic, handleForcePasswordChangeEpic } from './modules/cypher/cypherDuck'
 import { featuresDicoveryEpic } from './modules/features/featuresDuck'
 import { syncItemsEpic, clearSyncEpic, syncFavoritesEpic, loadFavoritesFromSyncEpic, loadFoldersFromSyncEpic, syncFoldersEpic } from './modules/sync/syncDuck'
+import { credentialsTimeoutEpic } from './modules/credentialsPolicy/credentialsPolicyDuck'
 
 export default combineEpics(
   handleCommandsEpic,
@@ -58,5 +59,6 @@ export default combineEpics(
   syncItemsEpic,
   clearSyncEpic,
   loadFoldersFromSyncEpic,
-  syncFoldersEpic
+  syncFoldersEpic,
+  credentialsTimeoutEpic
 )

--- a/src/shared/services/utils.js
+++ b/src/shared/services/utils.js
@@ -47,6 +47,16 @@ export const debounce = (fn, time, context = null) => {
   }
 }
 
+export const throttle = (fn, time, context = null) => {
+  let blocking
+  return (...args) => {
+    if (blocking) return
+    blocking = true
+    typeof fn === 'function' && fn.apply(context, args)
+    setTimeout(() => (blocking = false), parseInt(time))
+  }
+}
+
 export const isRoutingHost = (host) => {
   return /^bolt\+routing:\/\//.test(host)
 }

--- a/src/shared/services/utils.test.js
+++ b/src/shared/services/utils.test.js
@@ -94,6 +94,51 @@ describe('utils', () => {
     expect(callMe).toHaveBeenCalledTimes(1)
     expect(callMe).toHaveBeenCalledWith('hello', 'there')
   })
+  test('throttle limits the number of fn calls', () => {
+    // Given
+    jest.useFakeTimers()
+    const fn = jest.fn()
+    const fn2 = jest.fn()
+    const thFn = utils.throttle(fn, 500)
+    const thFn2 = utils.throttle(fn2, 500)
+
+    // When
+    thFn(4, 5, 6)
+    thFn(1, 2, 3)
+    jest.runAllTimers()
+    thFn2(1, 2, 3)
+    jest.runAllTimers()
+    thFn2(4, 5, 6)
+    jest.runAllTimers()
+
+    // Then
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(fn).toHaveBeenCalledWith(4, 5, 6)
+    expect(fn2).toHaveBeenCalledTimes(2)
+    expect(fn2).toHaveBeenCalledWith(1, 2, 3)
+    expect(fn2).toHaveBeenCalledWith(4, 5, 6)
+  })
+  test('throttle keeps context', () => {
+    // Given
+    jest.useFakeTimers()
+    const callMe = jest.fn()
+    function TestFn () {
+      this.val = 'hello'
+      this.fn = function (extVal) {
+        callMe(this.val, extVal)
+      }
+      this.thFn = utils.throttle(this.fn, 500, this)
+    }
+    const testFn = new TestFn()
+
+    // When
+    testFn.thFn('there')
+    jest.runAllTimers()
+
+    // Then
+    expect(callMe).toHaveBeenCalledTimes(1)
+    expect(callMe).toHaveBeenCalledWith('hello', 'there')
+  })
   test('getUrlInfo', () => {
     // When && Then
     expect(utils.getUrlInfo('http://anything.com')).toEqual({


### PR DESCRIPTION
The goal of this PR is to let the server control for how long a client using Neo4j Browser can be inactive until a automatic disconnect happens.

When server config `browser.credential_timeout` is set, a timer is started. When this times runs out, user gets disconnected.
Timer is reset on every user interaction (keyup || mouse click).