### PR TITLE
Display notification cursor on correct line in 'warn' view

### DIFF
--- a/src/browser/modules/Stream/Views/WarningsView.jsx
+++ b/src/browser/modules/Stream/Views/WarningsView.jsx
@@ -49,7 +49,7 @@ const WarningsView = ({notifications, cypher, style}) => {
         <StyledDiv>
           <StyledHelpDescription>{notification.description}</StyledHelpDescription>
           <StyledDiv>
-            <StyledPreformattedArea>{cypherLines[notification.position.line - 1]}
+            <StyledPreformattedArea>{cypherLines[notification.position.line]}
               <StyledBr />{Array(notification.position.column).join(' ')}^
             </StyledPreformattedArea>
           </StyledDiv>


### PR DESCRIPTION
Issue (incorrect cursor placement in code block): 
<img width="760" alt="screen shot 2017-05-30 at 13 09 45" src="https://cloud.githubusercontent.com/assets/849508/26582596/b1cc2c02-4539-11e7-8997-57d9d3d0802f.png">

Fixed:
<img width="760" alt="screen shot 2017-05-30 at 13 07 35" src="https://cloud.githubusercontent.com/assets/849508/26582619/c820530c-4539-11e7-9c5e-16d94e2279d3.png">
