### PR TITLE
Fix the error occurs on auto-complete when initial Node Display threshold is exceeded

### DIFF
--- a/src/browser/modules/D3Visualization/components/Explorer.jsx
+++ b/src/browser/modules/D3Visualization/components/Explorer.jsx
@@ -139,7 +139,7 @@ export class ExplorerComponent extends Component {
       <StyledFullSizeContainer id='svg-vis' className={Object.keys(this.state.stats.relTypes).length ? '' : 'one-legend-row'} forcePaddingBottom={inspectingItemType ? this.state.forcePaddingBottom : null}>
         {legend}
         <GraphComponent fullscreen={this.props.fullscreen} frameHeight={this.props.frameHeight} relationships={this.state.relationships} nodes={this.state.nodes} getNodeNeighbours={this.getNodeNeighbours.bind(this)} onItemMouseOver={this.onItemMouseOver.bind(this)}
-          onItemSelect={this.onItemSelect.bind(this)} graphStyle={this.state.graphStyle} onGraphModelChange={this.onGraphModelChange.bind(this)} assignVisElement={this.props.assignVisElement} getAutoCompleteCallback={this.props.getAutoCompleteCallback} />
+          onItemSelect={this.onItemSelect.bind(this)} graphStyle={this.state.graphStyle} onGraphModelChange={this.onGraphModelChange.bind(this)} assignVisElement={this.props.assignVisElement} getAutoCompleteCallback={this.props.getAutoCompleteCallback} setGraph={this.props.setGraph} />
         <InspectorComponent fullscreen={this.props.fullscreen} hoveredItem={this.state.hoveredItem} selectedItem={this.state.selectedItem} graphStyle={this.state.graphStyle} onExpandToggled={this.onInspectorExpandToggled.bind(this)} />
       </StyledFullSizeContainer>
     )

--- a/src/browser/modules/D3Visualization/components/Graph.jsx
+++ b/src/browser/modules/D3Visualization/components/Graph.jsx
@@ -80,6 +80,7 @@ export class GraphComponent extends Component {
         this.props.onGraphModelChange(getGraphStats(this.graph))
       }
 
+      this.graph && this.props.setGraph && this.props.setGraph(this.graph)
       this.props.getAutoCompleteCallback && this.props.getAutoCompleteCallback(this.addInternalRelationships.bind(this))
       this.props.assignVisElement && this.props.assignVisElement(this.svgElement, this.graphView)
     }

--- a/src/browser/modules/Stream/Visualization.jsx
+++ b/src/browser/modules/Stream/Visualization.jsx
@@ -65,9 +65,7 @@ export class Visualization extends Component {
   }
 
   populateDataToStateFromProps (props) {
-    this.setState({nodesAndRelationships: bolt.extractNodesAndRelationshipsFromRecordsForOldVis(props.records)}, () => {
-      this.autoCompleteRelationships([], this.state.nodesAndRelationships.nodes)
-    })
+    this.setState({ nodesAndRelationships: bolt.extractNodesAndRelationshipsFromRecordsForOldVis(props.records) })
   }
 
   mergeToList (list1, list2) {
@@ -103,9 +101,9 @@ export class Visualization extends Component {
             reject({nodes: [], rels: []})
           } else {
             let count = response.result.records.length > 0 ? parseInt(response.result.records[0].get('c').toString()) : 0
-            const graph = bolt.extractNodesAndRelationshipsFromRecordsForOldVis(response.result.records, false)
-            this.autoCompleteRelationships(this.state.nodesAndRelationships.nodes, graph.nodes)
-            resolve({...graph, count: count})
+            const resultGraph = bolt.extractNodesAndRelationshipsFromRecordsForOldVis(response.result.records, false)
+            this.autoCompleteRelationships(this.graph._nodes, resultGraph.nodes)
+            resolve({...resultGraph, count: count})
           }
         }
       )
@@ -132,6 +130,11 @@ export class Visualization extends Component {
     })
   }
 
+  setGraph (graph) {
+    this.graph = graph
+    this.autoCompleteRelationships([], this.graph._nodes)
+  }
+
   render () {
     // This workaround is to overcome the issue that if the svg is initiated with in a style.display = none component, it does not become visible even display changed to block or so
     if (this.state.justInitiated && this.props.style.display === 'none') {
@@ -152,6 +155,7 @@ export class Visualization extends Component {
           frameHeight={this.props.frameHeight}
           assignVisElement={this.props.assignVisElement}
           getAutoCompleteCallback={(callback) => { this.autoCompleteCallback = callback }}
+          setGraph={this.setGraph.bind(this)}
         />
       </StyledVisContainer>
     )


### PR DESCRIPTION
This bug happens when graph object cuts the nodes off when Initial Node Display limit is exceed. Visualisation component is unaware of the final displayed nodes and tries to find relations between all retrieved nodes. Fixed by passing graph object to Visualisation component thus it request relations between only displayed nodes.