### PR TITLE
Reset open drawer in state when closing drawer

### DIFF
--- a/src/browser/components/TabNavigation/Navigation.jsx
+++ b/src/browser/components/TabNavigation/Navigation.jsx
@@ -46,6 +46,7 @@ class Navigation extends Component {
           newState.transitionState = Opening
         }
       } else {
+        newState.drawerContent = ''
         if (this.state.transitionState === Open || this.state.transitionState === Opening) {
           newState.transitionState = Closing
         }


### PR DESCRIPTION
Drawers never went into non-selected mode when closed before this fix.

Before:
<img width="175" alt="oskar4j 2017-05-07 at 22 05 16" src="https://cloud.githubusercontent.com/assets/570998/25784660/658bed52-3371-11e7-8e4b-cb66a0d1ecfe.png">

After:
<img width="141" alt="oskar4j 2017-05-07 at 22 06 32" src="https://cloud.githubusercontent.com/assets/570998/25784663/77150266-3371-11e7-801e-538ed3d697ba.png">