### PR TITLE
Fetch internal relationships between displayed nodes (Auto complete)

### DIFF
--- a/src/browser/modules/D3Visualization/components/Explorer.jsx
+++ b/src/browser/modules/D3Visualization/components/Explorer.jsx
@@ -109,6 +109,14 @@ export class ExplorerComponent extends Component {
         )
       }
     }
+
+    if (nextProps.nodes !== this.props.nodes) {
+      this.setState({nodes: nextProps.nodes})
+    }
+
+    if (nextProps.relationships !== this.props.relationships) {
+      this.setState({relationships: nextProps.relationships})
+    }
   }
 
   onInspectorExpandToggled (contracted, inspectorHeight) {
@@ -131,7 +139,7 @@ export class ExplorerComponent extends Component {
       <StyledFullSizeContainer id='svg-vis' className={Object.keys(this.state.stats.relTypes).length ? '' : 'one-legend-row'} forcePaddingBottom={inspectingItemType ? this.state.forcePaddingBottom : null}>
         {legend}
         <GraphComponent fullscreen={this.props.fullscreen} frameHeight={this.props.frameHeight} relationships={this.state.relationships} nodes={this.state.nodes} getNodeNeighbours={this.getNodeNeighbours.bind(this)} onItemMouseOver={this.onItemMouseOver.bind(this)}
-          onItemSelect={this.onItemSelect.bind(this)} graphStyle={this.state.graphStyle} onGraphModelChange={this.onGraphModelChange.bind(this)} assignVisElement={this.props.assignVisElement} />
+          onItemSelect={this.onItemSelect.bind(this)} graphStyle={this.state.graphStyle} onGraphModelChange={this.onGraphModelChange.bind(this)} assignVisElement={this.props.assignVisElement} getAutoCompleteCallback={this.props.getAutoCompleteCallback} />
         <InspectorComponent fullscreen={this.props.fullscreen} hoveredItem={this.state.hoveredItem} selectedItem={this.state.selectedItem} graphStyle={this.state.graphStyle} onExpandToggled={this.onInspectorExpandToggled.bind(this)} />
       </StyledFullSizeContainer>
     )

--- a/src/browser/modules/D3Visualization/components/Graph.jsx
+++ b/src/browser/modules/D3Visualization/components/Graph.jsx
@@ -80,7 +80,15 @@ export class GraphComponent extends Component {
         this.props.onGraphModelChange(getGraphStats(this.graph))
       }
 
+      this.props.getAutoCompleteCallback && this.props.getAutoCompleteCallback(this.addInternalRelationships.bind(this))
       this.props.assignVisElement && this.props.assignVisElement(this.svgElement, this.graphView)
+    }
+  }
+
+  addInternalRelationships (internalRelationships) {
+    if (this.graph) {
+      this.graph.addInternalRelationships(mapRelationships(internalRelationships, this.graph))
+      this.graphView.update()
     }
   }
 

--- a/src/browser/modules/Sidebar/Settings.jsx
+++ b/src/browser/modules/Sidebar/Settings.jsx
@@ -81,6 +81,13 @@ const visualSettings =
             displayName: 'Max Rows',
             tooltip: "Max number of rows to render in 'Rows' result view"
           }
+        },
+        {
+          autoComplete: {
+            displayName: 'Auto Complete',
+            tooltip: 'Automatically fetch relationships between displayed nodes',
+            type: 'checkbox'
+          }
         }
       ]
     }

--- a/src/browser/modules/Sidebar/Settings.jsx
+++ b/src/browser/modules/Sidebar/Settings.jsx
@@ -85,7 +85,7 @@ const visualSettings =
         {
           autoComplete: {
             displayName: 'Connect result nodes',
-            tooltip: 'Automatically fetch relationships between displayed nodes',
+            tooltip: 'If this is checked, after a cypher query result is retrieved, a second query is executed to fetch relationships between result nodes.',
             type: 'checkbox'
           }
         }

--- a/src/browser/modules/Sidebar/Settings.jsx
+++ b/src/browser/modules/Sidebar/Settings.jsx
@@ -84,7 +84,7 @@ const visualSettings =
         },
         {
           autoComplete: {
-            displayName: 'Auto Complete',
+            displayName: 'Connect result nodes',
             tooltip: 'Automatically fetch relationships between displayed nodes',
             type: 'checkbox'
           }

--- a/src/browser/modules/Stream/Visualization.jsx
+++ b/src/browser/modules/Stream/Visualization.jsx
@@ -25,7 +25,7 @@ import bolt from 'services/bolt/bolt'
 import { withBus } from 'preact-suber'
 import { ExplorerComponent } from '../D3Visualization/components/Explorer'
 import { StyledVisContainer } from './styled'
-import { getMaxNeighbours, getSettings, autoComplete } from 'shared/modules/settings/settingsDuck'
+import { getMaxNeighbours, getSettings, shouldAutoComplete } from 'shared/modules/settings/settingsDuck'
 
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
 
@@ -160,7 +160,7 @@ const mapStateToProps = (state) => {
     graphStyleData: grassActions.getGraphStyleData(state),
     initialNodeDisplay: getSettings(state).initialNodeDisplay,
     maxNeighbours: getMaxNeighbours(state),
-    autoComplete: autoComplete(state)
+    autoComplete: shouldAutoComplete(state)
   }
 }
 

--- a/src/browser/modules/Stream/Visualization.jsx
+++ b/src/browser/modules/Stream/Visualization.jsx
@@ -113,15 +113,11 @@ export class Visualization extends Component {
 
   getInternalRelationships (existingNodeIds, newNodeIds) {
     existingNodeIds = existingNodeIds.concat(newNodeIds)
-    const query = `
-            MATCH (a)-[r]-(b) WHERE id(a) IN {existingNodeIds}
-            AND id(b) IN {newNodeIds}
-            RETURN r;`
-    const params = {existingNodeIds, newNodeIds}
+    const query = `MATCH (a)-[r]-(b) WHERE id(a) IN [${existingNodeIds}] AND id(b) IN [${newNodeIds}] RETURN r;`
     return new Promise((resolve, reject) => {
       this.props.bus.self(
         CYPHER_REQUEST,
-        {query, params},
+        {query},
         (response) => {
           if (!response.success) {
             reject({nodes: [], rels: []})

--- a/src/browser/modules/Stream/Visualization.jsx
+++ b/src/browser/modules/Stream/Visualization.jsx
@@ -83,6 +83,7 @@ export class Visualization extends Component {
         .then((graph) => {
           this.autoCompleteCallback && this.autoCompleteCallback(graph.relationships)
         })
+        .catch((e) => {})
     }
   }
 

--- a/src/browser/modules/Stream/Visualization.jsx
+++ b/src/browser/modules/Stream/Visualization.jsx
@@ -112,12 +112,14 @@ export class Visualization extends Component {
   }
 
   getInternalRelationships (existingNodeIds, newNodeIds) {
+    newNodeIds = newNodeIds.map(bolt.neo4j.int)
+    existingNodeIds = existingNodeIds.map(bolt.neo4j.int)
     existingNodeIds = existingNodeIds.concat(newNodeIds)
-    const query = `MATCH (a)-[r]-(b) WHERE id(a) IN [${existingNodeIds}] AND id(b) IN [${newNodeIds}] RETURN r;`
+    const query = 'MATCH (a)-[r]->(b) WHERE id(a) IN $existingNodeIds AND id(b) IN $newNodeIds RETURN r;'
     return new Promise((resolve, reject) => {
       this.props.bus.self(
         CYPHER_REQUEST,
-        {query},
+        {query, params: {existingNodeIds, newNodeIds}},
         (response) => {
           if (!response.success) {
             reject({nodes: [], rels: []})

--- a/src/browser/modules/Stream/Visualization.jsx
+++ b/src/browser/modules/Stream/Visualization.jsx
@@ -25,7 +25,7 @@ import bolt from 'services/bolt/bolt'
 import { withBus } from 'preact-suber'
 import { ExplorerComponent } from '../D3Visualization/components/Explorer'
 import { StyledVisContainer } from './styled'
-import { getMaxNeighbours, getSettings } from 'shared/modules/settings/settingsDuck'
+import { getMaxNeighbours, getSettings, autoComplete } from 'shared/modules/settings/settingsDuck'
 
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
 
@@ -65,7 +65,25 @@ export class Visualization extends Component {
   }
 
   populateDataToStateFromProps (props) {
-    this.setState({nodesAndRelationships: bolt.extractNodesAndRelationshipsFromRecordsForOldVis(props.records)})
+    this.setState({nodesAndRelationships: bolt.extractNodesAndRelationshipsFromRecordsForOldVis(props.records)}, () => {
+      this.autoCompleteRelationships([], this.state.nodesAndRelationships.nodes)
+    })
+  }
+
+  mergeToList (list1, list2) {
+    return list1.concat(list2.filter(itemInList2 => list1.findIndex(itemInList1 => itemInList1.id === itemInList2.id) < 0))
+  }
+
+  autoCompleteRelationships (existingNodes, newNodes) {
+    if (this.props.autoComplete) {
+      const existingNodeIds = existingNodes.map(node => parseInt(node.id))
+      const newNodeIds = newNodes.map(node => parseInt(node.id))
+
+      this.getInternalRelationships(existingNodeIds, newNodeIds)
+        .then((graph) => {
+          this.autoCompleteCallback && this.autoCompleteCallback(graph.relationships)
+        })
+    }
   }
 
   getNeighbours (id, currentNeighbourIds = []) {
@@ -84,7 +102,31 @@ export class Visualization extends Component {
             reject({nodes: [], rels: []})
           } else {
             let count = response.result.records.length > 0 ? parseInt(response.result.records[0].get('c').toString()) : 0
-            resolve({...bolt.extractNodesAndRelationshipsFromRecordsForOldVis(response.result.records, false), count: count})
+            const graph = bolt.extractNodesAndRelationshipsFromRecordsForOldVis(response.result.records, false)
+            this.autoCompleteRelationships(this.state.nodesAndRelationships.nodes, graph.nodes)
+            resolve({...graph, count: count})
+          }
+        }
+      )
+    })
+  }
+
+  getInternalRelationships (existingNodeIds, newNodeIds) {
+    existingNodeIds = existingNodeIds.concat(newNodeIds)
+    const query = `
+            MATCH (a)-[r]-(b) WHERE id(a) IN {existingNodeIds}
+            AND id(b) IN {newNodeIds}
+            RETURN r;`
+    const params = {existingNodeIds, newNodeIds}
+    return new Promise((resolve, reject) => {
+      this.props.bus.self(
+        CYPHER_REQUEST,
+        {query, params},
+        (response) => {
+          if (!response.success) {
+            reject({nodes: [], rels: []})
+          } else {
+            resolve({...bolt.extractNodesAndRelationshipsFromRecordsForOldVis(response.result.records, false)})
           }
         }
       )
@@ -110,6 +152,7 @@ export class Visualization extends Component {
           fullscreen={this.props.fullscreen}
           frameHeight={this.props.frameHeight}
           assignVisElement={this.props.assignVisElement}
+          getAutoCompleteCallback={(callback) => { this.autoCompleteCallback = callback }}
         />
       </StyledVisContainer>
     )
@@ -120,7 +163,8 @@ const mapStateToProps = (state) => {
   return {
     graphStyleData: grassActions.getGraphStyleData(state),
     initialNodeDisplay: getSettings(state).initialNodeDisplay,
-    maxNeighbours: getMaxNeighbours(state)
+    maxNeighbours: getMaxNeighbours(state),
+    autoComplete: autoComplete(state)
   }
 }
 

--- a/src/shared/modules/settings/settingsDuck.js
+++ b/src/shared/modules/settings/settingsDuck.js
@@ -38,7 +38,7 @@ export const getMaxNeighbours = (state) => state[NAME].maxNeighbours || initialS
 export const getMaxRows = (state) => state[NAME].maxRows || initialState.maxRows
 export const getInitialNodeDisplay = (state) => state[NAME].initialNodeDisplay || initialState.initialNodeDisplay
 export const shouldReportUdc = (state) => state[NAME].shouldReportUdc !== false
-export const autoComplete = (state) => state[NAME].autoComplete !== false
+export const shouldAutoComplete = (state) => state[NAME].autoComplete !== false
 
 const browserSyncConfig = {
   authWindowUrl: 'https://auth.neo4j.com/indexNewBrowser.html',

--- a/src/shared/modules/settings/settingsDuck.js
+++ b/src/shared/modules/settings/settingsDuck.js
@@ -38,6 +38,7 @@ export const getMaxNeighbours = (state) => state[NAME].maxNeighbours || initialS
 export const getMaxRows = (state) => state[NAME].maxRows || initialState.maxRows
 export const getInitialNodeDisplay = (state) => state[NAME].initialNodeDisplay || initialState.initialNodeDisplay
 export const shouldReportUdc = (state) => state[NAME].shouldReportUdc !== false
+export const autoComplete = (state) => state[NAME].autoComplete !== false
 
 const browserSyncConfig = {
   authWindowUrl: 'https://auth.neo4j.com/indexNewBrowser.html',
@@ -61,7 +62,8 @@ const initialState = {
   showSampleScripts: true,
   browserSyncDebugServer: null,
   maxRows: 1000,
-  shouldReportUdc: true
+  shouldReportUdc: true,
+  autoComplete: true
 }
 
 export default function settings (state = initialState, action) {


### PR DESCRIPTION
A setting has been added, 'Connect result nodes', replacing 'Auto complete' of the previous version.
If this setting is checked, after a cypher query result is retrieved, a second query is executed to fetch relationships between result nodes.

Movie dataset query response before:
<img width="710" alt="oskar4j 2017-05-04 at 19 58 08" src="https://cloud.githubusercontent.com/assets/570998/25717816/06980980-3104-11e7-9d69-2f56a8747edb.png">


and after:
<img width="709" alt="oskar4j 2017-05-04 at 19 53 43" src="https://cloud.githubusercontent.com/assets/570998/25717698/918b59b2-3103-11e7-8888-b370f6128252.png">

