### PR TITLE
Add cluster role, db filename and total store size to sidebar

### DIFF
--- a/src/browser/modules/DatabaseInfo/DatabaseKernelInfo.jsx
+++ b/src/browser/modules/DatabaseInfo/DatabaseKernelInfo.jsx
@@ -20,14 +20,15 @@
 
 import { connect } from 'preact-redux'
 import { withBus } from 'preact-suber'
-import { getVersion, getEdition } from 'shared/modules/dbMeta/dbMetaDuck'
+import { getVersion, getEdition, getDbName, getStoreSize } from 'shared/modules/dbMeta/dbMetaDuck'
 import { executeCommand } from 'shared/modules/commands/commandsDuck'
+import { toHumanReadableBytes } from 'services/utils'
 
 import Render from 'browser-components/Render'
 import {DrawerSection, DrawerSectionBody, DrawerSubHeader} from 'browser-components/drawer'
 import {StyledTable, StyledKey, StyledValue, StyledValueUCFirst, Link} from './styled'
 
-export const DatabaseKernelInfo = ({version, edition, onItemClick}) => {
+export const DatabaseKernelInfo = ({version, edition, dbName, storeSize, onItemClick}) => {
   return (
     <DrawerSection className='database-kernel-info'>
       <DrawerSubHeader>Database</DrawerSubHeader>
@@ -42,6 +43,16 @@ export const DatabaseKernelInfo = ({version, edition, onItemClick}) => {
             <Render if={edition}>
               <tr>
                 <StyledKey>Edition: </StyledKey><StyledValueUCFirst>{edition}</StyledValueUCFirst>
+              </tr>
+            </Render>
+            <Render if={dbName}>
+              <tr>
+                <StyledKey>Name: </StyledKey><StyledValue>{dbName}</StyledValue>
+              </tr>
+            </Render>
+            <Render if={storeSize}>
+              <tr>
+                <StyledKey>Size: </StyledKey><StyledValue>{toHumanReadableBytes(storeSize)}</StyledValue>
               </tr>
             </Render>
             <tr>
@@ -60,7 +71,9 @@ export const DatabaseKernelInfo = ({version, edition, onItemClick}) => {
 const mapStateToProps = (store) => {
   return {
     version: getVersion(store),
-    edition: getEdition(store)
+    edition: getEdition(store),
+    dbName: getDbName(store),
+    storeSize: getStoreSize(store)
   }
 }
 const mapDispatchToProps = (dispatch, ownProps) => {

--- a/src/browser/modules/DatabaseInfo/DatabaseKernelInfo.jsx
+++ b/src/browser/modules/DatabaseInfo/DatabaseKernelInfo.jsx
@@ -20,7 +20,7 @@
 
 import { connect } from 'preact-redux'
 import { withBus } from 'preact-suber'
-import { getVersion, getEdition, getDbName, getStoreSize } from 'shared/modules/dbMeta/dbMetaDuck'
+import { getVersion, getEdition, getDbName, getStoreSize, getClusterRole } from 'shared/modules/dbMeta/dbMetaDuck'
 import { executeCommand } from 'shared/modules/commands/commandsDuck'
 import { toHumanReadableBytes } from 'services/utils'
 
@@ -28,13 +28,18 @@ import Render from 'browser-components/Render'
 import {DrawerSection, DrawerSectionBody, DrawerSubHeader} from 'browser-components/drawer'
 import {StyledTable, StyledKey, StyledValue, StyledValueUCFirst, Link} from './styled'
 
-export const DatabaseKernelInfo = ({version, edition, dbName, storeSize, onItemClick}) => {
+export const DatabaseKernelInfo = ({role, version, edition, dbName, storeSize, onItemClick}) => {
   return (
     <DrawerSection className='database-kernel-info'>
       <DrawerSubHeader>Database</DrawerSubHeader>
       <DrawerSectionBody>
         <StyledTable>
           <tbody>
+            <Render if={role}>
+              <tr>
+                <StyledKey>Cluster role: </StyledKey><StyledValue>{role}</StyledValue>
+              </tr>
+            </Render>
             <Render if={version}>
               <tr>
                 <StyledKey>Version: </StyledKey><StyledValue>{version}</StyledValue>
@@ -73,7 +78,8 @@ const mapStateToProps = (store) => {
     version: getVersion(store),
     edition: getEdition(store),
     dbName: getDbName(store),
-    storeSize: getStoreSize(store)
+    storeSize: getStoreSize(store),
+    role: getClusterRole(store)
   }
 }
 const mapDispatchToProps = (dispatch, ownProps) => {

--- a/src/shared/modules/dbMeta/__snapshots__/dbMetaDuck.test.js.snap
+++ b/src/shared/modules/dbMeta/__snapshots__/dbMetaDuck.test.js.snap
@@ -7,9 +7,38 @@ Object {
   "procedures": Array [],
   "properties": Array [],
   "relationshipTypes": Array [],
+  "role": null,
   "server": Object {
+    "dbName": null,
     "edition": null,
     "storeId": null,
+    "storeSize": null,
+    "version": null,
+  },
+  "settings": Object {
+    "browser.allow_outgoing_connections": false,
+    "browser.remote_content_hostname_whitelist": "guides.neo4j.com, localhost",
+  },
+}
+`;
+
+exports[`updating metadata can update meta values with UPDATE 1`] = `
+Object {
+  "functions": Array [],
+  "hydrated": true,
+  "labels": Array [],
+  "myKey": "yo",
+  "noKey": true,
+  "procedures": Array [],
+  "properties": Array [],
+  "relationshipTypes": Array [],
+  "role": null,
+  "secondKey": true,
+  "server": Object {
+    "dbName": null,
+    "edition": null,
+    "storeId": null,
+    "storeSize": null,
     "version": null,
   },
   "settings": Object {
@@ -27,9 +56,12 @@ Object {
   "procedures": Array [],
   "properties": Array [],
   "relationshipTypes": Array [],
+  "role": null,
   "server": Object {
+    "dbName": undefined,
     "edition": "enterprise",
     "storeId": "xxxx",
+    "storeSize": undefined,
     "version": "3.2.0-RC2",
   },
   "settings": Object {
@@ -48,9 +80,12 @@ Object {
   "procedures": Array [],
   "properties": Array [],
   "relationshipTypes": Array [],
+  "role": null,
   "server": Object {
+    "dbName": null,
     "edition": null,
     "storeId": null,
+    "storeSize": null,
     "version": null,
   },
   "settings": Object {

--- a/src/shared/modules/dbMeta/dbMetaDuck.test.js
+++ b/src/shared/modules/dbMeta/dbMetaDuck.test.js
@@ -186,4 +186,19 @@ describe('updating metadata', () => {
     // Then
     expect(nextState).toMatchSnapshot()
   })
+
+  test('can update meta values with UPDATE', () => {
+    // Given
+    const initState = {
+      myKey: 'val',
+      noKey: true
+    }
+    const action = { type: meta.UPDATE, myKey: 'yo', secondKey: true }
+
+    // When
+    const nextState = reducer(initState, action)
+
+    // Then
+    expect(nextState).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
Bring back valuable info to the db drawer.

OBS: The role query cannot be part of the regular dbmeta query because if the db isn't in a cluster the whole query fails, making the sidebar empty.

Connected:

![oskar4j 2017-05-29 at 15 59 33](https://cloud.githubusercontent.com/assets/570998/26552536/de304f7e-4487-11e7-9af2-29b57442590f.png)


Disconnected:

![oskar4j 2017-05-29 at 16 00 24](https://cloud.githubusercontent.com/assets/570998/26552558/f4c322ca-4487-11e7-89fc-3059e628213a.png)

In a cluster:

![oskar4j 2017-05-29 at 16 41 46](https://cloud.githubusercontent.com/assets/570998/26553943/392181cc-448e-11e7-9dbf-8cb03a389791.png)
![oskar4j 2017-05-29 at 16 42 16](https://cloud.githubusercontent.com/assets/570998/26553944/39243200-448e-11e7-84c0-ace96079a2b1.png)