### PR TITLE
Align command in frame titlebar

### DIFF
--- a/src/browser/modules/Stream/styled.jsx
+++ b/src/browser/modules/Stream/styled.jsx
@@ -130,15 +130,18 @@ export const FrameTitlebarButtonSection = styled.ul`
 
 export const StyledFrameCommand = styled.label`
   font-family: ${props => props.theme.editorFont};
-  font-size: 1.1em;
-  margin: 3px 5px 3px 5px;
+  font-size: 1.2em;
+  line-height: 2.2em;
+  margin: 3px 5px 3px 15px;
   flex: 1 1 auto;
   min-width: 0;
   white-space: nowrap;
   text-overflow: ellipsis;
   overflow: hidden;
   display: block;
-
+  &:before {
+    content: '$ '
+  }
 `
 export const DottedLineHover = styled.span`
   cursor: pointer;


### PR DESCRIPTION
Also add `$` in the beginning.

Before:
![oskar4j 2017-05-02 at 11 25 46](https://cloud.githubusercontent.com/assets/570998/25612214/1dd7f49c-2f2a-11e7-87b6-d8d3725150d8.png)


After:
![oskar4j 2017-05-02 at 11 25 03](https://cloud.githubusercontent.com/assets/570998/25612192/0675d562-2f2a-11e7-89d7-ba3f64dfa484.png)
