### PR TITLE
Fixes issue where editor in fullscreen was thowing a 'style' error

### DIFF
--- a/src/browser/modules/Editor/Editor.jsx
+++ b/src/browser/modules/Editor/Editor.jsx
@@ -27,7 +27,7 @@ import * as favorites from 'shared/modules/favorites/favoritesDuck'
 import { SET_CONTENT, FOCUS, EXPAND } from 'shared/modules/editor/editorDuck'
 import { getHistory } from 'shared/modules/history/historyDuck'
 import { getSettings } from 'shared/modules/settings/settingsDuck'
-import { Bar, ExpandedBar, ActionButtonSection, EditorWrapper, EditorExpandedWrapper } from './styled'
+import { Bar, ActionButtonSection, EditorWrapper } from './styled'
 import { EditorButton } from 'browser-components/buttons'
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
 import { debounce } from 'services/utils'
@@ -268,12 +268,10 @@ export class Editor extends Component {
 
     const updateCode = (val, change) => this.updateCode(val, change)
     this.setGutterMarkers()
-    const wrapper = (this.state.expanded) ? { Component: EditorExpandedWrapper } : { Component: EditorWrapper }
-    const bar = (this.state.expanded) ? { Component: ExpandedBar } : { Component: Bar }
 
     return (
-      <bar.Component minHeight={this.state.editorHeight}>
-        <wrapper.Component minHeight={this.state.editorHeight}>
+      <Bar expanded={this.state.expanded} minHeight={this.state.editorHeight}>
+        <EditorWrapper expanded={this.state.expanded} minHeight={this.state.editorHeight}>
           <Codemirror
             ref={(ref) => {
               this.editor = ref
@@ -284,7 +282,7 @@ export class Editor extends Component {
             schema={this.props.schema}
             initialPosition={this.state.lastPosition}
           />
-        </wrapper.Component>
+        </EditorWrapper>
         <ActionButtonSection>
           <EditorButton
             onClick={() => this.props.onFavortieClick(this.state.code)}
@@ -308,7 +306,7 @@ export class Editor extends Component {
             icon='"\77"'
           />
         </ActionButtonSection>
-      </bar.Component>
+      </Bar>
     )
   }
 }

--- a/src/browser/modules/Editor/styled.jsx
+++ b/src/browser/modules/Editor/styled.jsx
@@ -23,7 +23,7 @@ import { dim } from 'browser-styles/constants'
 
 const editorPadding = 12
 
-export const Bar = styled.div`
+export const BaseBar = styled.div`
   display: flex;
   flex-direction: row;
   align-items: middle;
@@ -32,13 +32,17 @@ export const Bar = styled.div`
   box-shadow: 0 1px 4px rgba(0,0,0,.1);
   margin: 0 24px;
 `
-export const ExpandedBar = styled(Bar)`
-  position: absolute;
-  height: 100vh;
-  z-index: 100;
-  right: 0;
-  left: 0;
-  bottom: 0;
+export const Bar = styled(BaseBar)`
+  ${(props => {
+    if (props.expanded) {
+      return 'position: absolute;' +
+      'height: 100vh;' +
+      'z-index: 100;' +
+      'right: 0;' +
+      'left: 0;' +
+      'bottom: 0;'
+    }
+  })}
 `
 export const ActionButtonSection = styled.div`
   flex: 0 0 130px;
@@ -50,24 +54,29 @@ export const ActionButtonSection = styled.div`
   background-color: ${props => props.theme.editorBarBackground};
 `
 
-export const EditorWrapper = styled.div`
+const BaseEditorWrapper = styled.div`
   flex: auto;
   padding: ${editorPadding}px;
   background-color: ${props => props.theme.editorBarBackground};
   font-family: Monaco,"Courier New",Terminal,monospace;
   min-Height: ${props => Math.max(dim.editorbarHeight, props.minHeight + editorPadding * 2)}px
 `
-export const EditorExpandedWrapper = styled(EditorWrapper)`
-  height: 100%;
-  z-index: 2;
-  .CodeMirror {
-    position: absolute;
-    left: 12px;
-    right: 142px;
-    top: 12px;
-    bottom: 12px;
-  }
-  .CodeMirror-scroll {
-    max-height: initial !important;
-  }
+
+export const EditorWrapper = styled(BaseEditorWrapper)`
+  ${(props => {
+    if (props.expanded) {
+      return 'height: 100%;' +
+      'z-index: 2;' +
+      '.CodeMirror {' +
+      '  position: absolute;' +
+      '  left: 12px;' +
+      '  right: 142px;' +
+      '  top: 12px;' +
+      '  bottom: 12px;' +
+      '}' +
+      '.CodeMirror-scroll {' +
+      '   max-height: initial !important;' +
+      '}'
+    }
+  })}
 `


### PR DESCRIPTION
Seemed to be caused by the switching of wrapper components that were a parent to <CodeMirror />. This fix is to switch styling within the same styled component