### PR TITLE
Add config to disable automatic editor autocomplete (default on)

### DIFF
--- a/src/browser/modules/Editor/Editor.jsx
+++ b/src/browser/modules/Editor/Editor.jsx
@@ -26,7 +26,7 @@ import { executeCommand, executeSystemCommand } from 'shared/modules/commands/co
 import * as favorites from 'shared/modules/favorites/favoritesDuck'
 import { SET_CONTENT, FOCUS, EXPAND } from 'shared/modules/editor/editorDuck'
 import { getHistory } from 'shared/modules/history/historyDuck'
-import { getSettings } from 'shared/modules/settings/settingsDuck'
+import { getCmdChar, shouldEditorAutocomplete } from 'shared/modules/settings/settingsDuck'
 import { Bar, ActionButtonSection, EditorWrapper } from './styled'
 import { EditorButton } from 'browser-components/buttons'
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
@@ -135,7 +135,7 @@ export class Editor extends Component {
   }
 
   triggerAutocompletion (cm, changed) {
-    if (changed.text.length !== 1) {
+    if (changed.text.length !== 1 || !this.props.enableEditorAutocomplete) {
       return
     }
 
@@ -351,9 +351,10 @@ const mapDispatchToProps = (dispatch, ownProps) => {
 
 const mapStateToProps = (state) => {
   return {
+    enableEditorAutocomplete: shouldEditorAutocomplete(state),
     content: null,
     history: getHistory(state),
-    cmdchar: getSettings(state).cmdchar,
+    cmdchar: getCmdChar(state),
     schema: {
       consoleCommands: consoleCommands,
       labels: state.meta.labels.map(schemaConvert.toLabel),

--- a/src/browser/modules/Sidebar/Settings.jsx
+++ b/src/browser/modules/Sidebar/Settings.jsx
@@ -38,8 +38,8 @@ const visualSettings =
         },
         {
           'editorAutocomplete': {
-            displayName: 'Autocomplete queries',
-            tooltip: 'Autocomplete written queries in editor',
+            displayName: 'Trigger autocomplete when typing',
+            tooltip: 'Autocomplete written queries in editor (shortcut keys will still work)',
             type: 'checkbox'
           }
         }

--- a/src/browser/modules/Sidebar/Settings.jsx
+++ b/src/browser/modules/Sidebar/Settings.jsx
@@ -35,6 +35,13 @@ const visualSettings =
             type: 'radio',
             options: ['normal', 'outline']
           }
+        },
+        {
+          'editorAutocomplete': {
+            displayName: 'Autocomplete queries',
+            tooltip: 'Autocomplete written queries in editor',
+            type: 'checkbox'
+          }
         }
       ]
     },

--- a/src/shared/modules/settings/settingsDuck.js
+++ b/src/shared/modules/settings/settingsDuck.js
@@ -51,6 +51,7 @@ const browserSyncConfig = {
 }
 export const getUseNewVisualization = (state) => state[NAME].useNewVis
 export const getCmdChar = (state) => state[NAME].cmdchar || initialState.cmdchar
+export const shouldEditorAutocomplete = (state) => state[NAME].editorAutocomplete !== false
 
 const initialState = {
   cmdchar: ':',
@@ -66,7 +67,8 @@ const initialState = {
   shouldReportUdc: true,
   autoComplete: true,
   scrollToTop: true,
-  maxFrames: 30
+  maxFrames: 30,
+  editorAutocomplete: true
 }
 
 export default function settings (state = initialState, action) {


### PR DESCRIPTION
Simple checkbox in settings drawer to toggle the status for editor autocompletion/suggestions.
