### PR TITLE
Fix issue where table view was showing 'empty' for a valid 'false' value

### DIFF
--- a/src/browser/modules/Stream/Views/TableView.jsx
+++ b/src/browser/modules/Stream/Views/TableView.jsx
@@ -40,7 +40,7 @@ class TableView extends Component {
     )
     const buildData = (entries) => {
       return entries.map((entry) => {
-        if (entry) {
+        if (entry !== null) {
           if (entry.properties) {
             return <StyledTd className='table-properties' key={v4()}>{JSON.stringify(entry.properties)}</StyledTd>
           }


### PR DESCRIPTION
Now returns `false` value rather than `(empty)`

Issue: 
<img width="273" alt="screen shot 2017-05-02 at 10 56 35" src="https://cloud.githubusercontent.com/assets/849508/25613424/0e7e17dc-2f26-11e7-9f2a-32bf384bc7bc.png">

Fixed:
<img width="274" alt="screen shot 2017-05-02 at 10 55 53" src="https://cloud.githubusercontent.com/assets/849508/25613430/131f9bda-2f26-11e7-8c60-cb6e5bc83fe6.png">

