### PR TITLE
Remove untemplated help url

### DIFF
--- a/src/browser/modules/Help/html/help.html
+++ b/src/browser/modules/Help/html/help.html
@@ -29,10 +29,10 @@
             <th>Examples:</th>
             <td><a play-topic="movie graph">:play movie graph</a>&nbsp;<a play-topic="northwind graph">:play northwind graph</a></td>
           </tr>
-          <tr>
+          <!-- <tr>
             <th>Reference:</th>
             <td><a href="{{ neo4j.version | neo4jDeveloperDoc }}/">Neo4j Manual</a><br/><a href="http://neo4j.com/developer">Neo4j Developer Pages</a><br/><a href="{{ neo4j.version | neo4jCypherRefcardDoc }}/">Cypher Refcard</a></td>
-          </tr>
+          </tr> -->
         </table>
       </div>
     </section>


### PR DESCRIPTION
Commented out broken link as it seems to be what we have done everywhere else. I assume this is so we don't have to cross reference with the 2.0 code base as to what they should be