### PR TITLE
Don't add a default width to drawer

### DIFF
--- a/src/browser/components/TabNavigation/styled.jsx
+++ b/src/browser/components/TabNavigation/styled.jsx
@@ -32,7 +32,8 @@ export const StyledSidebar = styled.div`
 export const StyledDrawer = styled.div`
   flex: 0 0 auto;
   background-color: #30333A;
-  overflow: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   width: ${props => props.open ? '300px' : '0px'};
   transition: .2s ease-out;
   z-index: 1;

--- a/src/browser/components/TabNavigation/styled.jsx
+++ b/src/browser/components/TabNavigation/styled.jsx
@@ -21,7 +21,7 @@
 import styled from 'styled-components'
 
 export const StyledSidebar = styled.div`
-  flex: content;
+  flex: 0 0 auto;
   background-color: #4C4957;
   display: flex;
   flex-direction: row;
@@ -30,7 +30,7 @@ export const StyledSidebar = styled.div`
 `
 
 export const StyledDrawer = styled.div`
-  flex: 0 0 300px;
+  flex: 0 0 auto;
   background-color: #30333A;
   overflow: auto;
   width: ${props => props.open ? '300px' : '0px'};

--- a/src/browser/components/drawer/Drawer.jsx
+++ b/src/browser/components/drawer/Drawer.jsx
@@ -20,7 +20,9 @@
 
 import styled from 'styled-components'
 
-export const Drawer = styled.div``
+export const Drawer = styled.div`
+  width: 285px;
+`
 
 export const DrawerHeader = styled.h4`
   color: ${props => props.theme.primaryHeaderText}


### PR DESCRIPTION
Downside being that the content of the drawer get's relayed out during grow time.
Could potentially be slow when having a large amount of meta data items.

But this PR fixes the imminent issue of unclosable sidebar in IE.

![edge](https://cloud.githubusercontent.com/assets/570998/25699771/ebb9eba4-30c4-11e7-8e64-413c33a8159f.gif)
