### PR TITLE
Add fullscreen ability to guide frames

### DIFF
--- a/src/browser/modules/Stream/FrameTitlebar.jsx
+++ b/src/browser/modules/Stream/FrameTitlebar.jsx
@@ -91,7 +91,7 @@ class FrameTitlebar extends Component {
             props.togglePin()
             props.togglePinning(frame.id, frame.isPinned)
           }} pressed={props.pinned}><PinIcon /></FrameButton>
-          <Visible if={frame.type === 'cypher'}>
+          <Visible if={['cypher', 'play', 'play-remote'].indexOf(frame.type) > -1}>
             <FrameButton title={(props.fullscreen) ? 'Close fullscreen' : 'Fullscreen'} onClick={() => props.fullscreenToggle()}>{fullscreenIcon}</FrameButton>
           </Visible>
           <FrameButton title={(props.collapse) ? 'Expand' : 'Collapse'}onClick={() => props.collapseToggle()}>{expandCollapseIcon}</FrameButton>


### PR DESCRIPTION
Actually makes the guides (carousel) look worse. But there's a card for that.

![oskar4j 2017-05-22 at 22 05 08](https://cloud.githubusercontent.com/assets/570998/26326257/c40e2852-3f3a-11e7-93f6-862264b9f770.png)
