### PR TITLE
Fix for sensitive dropdown menu closing too easy

### DIFF
--- a/src/browser/modules/Stream/FrameTitlebar.jsx
+++ b/src/browser/modules/Stream/FrameTitlebar.jsx
@@ -30,7 +30,7 @@ import { FrameButton } from 'browser-components/buttons'
 import Visible from 'browser-components/Visible'
 import { CSVSerializer } from 'services/serializer'
 import { ExpandIcon, ContractIcon, RefreshIcon, CloseIcon, UpIcon, DownIcon, PinIcon, DownloadIcon } from 'browser-components/icons/Icons'
-import { StyledFrameTitleBar, StyledFrameCommand, DottedLineHover, FrameTitlebarButtonSection, DropdownContent, DropdownButton, DropdownItem } from './styled'
+import { StyledFrameTitleBar, StyledFrameCommand, DottedLineHover, FrameTitlebarButtonSection, DropdownList, DropdownContent, DropdownButton, DropdownItem } from './styled'
 import { downloadPNGFromSVG } from 'shared/services/exporting/pngUtils'
 
 const getCsvData = (exportData) => {
@@ -81,10 +81,12 @@ class FrameTitlebar extends Component {
           <Visible if={frame.type === 'cypher' && props.exportData}>
             <DropdownButton>
               <DownloadIcon />
-              <DropdownContent class='dropdown-content'>
-                <DropdownItem onClick={() => this.exportPNG()}>Export PNG</DropdownItem>
-                <DropdownItem download='export.csv' href={this.state.csvData}>Export CSV</DropdownItem>
-              </DropdownContent>
+              <DropdownList>
+                <DropdownContent>
+                  <DropdownItem onClick={() => this.exportPNG()}>Export PNG</DropdownItem>
+                  <DropdownItem download='export.csv' href={this.state.csvData}>Export CSV</DropdownItem>
+                </DropdownContent>
+              </DropdownList>
             </DropdownButton>
           </Visible>
           <FrameButton title='Pin at top' onClick={() => {

--- a/src/browser/modules/Stream/styled.jsx
+++ b/src/browser/modules/Stream/styled.jsx
@@ -275,10 +275,14 @@ export const DropdownButton = styled.li`
   }
   display: inline-block;
   &:hover {
-    > .dropdown-content {
+    > ul li {
     display: block;
     }
   };
+`
+
+export const DropdownList = styled.ul`
+
 `
 
 export const DropdownContent = styled.li`


### PR DESCRIPTION
Don't go `<li><li>xxx</li></li>`. Inner `<li>` should be wrapped by an `<ul>`.

![oskar4j 2017-05-22 at 23 03 56](https://cloud.githubusercontent.com/assets/570998/26328373/fcda63e6-3f42-11e7-86e3-45feaa9d4984.png)
