### PR TITLE
Escape backticks in meta item queries

### DIFF
--- a/src/shared/services/utils.js
+++ b/src/shared/services/utils.js
@@ -163,7 +163,7 @@ export const canUseDOM = () => !!(
   window.document && window.document.createElement)
 )
 
-export const ecsapeCypherMetaItem = (str) => /^[A-Za-z][A-Za-z0-9_]*$/.test(str) ? str : '`' + str + '`'
+export const ecsapeCypherMetaItem = (str) => /^[A-Za-z][A-Za-z0-9_]*$/.test(str) ? str : '`' + str.replace(/`/g, '``') + '`'
 
 export const stringifyMod = () => {
   const toString = Object.prototype.toString

--- a/src/shared/services/utils.test.js
+++ b/src/shared/services/utils.test.js
@@ -288,7 +288,8 @@ describe('utils', () => {
       { test: 'Label', expect: 'Label' },
       { test: 'Label Space', expect: '`Label Space`' },
       { test: 'Label1', expect: 'Label1' },
-      { test: 'Label-dash', expect: '`Label-dash`' }
+      { test: 'Label-dash', expect: '`Label-dash`' },
+      { test: 'Label`Backtick', expect: '`Label``Backtick`' }
     ]
 
     // When && Then


### PR DESCRIPTION


    MATCH(:`Label`Backtick`)
    // to
    MATCH(:`Label``Backtick`)