### PR TITLE
Fix missing scrollbars in left drawer in some web browsers

### DIFF
--- a/src/browser/modules/App/styled.jsx
+++ b/src/browser/modules/App/styled.jsx
@@ -44,6 +44,7 @@ export const StyledBody = styled.div`
   flex: auto;
   display: flex;
   flex-direction: row;
+  height: inherit;
 `
 
 export const StyledMainWrapper = styled.div`


### PR DESCRIPTION
Fixes #512 

Can you tell the different browsers apart? 😸 
Firefox in Mac OS and MS Edge also had this behavior.
Scrollbar visible on all screenshots below.

![oskar4j 2017-05-16 at 16 35 00](https://cloud.githubusercontent.com/assets/570998/26111724/2a87a8ea-3a56-11e7-9024-1f2520839191.png)

