### PR TITLE
Cypher Editor - Disable explode of matching brackets

### DIFF
--- a/src/browser/modules/Editor/Editor.jsx
+++ b/src/browser/modules/Editor/Editor.jsx
@@ -262,6 +262,7 @@ export class Editor extends Component {
         async: true
       },
       autoCloseBrackets: {
+        explode: ""
       }
     }
 


### PR DESCRIPTION
Matchbrackets have this behaviour by default to move ending bracket to a separate line.
We do not want it to be that smart.

What's more important - it screws autocompletion when you hit 'enter'.