### PR TITLE
Fix indicator being at start of line in error messages

### DIFF
--- a/src/browser/modules/Stream/styled.jsx
+++ b/src/browser/modules/Stream/styled.jsx
@@ -216,7 +216,7 @@ export const StyledBr = styled.br`
 export const StyledPreformattedArea = styled.pre`
   font-family: Monaco, "Courier New", Terminal, monospace;
   font-size: 14px;
-  white-space: pre-line;
+  white-space: pre-wrap;
   padding: 12px 16px;
   margin: 0;
   background: none;


### PR DESCRIPTION
But do keep the line wrapping of long messages.

Before:
![oskar4j 2017-05-22 at 22 45 19](https://cloud.githubusercontent.com/assets/570998/26327614/5c943a6c-3f40-11e7-93f2-12dc5a587e0c.png)


After:
![oskar4j 2017-05-22 at 22 44 20](https://cloud.githubusercontent.com/assets/570998/26327581/46b2ae4a-3f40-11e7-80a5-a0cc3bf20763.png)
