### PR TITLE
Present total db hits and time stats in PROFILE View

### DIFF
--- a/src/browser/modules/Stream/CypherFrame.jsx
+++ b/src/browser/modules/Stream/CypherFrame.jsx
@@ -72,7 +72,7 @@ class CypherFrame extends Component {
         const untransformedRows = bolt.recordsToTableArray(this.getRecordsToDisplay(nextProps.request.result.records), false)
         serializedPropertiesRows = bolt.stringifyRows(untransformedRows)
       }
-      plan = bolt.extractPlan(nextProps.request.result)
+      plan = bolt.extractPlan(nextProps.request.result, true)
       warnings = nextProps.request.result.summary ? nextProps.request.result.summary.notifications : null
 
       this.decideOpeningView({plan, nodesAndRelationships, warnings, props: nextProps})
@@ -160,7 +160,7 @@ class CypherFrame extends Component {
             this.changeView(viewTypes.TEXT)
           }}><AsciiIcon /></CypherFrameButton>
         </Visible>
-        <Visible if={(this.state.plan || bolt.extractPlan(this.props.request.result || false)) && !this.state.errors}>
+        <Visible if={(this.state.plan || bolt.extractPlan(this.props.request.result || false, true)) && !this.state.errors}>
           <CypherFrameButton selected={this.state.openView === viewTypes.PLAN} onClick={() =>
             this.changeView(viewTypes.PLAN)
           }><PlanIcon /></CypherFrameButton>
@@ -226,7 +226,7 @@ class CypherFrame extends Component {
   render () {
     const frame = this.props.frame
     const result = this.props.request.result || false
-    const plan = this.state.plan || bolt.extractPlan(result)
+    const plan = this.state.plan || bolt.extractPlan(result, true)
     const requestStatus = this.props.request.status
 
     let frameContents = <pre>{JSON.stringify(result, null, 2)}</pre>
@@ -251,6 +251,7 @@ class CypherFrame extends Component {
           <StyledStatsBar>
             <Ellipsis>
               Cypher version: {plan.root.version}, planner: {plan.root.planner}, runtime: {plan.root.runtime}.
+              { plan.root.totalDbHits ? ` ${plan.root.totalDbHits} total db hits in ${result.summary.resultAvailableAfter.add(result.summary.resultConsumedAfter).toNumber() || 0} ms.` : ``}
             </Ellipsis>
           </StyledStatsBar>
         )

--- a/src/shared/services/bolt/bolt.js
+++ b/src/shared/services/bolt/bolt.js
@@ -222,8 +222,8 @@ export default {
     const intConverter = (val) => val.toString()
     return mappings.extractNodesAndRelationshipsFromRecordsForOldVis(records, neo4j.types, filterRels, { intChecker, intConverter, objectConverter: mappings.extractFromNeoObjects })
   },
-  extractPlan: (result) => {
-    return mappings.extractPlan(result)
+  extractPlan: (result, calculateTotalDbHits) => {
+    return mappings.extractPlan(result, calculateTotalDbHits)
   },
   retrieveFormattedUpdateStatistics: mappings.retrieveFormattedUpdateStatistics,
   itemIntToNumber: (item) => mappings.itemIntToString(item, { intChecker: neo4j.isInt, intConverter: (val) => val.toNumber() }),


### PR DESCRIPTION
Accumulate **db hits** in a query plan when profiling and present them in PROFILE View as below.

<img width="660" alt="screen shot 2017-05-19 at 13 23 41" src="https://cloud.githubusercontent.com/assets/6452321/26247698/fa37c39e-3c96-11e7-9ae0-ef0658f2e218.png">
