### PR TITLE
Introduce fetching client configuration from a remote JSON file

### DIFF
--- a/src/shared/modules/commands/commandsDuck.test.js
+++ b/src/shared/modules/commands/commandsDuck.test.js
@@ -206,6 +206,32 @@ describe('commandsDuck', () => {
       // Then
       // See above
     })
+
+    test('does the right thing for :config', (done) => {
+      // Given
+      const cmd = store.getState().settings.cmdchar + 'config'
+      const cmdString = cmd
+      const id = 1
+      const action = commands.executeCommand(cmdString, id)
+      bus.take('NOOP', (currentAction) => {
+        // Then
+        expect(store.getActions()).toEqual([
+          action,
+          addHistory(cmdString, maxHistory),
+          { type: commands.KNOWN_COMMAND },
+          frames.add({...action, type: 'pre', result: JSON.stringify({cmdchar: ':', maxHistory: 20}, null, 2)}),
+          { type: 'NOOP' }
+        ])
+        done()
+      })
+
+      // When
+      store.dispatch(action)
+
+      // Then
+      // See above
+    })
+
     test('does the right thing for list queries', (done) => {
       const cmd = store.getState().settings.cmdchar + 'queries'
       const id = 1

--- a/src/shared/modules/commands/helpers/config.js
+++ b/src/shared/modules/commands/helpers/config.js
@@ -35,7 +35,7 @@ export function handleUpdateConfigCommand (action, cmdchar, put, store) {
   const strippedCmd = action.cmd.substr(cmdchar.length)
   const parts = splitStringOnFirst(strippedCmd, ' ')
   const p = new Promise((resolve, reject) => {
-    if (parts[1] === undefined) return resolve(true) // Nothing to do
+    if (parts[1] === undefined || parts[1] === '') return resolve(true) // Nothing to do
     if (!isValidURL(parts[1].trim())) { // Not an URL. Parse as command line params
       const params = extractCommandParameters(`config`, strippedCmd)
       if (!params) return reject(new Error('Could not parse input. Usage: `:config x: 2`.'))
@@ -50,7 +50,7 @@ export function handleUpdateConfigCommand (action, cmdchar, put, store) {
     }
     getJSON(url)
       .then((res) => {
-        put(update(res))
+        put(replace(res))
         resolve(res)
       })
       .catch((e) => {

--- a/src/shared/modules/commands/helpers/config.js
+++ b/src/shared/modules/commands/helpers/config.js
@@ -19,7 +19,9 @@
  */
 
 import { getSettings, update } from 'shared/modules/settings/settingsDuck'
-import { extractCommandParameters } from 'services/commandUtils'
+import { extractCommandParameters, splitStringOnFirst } from 'services/commandUtils'
+import { getJSON } from 'services/remote'
+import { isValidURL } from 'shared/modules/commands/helpers/http'
 
 export function handleGetConfigCommand (action, cmdchar, store) {
   const settingsState = getSettings(store.getState())
@@ -29,6 +31,23 @@ export function handleGetConfigCommand (action, cmdchar, store) {
 
 export function handleUpdateConfigCommand (action, cmdchar, put, store) {
   const strippedCmd = action.cmd.substr(cmdchar.length)
-  const toBeSet = extractCommandParameters(`config`, strippedCmd)
-  put(update(toBeSet))
+  const parts = splitStringOnFirst(strippedCmd, ' ')
+  const p = new Promise((resolve, reject) => {
+    if (parts[1] === undefined) return resolve(true) // Nothing to do
+    if (!isValidURL(parts[1].trim())) { // Not an URL. Parse as command line params
+      const params = extractCommandParameters(`config`, strippedCmd)
+      if (!params) return reject(new Error('Could not parse input. Usage: `:config x: 2`.'))
+      put(update(params))
+      return resolve(params)
+    }
+    getJSON(parts[1].trim()) // It's an URL. Fetch it.
+      .then((res) => {
+        put(update(res))
+        resolve(res)
+      })
+      .catch((e) => {
+        reject(new Error(e))
+      })
+  })
+  return p
 }

--- a/src/shared/modules/commands/helpers/config.js
+++ b/src/shared/modules/commands/helpers/config.js
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { getSettings, update } from 'shared/modules/settings/settingsDuck'
+import { getSettings, update, replace } from 'shared/modules/settings/settingsDuck'
 import { extractCommandParameters, splitStringOnFirst } from 'services/commandUtils'
 import { getRemoteContentHostnameWhitelist } from 'shared/modules/dbMeta/dbMetaDuck'
 import { hostIsAllowed } from 'services/utils'

--- a/src/shared/modules/settings/__snapshots__/settingsDuck.test.js.snap
+++ b/src/shared/modules/settings/__snapshots__/settingsDuck.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`settings reducer handles REPLACE 1`] = `
+Object {
+  "autoComplete": true,
+  "browserSyncDebugServer": null,
+  "cmdchar": ":",
+  "editorAutocomplete": true,
+  "initCmd": ":play start",
+  "initialNodeDisplay": 300,
+  "maxFrames": 30,
+  "maxHistory": 30,
+  "maxNeighbours": 100,
+  "maxRows": 1000,
+  "new": "conf",
+  "scrollToTop": true,
+  "shouldReportUdc": true,
+  "showSampleScripts": true,
+  "theme": "normal",
+  "useBoltRouting": false,
+}
+`;

--- a/src/shared/modules/settings/settingsDuck.js
+++ b/src/shared/modules/settings/settingsDuck.js
@@ -23,6 +23,7 @@ import { hydrate } from 'services/duckUtils'
 
 export const NAME = 'settings'
 export const UPDATE = 'settings/UPDATE'
+export const REPLACE = 'settings/REPLACE'
 
 export const getSettings = (state) => state[NAME]
 export const getMaxHistory = (state) => state[NAME].maxHistory || initialState.maxHistory
@@ -77,6 +78,8 @@ export default function settings (state = initialState, action) {
   switch (action.type) {
     case UPDATE:
       return Object.assign({}, state, action.state)
+    case REPLACE:
+      return Object.assign({}, {...initialState}, action.state)
     case USER_CLEAR:
       return initialState
     default:
@@ -96,6 +99,13 @@ export const updateBoltRouting = (useRouting) => {
 export const update = (settings) => {
   return {
     type: UPDATE,
+    state: settings
+  }
+}
+
+export const replace = (settings) => {
+  return {
+    type: REPLACE,
     state: settings
   }
 }

--- a/src/shared/modules/settings/settingsDuck.test.js
+++ b/src/shared/modules/settings/settingsDuck.test.js
@@ -19,7 +19,7 @@
  */
 
 /* global describe, test, expect */
-import reducer, { NAME, UPDATE, shouldReportUdc } from './settingsDuck'
+import reducer, { NAME, UPDATE, REPLACE, shouldReportUdc } from './settingsDuck'
 import { dehydrate } from 'services/duckUtils'
 
 describe('settings reducer', () => {
@@ -52,6 +52,19 @@ describe('settings reducer', () => {
     expect(nextState.cmdchar).toEqual(':')
     expect(nextState.greeting).toEqual('woff')
     expect(nextState.type).toEqual('dog')
+  })
+  test('handles REPLACE', () => {
+    const initialState = { greeting: 'hello', type: 'human' }
+    const action = {
+      type: REPLACE,
+      state: {
+        'new': 'conf'
+      }
+    }
+    const nextState = dehydrate(reducer(initialState, action))
+    expect(nextState.greeting).toBeUndefined()
+    expect(nextState.type).toBeUndefined()
+    expect(nextState).toMatchSnapshot()
   })
 })
 

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -49,7 +49,12 @@ const availableCommands = [{
   match: (cmd) => /^config(\s|$)/.test(cmd),
   exec: function (action, cmdchar, put, store) {
     handleUpdateConfigCommand(action, cmdchar, put, store)
-    put(frames.add({...action, ...handleGetConfigCommand(action, cmdchar, store)}))
+      .then((res) => {
+        put(frames.add({...action, ...handleGetConfigCommand(action, cmdchar, store)}))
+      })
+      .catch((e) => {
+        put(showErrorMessage(e.message))
+      })
   }
 }, {
   name: 'set-param',

--- a/src/shared/services/remote.js
+++ b/src/shared/services/remote.js
@@ -46,7 +46,7 @@ function get (url) {
   })
 }
 
-function getJSON (url) {
+export function getJSON (url) {
   return fetch(url, {
     method: 'get',
     headers: {
@@ -55,7 +55,7 @@ function getJSON (url) {
   }).then((response) => {
     return response.json()
   }).catch((e) => {
-    return e
+    throw new Error(e)
   })
 }
 


### PR DESCRIPTION
### Intro 
This introduces the ability for a client to be configured by passing an URL to the `:config` command, like: `:config https://oskarhane-dropshare-eu.s3-eu-central-1.amazonaws.com/conf-GHrEFakccy/conf.json`

If successfully found config params, the `:config` frame shows up with the new config in it (just as before).
If any error occurs, an error banner shows up below the editor (new feature introduced with styling support).

## To discuss
Two questions that comes up are:

1. Should we restrict fetching hosts to only those in the whitelist? The `:style` command has no restriction on this.
1. Should we replace the current config, or merge as we do in the current state of this PR? We replace the `:style` when fetching a new one. We also replace all params when `:params {x:2}`.

@akollegger @pe4cey ^^

### Error banners 
User input error i.e. `:config x:`:  
<img width="827" alt="oskar4j 2017-05-24 at 11 46 40" src="https://cloud.githubusercontent.com/assets/570998/26397950/3885410a-4078-11e7-917f-00249ded50f5.png">

Error in remote json file format:  
<img width="830" alt="oskar4j 2017-05-24 at 11 40 32" src="https://cloud.githubusercontent.com/assets/570998/26397948/3859c886-4078-11e7-9a17-59fff44b7c26.png">

Error in remote server headers:  
<img width="820" alt="oskar4j 2017-05-24 at 11 47 26" src="https://cloud.githubusercontent.com/assets/570998/26397949/3884f06a-4078-11e7-9fa6-334d32a29768.png">


### Example files that can be used:

_(first, add `oskarhane-dropshare-eu.s3-eu-central-1.amazonaws.com` to your server config `browser.remote_content_hostname_whitelist`)_

Correct formatted file with only new config params:
`https://oskarhane-dropshare-eu.s3-eu-central-1.amazonaws.com/conf-eKM9GgLJCo/conf.json`

Correct formatted file with existing config params in it: 
`https://oskarhane-dropshare-eu.s3-eu-central-1.amazonaws.com/conf-GHrEFakccy/conf.json`

Invalid formatted file: 
`https://oskarhane-dropshare-eu.s3-eu-central-1.amazonaws.com/conf2-SX8pcCviMC/conf2.json`

Non allowed URL (due to their CORS headers): 
`http://google.com`