### PR TITLE
Server status frame implementation

### DIFF
--- a/src/browser/modules/Stream/Auth/ConnectedView.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectedView.jsx
@@ -19,12 +19,15 @@
  */
 
 import { StyledConnectionBody, StyledCode, StyledConnectionFooter } from './styled'
+import Visible from 'browser-components/Visible'
 
-const ConnectedView = ({host, username, storeCredentials}) => {
+const ConnectedView = ({host, username, storeCredentials, showHost = true}) => {
   return (
     <StyledConnectionBody>
       You are connected as user <StyledCode>{username}</StyledCode><br />
-      to the server <StyledCode>{host}</StyledCode><br />
+      <Visible if={showHost}>
+        <span>to the server <StyledCode>{host}</StyledCode><br /></span>
+      </Visible>
       <StyledConnectionFooter>
         Connection credentials are {(storeCredentials ? '' : 'not ')}stored in your web browser.
       </StyledConnectionFooter>

--- a/src/browser/modules/Stream/Auth/ServerStatusFrame.jsx
+++ b/src/browser/modules/Stream/Auth/ServerStatusFrame.jsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Component } from 'preact'
+import { connect } from 'preact-redux'
+import FrameTemplate from '../FrameTemplate'
+import {
+  StyledConnectionFrame,
+  StyledConnectionAside,
+  StyledConnectionBodyContainer,
+  StyledConnectionBody
+} from './styled'
+import ConnectedView from './ConnectedView'
+import {H3} from 'browser-components/headers'
+import Visible from 'browser-components/Visible'
+import { getActiveConnectionData, getActiveConnection } from 'shared/modules/connections/connectionsDuck'
+import { shouldRetainConnectionCredentials } from 'shared/modules/dbMeta/dbMetaDuck'
+
+class ServerStatusFrame extends Component {
+  render () {
+    const { frame, activeConnectionData, storeCredentials } = this.props
+
+    return (
+      <FrameTemplate
+        header={frame}
+        contents={
+          <StyledConnectionFrame>
+            <StyledConnectionAside>
+              <span>
+                <H3>Connection status</H3>
+                This is your current server connection information.
+              </span>
+            </StyledConnectionAside>
+            <StyledConnectionBodyContainer>
+              <Visible if={!activeConnectionData}>
+                <StyledConnectionBody>You are not connected to the server.
+                </StyledConnectionBody>
+              </Visible>
+              <Visible if={activeConnectionData && activeConnectionData.authEnabled}>
+                <ConnectedView username={activeConnectionData && activeConnectionData.username}
+                               showHost={false} storeCredentials={storeCredentials}/>
+              </Visible>
+              <Visible if={activeConnectionData && !activeConnectionData.authEnabled}>
+                <StyledConnectionBody>You have a working connection with the Neo4j database and server auth is disabled.
+                </StyledConnectionBody>
+              </Visible>
+            </StyledConnectionBodyContainer>
+          </StyledConnectionFrame>
+        }
+      />
+    )
+  }
+}
+
+const mapStateToProps = (state) => {
+  return {
+    activeConnection: getActiveConnection(state),
+    activeConnectionData: getActiveConnectionData(state),
+    storeCredentials: shouldRetainConnectionCredentials(state)
+  }
+}
+
+export default connect(mapStateToProps, null)(ServerStatusFrame)

--- a/src/browser/modules/Stream/Stream.jsx
+++ b/src/browser/modules/Stream/Stream.jsx
@@ -35,6 +35,7 @@ import SchemaFrame from './SchemaFrame'
 import SysInfoFrame from './SysInfoFrame'
 import ConnectionFrame from './Auth/ConnectionFrame'
 import DisconnectFrame from './Auth/DisconnectFrame'
+import ServerStatusFrame from './Auth/ServerStatusFrame'
 import ChangePasswordFrame from './Auth/ChangePasswordFrame'
 import QueriesFrame from './Queries/QueriesFrame'
 import UserList from '../User/UserList'
@@ -63,6 +64,7 @@ const getFrame = (type) => {
     help: HelpFrame,
     queries: QueriesFrame,
     sysinfo: SysInfoFrame,
+    status: ServerStatusFrame,
     default: Frame
   }
   return trans[type] || trans['default']

--- a/src/shared/modules/commands/helpers/server.js
+++ b/src/shared/modules/commands/helpers/server.js
@@ -44,6 +44,9 @@ export function handleServerCommand (action, cmdchar, put, store) {
   if (serverCmd === 'change-password') {
     return handleChangePasswordCommand(action, props, cmdchar)
   }
+  if (serverCmd === 'status') {
+    return handleServerStatusCommand(action)
+  }
   return {...action, type: 'error', error: {message: getErrorMessage(UnknownCommandError(action.cmd))}}
 }
 
@@ -99,4 +102,8 @@ function handleServerAddCommand (action, cmdchar, put, store) {
   put(connections.addConnection({name, username, password, host}))
   const state = store.getState()
   return {...action, type: 'pre', result: JSON.stringify(connections.getConnections(state), null, 2)}
+}
+
+function handleServerStatusCommand (action) {
+  return {...action, type: 'status'}
 }

--- a/src/shared/modules/connections/connectionsDuck.js
+++ b/src/shared/modules/connections/connectionsDuck.js
@@ -42,6 +42,7 @@ export const DISCONNECTION_SUCCESS = 'connections/DISCONNECTION_SUCCESS'
 export const LOST_CONNECTION = 'connections/LOST_CONNECTION'
 export const UPDATE_CONNECTION_STATE = 'connections/UPDATE_CONNECTION_STATE'
 export const UPDATE_RETAIN_CREDENTIALS = NAME + '/UPDATE_RETAIN_CREDENTIALS'
+export const UPDATE_AUTH_ENABLED = NAME + '/UPDATE_AUTH_ENABLED'
 
 export const DISCONNECTED_STATE = 0
 export const CONNECTED_STATE = 1
@@ -141,6 +142,23 @@ const mergeConnectionHelper = (state, connection) => {
   )
 }
 
+const updateAuthEnabledHelper = (state, authEnabled) => {
+  const connectionId = state.activeConnection
+  const updatedConnection = Object.assign(
+    {},
+    state.connectionsById[connectionId],
+    { authEnabled: authEnabled }
+  )
+  const updatedConnectionByIds = Object.assign({}, state.connectionsById)
+  updatedConnectionByIds[connectionId] = updatedConnection
+
+  return Object.assign(
+    {},
+    state,
+    {connectionsById: updatedConnectionByIds}
+  )
+}
+
 // Local vars
 let memoryUsername = ''
 let memoryPassword = ''
@@ -162,6 +180,8 @@ export default function (state = initialState, action) {
       return mergeConnectionHelper(state, action.connection)
     case UPDATE_CONNECTION_STATE:
       return {...state, connectionState: action.state}
+    case UPDATE_AUTH_ENABLED:
+      return updateAuthEnabledHelper(state, action.authEnabled)
     case USER_CLEAR:
       return initialState
     default:
@@ -226,6 +246,13 @@ export const setRetainCredentials = (shouldRetain) => {
   return {
     type: UPDATE_RETAIN_CREDENTIALS,
     shouldRetain
+  }
+}
+
+export const setAuthEnabled = (authEnabled) => {
+  return {
+    type: UPDATE_AUTH_ENABLED,
+    authEnabled
   }
 }
 


### PR DESCRIPTION
The frame showing server status which is called by ':server status'
It presents information about connected user (only if authentication enabled), either authentication is enabled (dbms.security.auth_enabled) and connection credentials are stored in the local storage (browser.retain_connection_credentials=false)

<img width="887" alt="screen shot 2017-05-18 at 15 13 32" src="https://cloud.githubusercontent.com/assets/6452321/26206382/9554f27c-3bdc-11e7-996f-0994afbd376c.png">

<img width="1135" alt="screen shot 2017-05-18 at 15 16 21" src="https://cloud.githubusercontent.com/assets/6452321/26206538/fefc0224-3bdc-11e7-882a-d3d39c777043.png">
