### PR TITLE
Try to fetch guide remotely if not found locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
       "afterEach",
       "neo",
       "FileReader",
-      "Blob"
+      "Blob",
+      "fetch"
     ]
   },
   "repository": {},

--- a/src/shared/modules/commands/helpers/play.js
+++ b/src/shared/modules/commands/helpers/play.js
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { hostIsAllowed } from 'services/utils'
+import { cleanHtml } from 'services/remoteUtils'
+import remote from 'services/remote'
+
+export const fetchRemoteGuide = (url, whitelist = null) => {
+  return new Promise((resolve, reject) => {
+    if (!hostIsAllowed(url, whitelist)) {
+      return reject(new Error('Hostname is not allowed according to server whitelist'))
+    }
+    resolve()
+  }).then(() => {
+    return remote.get(url).then((r) => {
+      return cleanHtml(r)
+    })
+  })
+}

--- a/src/shared/modules/dbMeta/__snapshots__/dbMetaDuck.test.js.snap
+++ b/src/shared/modules/dbMeta/__snapshots__/dbMetaDuck.test.js.snap
@@ -14,6 +14,7 @@ Object {
   },
   "settings": Object {
     "browser.allow_outgoing_connections": false,
+    "browser.remote_content_hostname_whitelist": "guides.neo4j.com, localhost",
   },
 }
 `;
@@ -33,6 +34,7 @@ Object {
   },
   "settings": Object {
     "browser.allow_outgoing_connections": false,
+    "browser.remote_content_hostname_whitelist": "guides.neo4j.com, localhost",
   },
   "shouldKeep": true,
 }

--- a/src/shared/modules/dbMeta/dbMetaDuck.js
+++ b/src/shared/modules/dbMeta/dbMetaDuck.js
@@ -40,22 +40,6 @@ export const UPDATE_SETTINGS = 'meta/UPDATE_SETTINGS'
 export const CLEAR = 'meta/CLEAR'
 export const FORCE_FETCH = 'meta/FORCE_FETCH'
 
-const initialState = {
-  labels: [],
-  relationshipTypes: [],
-  properties: [],
-  functions: [],
-  procedures: [],
-  server: {
-    version: null,
-    edition: null,
-    storeId: null
-  },
-  settings: {
-    'browser.allow_outgoing_connections': false
-  }
-}
-
 /**
  * Selectors
  */
@@ -86,6 +70,7 @@ export const getStoreId = (state) => state[NAME].server.storeId
 export const getAvailableSettings = (state) => (state[NAME] || initialState).settings
 export const allowOutgoingConnections = (state) => getAvailableSettings(state)['browser.allow_outgoing_connections']
 export const credentialsTimeout = (state) => getAvailableSettings(state)['browser.credential_timeout'] || 0
+export const getRemoteContentHostnameWhitelist = (state) => getAvailableSettings(state)['browser.remote_content_hostname_whitelist'] || initialState.settings['browser.remote_content_hostname_whitelist']
 export const shouldRetainConnectionCredentials = (state) => {
   const conf = getAvailableSettings(state)['browser.retain_connection_credentials']
   if (conf === null || typeof conf === 'undefined') return true
@@ -138,6 +123,24 @@ function updateMetaForContext (state, meta, context) {
     properties,
     functions,
     procedures
+  }
+}
+
+// Initial state
+const initialState = {
+  labels: [],
+  relationshipTypes: [],
+  properties: [],
+  functions: [],
+  procedures: [],
+  server: {
+    version: null,
+    edition: null,
+    storeId: null
+  },
+  settings: {
+    'browser.allow_outgoing_connections': false,
+    'browser.remote_content_hostname_whitelist': 'guides.neo4j.com, localhost'
   }
 }
 

--- a/src/shared/rootEpic.js
+++ b/src/shared/rootEpic.js
@@ -19,7 +19,7 @@
  */
 
 import { combineEpics } from 'redux-observable'
-import { handleCommandsEpic, postConnectCmdEpic } from './modules/commands/commandsDuck'
+import { handleCommandsEpic, postConnectCmdEpic, fetchGuideFromWhitelistEpic } from './modules/commands/commandsDuck'
 import { retainCredentialsSettingsEpic, checkSettingsForRoutingDriver, connectEpic, disconnectEpic, startupConnectEpic, disconnectSuccessEpic, startupConnectionSuccessEpic, startupConnectionFailEpic, detectActiveConnectionChangeEpic, connectionLostEpic } from './modules/connections/connectionsDuck'
 import { dbMetaEpic, clearMetaOnDisconnectEpic } from './modules/dbMeta/dbMetaDuck'
 import { cancelRequestEpic } from './modules/requests/requestsDuck'
@@ -36,6 +36,7 @@ import { maxFramesConfigEpic } from './modules/stream/streamDuck'
 export default combineEpics(
   handleCommandsEpic,
   postConnectCmdEpic,
+  fetchGuideFromWhitelistEpic,
   connectionLostEpic,
   retainCredentialsSettingsEpic,
   checkSettingsForRoutingDriver,

--- a/src/shared/services/remote.js
+++ b/src/shared/services/remote.js
@@ -18,7 +18,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import fetch from 'isomorphic-fetch'
+/* global fetch */
+import 'isomorphic-fetch'
 
 function request (method, url, data = null) {
   return fetch(url, {
@@ -30,12 +31,15 @@ function request (method, url, data = null) {
     },
     body: data
   })
+  .then(checkStatus)
 }
 
 function get (url) {
   return fetch(url, {
     method: 'get'
-  }).then(function (response) {
+  })
+  .then(checkStatus)
+  .then(function (response) {
     return response.text()
   })
 }
@@ -51,6 +55,16 @@ function getJSON (url) {
   }).catch((e) => {
     return e
   })
+}
+
+function checkStatus (response) {
+  if (response.status >= 200 && response.status < 300) {
+    return response
+  } else {
+    var error = new Error(response.status + ' ' + response.statusText)
+    error.response = response
+    throw error
+  }
 }
 
 export default {

--- a/src/shared/services/utils.test.js
+++ b/src/shared/services/utils.test.js
@@ -187,6 +187,51 @@ describe('utils', () => {
       hash: ''
     })
   })
+  describe('extractWhitelistFromConfigString', () => {
+    test('extracts comma separated string of hosts to array', () => {
+      // Given
+      const input = 'localhost,guides.neo4j.com'
+
+      // When
+      const res = utils.extractWhitelistFromConfigString(input)
+
+      // Then
+      expect(res).toEqual(['localhost', 'guides.neo4j.com'])
+    })
+    test('trims each host value and removes trailing slash', () => {
+      // Given
+      const input = 'localhost , guides.neo4j.com/ , neo4j.com'
+
+      // When
+      const res = utils.extractWhitelistFromConfigString(input)
+
+      // Then
+      expect(res).toEqual(['localhost', 'guides.neo4j.com', 'neo4j.com'])
+    })
+  })
+  describe('addProtocolsToUrlList', () => {
+    test('Add protocol where needed', () => {
+      // Given
+      const input = [
+        'http://test.com',
+        'oskarhane.com',
+        '*',
+        null,
+        'https://mysite.com/guides'
+      ]
+
+      // When
+      const res = utils.addProtocolsToUrlList(input)
+
+      // Then
+      expect(res).toEqual([
+        'http://test.com',
+        'https://oskarhane.com',
+        'http://oskarhane.com',
+        'https://mysite.com/guides'
+      ])
+    })
+  })
   describe('hostIsAllowed', () => {
     test('should respect host whitelist', () => {
       // Given
@@ -205,16 +250,6 @@ describe('utils', () => {
 
       // When && Then
       expect(utils.hostIsAllowed('anything', whitelist)).toEqual(true)
-    })
-    test('should use defaults if no whitelist specified', () => {
-      // When && Then
-      expect(utils.hostIsAllowed('http://anything.com', null)).toEqual(false)
-      expect(utils.hostIsAllowed('http://anything.com', '')).toEqual(false)
-      expect(utils.hostIsAllowed('guides.neo4j.com', undefined)).toEqual(true)
-      expect(utils.hostIsAllowed('guides.neo4j.com', null)).toEqual(true)
-      expect(utils.hostIsAllowed('guides.neo4j.com', '')).toEqual(true)
-      expect(utils.hostIsAllowed('localhost', null)).toEqual(true)
-      expect(utils.hostIsAllowed('localhost', '')).toEqual(true)
     })
     test('can parse url params correctly', () => {
     // Given


### PR DESCRIPTION
When trying to play a local guide: `:play reco` and it isn't found, an attempt to find it on the url `browser.remote_content_hostname_whitelist + name` is made.

`browser.remote_content_hostname_whitelist` is a server configuration list of hosts (or urls:s) that the browser can fetch remote content from.

The default value for `browser.remote_content_hostname_whitelist` is `localhost,guides.neo4j.com`, so the above play command would resolve and display the reco guide hosted on https://localhost/reco, then on http://localhost/reco, then on https://guides.neo4j.com/reco and finally on http://guides.neo4j.com/reco.
It stops after the first successful fetch.

The steps followed are:

- Try locally. If found, display it
- Try remotely, by appending the guide name to each of server config list of `browser.remote_content_hostname_whitelist`
- Iterate over whitelist and if guide is found, display it and stop trying to fetch guide from the rest of the list
- If error
  - show 'Not found' frame

Some updates to on how we use `isomorphic-fetch` are added as well, so errors are thrown when we hit a non 200 status from a request.

![oskar4j 2017-05-04 at 11 10 23](https://cloud.githubusercontent.com/assets/570998/25697188/4e31ddf6-30ba-11e7-8663-da4979ab641a.png)
