### PR TITLE
Read and act on server config retain_connection_credentials

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "redux-devtools": "^3.2.0",
     "redux-devtools-dock-monitor": "^1.1.1",
     "redux-devtools-log-monitor": "^1.0.11",
-    "redux-mock-store": "^1.2.2",
+    "redux-mock-store": "^1.2.3",
     "standard": "^8.6.0",
     "style-loader": "^0.16.1",
     "url-loader": "^0.5.8",

--- a/src/browser/modules/Stream/Auth/ConnectedView.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectedView.jsx
@@ -20,13 +20,13 @@
 
 import { StyledConnectionBody, StyledCode, StyledConnectionFooter } from './styled'
 
-const ConnectedView = ({host, username}) => {
+const ConnectedView = ({host, username, storeCredentials}) => {
   return (
     <StyledConnectionBody>
       You are connected as user <StyledCode>{username}</StyledCode><br />
       to the server <StyledCode>{host}</StyledCode><br />
       <StyledConnectionFooter>
-        Connection credentials are stored in your web browser.
+        Connection credentials are {(storeCredentials ? '' : 'not ')}stored in your web browser.
       </StyledConnectionFooter>
     </StyledConnectionBody>
   )

--- a/src/browser/modules/Stream/Auth/ConnectionForm.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectionForm.jsx
@@ -24,6 +24,7 @@ import { withBus } from 'preact-suber'
 import { getActiveConnectionData, getActiveConnection, setActiveConnection, updateConnection, CONNECT } from 'shared/modules/connections/connectionsDuck'
 import { getInitCmd, updateBoltRouting } from 'shared/modules/settings/settingsDuck'
 import { executeSystemCommand } from 'shared/modules/commands/commandsDuck'
+import { shouldRetainConnectionCredentials } from 'shared/modules/dbMeta/dbMetaDuck'
 import { FORCE_CHANGE_PASSWORD } from 'shared/modules/cypher/cypherDuck'
 import { changeCurrentUsersPasswordQueryObj } from 'shared/modules/cypher/procedureFactory'
 import { toBoltHost, isRoutingHost } from 'services/utils'
@@ -151,6 +152,7 @@ export class ConnectionForm extends Component {
       view = <ConnectedView
         host={this.props.activeConnectionData.host}
         username={this.props.activeConnectionData.username}
+        storeCredentials={this.props.storeCredentials}
       />
     } else if (!this.state.isConnected && !this.state.passwordChangeNeeded) {
       view = (<ConnectForm
@@ -172,7 +174,8 @@ const mapStateToProps = (state) => {
   return {
     initCmd: getInitCmd(state),
     activeConnection: getActiveConnection(state),
-    activeConnectionData: getActiveConnectionData(state)
+    activeConnectionData: getActiveConnectionData(state),
+    storeCredentials: shouldRetainConnectionCredentials(state)
   }
 }
 
@@ -191,6 +194,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   return {
     activeConnection: stateProps.activeConnection,
     activeConnectionData: stateProps.activeConnectionData,
+    storeCredentials: stateProps.storeCredentials,
     ...ownProps,
     ...dispatchProps,
     executeInitCmd: () => {

--- a/src/shared/modules/connections/connectionsDuck.test.js
+++ b/src/shared/modules/connections/connectionsDuck.test.js
@@ -181,3 +181,44 @@ describe('connectionsDucks Epics', () => {
     store.dispatch(action)
   })
 })
+
+describe('retainCredentialsSettingsEpic', () => {
+  let store
+  beforeAll(() => {
+    store = mockStore({
+      connections: {
+        activeConnection: 'xxx',
+        connectionsById: {
+          xxx: {id: 'xxx', username: 'usr', password: 'pw'}
+        },
+        allConnectionIds: ['xxx']
+      }
+    })
+  })
+  afterEach(() => {
+    store.clearActions()
+    bus.reset()
+  })
+  test('Dispatches an action to remove credentials from localstorage', (done) => {
+    // Given
+    const action = connections.setRetainCredentials(false)
+    bus.take('NOOP', (currentAction) => {
+      // Then
+      expect(store.getActions()).toEqual([
+        action,
+        connections.updateConnection({
+          id: 'xxx',
+          username: '',
+          password: ''
+        })
+      ])
+      done()
+    })
+
+    // When
+    epicMiddleware.replaceEpic(connections.retainCredentialsSettingsEpic)
+    store.clearActions()
+
+    store.dispatch(action)
+  })
+})

--- a/src/shared/modules/connections/connectionsDuck.test.js
+++ b/src/shared/modules/connections/connectionsDuck.test.js
@@ -183,9 +183,13 @@ describe('connectionsDucks Epics', () => {
 })
 
 describe('retainCredentialsSettingsEpic', () => {
+  // Given
+  const epicMiddleware = createEpicMiddleware(connections.retainCredentialsSettingsEpic)
+  const myMockStore = configureMockStore([epicMiddleware, createReduxMiddleware(bus)])
   let store
   beforeAll(() => {
-    store = mockStore({
+    bus.reset()
+    store = myMockStore({
       connections: {
         activeConnection: 'xxx',
         connectionsById: {
@@ -210,15 +214,13 @@ describe('retainCredentialsSettingsEpic', () => {
           id: 'xxx',
           username: '',
           password: ''
-        })
+        }),
+        currentAction
       ])
       done()
     })
 
     // When
-    epicMiddleware.replaceEpic(connections.retainCredentialsSettingsEpic)
-    store.clearActions()
-
     store.dispatch(action)
   })
 })

--- a/src/shared/rootEpic.js
+++ b/src/shared/rootEpic.js
@@ -20,7 +20,7 @@
 
 import { combineEpics } from 'redux-observable'
 import { handleCommandsEpic, postConnectCmdEpic } from './modules/commands/commandsDuck'
-import { checkSettingsForRoutingDriver, connectEpic, disconnectEpic, startupConnectEpic, disconnectSuccessEpic, startupConnectionSuccessEpic, startupConnectionFailEpic, detectActiveConnectionChangeEpic, connectionLostEpic } from './modules/connections/connectionsDuck'
+import { retainCredentialsSettingsEpic, checkSettingsForRoutingDriver, connectEpic, disconnectEpic, startupConnectEpic, disconnectSuccessEpic, startupConnectionSuccessEpic, startupConnectionFailEpic, detectActiveConnectionChangeEpic, connectionLostEpic } from './modules/connections/connectionsDuck'
 import { dbMetaEpic, clearMetaOnDisconnectEpic } from './modules/dbMeta/dbMetaDuck'
 import { cancelRequestEpic } from './modules/requests/requestsDuck'
 import { discoveryOnStartupEpic } from './modules/discovery/discoveryDuck'
@@ -36,6 +36,7 @@ export default combineEpics(
   handleCommandsEpic,
   postConnectCmdEpic,
   connectionLostEpic,
+  retainCredentialsSettingsEpic,
   checkSettingsForRoutingDriver,
   connectEpic,
   disconnectEpic,

--- a/src/shared/services/bolt/boltHelpers.js
+++ b/src/shared/services/bolt/boltHelpers.js
@@ -68,3 +68,6 @@ export const getJmxValues = (nameAttributePairs = []) => {
       return null
     })
 }
+
+export const isConfigValTruthy = (val) => [true, 'true', 'yes', 1, '1'].indexOf(val) > -1
+export const isConfigValFalsy = (val) => [false, 'false', 'no', 0, '0'].indexOf(val) > -1

--- a/yarn.lock
+++ b/yarn.lock
@@ -5577,7 +5577,7 @@ redux-devtools@^3.2.0:
     lodash "^4.2.0"
     redux-devtools-instrument "^1.0.1"
 
-redux-mock-store@^1.2.2:
+redux-mock-store@^1.2.3:
   version "1.2.3"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/redux-mock-store/-/redux-mock-store-1.2.3.tgz#1b3ad299da91cb41ba30d68e3b6f024475fb9e1b"
 


### PR DESCRIPTION
On connect (and at the regular interval) read server config `browser.retain_connection_credentials`.
If set to a falsy value, remove persisted connection credentials from web browsers localstorage. 
Keep in memory to be able to use in a Causal clustered environment where new connections might be opened to run a query on every cluster member (`:queries` for example).

Show persist status on the `:server connect` frame.

Connect when set to false:
![oskar4j 2017-05-08 at 15 05 26](https://cloud.githubusercontent.com/assets/570998/25805444/f725a90e-33ff-11e7-9785-335212d16b81.png)


and true (default):
![oskar4j 2017-05-08 at 15 05 02](https://cloud.githubusercontent.com/assets/570998/25805449/fae20ac4-33ff-11e7-8d76-2eed9707ad28.png)
