### PR TITLE
Only strip comments and empty lines from `:`-commands

### DIFF
--- a/src/browser/modules/Stream/FrameTitlebar.jsx
+++ b/src/browser/modules/Stream/FrameTitlebar.jsx
@@ -73,7 +73,7 @@ class FrameTitlebar extends Component {
     return (
       <StyledFrameTitleBar>
         <StyledFrameCommand>
-          <DottedLineHover onClick={() => props.onTitlebarClick(cmd)}>
+          <DottedLineHover onClick={() => props.onTitlebarClick(frame.cmd)}>
             {cmd}
           </DottedLineHover>
         </StyledFrameCommand>

--- a/src/shared/modules/commands/commandsDuck.js
+++ b/src/shared/modules/commands/commandsDuck.js
@@ -111,7 +111,7 @@ export const handleCommandsEpic = (action$, store) =>
     })
     .mergeMap(({action, interpreted, cmdchar}) => {
       return new Promise((resolve, reject) => {
-        action.cmd = cleanCommand(action.cmd)
+        if (interpreted.name !== 'cypher') action.cmd = cleanCommand(action.cmd)
         const res = interpreted.exec(action, cmdchar, store.dispatch, store)
         const noop = { type: 'NOOP' }
         if (!res || !res.then) {

--- a/src/shared/modules/commands/commandsDuck.test.js
+++ b/src/shared/modules/commands/commandsDuck.test.js
@@ -239,10 +239,10 @@ describe('commandsDuck', () => {
           addHistory(cmd, maxHistory),
           { type: commands.KNOWN_COMMAND },
           send('cypher', requestId),
-          commands.cypher(actualCommand),
+          commands.cypher(cmd),
           frames.add({...action, type: 'cypher'}),
           updateQueryResult(requestId, createErrorObject(BoltConnectionError), 'error'),
-          commands.unsuccessfulCypher(actualCommand),
+          commands.unsuccessfulCypher(cmd),
           { type: 'NOOP' }
         ])
         done()


### PR DESCRIPTION
This could be seen as a short term fix to bring back the desired behavior.
The real fix would be to not strip anything from any command and leave that responability to every interpreter.

This also populates the editor with the original query (incl. empty lines and comments) when clicking the frame titlebar. Only for Cypher queries though.

Before this fix, 

```
WITH 1 as One
//Comment
RETURN One
```

would yield and error.