### PR TITLE
Remove untemplated version variable from start guide

### DIFF
--- a/src/browser/modules/Guides/html/start.html
+++ b/src/browser/modules/Guides/html/start.html
@@ -2,8 +2,8 @@
   <div class="container-fluid">
     <div class="row">
       <div class="col-sm-2">
-        <div class="box-max"><img src="images/neo4j-world.png" class="img-responsive">
-          <p class="lead text-right">3.2-RC2</p>
+        <div class="box-max">
+          <img src="images/neo4j-world.png" class="img-responsive">
         </div>
       </div>
       <div class="col-sm-10">


### PR DESCRIPTION
Currently we don't add variables in `:play` guides. This removes this usage from the start guide.