### PR TITLE
Fix headers for HTTP commands

### DIFF
--- a/src/shared/services/remote.js
+++ b/src/shared/services/remote.js
@@ -24,7 +24,9 @@ function request (method, url, data = null) {
   return fetch(url, {
     method,
     headers: {
-      'Content-Type': 'application/json;charset=UTF-8'
+      'Content-Type': 'application/json',
+      'X-Ajax-Browser-Auth': 'true',
+      'X-stream': 'true'
     },
     body: data
   })


### PR DESCRIPTION
`'Content-Type': 'application/json;charset=UTF-8'` is not a valid header.
Also add more headers that should be there.