### PR TITLE
Transform :help topic input correctly

### DIFF
--- a/src/browser/modules/Stream/HelpFrame.jsx
+++ b/src/browser/modules/Stream/HelpFrame.jsx
@@ -22,16 +22,14 @@ import Slide from '../Guides/Slide'
 import * as html from '../Help/html'
 import Directives from 'browser-components/Directives'
 import FrameTemplate from './FrameTemplate'
-import { splitStringOnFirst } from 'services/commandUtils'
+import { transformCommandToHelpTopic } from 'services/commandUtils'
 
 const HelpFrame = ({frame}) => {
-  const snakeToCamel = (string) => string.replace(/(-\w)/g, (match) => { return match[1].toUpperCase() })
-
   let help = 'Help topic not specified'
   if (frame.result) {
     help = <Slide html={frame.result} />
   } else {
-    const helpTopic = snakeToCamel('_' + (splitStringOnFirst(frame.cmd, ' ')[1].toLowerCase() || 'help')) // Empty means ':help help'
+    const helpTopic = transformCommandToHelpTopic(frame.cmd)
     if (helpTopic !== '') {
       const content = html.default[helpTopic]
       if (content !== undefined) {

--- a/src/shared/services/commandUtils.js
+++ b/src/shared/services/commandUtils.js
@@ -103,3 +103,21 @@ export const extractPostConnectCommandsFromServerConfig = (str) => {
     .filter((item) => item && item.length)
   return splitted && splitted.length ? splitted : undefined
 }
+
+const getHelpTopic = (str) => splitStringOnFirst(str, ' ')[1] || 'help' // Map empty input to :help help
+const lowerCase = (str) => str.toLowerCase()
+const trim = (str) => str.trim()
+const replaceSpaceWithDash = (str) => str.replace(/\s/g, '-')
+const snakeToCamel = (str) => str.replace(/(-\w)/g, (match) => match[1].toUpperCase())
+const prependUnderscore = (str) => '_' + str
+
+export const transformCommandToHelpTopic = (inputStr) => {
+  const res = [(inputStr || '')]
+    .map(getHelpTopic)
+    .map(lowerCase)
+    .map(trim)
+    .map(replaceSpaceWithDash)
+    .map(snakeToCamel)
+    .map(prependUnderscore)
+  return res[0]
+}

--- a/src/shared/services/commandUtils.test.js
+++ b/src/shared/services/commandUtils.test.js
@@ -139,4 +139,22 @@ describe('commandutils', () => {
       expect(utils.extractPostConnectCommandsFromServerConfig(item.str)).toEqual(item.expect)
     })
   })
+  test('transformCommandToHelpTopic transforms input to help topics', () => {
+    // Given
+    const input = [
+      { test: '', expect: '_help' },
+      { test: 'help', expect: '_help' },
+      { test: 'help topic', expect: '_topic' },
+      { test: 'help  TOpic ', expect: '_topic' },
+      { test: 'help topic me', expect: '_topicMe' },
+      { test: 'help topic me now', expect: '_topicMeNow' },
+      { test: 'help topic-me', expect: '_topicMe' },
+      { test: 'help topic_me', expect: '_topic_me' }
+    ]
+
+    // When & Then
+    input.forEach((inp) => {
+      expect(utils.transformCommandToHelpTopic(inp.test)).toEqual(inp.expect)
+    })
+  })
 })


### PR DESCRIPTION
Fixes topics with space i.e. `:help rest get` error

changelog: Fix :help input with space