### PR TITLE
Only scroll to top of stream when frame is added and toggle is on

### DIFF
--- a/src/browser/modules/Sidebar/Settings.jsx
+++ b/src/browser/modules/Sidebar/Settings.jsx
@@ -58,6 +58,13 @@ const visualSettings =
             displayName: 'Max History',
             tooltip: 'Max number of history entries. When reached, old entries gets retired.'
           }
+        },
+        {
+          scrollToTop: {
+            displayName: 'Scroll To Top',
+            tooltip: 'Automatically scroll stream to top on new frames.',
+            type: 'checkbox'
+          }
         }
       ]
     },

--- a/src/browser/modules/Stream/Stream.jsx
+++ b/src/browser/modules/Stream/Stream.jsx
@@ -36,13 +36,13 @@ import SysInfoFrame from './SysInfoFrame'
 import ConnectionFrame from './Auth/ConnectionFrame'
 import DisconnectFrame from './Auth/DisconnectFrame'
 import ChangePasswordFrame from './Auth/ChangePasswordFrame'
+import QueriesFrame from './Queries/QueriesFrame'
 import UserList from '../User/UserList'
 import UserAdd from '../User/UserAdd'
 import { getFrames, setRecentView, getRecentView } from 'shared/modules/stream/streamDuck'
 import { getRequests } from 'shared/modules/requests/requestsDuck'
 import { getActiveConnectionData } from 'shared/modules/connections/connectionsDuck'
-import QueriesFrame from './Queries/QueriesFrame'
-import { getMaxRows, getInitialNodeDisplay } from 'shared/modules/settings/settingsDuck'
+import { getMaxRows, getInitialNodeDisplay, getScrollToTop } from 'shared/modules/settings/settingsDuck'
 
 const getFrame = (type) => {
   const trans = {
@@ -85,7 +85,7 @@ class Stream extends Component {
     ) {
       return false
     } else {
-      if (frameHasBeenAdded) {
+      if (this.props.scrollToTop && frameHasBeenAdded) {
         this.base.scrollTop = 0
       }
       return true
@@ -122,7 +122,8 @@ const mapStateToProps = (state) => {
     activeConnectionData: getActiveConnectionData(state),
     recentView: getRecentView(state),
     maxRows: getMaxRows(state),
-    initialNodeDisplay: getInitialNodeDisplay(state)
+    initialNodeDisplay: getInitialNodeDisplay(state),
+    scrollToTop: getScrollToTop(state)
   }
 }
 

--- a/src/browser/modules/Stream/Stream.jsx
+++ b/src/browser/modules/Stream/Stream.jsx
@@ -70,7 +70,8 @@ const getFrame = (type) => {
 
 class Stream extends Component {
   shouldComponentUpdate (nextProps, nextState) {
-    const hasSameAmountOfFrames = this.props.frames.length === nextProps.frames.length
+    const frameHasBeenAdded = this.props.frames.length < nextProps.frames.length
+
     if (this.props.activeConnectionData === nextProps.activeConnectionData &&
       this.props.requests === nextProps.requests &&
       (this.props.children.length === nextProps.children.length &&
@@ -84,7 +85,7 @@ class Stream extends Component {
     ) {
       return false
     } else {
-      if (!hasSameAmountOfFrames) {
+      if (frameHasBeenAdded) {
         this.base.scrollTop = 0
       }
       return true

--- a/src/shared/modules/settings/settingsDuck.js
+++ b/src/shared/modules/settings/settingsDuck.js
@@ -37,6 +37,7 @@ export const getBrowserSyncConfig = (state) => {
 export const getMaxNeighbours = (state) => state[NAME].maxNeighbours || initialState.maxNeighbours
 export const getMaxRows = (state) => state[NAME].maxRows || initialState.maxRows
 export const getInitialNodeDisplay = (state) => state[NAME].initialNodeDisplay || initialState.initialNodeDisplay
+export const getScrollToTop = (state) => state[NAME].scrollToTop || initialState.scrollToTop
 export const shouldReportUdc = (state) => state[NAME].shouldReportUdc !== false
 export const shouldAutoComplete = (state) => state[NAME].autoComplete !== false
 
@@ -63,7 +64,8 @@ const initialState = {
   browserSyncDebugServer: null,
   maxRows: 1000,
   shouldReportUdc: true,
-  autoComplete: true
+  autoComplete: true,
+  scrollToTop: true
 }
 
 export default function settings (state = initialState, action) {

--- a/src/shared/modules/settings/settingsDuck.js
+++ b/src/shared/modules/settings/settingsDuck.js
@@ -37,7 +37,7 @@ export const getBrowserSyncConfig = (state) => {
 export const getMaxNeighbours = (state) => state[NAME].maxNeighbours || initialState.maxNeighbours
 export const getMaxRows = (state) => state[NAME].maxRows || initialState.maxRows
 export const getInitialNodeDisplay = (state) => state[NAME].initialNodeDisplay || initialState.initialNodeDisplay
-export const getScrollToTop = (state) => state[NAME].scrollToTop || initialState.scrollToTop
+export const getScrollToTop = (state) => state[NAME].scrollToTop
 export const shouldReportUdc = (state) => state[NAME].shouldReportUdc !== false
 export const shouldAutoComplete = (state) => state[NAME].autoComplete !== false
 


### PR DESCRIPTION
The scroll to top will only kick in once a frame is added (this handles rerun/frame removal issues we've had)

Added toggle to the sidebar
<img width="360" alt="screen shot 2017-05-04 at 20 04 32" src="https://cloud.githubusercontent.com/assets/849508/25720537/26be78a6-3105-11e7-9e4d-8b11c0aa0bf1.png">
