### PR TITLE
Parse server config duration strings correctly

### DIFF
--- a/src/shared/modules/credentialsPolicy/credentialsPolicyDuck.js
+++ b/src/shared/modules/credentialsPolicy/credentialsPolicyDuck.js
@@ -21,6 +21,7 @@
 import { USER_INTERACTION } from 'shared/modules/userInteraction/userInteractionDuck'
 import { credentialsTimeout } from 'shared/modules/dbMeta/dbMetaDuck'
 import { disconnectAction, getActiveConnection } from 'shared/modules/connections/connectionsDuck'
+import { parseTimeMillis } from 'services/utils'
 
 // Local variables (used in epics)
 let timer = null
@@ -29,7 +30,7 @@ let timer = null
 export const credentialsTimeoutEpic = (action$, store) =>
   action$.ofType(USER_INTERACTION)
     .do((action) => {
-      const cTimeout = credentialsTimeout(store.getState())
+      const cTimeout = parseTimeMillis(credentialsTimeout(store.getState()))
       if (!cTimeout) return clearTimeout(timer)
       clearTimeout(timer)
       timer = setTimeout(() => {

--- a/src/shared/services/utils.js
+++ b/src/shared/services/utils.js
@@ -179,6 +179,25 @@ export const canUseDOM = () => !!(
 
 export const ecsapeCypherMetaItem = (str) => /^[A-Za-z][A-Za-z0-9_]*$/.test(str) ? str : '`' + str.replace(/`/g, '``') + '`'
 
+export const parseTimeMillis = (timeWithOrWithoutUnit) => {
+  timeWithOrWithoutUnit += '' // cast to string
+  const readUnit = timeWithOrWithoutUnit.match(/\D+/)
+  const value = parseInt(timeWithOrWithoutUnit)
+
+  const unit = (readUnit === undefined || readUnit === null) ? 's' : readUnit[0] // Assume seconds
+
+  switch (unit) {
+    case 'ms':
+      return value
+    case 's':
+      return value * 1000
+    case 'm':
+      return value * 60 * 1000
+    default:
+      return 0
+  }
+}
+
 export const stringifyMod = () => {
   const toString = Object.prototype.toString
   const isArray = Array.isArray || function (a) { return toString.call(a) === '[object Array]' }

--- a/src/shared/services/utils.test.js
+++ b/src/shared/services/utils.test.js
@@ -317,6 +317,23 @@ describe('utils', () => {
       expect(utils.stringifyMod()(t, modFn)).toEqual(expects[index])
     })
   })
+  test('parseTimeMillis correctly parses human readable units correctly', () => {
+    // Given
+    const times = [
+      { test: '100', expect: 100 * 1000 },
+      { test: 100, expect: 100 * 1000 },
+      { test: '100ms', expect: 100 },
+      { test: '100s', expect: 100 * 1000 },
+      { test: '100m', expect: 100 * 60 * 1000 },
+      { test: '100x', expect: 0 },
+      { test: 'x', expect: 0 }
+    ]
+
+    // When & Then
+    times.forEach((time) => {
+      expect(utils.parseTimeMillis(time.test)).toEqual(time.expect)
+    })
+  })
   describe('ecsapeCypherMetaItem', () => {
     // Given
     const items = [


### PR DESCRIPTION
Applies to server config `browser.credential_timeout`

When receiving values from JMX, the units default is `s`. 
So entering `browser.credential_timeout=60` in the server config will give `browser.credential_timeout=60` when fetching from JMX.

When parsing JMX values:
No unit => x * 1000 (seconds assumed)
ms => x
s => x * 1000
m => x * 60 * 1000