### PR TITLE
Listen for config maxFrames and enforce that limit in stream

### DIFF
--- a/src/browser/modules/Sidebar/Settings.jsx
+++ b/src/browser/modules/Sidebar/Settings.jsx
@@ -54,6 +54,12 @@ const visualSettings =
       title: 'Result Frames',
       settings: [
         {
+          maxFrames: {
+            displayName: 'Maximum number of result frames',
+            tooltip: 'Max number of result frames. When reached, old frames gets retired.'
+          }
+        },
+        {
           maxHistory: {
             displayName: 'Max History',
             tooltip: 'Max number of history entries. When reached, old entries gets retired.'

--- a/src/shared/modules/settings/settingsDuck.js
+++ b/src/shared/modules/settings/settingsDuck.js
@@ -65,7 +65,8 @@ const initialState = {
   maxRows: 1000,
   shouldReportUdc: true,
   autoComplete: true,
-  scrollToTop: true
+  scrollToTop: true,
+  maxFrames: 30
 }
 
 export default function settings (state = initialState, action) {

--- a/src/shared/modules/stream/__snapshots__/streamDuck.test.js.snap
+++ b/src/shared/modules/stream/__snapshots__/streamDuck.test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`streamDuck cuts the number of frames when config is set 1`] = `
+Array [
+  1,
+]
+`;
+
+exports[`streamDuck cuts the number of frames when config is set 2`] = `
+Object {
+  "1": Object {
+    "id": 1,
+  },
+}
+`;
+
+exports[`streamDuck dont remove pinned frames when cutting frames 1`] = `
+Array [
+  1,
+  2,
+]
+`;
+
+exports[`streamDuck dont remove pinned frames when cutting frames 2`] = `
+Object {
+  "1": Object {
+    "isPinned": 1,
+  },
+  "2": Object {
+    "isPinned": 1,
+  },
+}
+`;

--- a/src/shared/modules/stream/epics.test.js
+++ b/src/shared/modules/stream/epics.test.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* global describe, afterEach, test, expect, beforeAll */
+import configureMockStore from 'redux-mock-store'
+import { createEpicMiddleware } from 'redux-observable'
+import { createBus, createReduxMiddleware } from 'suber'
+
+import * as stream from './streamDuck'
+import { update as updateSettings } from 'shared/modules/settings/settingsDuck'
+
+const bus = createBus()
+const epicMiddleware = createEpicMiddleware(stream.maxFramesConfigEpic)
+const mockStore = configureMockStore([epicMiddleware, createReduxMiddleware(bus)])
+
+describe('streamDuckEpics', () => {
+  let store
+  beforeAll(() => {
+    store = mockStore({
+      settings: {
+        cmdchar: ':',
+        maxFrames: 50
+      },
+      frames: {
+        allIds: [],
+        byId: {},
+        maxFrames: 50
+      }
+    })
+  })
+  afterEach(() => {
+    store.clearActions()
+    bus.reset()
+  })
+
+  test('listens on UPDATE and sets new maxFrames', (done) => {
+    // Given
+    const action = updateSettings({maxFrames: 3})
+    bus.take('NOOP', (currentAction) => {
+      // Then
+      expect(store.getActions()).toEqual([
+        action,
+        { type: stream.SET_MAX_FRAMES, maxFrames: 3 },
+        { type: 'NOOP' }
+      ])
+      done()
+    })
+
+    // When
+    store.dispatch(action)
+  })
+})

--- a/src/shared/modules/stream/streamDuck.test.js
+++ b/src/shared/modules/stream/streamDuck.test.js
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* global describe, test, expect */
+import reducer, { add, SET_MAX_FRAMES, initialState } from './streamDuck'
+
+describe('streamDuck', () => {
+  test('limits the number of frames in the reducer', () => {
+    // Given
+    const init = {...initialState, maxFrames: 1}
+    const action = add({cmd: 'xxx', id: 1})
+    const action2 = add({cmd: 'yyy', id: 2})
+
+    // When
+    const newState = reducer(init, action)
+
+    // Then
+    expect(newState.allIds.length).toBe(1)
+
+    // When
+    const newState2 = reducer(newState, action2)
+
+    // Then
+    expect(newState2.allIds.length).toBe(1)
+  })
+  test('cuts the number of frames when config is set', () => {
+    // Given
+    const init = {...initialState, maxFrames: 2, allIds: [1, 2], byId: {'1': {id: 1}, '2': {id: 2}}}
+    const action = { type: SET_MAX_FRAMES, maxFrames: 1 }
+
+    // When
+    const newState = reducer(init, action)
+
+    // Then
+    expect(newState.allIds.length).toBe(1)
+    expect(newState.allIds).toMatchSnapshot()
+    expect(newState.byId).toMatchSnapshot()
+  })
+  test('dont remove pinned frames when cutting frames', () => {
+    // Given
+    const byId = {'1': {isPinned: 1}, '2': {isPinned: 1}}
+    const init = {...initialState, maxFrames: 2, allIds: [1, 2], byId}
+    const action = { type: SET_MAX_FRAMES, maxFrames: 1 }
+
+    // When
+    const newState = reducer(init, action)
+
+    // Then
+    expect(newState.allIds.length).toBe(2)
+    expect(newState.allIds).toMatchSnapshot()
+    expect(newState.byId).toMatchSnapshot()
+  })
+})

--- a/src/shared/rootEpic.js
+++ b/src/shared/rootEpic.js
@@ -31,6 +31,7 @@ import { featuresDiscoveryEpic } from './modules/features/featuresDuck'
 import { syncItemsEpic, clearSyncEpic, syncFavoritesEpic, loadFavoritesFromSyncEpic, loadFoldersFromSyncEpic, syncFoldersEpic } from './modules/sync/syncDuck'
 import { credentialsTimeoutEpic } from './modules/credentialsPolicy/credentialsPolicyDuck'
 import { bootEpic, incrementEventEpic, udcStartupEpic, trackSyncLogoutEpic, trackConnectsEpic, eventFiredEpic } from './modules/udc/udcDuck'
+import { maxFramesConfigEpic } from './modules/stream/streamDuck'
 
 export default combineEpics(
   handleCommandsEpic,
@@ -68,5 +69,6 @@ export default combineEpics(
   incrementEventEpic,
   trackSyncLogoutEpic,
   trackConnectsEpic,
-  eventFiredEpic
+  eventFiredEpic,
+  maxFramesConfigEpic
 )


### PR DESCRIPTION
Will not affect pinned frames.
I separated the epic tests from reducer tests because I think it gets messy with both of them in the same file.