### PR TITLE
Render enterprise frame for :queries when procedures are unavailable

### DIFF
--- a/src/browser/components/EditionView.jsx
+++ b/src/browser/components/EditionView.jsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import styled from 'styled-components'
+import {H3} from 'browser-components/headers'
+
+const Aside = styled.div`
+  display: table-cell;
+  padding: 0 15px;
+  width: 25%;
+  font-family: ${props => props.theme.primaryFontFamily};
+  font-size: 16px;
+  font-weight: 300;
+  color: ${props => props.theme.asideText};
+`
+const PaddedDiv = styled.div`
+  padding: 30px 45px;
+`
+const StyledConnectionBody = styled.div`
+  font-size: 1.3em;
+  line-height: 1.6em;
+  padding-left: 50px;
+`
+const BodyContainer = styled.div`
+  display: table-cell;
+`
+const Code = styled.code`
+  white-space: nowrap;
+  overflow: hidden;
+  color: #c7254e;
+  background-color: #f9f2f4;
+  border-radius: 4px
+`
+const P = styled.p`
+  margin: 20px 0;
+`
+
+export const EnterpriseOnlyFrame = (props) => {
+  const {command, ...rest} = props
+  return (
+    <PaddedDiv {...rest}>
+      <Aside>
+        <H3>Frame unavailable</H3>
+        What edition are you running?
+      </Aside>
+      <BodyContainer>
+        <StyledConnectionBody>
+          <P>Unable to display <Code>{command}</Code> because the procedures required to run this frame are missing. These procedures are usually found in Neo4j Enterprise edition.</P>
+          <P>Find out more over at <a href='https://neo4j.com/editions/' target='_blank'>neo4j.com/editions</a></P>
+        </StyledConnectionBody>
+      </BodyContainer>
+    </PaddedDiv>
+  )
+}

--- a/src/browser/modules/Stream/Queries/QueriesFrame.jsx
+++ b/src/browser/modules/Stream/Queries/QueriesFrame.jsx
@@ -28,6 +28,7 @@ import {CYPHER_REQUEST, CLUSTER_CYPHER_REQUEST, AD_HOC_CYPHER_REQUEST} from 'sha
 import {getConnectionState, CONNECTED_STATE} from 'shared/modules/connections/connectionsDuck'
 import {ConfirmationButton} from 'browser-components/buttons/ConfirmationButton'
 import {StyledTh, StyledHeaderRow, StyledTable, StyledTd, Code, StyledStatusBar, AutoRefreshToogle, RefreshQueriesButton, AutoRefreshSpan} from './styled'
+import {EnterpriseOnlyFrame} from 'browser-components/EditionView'
 import {RefreshIcon} from 'browser-components/icons/Icons'
 import Visible from 'browser-components/Visible'
 import FrameError from '../FrameError'
@@ -65,6 +66,9 @@ export class QueriesFrame extends Component {
 
   isCC () {
     return this.props.availableProcedures.includes('dbms.cluster.overview')
+  }
+  canListQueries () {
+    return this.props.availableProcedures.includes('dbms.listQueries')
   }
 
   getRunningQueries (suppressQuerySuccessMessage = false) {
@@ -195,24 +199,30 @@ export class QueriesFrame extends Component {
   }
 
   render () {
-    const frameContents = this.constructViewFromQueryList(this.state.queries)
+    let frameContents
+    let statusbar
 
-    const statusbar = (
-      <div>
-        <Visible if={this.state.errors}>
-          <FrameError message={(this.state.errors || []).join(', ')} />
-        </Visible>
-        <Visible if={this.state.success}>
-          <StyledStatusBar>
-            {this.state.success}
-            <RefreshQueriesButton onClick={() => this.getRunningQueries()}><RefreshIcon /></RefreshQueriesButton>
-            <AutoRefreshSpan>
-              <AutoRefreshToogle checked={this.state.autoRefresh} onClick={(e) => this.setAutoRefresh(e.target.checked)} />
-            </AutoRefreshSpan>
-          </StyledStatusBar>
-        </Visible>
-      </div>
-    )
+    if (this.canListQueries()) {
+      frameContents = this.constructViewFromQueryList(this.state.queries)
+      statusbar = (
+        <div>
+          <Visible if={this.state.errors}>
+            <FrameError message={(this.state.errors || []).join(', ')} />
+          </Visible>
+          <Visible if={this.state.success}>
+            <StyledStatusBar>
+              {this.state.success}
+              <RefreshQueriesButton onClick={() => this.getRunningQueries()}><RefreshIcon /></RefreshQueriesButton>
+              <AutoRefreshSpan>
+                <AutoRefreshToogle checked={this.state.autoRefresh} onClick={(e) => this.setAutoRefresh(e.target.checked)} />
+              </AutoRefreshSpan>
+            </StyledStatusBar>
+          </Visible>
+        </div>
+      )
+    } else {
+      frameContents = (<EnterpriseOnlyFrame command={this.props.frame.cmd} />)
+    }
     return (
       <FrameTemplate
         header={this.props.frame}


### PR DESCRIPTION
When running `:queries` in community edition we now get <img width="1156" alt="screen shot 2017-05-02 at 09 04 50" src="https://cloud.githubusercontent.com/assets/849508/25609525/77f85f38-2f17-11e7-9e14-1a37907dca5e.png">
