### PR TITLE
Fix typo in SysInfoFrame.jsx

### DIFF
--- a/src/browser/modules/Stream/SysInfoFrame.jsx
+++ b/src/browser/modules/Stream/SysInfoFrame.jsx
@@ -140,7 +140,7 @@ export class SysInfoFrame extends Component {
       ],
         'idAllocation': [
           <SysInfoTableEntry label='Node ID' value={primitive.NumberOfNodeIdsInUse} />,
-          <SysInfoTableEntry label='Propery ID' value={primitive.NumberOfPropertyIdsInUse} />,
+          <SysInfoTableEntry label='Property ID' value={primitive.NumberOfPropertyIdsInUse} />,
           <SysInfoTableEntry label='Relationship ID' value={primitive.NumberOfRelationshipIdsInUse} />,
           <SysInfoTableEntry label='Relationship Type ID' value={primitive.NumberOfRelationshipTypeIdsInUse} />
         ],


### PR DESCRIPTION
This is a very simple typo-change (hopefully I didn't break any contribution protocol 😃 )

I changed "Propery ID" to "Property ID":

![image](https://cloud.githubusercontent.com/assets/225374/26189360/99236ccc-3ba4-11e7-9289-2f827173fe95.png)
