### PR TITLE
Limit meta data items returned by the cypher query

### DIFF
--- a/src/shared/modules/dbMeta/dbMetaDuck.js
+++ b/src/shared/modules/dbMeta/dbMetaDuck.js
@@ -206,15 +206,15 @@ export const updateSettings = (settings) => {
 // Epics
 export const metaQuery = `
 CALL db.labels() YIELD label
-WITH COLLECT(label) AS labels
+WITH COLLECT(label)[..1000] AS labels
 RETURN 'labels' as a, labels as result
 UNION
 CALL db.relationshipTypes() YIELD relationshipType
-WITH COLLECT(relationshipType) AS relationshipTypes
+WITH COLLECT(relationshipType)[..1000] AS relationshipTypes
 RETURN 'relationshipTypes' as a, relationshipTypes as result
 UNION
 CALL db.propertyKeys() YIELD propertyKey
-WITH COLLECT(propertyKey) AS propertyKeys
+WITH COLLECT(propertyKey)[..1000] AS propertyKeys
 RETURN 'propertyKeys' as a, propertyKeys as result
 UNION
 CALL dbms.functions() YIELD name, signature, description


### PR DESCRIPTION
Limited to 1000 per meta type (labels/propertyKeys/relationshipTypes)

Fixes issue of storing large amounts of meta items in state

changelog: Fix sluggish experience when having hundreds of thousands meta items