### PR TITLE
Make the Browser commands case insensitive

### DIFF
--- a/src/browser/modules/Stream/HelpFrame.jsx
+++ b/src/browser/modules/Stream/HelpFrame.jsx
@@ -22,6 +22,7 @@ import Slide from '../Guides/Slide'
 import * as html from '../Help/html'
 import Directives from 'browser-components/Directives'
 import FrameTemplate from './FrameTemplate'
+import { splitStringOnFirst } from 'services/commandUtils'
 
 const HelpFrame = ({frame}) => {
   const snakeToCamel = (string) => string.replace(/(-\w)/g, (match) => { return match[1].toUpperCase() })
@@ -30,7 +31,7 @@ const HelpFrame = ({frame}) => {
   if (frame.result) {
     help = <Slide html={frame.result} />
   } else {
-    const helpTopic = snakeToCamel('_' + (frame.cmd.replace(':help', '').trim().toLowerCase() || 'help')) // Empty means ':help help'
+    const helpTopic = snakeToCamel('_' + (splitStringOnFirst(frame.cmd, ' ')[1].toLowerCase() || 'help')) // Empty means ':help help'
     if (helpTopic !== '') {
       const content = html.default[helpTopic]
       if (content !== undefined) {

--- a/src/browser/modules/Stream/PlayFrame.jsx
+++ b/src/browser/modules/Stream/PlayFrame.jsx
@@ -21,13 +21,14 @@
 import Guides from '../Guides/Guides'
 import * as html from '../Guides/html'
 import FrameTemplate from './FrameTemplate'
+import { splitStringOnFirst } from 'services/commandUtils'
 
 const PlayFrame = ({frame}) => {
   let guide = 'Play guide not specified'
   if (frame.result) {
     guide = <Guides withDirectives html={frame.result} />
   } else {
-    const guideName = frame.cmd.replace(':play', '').replace(/\s|-/g, '').trim() || 'start'
+    const guideName = splitStringOnFirst(frame.cmd, ' ')[1].toLowerCase() || 'start'
     if (guideName !== '') {
       const content = html[guideName]
       if (content !== undefined) {

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -235,7 +235,7 @@ const availableCommands = [{
 const interpret = (cmd) => {
   return availableCommands.reduce((match, candidate) => {
     if (match) return match
-    const isMatch = candidate.match(cmd)
+    const isMatch = candidate.match(cmd.toLowerCase())
     return isMatch ? candidate : null
   }, null)
 }

--- a/src/shared/services/commandInterpreterHelper.test.js
+++ b/src/shared/services/commandInterpreterHelper.test.js
@@ -82,5 +82,17 @@ describe('commandInterpreterHelper', () => {
       // Then
       expect(actualCommandName).toEqual(expectedCommandName)
     })
+
+    test('should be case insensitive for browser commands', () => {
+      // Given
+      const cmd = 'PlaY anyThing'
+      const expectedCommandName = 'play'
+
+      // When
+      const actualCommandName = helper.interpret(cmd).name
+
+      // Then
+      expect(actualCommandName).toEqual(expectedCommandName)
+    })
   })
 })


### PR DESCRIPTION
The commands are now case insensitive `:play` -> `:PlAy` and the parameters for `play` and `help` topics are case insensitive `:play cypher` -> `:PlAy CyPhEr`
![screen shot 2017-05-16 at 16 11 56](https://cloud.githubusercontent.com/assets/849508/26114603/9a58f33c-3a55-11e7-8909-e317186ef147.png)
