### PR TITLE
Only display truthy connection data in the browser title

### DIFF
--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -35,6 +35,7 @@ import Main from '../Main/Main'
 import Sidebar from '../Sidebar/Sidebar'
 import UserInteraction from '../UserInteraction'
 import DocTitle from '../DocTitle'
+import asTitleString from '../DocTitle/titleStringBuilder'
 import Intercom from '../Intercom'
 import Render from 'browser-components/Render'
 
@@ -98,7 +99,7 @@ const mapStateToProps = (state) => {
     showUnknownCommandBanner: wasUnknownCommand(state),
     errorMessage: getErrorMessage(state),
     loadUdc: allowOutgoingConnections(state),
-    titleString: (connectionData ? connectionData.username + '@' + connectionData.host + ' - ' : '') + 'Neo4j Browser'
+    titleString: asTitleString(connectionData)
   }
 }
 

--- a/src/browser/modules/DocTitle/titleStringBuilder.js
+++ b/src/browser/modules/DocTitle/titleStringBuilder.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+const asTitleString = (connectionData) => {
+  const buildTitleFromConnectionData = () => {
+    if (!connectionData) return null
+    if (connectionData.username && connectionData.host) {
+      return `${connectionData.username}@${connectionData.host}`
+    }
+    if (connectionData.username) { return connectionData.username }
+    if (connectionData.host) { return connectionData.host }
+    return null
+  }
+  const builtTitle = buildTitleFromConnectionData()
+  return (builtTitle ? builtTitle + ' - ' : '') + 'Neo4j Browser'
+}
+
+export default asTitleString

--- a/src/browser/modules/DocTitle/titleStringBuilder.test.js
+++ b/src/browser/modules/DocTitle/titleStringBuilder.test.js
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2002-2017 "Neo Technology,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ /* global describe, beforeEach, afterEach, test, expect */
+import asTitleString from './titleStringBuilder'
+
+describe('asTitleString', () => {
+  test('should return static copy if there is no connectionData', () => {
+    // Given
+    const connectionData = null
+
+    // When
+    const title = asTitleString(connectionData)
+
+    // Then
+    expect(title).toBe('Neo4j Browser')
+  })
+  test('should return static copy if there is connectionData but values are both falsey', () => {
+    // Given
+    const username = undefined
+    const host = null
+    const connectionData = {username, host}
+
+    // When
+    const title = asTitleString(connectionData)
+
+    // Then
+    expect(title).toBe('Neo4j Browser')
+  })
+  test('should return host + static copy if there is connectionData host', () => {
+    // Given
+    const username = undefined
+    const host = 'foo'
+    const connectionData = {username, host}
+
+    // When
+    const title = asTitleString(connectionData)
+
+    // Then
+    expect(title).toBe(`${host} - Neo4j Browser`)
+  })
+  test('should return username + static copy if there is connectionData host', () => {
+    // Given
+    const username = 'foo'
+    const host = undefined
+    const connectionData = {username, host}
+
+    // When
+    const title = asTitleString(connectionData)
+
+    // Then
+    expect(title).toBe(`${username} - Neo4j Browser`)
+  })
+  test('should return string with username and host from connectionData', () => {
+    // Given
+    const username = 'foo'
+    const host = 'bar'
+    const connectionData = {username, host}
+
+    // When
+    const title = asTitleString(connectionData)
+
+    // Then
+    expect(title).toContain(`${username}@${host}`)
+  })
+})


### PR DESCRIPTION
Fixes issue where undefined is being displayed in the browsers title bar when authentication is disabled in Neo4j