### PR TITLE
Define URL to connect to with URL param 'connectURL'

### DIFF
--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -74,7 +74,7 @@ bus.applyMiddleware((_, origin) => (channel, message, source) => {
 })
 
 // Signal app upstart (for epics)
-store.dispatch({ type: APP_START })
+store.dispatch({ type: APP_START, url: window.location.href })
 
 const mountElement = document.getElementById('mount')
 let elem

--- a/src/shared/modules/discovery/discoveryDuck.js
+++ b/src/shared/modules/discovery/discoveryDuck.js
@@ -23,7 +23,9 @@ import remote from 'services/remote'
 import { hydrate } from 'services/duckUtils'
 import { updateConnection } from 'shared/modules/connections/connectionsDuck'
 import { APP_START, USER_CLEAR } from 'shared/modules/app/appDuck'
+import { updateBoltRouting } from 'shared/modules/settings/settingsDuck'
 import { getDiscoveryEndpoint } from 'services/bolt/boltHelpers'
+import { getUrlParamValue, toBoltHost, isRoutingHost } from 'services/utils'
 
 export const NAME = 'discover-bolt-host'
 export const CONNECTION_ID = '$$discovery'
@@ -63,7 +65,23 @@ export const getBoltHost = (state) => {
 
 export const discoveryOnStartupEpic = (some$, store) => {
   return some$.ofType(APP_START).merge(some$.ofType(USER_CLEAR))
+    .map((action) => {
+      if (action.type !== APP_START) return action // Only read on app startup
+      if (!action.url) return action
+      const passedURL = getUrlParamValue('connectURL', action.url)
+      if (!passedURL || !passedURL.length) return action
+      const forceURL = decodeURIComponent(passedURL[0])
+      action.forceURL = toBoltHost(forceURL) // Remove any protocol and prepend with bolt://
+      if (isRoutingHost(forceURL)) { // Set config to use routing if bolt+routing:// protocol
+        store.dispatch(updateBoltRouting(true))
+      }
+      return action
+    })
     .mergeMap((action) => {
+      if (action.forceURL) {
+        store.dispatch(updateDiscoveryConnection({ host: action.forceURL }))
+        return Promise.resolve()
+      }
       return Rx.Observable.fromPromise(
         remote.getJSON(getDiscoveryEndpoint()).then((result) => { // Try to get info from server
           if (!result || !result.bolt) {

--- a/src/shared/modules/discovery/discoveryDuck.test.js
+++ b/src/shared/modules/discovery/discoveryDuck.test.js
@@ -26,6 +26,7 @@ import nock from 'nock'
 
 import * as discovery from './discoveryDuck'
 import { APP_START } from 'shared/modules/app/appDuck'
+import { updateBoltRouting } from 'shared/modules/settings/settingsDuck'
 import { getDiscoveryEndpoint } from 'services/bolt/boltHelpers'
 
 const bus = createBus()
@@ -91,6 +92,41 @@ describe('discoveryOnStartupEpic', () => {
       expect(store.getActions()).toEqual([
         action,
         discovery.updateDiscoveryConnection({ host: expectedHost }),
+        { type: discovery.DONE }
+      ])
+      done()
+    })
+
+    // When
+    store.dispatch(action)
+  })
+  test('listens on APP_START and reads bolt URL from location URL and dispatches an action with the found host', (done) => {
+    // Given
+    const action = { type: APP_START, url: 'http://localhost/?connectURL=myhost:8888' }
+    const expectedURL = 'bolt://myhost:8888'
+    bus.take(discovery.DONE, (currentAction) => {
+      // Then
+      expect(store.getActions()).toEqual([
+        action,
+        discovery.updateDiscoveryConnection({ host: expectedURL }),
+        { type: discovery.DONE }
+      ])
+      done()
+    })
+
+    // When
+    store.dispatch(action)
+  })
+  test('listens on APP_START and reads bolt URL from location URL and dispatches an action with the found host, incl protocol', (done) => {
+    // Given
+    const action = { type: APP_START, url: 'http://localhost/?connectURL=bolt%2Brouting%3A%2F%2Fmyhost%3A8889' }
+    const expectedURL = 'bolt://myhost:8889'
+    bus.take(discovery.DONE, (currentAction) => {
+      // Then
+      expect(store.getActions()).toEqual([
+        action,
+        updateBoltRouting(true),
+        discovery.updateDiscoveryConnection({ host: expectedURL }),
         { type: discovery.DONE }
       ])
       done()

--- a/src/shared/modules/editor/editorDuck.js
+++ b/src/shared/modules/editor/editorDuck.js
@@ -33,11 +33,12 @@ export const setContent = (newContent) => ({ type: SET_CONTENT, message: newCont
 export const populateEditorFromUrlEpic = (some$, store) => {
   return some$.ofType(APP_START)
     .delay(1) // Timing issue. Needs to be detached like this
-    .mergeMap(() => {
-      const cmdParam = getUrlParamValue('cmd', window.location.href)
+    .mergeMap((action) => {
+      if (!action.url) return Rx.Observable.never()
+      const cmdParam = getUrlParamValue('cmd', action.url)
       if (!cmdParam || cmdParam[0] !== 'play') return Rx.Observable.never()
       const cmdCommand = getSettings(store.getState()).cmdchar + cmdParam[0]
-      const cmdArgs = getUrlParamValue('arg', decodeURIComponent(window.location.href)) || []
+      const cmdArgs = getUrlParamValue('arg', decodeURIComponent(action.url)) || []
       const fullCommand = `${cmdCommand} ${cmdArgs.join(' ')}`
       return Rx.Observable.of({ type: SET_CONTENT, ...setContent(fullCommand) })
     })


### PR DESCRIPTION
When Neo4j Browser is served from Neo4j Server the bolt url is auto discovered through a request to Neo4j Server `GET /`.
In the case of a externally hosted Neo4j Browser it can make connecting to Neo4j easier if a connect url can be passed along with the link to Neo4j Browser.

Example: `http://browser.neo4j.com/?connectURL=neo4jdb.xxyyzz.com:26000`.
If a hosted Neo4j Browser was available on `http://browser.neo4j.com` it would set the bolt url to `neo4jdb.xxyyzz.com:26000` and try to connect.

If no protocol is prepended the host, `bolt://` is assumed. If protocol is `bolt+routing://`, user settings `useBoltRouting` is set to `true` to enable routing when it's available.

A refactor of how to get the current url is in this as well.
To make the epics testable the action `APP_START` passes along the current url.