### PR TITLE
Display integers as integers in response

### DIFF
--- a/src/browser/modules/Stream/CypherFrame.jsx
+++ b/src/browser/modules/Stream/CypherFrame.jsx
@@ -54,7 +54,7 @@ class CypherFrame extends Component {
 
   componentWillReceiveProps (nextProps) {
     let rows
-    let serializedPropertiesRows = []
+    let serializedPropertiesRows
     let plan
     let nodesAndRelationships
     let warnings

--- a/src/browser/modules/Stream/Views/AsciiView.jsx
+++ b/src/browser/modules/Stream/Views/AsciiView.jsx
@@ -19,13 +19,12 @@
  */
 
 import asciitable from 'ascii-data-table'
-import { flattenProperties } from 'services/bolt/boltMappings'
 
 import { PaddedDiv, StyledBodyMessage } from '../styled'
 
 const AsciiView = ({rows, style, message}) => {
   const contents = rows
-    ? <pre>{asciitable.table(flattenProperties(rows), 70)}</pre>
+    ? <pre>{asciitable.tableFromSerializedData(rows, 70)}</pre>
     : <StyledBodyMessage>{message}</StyledBodyMessage>
   return <PaddedDiv style={style}>{contents}</PaddedDiv>
 }

--- a/src/browser/modules/Stream/Views/TableView.jsx
+++ b/src/browser/modules/Stream/Views/TableView.jsx
@@ -41,10 +41,7 @@ class TableView extends Component {
     const buildData = (entries) => {
       return entries.map((entry) => {
         if (entry !== null) {
-          if (entry.properties) {
-            return <StyledTd className='table-properties' key={v4()}>{JSON.stringify(entry.properties)}</StyledTd>
-          }
-          return <StyledTd className='table-properties' key={v4()}>{JSON.stringify(entry)}</StyledTd>
+          return <StyledTd className='table-properties' key={v4()}>{entry}</StyledTd>
         }
         return <StyledTd className='table-properties' key={v4()}>(empty)</StyledTd>
       })

--- a/src/shared/services/utils.js
+++ b/src/shared/services/utils.js
@@ -158,5 +158,40 @@ export const removeComments = (string) => {
   return string.split(/\r?\n/).filter((line) => !line.startsWith('//')).join('\r\n')
 }
 
+export const stringifyMod = () => {
+  const toString = Object.prototype.toString
+  const isArray = Array.isArray || function (a) { return toString.call(a) === '[object Array]' }
+  const escMap = {'"': '\\"', '\\': '\\\\', '\b': '\\b', '\f': '\\f', '\n': '\\n', '\r': '\\r', '\t': '\\t'}
+  const escFunc = function (m) { return escMap[m] || '\\u' + (m.charCodeAt(0) + 0x10000).toString(16).substr(1) }
+  const escRE = /[\\"\u0000-\u001F\u2028\u2029]/g
+  return function stringify (value, modFn = null) {
+    if (modFn) {
+      const modVal = modFn && modFn(value)
+      if (typeof modVal !== 'undefined') return modVal
+    }
+    if (value == null) return 'null'
+    if (typeof value === 'number') return isFinite(value) ? value.toString() : 'null'
+    if (typeof value === 'boolean') return value.toString()
+    if (typeof value === 'object') {
+      if (typeof value.toJSON === 'function') {
+        return stringify(value.toJSON(), modFn)
+      } else if (isArray(value)) {
+        let res = '['
+        for (let i = 0; i < value.length; i++) {
+          res += (i ? ',' : '') + stringify(value[i], modFn)
+        }
+        return res + ']'
+      } else if (toString.call(value) === '[object Object]') {
+        let tmp = []
+        for (const k in value) {
+          if (value.hasOwnProperty(k)) tmp.push(stringify(k, modFn) + ':' + stringify(value[k], modFn))
+        }
+        return '{' + tmp.join(',') + '}'
+      }
+    }
+    return '"' + value.toString().replace(escRE, escFunc) + '"'
+  }
+}
+
 // Epic helpers
 export const put = (dispatch) => (action) => dispatch(action)

--- a/src/shared/services/utils.test.js
+++ b/src/shared/services/utils.test.js
@@ -240,4 +240,46 @@ describe('utils', () => {
       expect(utils.removeComments(stringWithComments)).toEqual('Some string')
     })
   })
+  test('stringifyMod works just as JSON.stringify with no modFn', () => {
+    // Given
+    const tests = [
+      {x: 1, y: ['yy', true, undefined, null]},
+      null,
+      false,
+      [[], [0]],
+      4
+    ]
+
+    // When & Then
+    tests.forEach((t) => {
+      expect(utils.stringifyMod()(t)).toEqual(JSON.stringify(t))
+    })
+  })
+
+  test('stringifyMod works just as JSON.stringify with modFn', () => {
+    // Given
+    const modFn = (val) => {
+      if (Number.isInteger(val)) return val + 1
+      if (typeof val === 'string') return val.toString()
+    }
+    const tests = [
+      null,
+      false,
+      [[], [0]],
+      4,
+      ['string']
+    ]
+    const expects = [
+      'null',
+      'false',
+      JSON.stringify([[], [1]]),
+      5,
+      '[string]'
+    ]
+
+    // When & Then
+    tests.forEach((t, index) => {
+      expect(utils.stringifyMod()(t, modFn)).toEqual(expects[index])
+    })
+  })
 })


### PR DESCRIPTION
To not have precision loss we did `val.toString()` on `neo4j.integers` when displaying the response.
This did have the implication that integers got quoted, just as any string, which is very misleading.

The changes in this PR changes that.

The change is made that we now implement our own version of `JSON.stringify` that should be compatible, but with one important change: our version takes a modifier function that have first access to all values passing through and can choose to modify the value, or just skip and let other handle it.

Before:
![oskar4j 2017-05-02 at 15 16 05](https://cloud.githubusercontent.com/assets/570998/25619193/4bafdcc0-2f4a-11e7-9b47-aaa5aa7b55c1.png)


After:
![oskar4j 2017-05-02 at 15 15 02](https://cloud.githubusercontent.com/assets/570998/25619155/24d846e6-2f4a-11e7-96db-61eadedf06f7.png)