### PR TITLE
Add 'Directive' to bind input field values to the guide content

### DIFF
--- a/src/browser/components/Directives.jsx
+++ b/src/browser/components/Directives.jsx
@@ -70,6 +70,24 @@ const prependPlayIcon = (element) => {
   prependIcon(element, 'fa fa-play-circle-o')
 }
 
+const bindDynamicInputToDom = (element) => {
+  const valueForElems = element.querySelectorAll('[value-for]')
+  const valueKeyElems = element.querySelectorAll('[value-key]')
+  if (valueForElems.length > 0 && valueKeyElems.length > 0) {
+    valueForElems.forEach((valueForElem) => {
+      const newArray = [...valueKeyElems]
+      const filteredValueKeyElems = newArray.filter((e) => {
+        return e.getAttribute('value-key') === valueForElem.getAttribute('value-for')
+      })
+      if (filteredValueKeyElems.length > 0) {
+        valueForElem.onkeyup = (event) => {
+          filteredValueKeyElems[0].innerText = event.target.value
+        }
+      }
+    })
+  }
+}
+
 export const Directives = (props) => {
   const callback = (elem) => {
     if (elem) {
@@ -86,6 +104,7 @@ export const Directives = (props) => {
           }
         })
       })
+      bindDynamicInputToDom(elem)
     }
   }
   return (


### PR DESCRIPTION
Replicate the old functionality where an `<input/>.value()` can be bound to part of a guide.

E.g (`<input value-for="foo"/>`) -[:BINDS_TO]-> (`<span value-key="foo"></span>`)

The feature in action:
![dynamic-content](https://cloud.githubusercontent.com/assets/849508/26455481/446bcb66-4162-11e7-9ac3-a05224f87b70.gif)
