### PR TITLE
Fix broken elapsed time in :queries frame

### DIFF
--- a/src/browser/modules/Stream/Queries/QueriesFrame.jsx
+++ b/src/browser/modules/Stream/Queries/QueriesFrame.jsx
@@ -19,9 +19,10 @@
  */
 
 import {Component} from 'preact'
-import FrameTemplate from '../FrameTemplate'
 import {connect} from 'preact-redux'
 import {withBus} from 'preact-suber'
+import FrameTemplate from '../FrameTemplate'
+import bolt from 'services/bolt/bolt'
 import {listQueriesProcedure, killQueriesProcedure} from 'shared/modules/cypher/queriesProcedureHelper'
 import {getAvailableProcedures} from 'shared/modules/features/featuresDuck'
 import {CYPHER_REQUEST, CLUSTER_CYPHER_REQUEST, AD_HOC_CYPHER_REQUEST} from 'shared/modules/cypher/cypherDuck'
@@ -111,7 +112,7 @@ export class QueriesFrame extends Component {
     return result.records.map((queryRecord) => {
       let queryInfo = {}
       queryRecord.keys.forEach((key, idx) => {
-        queryInfo[key] = queryRecord._fields[idx]
+        queryInfo[key] = bolt.itemIntToNumber(queryRecord._fields[idx])
       })
       if (queryRecord.host) {
         queryInfo.host = 'bolt://' + queryRecord.host
@@ -167,7 +168,7 @@ export class QueriesFrame extends Component {
           <StyledTd title={query.query} width={tableHeaderSizes[2][1]}><Code>{query.query}</Code></StyledTd>
           <StyledTd width={tableHeaderSizes[3][1]}><Code>{query.parameters}</Code></StyledTd>
           <StyledTd width={tableHeaderSizes[4][1]}><Code>{query.metaData}</Code></StyledTd>
-          <StyledTd width={tableHeaderSizes[5][1]}>{query.elapsedTime}</StyledTd>
+          <StyledTd width={tableHeaderSizes[5][1]}>{query.elapsedTimeMillis} ms</StyledTd>
           <StyledTd width={tableHeaderSizes[6][1]}><ConfirmationButton
             onConfirmed={this.onCancelQuery.bind(this, query.host, query.queryId)} /></StyledTd>
         </tr>)


### PR DESCRIPTION
Property name have changed from `query.elapsedTime ` -> `query.elapsedTimeMillis` and the type have changed to be neo4j integers.