### PR TITLE
Add http auth header on :GET, :POST etc requests when appropriate

### DIFF
--- a/src/shared/modules/app/appDuck.test.js
+++ b/src/shared/modules/app/appDuck.test.js
@@ -18,20 +18,34 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Action type constants
-export const NAME = 'app'
-export const APP_START = `${NAME}/APP_START`
-export const USER_CLEAR = `${NAME}/USER_CLEAR`
+/* global test, expect */
+import reducer, { NAME, APP_START, getHostedUrl } from './appDuck'
 
-// Selectors
-export const getHostedUrl = (state) => (state[NAME] || {}).hostedUrl || null
+test('reducer stores hostedUrl', () => {
+  // Given
+  const url = 'xxx'
+  const initState = {}
+  const action = { type: APP_START, url }
 
-// Reducer
-export default function reducer (state = { hostedUrl: null }, action) {
-  switch (action.type) {
-    case APP_START:
-      return {...state, hostedUrl: action.url}
-    default:
-      return state
-  }
-}
+  // When
+  const state = reducer(initState, action)
+
+  // Then
+  expect(state.hostedUrl).toEqual(url)
+})
+
+test('selector getHostedUrl returns whats in the store', () => {
+  // Given
+  const url = 'xxx'
+  const initState = {}
+  const action = { type: APP_START, url }
+
+  // Then
+  expect(getHostedUrl({[NAME]: initState})).toEqual(null)
+
+  // When
+  const state = reducer(initState, action)
+
+  // Then
+  expect(getHostedUrl({[NAME]: state})).toEqual(url)
+})

--- a/src/shared/rootReducer.js
+++ b/src/shared/rootReducer.js
@@ -34,6 +34,7 @@ import { syncReducer, syncConsentReducer, NAME_CONSENT as syncConsent, NAME as s
 import foldersReducer, { NAME as folders } from 'shared/modules/favorites/foldersDuck'
 import commandsReducer, { NAME as commands } from 'shared/modules/commands/commandsDuck'
 import udcReducer, { NAME as udc } from 'shared/modules/udc/udcDuck'
+import appReducer, { NAME as app } from 'shared/modules/app/appDuck'
 
 export default {
   [connections]: connectionsReducer,
@@ -52,5 +53,6 @@ export default {
   [sync]: syncReducer,
   [syncConsent]: syncConsentReducer,
   [commands]: commandsReducer,
-  [udc]: udcReducer
+  [udc]: udcReducer,
+  [app]: appReducer
 }

--- a/src/shared/services/remote.js
+++ b/src/shared/services/remote.js
@@ -21,14 +21,16 @@
 /* global fetch */
 import 'isomorphic-fetch'
 
-function request (method, url, data = null) {
+function request (method, url, data = null, extraHeaders = {}) {
+  const headers = {
+    'Content-Type': 'application/json',
+    'X-Ajax-Browser-Auth': 'true',
+    'X-stream': 'true',
+    ...extraHeaders
+  }
   return fetch(url, {
     method,
-    headers: {
-      'Content-Type': 'application/json',
-      'X-Ajax-Browser-Auth': 'true',
-      'X-stream': 'true'
-    },
+    headers: headers,
     body: data
   })
   .then(checkStatus)

--- a/src/shared/services/remoteUtils.js
+++ b/src/shared/services/remoteUtils.js
@@ -18,8 +18,33 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/* global btoa */
+import { getUrlInfo } from 'services/utils'
+
 export function cleanHtml (string) {
   if (typeof string !== 'string') return string
   string = string.replace(/(\s+(on[^\s=]+)[^\s=]*\s*=\s*("[^"]*"|'[^']*'|[\w\-.:]+\s*))/ig, '')
   return string.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*(<\/script>)?/gi, '')
+}
+
+export const authHeaderFromCredentials = (username, password) => {
+  if (!btoa) throw new Error('btoa not defined') // Non browser env
+  return btoa(`${username}:${password}`)
+}
+
+export const isLocalRequest = (localUrl, requestUrl, opts = { hostnameOnly: false }) => {
+  if (!localUrl) return false
+
+  if (opts.hostnameOnly === true) {
+    localUrl = localUrl.trim().replace(/^[^:]+:\/\//, '')
+    requestUrl = requestUrl.trim().replace(/^[^:]+:\/\//, '')
+  }
+  const localUrlInfo = getUrlInfo(localUrl)
+  const requestUrlInfo = getUrlInfo(requestUrl)
+  if (!requestUrlInfo.host) return true // GET /path
+  if (opts.hostnameOnly === true) return requestUrlInfo.hostname === localUrlInfo.hostname // GET localhost:8080 from localhost:9000
+  if (requestUrlInfo.host === localUrlInfo.host && requestUrlInfo.protocol === localUrlInfo.protocol) { // Same host and protocol
+    return true
+  }
+  return false
 }

--- a/src/shared/services/remoteUtils.test.js
+++ b/src/shared/services/remoteUtils.test.js
@@ -18,12 +18,40 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* global test, expect */
+/* global describe, test, expect */
 import * as utils from './remoteUtils'
 
-describe('commandutils', () => {
+describe('remoteUtils', () => {
   test('removes script tags', () => {
     const text = 'hello<script>alert(1)</script> <p onclick="alert(1)">test</p>'
     expect(utils.cleanHtml(text)).toEqual('hello <p>test</p>')
+  })
+  test('isLocalRequest figures out if a request is local or remote', () => {
+    // Given
+    const itemsStrict = [
+      { local: undefined, request: '/yo', expect: false },
+      { local: 'http://hej.com', request: '/yo', expect: true },
+      { local: 'http://hej.com', request: 'http://hej.com/yo', expect: true },
+      { local: 'http://hej.com:8080', request: 'http://hej.com:9000/mine', expect: false },
+      { local: 'http://hej.com', request: 'https://hej.com', expect: false },
+      { local: 'http://hej.com', request: 'http://bye.com', expect: false }
+    ]
+    const itemsHostnameOnly = [
+      { local: undefined, request: '/yo', expect: false },
+      { local: 'http://hej.com', request: '/yo', expect: true },
+      { local: 'http://hej.com', request: 'http://hej.com/yo', expect: true },
+      { local: 'http://hej.com:8080', request: 'http://hej.com:9000/mine', expect: true },
+      { local: 'http://hej.com', request: 'https://hej.com', expect: true },
+      { local: 'http://hej.com', request: 'http://bye.com', expect: false },
+      { local: 'bolt://hej.com:7687', request: 'http://hej.com:7474', expect: true }
+    ]
+
+    // When && Then
+    itemsStrict.forEach((item) => {
+      expect(utils.isLocalRequest(item.local, item.request)).toBe(item.expect)
+    })
+    itemsHostnameOnly.forEach((item) => {
+      expect(utils.isLocalRequest(item.local, item.request, { hostnameOnly: true })).toBe(item.expect)
+    })
   })
 })


### PR DESCRIPTION
### Info

If a requested url matches any of these criterias, the `Authorization` header will be added to requests from the commands `:GET`, `:POST` etc.

1. is local url (no host defined, i.e. `:GET /db/data`)
1. has same host (protocol, hostname, port) as from where the browser is hosted ( i.e. `:GET http://localhost:7474/db/data/` from a browser host on `http://localhost:7474`)
1. has the same hostname as the active database connection (i.e. `:GET http://localhost:7474/db/data/` from a browser which is connected to Neo4j on `bolt://localhost:7687`)

(the reason we need (2) above is because the bolt host can be different from the host where the browser is served from even though it's the same machine)

## Manual test cases
Open the web browsers dev tools, network tab.

- `:GET /hello` - Should include authorization header.
- `:GET http://localhost:7474/db/data/` (note trailing slash) - if request when connected to localhost over bolt: should include an authorization header. Response should be available.
- `:GET http://127.0.01:7474/db/data/` - should fail with error code 401 because no auth header present.
- `:GET https://oskarhane-dropshare-eu.s3-eu-central-1.amazonaws.com/conf2-SX8pcCviMC/conf2.json` should not include an authorization header. Response should be available.

changelog: Fix missing auth headers on local `:GET`, `:POST` etc command requests