### PR TITLE
Automatic code formatting with prettier

### DIFF
--- a/__mocks__/neo4j.js
+++ b/__mocks__/neo4j.js
@@ -32,8 +32,14 @@ var out = {
   }
 }
 
-out.v1.types.Node.prototype.toString = function () { return 'node' }
-out.v1.types.Relationship.prototype.toString = function () { return 'rel' }
-out.v1.types.Path.prototype.toString = function () { return 'path' }
+out.v1.types.Node.prototype.toString = function () {
+  return 'node'
+}
+out.v1.types.Relationship.prototype.toString = function () {
+  return 'rel'
+}
+out.v1.types.Path.prototype.toString = function () {
+  return 'path'
+}
 
 module.exports = out

--- a/package.json
+++ b/package.json
@@ -12,7 +12,18 @@
     "build": "rm -rf ./build && NODE_ENV=\"production\" webpack",
     "jar": "yarn build && mvn package",
     "version-pom": "node ./scripts/set-pom-version.js -f ./pom.xml -v $npm_package_version",
-    "version": "npm run version-pom && git add ./pom.xml"
+    "version": "npm run version-pom && git add ./pom.xml",
+    "precommit": "lint-staged",
+    "prettify:js": "prettier --single-quote --no-semi --write **/*.js",
+    "prettify:jsx": "prettier --single-quote --no-semi --write **/*.jsx",
+    "prettify": "yarn run prettify:js && yarn run prettify:jsx && yarn run lint"
+  },
+  "lint-staged": {
+    "*.{js,jsx}": [
+      "prettier --single-quote --no-semi --write",
+      "standard --fix",
+      "git add"
+    ]
   },
   "jest": {
     "testPathIgnorePatterns": [
@@ -92,9 +103,11 @@
     "file-loader": "^0.11.1",
     "html-loader": "^0.4.5",
     "html-webpack-plugin": "^2.28.0",
+    "husky": "^0.13.4",
     "jest": "^20.0.0",
     "jest-cli": "^20.0.0",
     "json-loader": "^0.5.4",
+    "lint-staged": "^4.0.0",
     "nock": "^9.0.6",
     "postcss": "^6.0.1",
     "postcss-cssnext": "^2.6.0",
@@ -103,6 +116,7 @@
     "preact-render-to-string": "^3.6.0",
     "preact-test-utils": "^0.1.3",
     "precss": "^1.4.0",
+    "prettier": "^1.4.4",
     "react-addons-test-utils": "^15.0.2",
     "react-hot-loader": "^1.3.0",
     "redux-devtools": "^3.2.0",

--- a/scripts/set-pom-version.js
+++ b/scripts/set-pom-version.js
@@ -53,13 +53,16 @@ function main (args) {
 
 function parseArgv (argv) {
   let out = {}
-  for (let i = 0; i < argv.length; i += 2) { // Pairs
+  for (let i = 0; i < argv.length; i += 2) {
+    // Pairs
     out[argv[i]] = argv[i + 1]
   }
   return out
 }
 
 function failExit () {
-  console.log('Error. Usage: "node set-pom-version.js -f filepath/from/project/root/pom.xml -v new-version-semver"')
+  console.log(
+    'Error. Usage: "node set-pom-version.js -f filepath/from/project/root/pom.xml -v new-version-semver"'
+  )
   process.exit(1)
 }

--- a/src/browser/components/Directives.jsx
+++ b/src/browser/components/Directives.jsx
@@ -24,63 +24,72 @@ import { executeCommand } from 'shared/modules/commands/commandsDuck'
 import * as editor from 'shared/modules/editor/editorDuck'
 import { addClass, prependIcon } from 'shared/services/dom-helpers'
 
-const directives = [{
-  selector: '[exec-topic]',
-  valueExtractor: (elem) => {
-    return `:${elem.getAttribute('exec-topic')}`
+const directives = [
+  {
+    selector: '[exec-topic]',
+    valueExtractor: elem => {
+      return `:${elem.getAttribute('exec-topic')}`
+    },
+    autoExec: true
   },
-  autoExec: true
-}, {
-  selector: '[play-topic]',
-  valueExtractor: (elem) => {
-    return `:play ${elem.getAttribute('play-topic')}`
+  {
+    selector: '[play-topic]',
+    valueExtractor: elem => {
+      return `:play ${elem.getAttribute('play-topic')}`
+    },
+    autoExec: true
   },
-  autoExec: true
-}, {
-  selector: '[server-topic]',
-  valueExtractor: (elem) => {
-    return `:server ${elem.getAttribute('server-topic')}`
+  {
+    selector: '[server-topic]',
+    valueExtractor: elem => {
+      return `:server ${elem.getAttribute('server-topic')}`
+    },
+    autoExec: true
   },
-  autoExec: true
-}, {
-  selector: '[help-topic]',
-  valueExtractor: (elem) => {
-    return `:help ${elem.getAttribute('help-topic')}`
+  {
+    selector: '[help-topic]',
+    valueExtractor: elem => {
+      return `:help ${elem.getAttribute('help-topic')}`
+    },
+    autoExec: true
   },
-  autoExec: true
-}, {
-  selector: '.runnable pre',
-  valueExtractor: (elem) => {
-    return elem.textContent.trim()
+  {
+    selector: '.runnable pre',
+    valueExtractor: elem => {
+      return elem.textContent.trim()
+    },
+    autoExec: false
   },
-  autoExec: false
-}, {
-  selector: 'pre.runnable',
-  valueExtractor: (elem) => {
-    return elem.textContent.trim()
-  },
-  autoExec: false
-}]
+  {
+    selector: 'pre.runnable',
+    valueExtractor: elem => {
+      return elem.textContent.trim()
+    },
+    autoExec: false
+  }
+]
 
-const prependHelpIcon = (element) => {
+const prependHelpIcon = element => {
   prependIcon(element, 'fa fa-question-circle-o')
 }
 
-const prependPlayIcon = (element) => {
+const prependPlayIcon = element => {
   prependIcon(element, 'fa fa-play-circle-o')
 }
 
-const bindDynamicInputToDom = (element) => {
+const bindDynamicInputToDom = element => {
   const valueForElems = element.querySelectorAll('[value-for]')
   const valueKeyElems = element.querySelectorAll('[value-key]')
   if (valueForElems.length > 0 && valueKeyElems.length > 0) {
-    valueForElems.forEach((valueForElem) => {
+    valueForElems.forEach(valueForElem => {
       const newArray = [...valueKeyElems]
-      const filteredValueKeyElems = newArray.filter((e) => {
-        return e.getAttribute('value-key') === valueForElem.getAttribute('value-for')
+      const filteredValueKeyElems = newArray.filter(e => {
+        return (
+          e.getAttribute('value-key') === valueForElem.getAttribute('value-for')
+        )
       })
       if (filteredValueKeyElems.length > 0) {
-        valueForElem.onkeyup = (event) => {
+        valueForElem.onkeyup = event => {
           filteredValueKeyElems[0].innerText = event.target.value
         }
       }
@@ -88,19 +97,24 @@ const bindDynamicInputToDom = (element) => {
   }
 }
 
-export const Directives = (props) => {
-  const callback = (elem) => {
+export const Directives = props => {
+  const callback = elem => {
     if (elem) {
-      directives.forEach((directive) => {
+      directives.forEach(directive => {
         const elems = elem.querySelectorAll(directive.selector)
-        Array.from(elems).forEach((e) => {
+        Array.from(elems).forEach(e => {
           if (e.firstChild.nodeName !== 'I') {
-            directive.selector === '[help-topic]' ? prependHelpIcon(e) : prependPlayIcon(e)
+            directive.selector === '[help-topic]'
+              ? prependHelpIcon(e)
+              : prependPlayIcon(e)
           }
 
           e.onclick = () => {
             addClass(e, 'clicked')
-            return props.onItemClick(directive.valueExtractor(e), directive.autoExec)
+            return props.onItemClick(
+              directive.valueExtractor(e),
+              directive.autoExec
+            )
           }
         })
       })

--- a/src/browser/components/EditionView.jsx
+++ b/src/browser/components/EditionView.jsx
@@ -19,7 +19,7 @@
  */
 
 import styled from 'styled-components'
-import {H3} from 'browser-components/headers'
+import { H3 } from 'browser-components/headers'
 
 const Aside = styled.div`
   display: table-cell;
@@ -52,8 +52,8 @@ const P = styled.p`
   margin: 20px 0;
 `
 
-export const EnterpriseOnlyFrame = (props) => {
-  const {command, ...rest} = props
+export const EnterpriseOnlyFrame = props => {
+  const { command, ...rest } = props
   return (
     <PaddedDiv {...rest}>
       <Aside>
@@ -62,8 +62,17 @@ export const EnterpriseOnlyFrame = (props) => {
       </Aside>
       <BodyContainer>
         <StyledConnectionBody>
-          <P>Unable to display <Code>{command}</Code> because the procedures required to run this frame are missing. These procedures are usually found in Neo4j Enterprise edition.</P>
-          <P>Find out more over at <a href='https://neo4j.com/editions/' target='_blank'>neo4j.com/editions</a></P>
+          <P>
+            Unable to display <Code>{command}</Code> because the procedures
+            required to run this frame are missing. These procedures are usually
+            found in Neo4j Enterprise edition.
+          </P>
+          <P>
+            Find out more over at{' '}
+            <a href='https://neo4j.com/editions/' target='_blank'>
+              neo4j.com/editions
+            </a>
+          </P>
         </StyledConnectionBody>
       </BodyContainer>
     </PaddedDiv>

--- a/src/browser/components/FileImporter/FileDrop.jsx
+++ b/src/browser/components/FileImporter/FileDrop.jsx
@@ -19,7 +19,7 @@
  */
 
 import { Component } from 'preact'
-import {NativeTypes} from 'react-dnd-html5-backend'
+import { NativeTypes } from 'react-dnd-html5-backend'
 import { DropTarget } from 'react-dnd'
 import { wrapWithDndContext } from './dndGlobalContext'
 
@@ -28,13 +28,15 @@ const fileTarget = {
     const file = monitor.getItem().files[0]
     if (file.name.endsWith(`.${props.expectedExtension}`)) {
       const fileReader = new FileReader()
-      fileReader.onloadend = (evt) => {
+      fileReader.onloadend = evt => {
         props.onImportSuccess(evt.target.result)
       }
       fileReader.readAsText(file)
-      return {message: `Imported file: ${file.name}`}
+      return { message: `Imported file: ${file.name}` }
     } else {
-      return {message: `File not imported. Expected File to have an extension of '${props.expectedExtension}'`}
+      return {
+        message: `File not imported. Expected File to have an extension of '${props.expectedExtension}'`
+      }
     }
   }
 }
@@ -50,7 +52,7 @@ class FileDropZone extends Component {
   componentWillUpdate () {
     const result = this.props.getDropResult
     if (result && result.message) {
-      this.setState({text: result.message})
+      this.setState({ text: result.message })
     }
   }
   render () {
@@ -63,13 +65,17 @@ class FileDropZone extends Component {
 }
 
 export const FileDrop = (Component, applyContext) => {
-  let WrappedComponent = (props) => {
-    return (<FileDropZone {...props} Component={Component} />)
+  let WrappedComponent = props => {
+    return <FileDropZone {...props} Component={Component} />
   }
-  const Target = DropTarget(NativeTypes.FILE, fileTarget, (connect, monitor) => ({
-    connectDropTarget: connect.dropTarget(),
-    canDrop: monitor.canDrop(),
-    getDropResult: monitor.getDropResult()
-  }))(WrappedComponent)
+  const Target = DropTarget(
+    NativeTypes.FILE,
+    fileTarget,
+    (connect, monitor) => ({
+      connectDropTarget: connect.dropTarget(),
+      canDrop: monitor.canDrop(),
+      getDropResult: monitor.getDropResult()
+    })
+  )(WrappedComponent)
   return wrapWithDndContext(Target)
 }

--- a/src/browser/components/FileImporter/FileDrop.test.jsx
+++ b/src/browser/components/FileImporter/FileDrop.test.jsx
@@ -21,12 +21,12 @@
 /* global test, expect */
 import React from 'react'
 import { mount } from 'enzyme'
-import {FileDrop} from './FileDrop'
+import { FileDrop } from './FileDrop'
 
 describe('FileDrop', () => {
   test('should render child component', () => {
-    const ChildComponent = (props) => {
-      return (<div className='child' />)
+    const ChildComponent = props => {
+      return <div className='child' />
     }
     const FileDropComp = FileDrop(ChildComponent, true)
     const wrapper = mount(<FileDropComp />)

--- a/src/browser/components/FileImporter/FileDropBar.jsx
+++ b/src/browser/components/FileImporter/FileDropBar.jsx
@@ -18,10 +18,10 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {FileDrop} from './FileDrop'
+import { FileDrop } from './FileDrop'
 
-const DropBar = (props) => {
-  return (<div>{props.text}</div>)
+const DropBar = props => {
+  return <div>{props.text}</div>
 }
 
 export const FileDropBar = FileDrop(DropBar, true)

--- a/src/browser/components/Form.jsx
+++ b/src/browser/components/Form.jsx
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {Component} from 'preact'
+import { Component } from 'preact'
 import styled from 'styled-components'
 
 const StyledSettingTextInput = styled.input`
@@ -46,13 +46,15 @@ const StyledRadioEntry = styled.div`
   margin: 10px 0;
 `
 
-export const TextInput = (props) => {
-  const {children, ...rest} = props
+export const TextInput = props => {
+  const { children, ...rest } = props
   return <StyledSettingTextInput {...rest}>{children}</StyledSettingTextInput>
 }
 
-export const CheckboxSelector = (props) => {
-  return (props.checked) ? <StyledCheckbox type='checkbox' {...props} /> : <StyledCheckbox type='checkbox' {...props} />
+export const CheckboxSelector = props => {
+  return props.checked
+    ? <StyledCheckbox type='checkbox' {...props} />
+    : <StyledCheckbox type='checkbox' {...props} />
 }
 
 export class RadioSelector extends Component {
@@ -66,14 +68,21 @@ export class RadioSelector extends Component {
   render () {
     return (
       <form>
-        {this.props.options.map((option) => {
-          return (<StyledRadioEntry>
-            <input type='radio' value={option} checked={this.isSelectedValue(option)} onClick={(event) => {
-              this.state.selectedValue = option
-              this.props.onChange(event)
-            }} />
-            <StyledLabel>{option}</StyledLabel>
-          </StyledRadioEntry>)
+        {this.props.options.map(option => {
+          return (
+            <StyledRadioEntry>
+              <input
+                type='radio'
+                value={option}
+                checked={this.isSelectedValue(option)}
+                onClick={event => {
+                  this.state.selectedValue = option
+                  this.props.onChange(event)
+                }}
+              />
+              <StyledLabel>{option}</StyledLabel>
+            </StyledRadioEntry>
+          )
         })}
       </form>
     )

--- a/src/browser/components/Render/index.jsx
+++ b/src/browser/components/Render/index.jsx
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const Render = ({if: cond, children}) => {
+const Render = ({ if: cond, children }) => {
   return cond ? children[0] : null
 }
 export default Render

--- a/src/browser/components/TabNavigation/Navigation.jsx
+++ b/src/browser/components/TabNavigation/Navigation.jsx
@@ -19,8 +19,17 @@
  */
 
 import { Component } from 'preact'
-import { StyledNavigationButton, NavigationButtonContainer } from 'browser-components/buttons'
-import { StyledSidebar, StyledDrawer, StyledTabsWrapper, StyledTopNav, StyledBottomNav } from './styled'
+import {
+  StyledNavigationButton,
+  NavigationButtonContainer
+} from 'browser-components/buttons'
+import {
+  StyledSidebar,
+  StyledDrawer,
+  StyledTabsWrapper,
+  StyledTopNav,
+  StyledBottomNav
+} from './styled'
 
 const Closing = 'CLOSING'
 const Closed = 'CLOSED'
@@ -41,12 +50,18 @@ class Navigation extends Component {
       var newState = {}
       if (nextProps.openDrawer) {
         newState.drawerContent = nextProps.openDrawer
-        if (this.state.transitionState === Closed || this.state.transitionState === Closing) {
+        if (
+          this.state.transitionState === Closed ||
+          this.state.transitionState === Closing
+        ) {
           newState.transitionState = Opening
         }
       } else {
         newState.drawerContent = ''
-        if (this.state.transitionState === Open || this.state.transitionState === Opening) {
+        if (
+          this.state.transitionState === Open ||
+          this.state.transitionState === Opening
+        ) {
           newState.transitionState = Closing
         }
       }
@@ -69,11 +84,7 @@ class Navigation extends Component {
   }
 
   render () {
-    let {
-      onNavClick,
-      topNavItems,
-      bottomNavItems = []
-    } = this.props
+    let { onNavClick, topNavItems, bottomNavItems = [] } = this.props
 
     const buildNavList = (list, selected) => {
       return list.map((item, index) => {
@@ -85,14 +96,16 @@ class Navigation extends Component {
             onClick={() => onNavClick(item.name.toLowerCase())}
             isOpen={isOpen}
           >
-            <StyledNavigationButton name={item.name}>{item.icon(isOpen)}</StyledNavigationButton>
+            <StyledNavigationButton name={item.name}>
+              {item.icon(isOpen)}
+            </StyledNavigationButton>
           </NavigationButtonContainer>
         )
       })
     }
-    const getContentToShow = (openDrawer) => {
+    const getContentToShow = openDrawer => {
       if (openDrawer) {
-        let filteredList = topNavItems.concat(bottomNavItems).filter((item) => {
+        let filteredList = topNavItems.concat(bottomNavItems).filter(item => {
           return item.name.toLowerCase() === openDrawer
         })
         let TabContent = filteredList[0].content
@@ -101,7 +114,10 @@ class Navigation extends Component {
       return null
     }
     const topNavItemsList = buildNavList(topNavItems, this.state.drawerContent)
-    const bottomNavItemsList = buildNavList(bottomNavItems, this.state.drawerContent)
+    const bottomNavItemsList = buildNavList(
+      bottomNavItems,
+      this.state.drawerContent
+    )
 
     return (
       <StyledSidebar>
@@ -110,8 +126,11 @@ class Navigation extends Component {
           <StyledBottomNav>{bottomNavItemsList}</StyledBottomNav>
         </StyledTabsWrapper>
         <StyledDrawer
-          open={this.state.transitionState === Open || this.state.transitionState === Opening}
-          innerRef={(ref) => {
+          open={
+            this.state.transitionState === Open ||
+            this.state.transitionState === Opening
+          }
+          innerRef={ref => {
             if (ref) {
               // Remove old listeners so we don't get multiple callbacks.
               // This function is called more than once with same html element

--- a/src/browser/components/TabNavigation/Navigation.test.jsx
+++ b/src/browser/components/TabNavigation/Navigation.test.jsx
@@ -32,7 +32,10 @@ describe('Navigation', () => {
   }
   const navItem1 = 'item1' + Math.random()
   const navItem2 = 'item2' + Math.random()
-  const navItems = [{name: navItem1, icon: null, content: Tab1Content}, {name: navItem2, icon: null, content: Tab2Content}]
+  const navItems = [
+    { name: navItem1, icon: null, content: Tab1Content },
+    { name: navItem2, icon: null, content: Tab2Content }
+  ]
 
   test('renders a list of navigation links', () => {
     const wrapper = mount(<Navigation topNavItems={navItems} />)
@@ -41,19 +44,25 @@ describe('Navigation', () => {
 
   test('hides drawer when no drawer should be open', () => {
     const drawer = null
-    const wrapper = mount(<Navigation openDrawer={drawer} topNavItems={navItems} />)
+    const wrapper = mount(
+      <Navigation openDrawer={drawer} topNavItems={navItems} />
+    )
     expect(wrapper.find('.tab').at(0).hasClass('hidden')).toEqual(true)
   })
 
   test('shows drawer when drawer should be open', () => {
     const drawer = navItem1
-    const wrapper = mount(<Navigation openDrawer={drawer} topNavItems={navItems} />)
+    const wrapper = mount(
+      <Navigation openDrawer={drawer} topNavItems={navItems} />
+    )
     expect(wrapper.find('.tab').at(0).hasClass('hidden')).toEqual(false)
   })
 
   test('should render the selected tab', () => {
     const drawer = navItem1
-    const wrapper = mount(<Navigation openDrawer={drawer} topNavItems={navItems} />)
+    const wrapper = mount(
+      <Navigation openDrawer={drawer} topNavItems={navItems} />
+    )
     expect(wrapper.find('.tab').at(0).hasClass('hidden')).toEqual(false)
     expect(wrapper.find('#thing').length).toBe(1)
     expect(wrapper.find('#thing2').length).toBe(0)

--- a/src/browser/components/TabNavigation/styled.jsx
+++ b/src/browser/components/TabNavigation/styled.jsx
@@ -34,7 +34,7 @@ export const StyledDrawer = styled.div`
   background-color: #30333A;
   overflow-x: hidden;
   overflow-y: auto;
-  width: ${props => props.open ? '300px' : '0px'};
+  width: ${props => (props.open ? '300px' : '0px')};
   transition: .2s ease-out;
   z-index: 1;
 `

--- a/src/browser/components/Tables.jsx
+++ b/src/browser/components/Tables.jsx
@@ -53,7 +53,7 @@ export const SysInfoTableContainer = styled.div`
   padding: 30px;
   width: 100%;
 `
-export const SysInfoTable = ({header, colspan, children}) => {
+export const SysInfoTable = ({ header, colspan, children }) => {
   return (
     <StyledTable>
       <thead>
@@ -68,18 +68,18 @@ export const SysInfoTable = ({header, colspan, children}) => {
   )
 }
 
-export const SysInfoTableEntry = ({label, value, values, headers}) => {
+export const SysInfoTableEntry = ({ label, value, values, headers }) => {
   if (headers) {
     return (
       <StyledTr>
-        {headers.map((value) => <StyledTdKey>{value || '-'}</StyledTdKey>)}
+        {headers.map(value => <StyledTdKey>{value || '-'}</StyledTdKey>)}
       </StyledTr>
     )
   }
   if (values) {
     return (
       <StyledTr>
-        {values.map((value) => <StyledTd>{value || '-'}</StyledTd>)}
+        {values.map(value => <StyledTd>{value || '-'}</StyledTd>)}
       </StyledTr>
     )
   }

--- a/src/browser/components/badge/index.jsx
+++ b/src/browser/components/badge/index.jsx
@@ -20,7 +20,7 @@
 
 import style from './style.css'
 
-const Badge = ({children = null, status = 'ok', size = 'medium'}) => {
+const Badge = ({ children = null, status = 'ok', size = 'medium' }) => {
   let cn = style.badge
   if (status) cn += ' ' + style[status]
   if (size) cn += ' ' + style[size]

--- a/src/browser/components/buttons/ConfirmationButton.jsx
+++ b/src/browser/components/buttons/ConfirmationButton.jsx
@@ -18,9 +18,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {Component} from 'preact'
+import { Component } from 'preact'
 import styles from './style.css'
-import { MinusIcon, RightArrowIcon, CancelIcon } from 'browser-components/icons/Icons'
+import {
+  MinusIcon,
+  RightArrowIcon,
+  CancelIcon
+} from 'browser-components/icons/Icons'
 
 export class ConfirmationButton extends Component {
   constructor (props) {
@@ -32,21 +36,41 @@ export class ConfirmationButton extends Component {
   }
 
   componentWillMount () {
-    this.confirmIcon = this.props.confirmIcon || (<RightArrowIcon />)
-    this.cancelIcon = this.props.cancelIcon || (<CancelIcon />)
-    this.requestIcon = this.props.requestIcon || (<MinusIcon />)
+    this.confirmIcon = this.props.confirmIcon || <RightArrowIcon />
+    this.cancelIcon = this.props.cancelIcon || <CancelIcon />
+    this.requestIcon = this.props.requestIcon || <MinusIcon />
   }
 
   render () {
     if (this.state.requested) {
       return (
         <div>
-          <button className={styles.icon} onClick={() => { this.setState({ requested: false }); this.props.onConfirmed() }}>{this.confirmIcon}</button>
-          <button className={styles.icon} onClick={() => this.setState({ requested: false })}>{this.cancelIcon}</button>
+          <button
+            className={styles.icon}
+            onClick={() => {
+              this.setState({ requested: false })
+              this.props.onConfirmed()
+            }}
+          >
+            {this.confirmIcon}
+          </button>
+          <button
+            className={styles.icon}
+            onClick={() => this.setState({ requested: false })}
+          >
+            {this.cancelIcon}
+          </button>
         </div>
       )
     } else {
-      return (<button className={styles.icon} onClick={() => this.setState({ requested: true })}>{this.requestIcon}</button>)
+      return (
+        <button
+          className={styles.icon}
+          onClick={() => this.setState({ requested: true })}
+        >
+          {this.requestIcon}
+        </button>
+      )
     }
   }
 }

--- a/src/browser/components/buttons/index.jsx
+++ b/src/browser/components/buttons/index.jsx
@@ -36,15 +36,18 @@ export class ToolTip extends Component {
     }
   }
   onMouseEnterHandler () {
-    this.setState({mouseover: true})
+    this.setState({ mouseover: true })
   }
   onMouseLeaveHandler () {
-    this.setState({mouseover: false})
+    this.setState({ mouseover: false })
   }
   render () {
     const tooltip = null
     return (
-      <div onMouseLeave={this.onMouseLeaveHandler.bind(this)} onMouseEnter={this.onMouseEnterHandler.bind(this)}>
+      <div
+        onMouseLeave={this.onMouseLeaveHandler.bind(this)}
+        onMouseEnter={this.onMouseEnterHandler.bind(this)}
+      >
         {this.props.children}
         {tooltip}
       </div>
@@ -52,10 +55,8 @@ export class ToolTip extends Component {
   }
 }
 
-export const CloseButton = (props) => {
-  return (
-    <button {...props}>×</button>
-  )
+export const CloseButton = props => {
+  return <button {...props}>×</button>
 }
 
 export const EditorButton = styled.span`
@@ -101,7 +102,8 @@ export const StyledNavigationButton = styled.button`
 export const NavigationButtonContainer = styled.li`
   min-height: 70px;
   height: 70px;
-  background-color: ${props => !props.isOpen ? 'transparent' : props.theme.drawerBackground};
+  background-color: ${props =>
+    !props.isOpen ? 'transparent' : props.theme.drawerBackground};
   &:focus {
     outline: none;
   }
@@ -154,19 +156,23 @@ const buttonTypes = {
   drawer: StyledDrawerFormButton
 }
 
-export const FormButton = (props) => {
-  const {icon, label, children, ...rest} = props
+export const FormButton = props => {
+  const { icon, label, children, ...rest } = props
   const ButtonType = buttonTypes[props.buttonType] || buttonTypes.primary
 
-  if (icon && label) return (<ButtonType {...rest} type='button'>{label} {icon}</ButtonType>)
-  if (icon) return (<ButtonType {...rest} type='button'>{icon}</ButtonType>)
-  if (label) return (<ButtonType {...rest} type='button'>{label}</ButtonType>)
-  return (<ButtonType {...props} type='button'>{children}</ButtonType>)
+  if (icon && label) {
+    return <ButtonType {...rest} type='button'>{label} {icon}</ButtonType>
+  }
+  if (icon) return <ButtonType {...rest} type='button'>{icon}</ButtonType>
+  if (label) return <ButtonType {...rest} type='button'>{label}</ButtonType>
+  return <ButtonType {...props} type='button'>{children}</ButtonType>
 }
 
-export const CypherFrameButton = (props) => {
-  const {selected, ...rest} = props
-  return (selected) ? <StyledSelectedCypherFrameButton {...rest} /> : <StyledCypherFrameButton {...rest} />
+export const CypherFrameButton = props => {
+  const { selected, ...rest } = props
+  return selected
+    ? <StyledSelectedCypherFrameButton {...rest} />
+    : <StyledCypherFrameButton {...rest} />
 }
 
 const StyledCypherFrameButton = styled.li`
@@ -193,9 +199,11 @@ const StyledSelectedCypherFrameButton = styled(StyledCypherFrameButton)`
   color: ${props => props.theme.secondaryButtonTextHover};
   fill: ${props => props.theme.secondaryButtonTextHover};
 `
-export const FrameButton = (props) => {
-  const {pressed, children, ...rest} = props
-  return (pressed) ? <StyledFrameButtonPressed {...rest}>{children}</StyledFrameButtonPressed> : <StyledFrameButton {...rest}>{children}</StyledFrameButton>
+export const FrameButton = props => {
+  const { pressed, children, ...rest } = props
+  return pressed
+    ? <StyledFrameButtonPressed {...rest}>{children}</StyledFrameButtonPressed>
+    : <StyledFrameButton {...rest}>{children}</StyledFrameButton>
 }
 const StyledFrameButton = styled.li`
   color: ${props => props.theme.secondaryButtonText};
@@ -236,9 +244,9 @@ export const FrameButtonAChild = styled(DefaultA)`
   }
 `
 
-export const ActionButton = (props) => {
-  const {className, ...rest} = props
-  return (<button className={className + ' ' + styles.action} {...rest} />)
+export const ActionButton = props => {
+  const { className, ...rest } = props
+  return <button className={className + ' ' + styles.action} {...rest} />
 }
 
 const BaseCarouselButton = styled.button`
@@ -281,8 +289,8 @@ const CarouselButtonOverlay = styled.span`
   top: 13px;
   left: 9px;
 `
-export const CarouselButton = (props) => {
-  const {children, ...rest} = props
+export const CarouselButton = props => {
+  const { children, ...rest } = props
   return (
     <BaseCarouselButton {...rest}>
       <CarouselButtonOverlay>{children}</CarouselButtonOverlay>

--- a/src/browser/components/headers/Headers.jsx
+++ b/src/browser/components/headers/Headers.jsx
@@ -26,15 +26,15 @@ export const H3 = styled.h3`
   font-family: ${props => props.theme.primaryFontFamily};
   color: ${props => props.theme.headerText};
 `
-export const H2 = (props) => {
-  return (<h2 {...props} />)
+export const H2 = props => {
+  return <h2 {...props} />
 }
-export const H1 = (props) => {
-  return (<h1 {...props} />)
+export const H1 = props => {
+  return <h1 {...props} />
 }
-export const H4 = (props) => {
-  return (<h4 {...props} />)
+export const H4 = props => {
+  return <h4 {...props} />
 }
-export const H5 = (props) => {
-  return (<h5 {...props} />)
+export const H5 = props => {
+  return <h5 {...props} />
 }

--- a/src/browser/components/icons/Icons.jsx
+++ b/src/browser/components/icons/Icons.jsx
@@ -30,20 +30,39 @@ class IconContainer extends Component {
     }
   }
   mouseover () {
-    this.setState({mouseover: true})
+    this.setState({ mouseover: true })
   }
   mouseout () {
-    this.setState({mouseover: false})
+    this.setState({ mouseover: false })
   }
   render () {
-    const {activeStyle, inactiveStyle, isOpen, text, regulateSize, ...rest} = this.props
-    const state = (this.state.mouseover || isOpen) ? activeStyle || '' : inactiveStyle || ''
-    const newClass = this.props.suppressIconStyles ? this.props.className : state + ' ' + this.props.className
-    const regulateSizeStyle = (regulateSize) ? {'font-size': regulateSize + 'em'} : null
-    const icon = <i {...rest} className={newClass} onMouseEnter={this.mouseover.bind(this)} onMouseLeave={this.mouseout.bind(this)} style={regulateSizeStyle} />
-    return text
-      ? <span>{icon}<StyledText>{text}</StyledText></span>
-      : icon
+    const {
+      activeStyle,
+      inactiveStyle,
+      isOpen,
+      text,
+      regulateSize,
+      ...rest
+    } = this.props
+    const state = this.state.mouseover || isOpen
+      ? activeStyle || ''
+      : inactiveStyle || ''
+    const newClass = this.props.suppressIconStyles
+      ? this.props.className
+      : state + ' ' + this.props.className
+    const regulateSizeStyle = regulateSize
+      ? { 'font-size': regulateSize + 'em' }
+      : null
+    const icon = (
+      <i
+        {...rest}
+        className={newClass}
+        onMouseEnter={this.mouseover.bind(this)}
+        onMouseLeave={this.mouseout.bind(this)}
+        style={regulateSizeStyle}
+      />
+    )
+    return text ? <span>{icon}<StyledText>{text}</StyledText></span> : icon
   }
 }
 
@@ -72,54 +91,166 @@ const databaseConnectionStateStyles = {
   }
 }
 
-export const DatabaseIcon = ({isOpen, connectionState}) => (<IconContainer isOpen={isOpen}
-  activeStyle={databaseConnectionStateStyles[connectionState].active}
-  inactiveStyle={databaseConnectionStateStyles[connectionState].inactive}
-  className={'sl sl-database-' + databaseConnectionStateStyles[connectionState].classModifier}
-/>)
-export const FavoritesIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.white} inactiveStyle={styles.inactive} className='sl sl-star' />)
-export const DocumentsIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.white} inactiveStyle={styles.inactive} className='sl sl-book' />)
+export const DatabaseIcon = ({ isOpen, connectionState }) =>
+  <IconContainer
+    isOpen={isOpen}
+    activeStyle={databaseConnectionStateStyles[connectionState].active}
+    inactiveStyle={databaseConnectionStateStyles[connectionState].inactive}
+    className={
+      'sl sl-database-' +
+      databaseConnectionStateStyles[connectionState].classModifier
+    }
+  />
+export const FavoritesIcon = ({ isOpen }) =>
+  <IconContainer
+    isOpen={isOpen}
+    activeStyle={styles.white}
+    inactiveStyle={styles.inactive}
+    className='sl sl-star'
+  />
+export const DocumentsIcon = ({ isOpen }) =>
+  <IconContainer
+    isOpen={isOpen}
+    activeStyle={styles.white}
+    inactiveStyle={styles.inactive}
+    className='sl sl-book'
+  />
 
-export const CloudIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.successGreen} inactiveStyle={styles.inactive} className='sl sl-cloud-checked' />)
-export const CloudDisconnectedIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.warningRed} inactiveStyle={styles.warningRed} className='sl sl-cloud-delete' />)
-export const CloudSyncIcon = ({isOpen, connected}) => (<IconContainer isOpen={isOpen} activeStyle={connected ? styles.successGreen : styles.warningRed} inactiveStyle={connected ? styles.inactive : styles.warningRed} className={'sl sl-cloud' + (connected ? '-checked' : '-delete')} />)
+export const CloudIcon = ({ isOpen }) =>
+  <IconContainer
+    isOpen={isOpen}
+    activeStyle={styles.successGreen}
+    inactiveStyle={styles.inactive}
+    className='sl sl-cloud-checked'
+  />
+export const CloudDisconnectedIcon = ({ isOpen }) =>
+  <IconContainer
+    isOpen={isOpen}
+    activeStyle={styles.warningRed}
+    inactiveStyle={styles.warningRed}
+    className='sl sl-cloud-delete'
+  />
+export const CloudSyncIcon = ({ isOpen, connected }) =>
+  <IconContainer
+    isOpen={isOpen}
+    activeStyle={connected ? styles.successGreen : styles.warningRed}
+    inactiveStyle={connected ? styles.inactive : styles.warningRed}
+    className={'sl sl-cloud' + (connected ? '-checked' : '-delete')}
+  />
 
-export const SettingsIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.white} inactiveStyle={styles.inactive} className='sl sl-setting-gear' />)
-export const AboutIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.credits} inactiveStyle={styles.inactive} className='nw nw-neo4j-outline-32px' />)
+export const SettingsIcon = ({ isOpen }) =>
+  <IconContainer
+    isOpen={isOpen}
+    activeStyle={styles.white}
+    inactiveStyle={styles.inactive}
+    className='sl sl-setting-gear'
+  />
+export const AboutIcon = ({ isOpen }) =>
+  <IconContainer
+    isOpen={isOpen}
+    activeStyle={styles.credits}
+    inactiveStyle={styles.inactive}
+    className='nw nw-neo4j-outline-32px'
+  />
 
-export const TableIcon = () => (<IconContainer className='fa fa-table' text='Table' />)
-export const VisualizationIcon = () => (<IconContainer className='nw nw-neo4j-outline-16px' text='Graph' />)
-export const AsciiIcon = () => (<IconContainer className='fa fa-font' text='Text' />)
-export const CodeIcon = () => (<IconContainer className='fa fa-code' text='Code' />)
-export const PlanIcon = () => (<IconContainer className='sl-hierarchy' text='Plan' />)
-export const AlertIcon = () => (<IconContainer className='sl-alert' text='Warn' />)
-export const ErrorIcon = () => (<IconContainer className='fa fa-file-text-o' text='Error' />)
+export const TableIcon = () =>
+  <IconContainer className='fa fa-table' text='Table' />
+export const VisualizationIcon = () =>
+  <IconContainer className='nw nw-neo4j-outline-16px' text='Graph' />
+export const AsciiIcon = () =>
+  <IconContainer className='fa fa-font' text='Text' />
+export const CodeIcon = () =>
+  <IconContainer className='fa fa-code' text='Code' />
+export const PlanIcon = () =>
+  <IconContainer className='sl-hierarchy' text='Plan' />
+export const AlertIcon = () =>
+  <IconContainer className='sl-alert' text='Warn' />
+export const ErrorIcon = () =>
+  <IconContainer className='fa fa-file-text-o' text='Error' />
 
-export const ZoomInIcon = () => (<IconContainer activeStyle={styles.active} inactiveStyle={styles.inactive} className='sl-zoom-in' />)
-export const ZoomOutIcon = () => (<IconContainer activeStyle={styles.active} inactiveStyle={styles.inactive} className='sl-zoom-out' />)
+export const ZoomInIcon = () =>
+  <IconContainer
+    activeStyle={styles.active}
+    inactiveStyle={styles.inactive}
+    className='sl-zoom-in'
+  />
+export const ZoomOutIcon = () =>
+  <IconContainer
+    activeStyle={styles.active}
+    inactiveStyle={styles.inactive}
+    className='sl-zoom-out'
+  />
 
-export const BinIcon = (props) => (<IconContainer activeStyle={styles.white} inactiveStyle={styles.inactive} {...props} className='sl-bin' />)
+export const BinIcon = props =>
+  <IconContainer
+    activeStyle={styles.white}
+    inactiveStyle={styles.inactive}
+    {...props}
+    className='sl-bin'
+  />
 
-export const ExpandIcon = () => (<IconContainer className='sl-scale-spread' />)
-export const ContractIcon = () => (<IconContainer className='sl-scale-reduce' />)
-export const RefreshIcon = () => (<IconContainer className='sl-loop' />)
-export const CloseIcon = () => (<IconContainer className='sl-delete' regulateSize='0.85' />)
-export const UpIcon = () => (<IconContainer className='sl-chevron-up' />)
-export const DownIcon = () => (<IconContainer className='sl-chevron-down' />)
-export const DoubleUpIcon = () => (<IconContainer className='sl-double-up' />)
-export const DoubleDownIcon = () => (<IconContainer className='sl-double-down' />)
-export const PinIcon = () => (<IconContainer className='sl-pin' />)
-export const MinusIcon = () => (<IconContainer activeStyle={styles.blue} inactiveStyle={styles.inactive} className='sl-minus-circle' />)
-export const RightArrowIcon = () => (<IconContainer activeStyle={styles.blue} inactiveStyle={styles.inactive} className='sl-arrow-circle-right' />)
-export const CancelIcon = () => (<IconContainer activeStyle={styles.blue} inactiveStyle={styles.inactive} className='sl-delete-circle' />)
-export const DownloadIcon = () => (<IconContainer className='sl-download-drive' />)
-export const ExpandMenuIcon = () => (<IconContainer activeStyle={styles.blue} className='fa fa-caret-right' />)
-export const CollapseMenuIcon = () => (<IconContainer activeStyle={styles.blue} className='fa fa-caret-down' />)
-export const PlayIcon = () => (<IconContainer activeStyle={styles.lightBlue} inactiveStyle={styles.blue} className='fa fa-play-circle-o' />)
-export const PlainPlayIcon = () => (<IconContainer className='fa fa-play-circle' />)
-export const QuestionIcon = () => (<IconContainer activeStyle={styles.lightBlue} inactiveStyle={styles.blue} className='fa fa-question-circle-o' />)
-export const PlusIcon = () => (<IconContainer activeStyle={styles.white} inactiveStyle={styles.white} className='fa fa-plus' />)
-export const EditIcon = () => (<IconContainer activeStyle={styles.white} inactiveStyle={styles.white} className='sl-pencil' />)
-export const Spinner = () => (<IconContainer className='fa fa-spinner fa-spin fa-2x' />)
+export const ExpandIcon = () => <IconContainer className='sl-scale-spread' />
+export const ContractIcon = () => <IconContainer className='sl-scale-reduce' />
+export const RefreshIcon = () => <IconContainer className='sl-loop' />
+export const CloseIcon = () =>
+  <IconContainer className='sl-delete' regulateSize='0.85' />
+export const UpIcon = () => <IconContainer className='sl-chevron-up' />
+export const DownIcon = () => <IconContainer className='sl-chevron-down' />
+export const DoubleUpIcon = () => <IconContainer className='sl-double-up' />
+export const DoubleDownIcon = () => <IconContainer className='sl-double-down' />
+export const PinIcon = () => <IconContainer className='sl-pin' />
+export const MinusIcon = () =>
+  <IconContainer
+    activeStyle={styles.blue}
+    inactiveStyle={styles.inactive}
+    className='sl-minus-circle'
+  />
+export const RightArrowIcon = () =>
+  <IconContainer
+    activeStyle={styles.blue}
+    inactiveStyle={styles.inactive}
+    className='sl-arrow-circle-right'
+  />
+export const CancelIcon = () =>
+  <IconContainer
+    activeStyle={styles.blue}
+    inactiveStyle={styles.inactive}
+    className='sl-delete-circle'
+  />
+export const DownloadIcon = () =>
+  <IconContainer className='sl-download-drive' />
+export const ExpandMenuIcon = () =>
+  <IconContainer activeStyle={styles.blue} className='fa fa-caret-right' />
+export const CollapseMenuIcon = () =>
+  <IconContainer activeStyle={styles.blue} className='fa fa-caret-down' />
+export const PlayIcon = () =>
+  <IconContainer
+    activeStyle={styles.lightBlue}
+    inactiveStyle={styles.blue}
+    className='fa fa-play-circle-o'
+  />
+export const PlainPlayIcon = () =>
+  <IconContainer className='fa fa-play-circle' />
+export const QuestionIcon = () =>
+  <IconContainer
+    activeStyle={styles.lightBlue}
+    inactiveStyle={styles.blue}
+    className='fa fa-question-circle-o'
+  />
+export const PlusIcon = () =>
+  <IconContainer
+    activeStyle={styles.white}
+    inactiveStyle={styles.white}
+    className='fa fa-plus'
+  />
+export const EditIcon = () =>
+  <IconContainer
+    activeStyle={styles.white}
+    inactiveStyle={styles.white}
+    className='sl-pencil'
+  />
+export const Spinner = () =>
+  <IconContainer className='fa fa-spinner fa-spin fa-2x' />
 
-export const ExclamationTriangleIcon = () => <IconContainer suppressIconStyles className='fa fa-exclamation-triangle' />
+export const ExclamationTriangleIcon = () =>
+  <IconContainer suppressIconStyles className='fa fa-exclamation-triangle' />

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -23,7 +23,10 @@ import { createEpicMiddleware } from 'redux-observable'
 import { render } from 'preact'
 import { createStore, combineReducers, applyMiddleware, compose } from 'redux'
 import { Provider } from 'preact-redux'
-import { createBus, createReduxMiddleware as createSuberReduxMiddleware } from 'suber'
+import {
+  createBus,
+  createReduxMiddleware as createSuberReduxMiddleware
+} from 'suber'
 import { BusProvider } from 'preact-suber'
 
 import reducers from 'shared/rootReducer'
@@ -56,7 +59,7 @@ const reducer = combineReducers({ ...reducers })
 
 const enhancer = compose(
   applyMiddleware(suberMiddleware, epicMiddleware, localStorageMiddleware),
-  window.devToolsExtension ? window.devToolsExtension() : (f) => f
+  window.devToolsExtension ? window.devToolsExtension() : f => f
 )
 
 const store = createStore(
@@ -70,7 +73,7 @@ bus.applyMiddleware((_, origin) => (channel, message, source) => {
   // No loop-backs
   if (source === 'redux') return
   // Send to Redux with the channel as the action type
-  store.dispatch({...message, type: channel, ...origin})
+  store.dispatch({ ...message, type: channel, ...origin })
 })
 
 // Signal app upstart (for epics)
@@ -85,9 +88,9 @@ const renderApp = () => {
       <BusProvider bus={bus}>
         <App />
       </BusProvider>
-    </Provider>
-    , mountElement
-    , elem
+    </Provider>,
+    mountElement,
+    elem
   )
 }
 renderApp()

--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -25,12 +25,24 @@ import { ThemeProvider } from 'styled-components'
 import * as themes from 'browser/styles/themes'
 import { getTheme, getCmdChar } from 'shared/modules/settings/settingsDuck'
 import { FOCUS, EXPAND } from 'shared/modules/editor/editorDuck'
-import { wasUnknownCommand, getErrorMessage } from 'shared/modules/commands/commandsDuck'
+import {
+  wasUnknownCommand,
+  getErrorMessage
+} from 'shared/modules/commands/commandsDuck'
 import { allowOutgoingConnections } from 'shared/modules/dbMeta/dbMetaDuck'
-import { getActiveConnection, getConnectionState, getActiveConnectionData } from 'shared/modules/connections/connectionsDuck'
+import {
+  getActiveConnection,
+  getConnectionState,
+  getActiveConnectionData
+} from 'shared/modules/connections/connectionsDuck'
 import { toggle } from 'shared/modules/sidebar/sidebarDuck'
 
-import { StyledWrapper, StyledApp, StyledBody, StyledMainWrapper } from './styled'
+import {
+  StyledWrapper,
+  StyledApp,
+  StyledBody,
+  StyledMainWrapper
+} from './styled'
 import Main from '../Main/Main'
 import Sidebar from '../Sidebar/Sidebar'
 import UserInteraction from '../UserInteraction'
@@ -58,7 +70,17 @@ class App extends Component {
     this.props.bus && this.props.bus.send(EXPAND)
   }
   render () {
-    const {drawer, cmdchar, handleNavClick, activeConnection, connectionState, theme, showUnknownCommandBanner, errorMessage, loadUdc} = this.props
+    const {
+      drawer,
+      cmdchar,
+      handleNavClick,
+      activeConnection,
+      connectionState,
+      theme,
+      showUnknownCommandBanner,
+      errorMessage,
+      loadUdc
+    } = this.props
     const themeData = themes[theme] || themes['normal']
     return (
       <ThemeProvider theme={themeData}>
@@ -88,7 +110,7 @@ class App extends Component {
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   const connectionData = getActiveConnectionData(state)
   return {
     drawer: state.drawer,
@@ -103,9 +125,9 @@ const mapStateToProps = (state) => {
   }
 }
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
-    handleNavClick: (id) => {
+    handleNavClick: id => {
       dispatch(toggle(id))
     }
   }

--- a/src/browser/modules/ClickToCode/index.jsx
+++ b/src/browser/modules/ClickToCode/index.jsx
@@ -21,10 +21,19 @@ import { withBus } from 'preact-suber'
 import { SET_CONTENT, setContent } from 'shared/modules/editor/editorDuck'
 import { StyledCodeBlock } from './styled'
 
-export const ClickToCode = ({CodeComponent = StyledCodeBlock, bus, code, children}) => {
+export const ClickToCode = ({
+  CodeComponent = StyledCodeBlock,
+  bus,
+  code,
+  children
+}) => {
   if (!children || children.length === 0) return null
   code = code || children.join('')
-  return <CodeComponent onClick={() => bus.send(SET_CONTENT, setContent(code))}>{children}</CodeComponent>
+  return (
+    <CodeComponent onClick={() => bus.send(SET_CONTENT, setContent(code))}>
+      {children}
+    </CodeComponent>
+  )
 }
 
 export default withBus(ClickToCode)

--- a/src/browser/modules/ConnectionsDropdown/ConnectionsDropdown.jsx
+++ b/src/browser/modules/ConnectionsDropdown/ConnectionsDropdown.jsx
@@ -26,36 +26,38 @@ import { getBookmarks, getActiveBookmark } from '../reducer'
 export class Dropdown extends Component {
   constructor (props) {
     super(props)
-    this.state = {selected: this.props.activeBookmark}
+    this.state = { selected: this.props.activeBookmark }
   }
   change (event) {
-    this.setState({selected: event.target.value}, () => {
+    this.setState({ selected: event.target.value }, () => {
       this.props.onBookmarkChange(this.state.selected)
     })
   }
   componentWillReceiveProps (newProps) {
-    this.setState({selected: newProps.activeBookmark})
+    this.setState({ selected: newProps.activeBookmark })
   }
   render () {
-    let bms = this.props.bookmarks.map((bm) => {
+    let bms = this.props.bookmarks.map(bm => {
       return <option value={bm.id} key={bm.id}>{bm.name}</option>
     })
     return (
-      <select onChange={this.change.bind(this)} value={this.state.selected}>{bms}</select>
+      <select onChange={this.change.bind(this)} value={this.state.selected}>
+        {bms}
+      </select>
     )
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     bookmarks: getBookmarks(state),
     activeBookmark: getActiveBookmark(state)
   }
 }
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
-    onBookmarkChange: (id) => {
+    onBookmarkChange: id => {
       dispatch(selectBookmark(id))
     }
   }

--- a/src/browser/modules/D3Visualization/components/Graph.jsx
+++ b/src/browser/modules/D3Visualization/components/Graph.jsx
@@ -19,11 +19,16 @@
  */
 
 import { Component } from 'preact'
-import {createGraph, mapNodes, mapRelationships, getGraphStats} from '../mapper'
-import {GraphEventHandler} from '../GraphEventHandler'
+import {
+  createGraph,
+  mapNodes,
+  mapRelationships,
+  getGraphStats
+} from '../mapper'
+import { GraphEventHandler } from '../GraphEventHandler'
 import '../lib/visualization/index'
 import { dim } from 'browser-styles/constants'
-import {StyledZoomHolder, StyledSvgWrapper, StyledZoomButton} from './styled'
+import { StyledZoomHolder, StyledSvgWrapper, StyledZoomButton } from './styled'
 import { ZoomInIcon, ZoomOutIcon } from 'browser-components/icons/Icons'
 
 export class GraphComponent extends Component {
@@ -41,19 +46,32 @@ export class GraphComponent extends Component {
 
   zoomInClicked (el) {
     let limits = this.graphView.zoomIn(el)
-    this.setState({zoomInLimitReached: limits.zoomInLimit, zoomOutLimitReached: limits.zoomOutLimit})
+    this.setState({
+      zoomInLimitReached: limits.zoomInLimit,
+      zoomOutLimitReached: limits.zoomOutLimit
+    })
   }
 
   zoomOutlicked (el) {
     let limits = this.graphView.zoomOut(el)
-    this.setState({zoomInLimitReached: limits.zoomInLimit, zoomOutLimitReached: limits.zoomOutLimit})
+    this.setState({
+      zoomInLimitReached: limits.zoomInLimit,
+      zoomOutLimitReached: limits.zoomOutLimit
+    })
   }
 
   getVisualAreaHeight () {
     if (this.props.frameHeight && this.props.fullscreen) {
-      return this.props.frameHeight - (dim.frameStatusbarHeight + dim.frameTitlebarHeight * 2)
+      return (
+        this.props.frameHeight -
+        (dim.frameStatusbarHeight + dim.frameTitlebarHeight * 2)
+      )
     } else {
-      return this.props.frameHeight - (dim.frameStatusbarHeight + dim.frameTitlebarHeight * 2) || this.svgElement.parentNode.offsetHeight
+      return (
+        this.props.frameHeight -
+          (dim.frameStatusbarHeight + dim.frameTitlebarHeight * 2) ||
+        this.svgElement.parentNode.offsetHeight
+      )
     }
   }
 
@@ -62,11 +80,20 @@ export class GraphComponent extends Component {
       if (!this.graphView) {
         let NeoConstructor = neo.graphView
         let measureSize = () => {
-          return {width: this.svgElement.offsetWidth, height: this.getVisualAreaHeight()}
+          return {
+            width: this.svgElement.offsetWidth,
+            height: this.getVisualAreaHeight()
+          }
         }
         this.graph = createGraph(this.props.nodes, this.props.relationships)
-        this.graphView = new NeoConstructor(this.svgElement, measureSize, this.graph, this.props.graphStyle)
-        new GraphEventHandler(this.graph,
+        this.graphView = new NeoConstructor(
+          this.svgElement,
+          measureSize,
+          this.graph,
+          this.props.graphStyle
+        )
+        new GraphEventHandler(
+          this.graph,
           this.graphView,
           this.props.getNodeNeighbours,
           this.props.onItemMouseOver,
@@ -80,32 +107,49 @@ export class GraphComponent extends Component {
       }
 
       this.graph && this.props.setGraph && this.props.setGraph(this.graph)
-      this.props.getAutoCompleteCallback && this.props.getAutoCompleteCallback(this.addInternalRelationships.bind(this))
-      this.props.assignVisElement && this.props.assignVisElement(this.svgElement, this.graphView)
+      this.props.getAutoCompleteCallback &&
+        this.props.getAutoCompleteCallback(
+          this.addInternalRelationships.bind(this)
+        )
+      this.props.assignVisElement &&
+        this.props.assignVisElement(this.svgElement, this.graphView)
     }
   }
 
   addInternalRelationships (internalRelationships) {
     if (this.graph) {
-      this.graph.addInternalRelationships(mapRelationships(internalRelationships, this.graph))
+      this.graph.addInternalRelationships(
+        mapRelationships(internalRelationships, this.graph)
+      )
       this.graphView.update()
     }
   }
 
   componentWillReceiveProps (nextProps) {
-    if ((nextProps.relationships !== this.props.relationships || nextProps.nodes !== this.props.nodes) && this.graphView !== undefined) {
+    if (
+      (nextProps.relationships !== this.props.relationships ||
+        nextProps.nodes !== this.props.nodes) &&
+      this.graphView !== undefined
+    ) {
       this.graph.resetGraph()
       this.graph.addNodes(mapNodes(nextProps.nodes))
-      this.graph.addRelationships(mapRelationships(nextProps.relationships, this.graph))
-    } else if (this.state.currentStyleRules !== nextProps.graphStyle.toString()) {
+      this.graph.addRelationships(
+        mapRelationships(nextProps.relationships, this.graph)
+      )
+    } else if (
+      this.state.currentStyleRules !== nextProps.graphStyle.toString()
+    ) {
       this.graphView.update()
       this.state.currentStyleRules = nextProps.graphStyle.toString()
     }
 
-    if (this.props.fullscreen !== nextProps.fullscreen || this.props.frameHeight !== nextProps.frameHeight) {
-      this.setState({shouldResize: true})
+    if (
+      this.props.fullscreen !== nextProps.fullscreen ||
+      this.props.frameHeight !== nextProps.frameHeight
+    ) {
+      this.setState({ shouldResize: true })
     } else {
-      this.setState({shouldResize: false})
+      this.setState({ shouldResize: false })
     }
   }
 
@@ -119,10 +163,20 @@ export class GraphComponent extends Component {
     if (this.props.fullscreen) {
       return (
         <StyledZoomHolder>
-          <StyledZoomButton className={this.state.zoomInLimitReached ? 'faded zoom-in' : 'zoom-in'} onClick={this.zoomInClicked.bind(this)}>
+          <StyledZoomButton
+            className={
+              this.state.zoomInLimitReached ? 'faded zoom-in' : 'zoom-in'
+            }
+            onClick={this.zoomInClicked.bind(this)}
+          >
             <ZoomInIcon />
           </StyledZoomButton>
-          <StyledZoomButton className={this.state.zoomOutLimitReached ? 'faded zoom-out' : 'zoom-out'} onClick={this.zoomOutlicked.bind(this)}>
+          <StyledZoomButton
+            className={
+              this.state.zoomOutLimitReached ? 'faded zoom-out' : 'zoom-out'
+            }
+            onClick={this.zoomOutlicked.bind(this)}
+          >
             <ZoomOutIcon />
           </StyledZoomButton>
         </StyledZoomHolder>

--- a/src/browser/modules/D3Visualization/components/GrassEditor.jsx
+++ b/src/browser/modules/D3Visualization/components/GrassEditor.jsx
@@ -21,7 +21,16 @@
 import { Component } from 'preact'
 import { connect } from 'preact-redux'
 import neoGraphStyle from '../graphStyle'
-import {StyledPickerSelector, StyledTokenRelationshipType, StyledInlineList, StyledInlineListItem, StyledLabelToken, StyledPickerListItem, StyledCircleSelector, StyledCaptionSelector} from './styled'
+import {
+  StyledPickerSelector,
+  StyledTokenRelationshipType,
+  StyledInlineList,
+  StyledInlineListItem,
+  StyledLabelToken,
+  StyledPickerListItem,
+  StyledCircleSelector,
+  StyledCaptionSelector
+} from './styled'
 import * as actions from 'shared/modules/grass/grassDuck'
 
 export class GrassEditorComponent extends Component {
@@ -50,7 +59,16 @@ export class GrassEditorComponent extends Component {
     this.props.update(this.graphStyle.toSheet())
   }
 
-  circleSelector (styleProps, styleProvider, activeProvider, className, selector, textProvider = () => { return '' }) {
+  circleSelector (
+    styleProps,
+    styleProvider,
+    activeProvider,
+    className,
+    selector,
+    textProvider = () => {
+      return ''
+    }
+  ) {
     return styleProps.map((styleProp, i) => {
       const onClick = () => {
         this.updateStyle(selector, styleProp)
@@ -60,7 +78,13 @@ export class GrassEditorComponent extends Component {
       const active = activeProvider(styleProp)
       return (
         <StyledPickerListItem className={className} key={i}>
-          <StyledCircleSelector className={active ? 'active' : ''} style={style} onClick={onClick}>{text}</StyledCircleSelector>
+          <StyledCircleSelector
+            className={active ? 'active' : ''}
+            style={style}
+            onClick={onClick}
+          >
+            {text}
+          </StyledCircleSelector>
         </StyledPickerListItem>
       )
     })
@@ -71,7 +95,17 @@ export class GrassEditorComponent extends Component {
       <StyledInlineListItem key='color-picker'>
         <StyledInlineList className='color-picker picker'>
           <StyledInlineListItem>Color:</StyledInlineListItem>
-          {this.circleSelector(this.graphStyle.defaultColors(), (color) => { return {'backgroundColor': color.color} }, (color) => { return color.color === styleForLabel.get('color') }, 'color-picker-item', selector)}
+          {this.circleSelector(
+            this.graphStyle.defaultColors(),
+            color => {
+              return { backgroundColor: color.color }
+            },
+            color => {
+              return color.color === styleForLabel.get('color')
+            },
+            'color-picker-item',
+            selector
+          )}
         </StyledInlineList>
       </StyledInlineListItem>
     )
@@ -82,24 +116,47 @@ export class GrassEditorComponent extends Component {
       <StyledInlineListItem key='size-picker'>
         <StyledInlineList className='size-picker picker'>
           <StyledInlineListItem>Size:</StyledInlineListItem>
-          {this.circleSelector(this.graphStyle.defaultSizes(), (size, index) => { return { width: this.nodeDisplaySizes[index], height: this.nodeDisplaySizes[index] } }, (size) => { return this.sizeLessThan(size.diameter, styleForLabel.get('diameter')) }, 'size-picker-item', selector)}
+          {this.circleSelector(
+            this.graphStyle.defaultSizes(),
+            (size, index) => {
+              return {
+                width: this.nodeDisplaySizes[index],
+                height: this.nodeDisplaySizes[index]
+              }
+            },
+            size => {
+              return this.sizeLessThan(
+                size.diameter,
+                styleForLabel.get('diameter')
+              )
+            },
+            'size-picker-item',
+            selector
+          )}
         </StyledInlineList>
       </StyledInlineListItem>
     )
   }
   widthPicker (selector, styleForItem) {
-    let widthSelectors = this.graphStyle.defaultArrayWidths().map((widthValue, i) => {
-      const onClick = () => {
-        this.updateStyle(selector, widthValue)
-      }
-      const style = { width: this.widths[i] }
-      const active = styleForItem.get('shaft-width') === widthValue['shaft-width']
-      return (
-        <StyledPickerListItem className='width-picker-item' key={i}>
-          <StyledPickerSelector className={active ? 'active' : ''} style={style} onClick={onClick} />
-        </StyledPickerListItem>
-      )
-    })
+    let widthSelectors = this.graphStyle
+      .defaultArrayWidths()
+      .map((widthValue, i) => {
+        const onClick = () => {
+          this.updateStyle(selector, widthValue)
+        }
+        const style = { width: this.widths[i] }
+        const active =
+          styleForItem.get('shaft-width') === widthValue['shaft-width']
+        return (
+          <StyledPickerListItem className='width-picker-item' key={i}>
+            <StyledPickerSelector
+              className={active ? 'active' : ''}
+              style={style}
+              onClick={onClick}
+            />
+          </StyledPickerListItem>
+        )
+      })
     return (
       <StyledInlineListItem key='width-picker'>
         <StyledInlineList className='width-picker picker'>
@@ -115,13 +172,28 @@ export class GrassEditorComponent extends Component {
       <li key='icon-picker'>
         Icon:
         <ul className='icon-picker picker'>
-          {this.picker(this.graphStyle.defaultIconCodes(), (iconCode) => { return { 'fontFamily': 'streamline' } }, 'icon-picker-item', selector, (iconCode) => { return iconCode['icon-code'] })}
+          {this.picker(
+            this.graphStyle.defaultIconCodes(),
+            iconCode => {
+              return { fontFamily: 'streamline' }
+            },
+            'icon-picker-item',
+            selector,
+            iconCode => {
+              return iconCode['icon-code']
+            }
+          )}
         </ul>
       </li>
     )
   }
 
-  captionPicker (selector, styleForItem, propertyKeys, showTypeSelector = false) {
+  captionPicker (
+    selector,
+    styleForItem,
+    propertyKeys,
+    showTypeSelector = false
+  ) {
     let captionSelector = (displayCaption, captionToSave, key) => {
       const onClick = () => {
         this.updateStyle(selector, { caption: captionToSave })
@@ -129,7 +201,12 @@ export class GrassEditorComponent extends Component {
       let active = styleForItem.props.caption === captionToSave
       return (
         <StyledPickerListItem key={key}>
-          <StyledCaptionSelector className={active ? 'active' : ''} onClick={onClick}>{displayCaption}</StyledCaptionSelector>
+          <StyledCaptionSelector
+            className={active ? 'active' : ''}
+            onClick={onClick}
+          >
+            {displayCaption}
+          </StyledCaptionSelector>
         </StyledPickerListItem>
       )
     }
@@ -156,17 +233,55 @@ export class GrassEditorComponent extends Component {
     let pickers
     let title
     if (this.props.selectedLabel) {
-      const labelList = this.props.selectedLabel.label !== '*' ? [this.props.selectedLabel.label] : []
+      const labelList = this.props.selectedLabel.label !== '*'
+        ? [this.props.selectedLabel.label]
+        : []
       const styleForLabel = this.graphStyle.forNode({ labels: labelList })
-      const inlineStyle = {'backgroundColor': styleForLabel.get('color'), 'color': styleForLabel.get('text-color-internal')}
-      pickers = [this.colorPicker(styleForLabel.selector, styleForLabel), this.sizePicker(styleForLabel.selector, styleForLabel), this.captionPicker(styleForLabel.selector, styleForLabel, this.props.selectedLabel.propertyKeys)]
-      title = (<StyledLabelToken className='token token-label' style={inlineStyle}>{this.props.selectedLabel.label || '*'}</StyledLabelToken>)
+      const inlineStyle = {
+        backgroundColor: styleForLabel.get('color'),
+        color: styleForLabel.get('text-color-internal')
+      }
+      pickers = [
+        this.colorPicker(styleForLabel.selector, styleForLabel),
+        this.sizePicker(styleForLabel.selector, styleForLabel),
+        this.captionPicker(
+          styleForLabel.selector,
+          styleForLabel,
+          this.props.selectedLabel.propertyKeys
+        )
+      ]
+      title = (
+        <StyledLabelToken className='token token-label' style={inlineStyle}>
+          {this.props.selectedLabel.label || '*'}
+        </StyledLabelToken>
+      )
     } else if (this.props.selectedRelType) {
-      const relTypeSelector = this.props.selectedRelType.relType !== '*' ? {type: this.props.selectedRelType.relType} : {}
+      const relTypeSelector = this.props.selectedRelType.relType !== '*'
+        ? { type: this.props.selectedRelType.relType }
+        : {}
       const styleForRelType = this.graphStyle.forRelationship(relTypeSelector)
-      const inlineStyle = {'backgroundColor': styleForRelType.get('color'), 'color': styleForRelType.get('text-color-internal')}
-      pickers = [this.colorPicker(styleForRelType.selector, styleForRelType), this.widthPicker(styleForRelType.selector, styleForRelType), this.captionPicker(styleForRelType.selector, styleForRelType, this.props.selectedRelType.propertyKeys, true)]
-      title = (<StyledTokenRelationshipType className='token token-relationship' style={inlineStyle}>{this.props.selectedRelType.relType || '*'}</StyledTokenRelationshipType>)
+      const inlineStyle = {
+        backgroundColor: styleForRelType.get('color'),
+        color: styleForRelType.get('text-color-internal')
+      }
+      pickers = [
+        this.colorPicker(styleForRelType.selector, styleForRelType),
+        this.widthPicker(styleForRelType.selector, styleForRelType),
+        this.captionPicker(
+          styleForRelType.selector,
+          styleForRelType,
+          this.props.selectedRelType.propertyKeys,
+          true
+        )
+      ]
+      title = (
+        <StyledTokenRelationshipType
+          className='token token-relationship'
+          style={inlineStyle}
+        >
+          {this.props.selectedRelType.relType || '*'}
+        </StyledTokenRelationshipType>
+      )
     } else {
       return null
     }
@@ -179,7 +294,10 @@ export class GrassEditorComponent extends Component {
   }
 
   componentWillReceiveProps (nextProps) {
-    if (nextProps.graphStyleData && nextProps.graphStyleData !== this.props.graphStyleData) {
+    if (
+      nextProps.graphStyleData &&
+      nextProps.graphStyleData !== this.props.graphStyleData
+    ) {
       this.graphStyle.loadRules(nextProps.graphStyleData)
     }
   }
@@ -188,19 +306,21 @@ export class GrassEditorComponent extends Component {
     return this.stylePicker()
   }
 }
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     graphStyleData: actions.getGraphStyleData(state),
     meta: state.meta
   }
 }
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
-    update: (data) => {
+    update: data => {
       dispatch(actions.updateGraphStyleData(data))
     }
   }
 }
 
-export const GrassEditor = connect(mapStateToProps, mapDispatchToProps)(GrassEditorComponent)
+export const GrassEditor = connect(mapStateToProps, mapDispatchToProps)(
+  GrassEditorComponent
+)

--- a/src/browser/modules/D3Visualization/components/Inspector.jsx
+++ b/src/browser/modules/D3Visualization/components/Inspector.jsx
@@ -19,9 +19,23 @@
  */
 
 import { Component } from 'preact'
-import {inspectorFooterContractedHeight, StyledInspectorFooterStatusMessage, StyledTokenContextMenuKey, StyledTokenRelationshipType, StyledLabelToken, StyledStatusBar, StyledStatus, StyledInspectorFooter, StyledInspectorFooterRow, StyledInspectorFooterRowListPair, StyledInspectorFooterRowListKey, StyledInspectorFooterRowListValue, StyledInlineList} from './styled'
-import {GrassEditor} from './GrassEditor'
-import {RowExpandToggleComponent} from './RowExpandToggle'
+import {
+  inspectorFooterContractedHeight,
+  StyledInspectorFooterStatusMessage,
+  StyledTokenContextMenuKey,
+  StyledTokenRelationshipType,
+  StyledLabelToken,
+  StyledStatusBar,
+  StyledStatus,
+  StyledInspectorFooter,
+  StyledInspectorFooterRow,
+  StyledInspectorFooterRowListPair,
+  StyledInspectorFooterRowListKey,
+  StyledInspectorFooterRowListValue,
+  StyledInlineList
+} from './styled'
+import { GrassEditor } from './GrassEditor'
+import { RowExpandToggleComponent } from './RowExpandToggle'
 
 export class InspectorComponent extends Component {
   constructor (props) {
@@ -42,23 +56,38 @@ export class InspectorComponent extends Component {
     let type
     let inspectorContent
 
-    const mapItemProperties = (itemProperties) => {
+    const mapItemProperties = itemProperties => {
       return itemProperties.map((prop, i) => {
         return (
           <StyledInspectorFooterRowListPair className='pair' key={'prop' + i}>
-            <StyledInspectorFooterRowListKey className='key'>{prop.key + ': '}</StyledInspectorFooterRowListKey>
-            <StyledInspectorFooterRowListValue className='value'>{prop.value.toString()}</StyledInspectorFooterRowListValue>
+            <StyledInspectorFooterRowListKey className='key'>
+              {prop.key + ': '}
+            </StyledInspectorFooterRowListKey>
+            <StyledInspectorFooterRowListValue className='value'>
+              {prop.value.toString()}
+            </StyledInspectorFooterRowListValue>
           </StyledInspectorFooterRowListPair>
         )
       })
     }
 
-    const mapLabels = (itemLabels) => {
+    const mapLabels = itemLabels => {
       return itemLabels.map((label, i) => {
-        const graphStyleForLabel = this.state.graphStyle.forNode({labels: [label]})
-        const style = {'backgroundColor': graphStyleForLabel.get('color'), 'color': graphStyleForLabel.get('text-color-internal')}
+        const graphStyleForLabel = this.state.graphStyle.forNode({
+          labels: [label]
+        })
+        const style = {
+          backgroundColor: graphStyleForLabel.get('color'),
+          color: graphStyleForLabel.get('text-color-internal')
+        }
         return (
-          <StyledLabelToken key={'label' + i} style={style} className={'token' + ' ' + 'token-label'}>{label}</StyledLabelToken>
+          <StyledLabelToken
+            key={'label' + i}
+            style={style}
+            className={'token' + ' ' + 'token-label'}
+          >
+            {label}
+          </StyledLabelToken>
         )
       })
     }
@@ -75,20 +104,34 @@ export class InspectorComponent extends Component {
     if (item && type) {
       if (type === 'legend-item') {
         inspectorContent = (
-          <GrassEditor selectedLabel={item.selectedLabel} selectedRelType={item.selectedRelType} />
+          <GrassEditor
+            selectedLabel={item.selectedLabel}
+            selectedRelType={item.selectedRelType}
+          />
         )
       }
       if (type === 'status-item') {
         inspectorContent = (
-          <StyledInspectorFooterStatusMessage className='value'>{item}</StyledInspectorFooterStatusMessage>
+          <StyledInspectorFooterStatusMessage className='value'>
+            {item}
+          </StyledInspectorFooterStatusMessage>
         )
       }
       if (type === 'context-menu-item') {
         inspectorContent = (
           <StyledInlineList className='list-inline'>
-            <StyledTokenContextMenuKey key='token' className={'token' + ' ' + 'token-context-menu-key' + ' ' + 'token-label'}>{item.label}</StyledTokenContextMenuKey>
+            <StyledTokenContextMenuKey
+              key='token'
+              className={
+                'token' + ' ' + 'token-context-menu-key' + ' ' + 'token-label'
+              }
+            >
+              {item.label}
+            </StyledTokenContextMenuKey>
             <StyledInspectorFooterRowListPair key='pair' className='pair'>
-              <StyledInspectorFooterRowListValue className='value'>{item.content}</StyledInspectorFooterRowListValue>
+              <StyledInspectorFooterRowListValue className='value'>
+                {item.content}
+              </StyledInspectorFooterRowListValue>
             </StyledInspectorFooterRowListPair>
           </StyledInlineList>
         )
@@ -97,7 +140,9 @@ export class InspectorComponent extends Component {
         inspectorContent = (
           <StyledInlineList className='list-inline'>
             <StyledInspectorFooterRowListPair className='pair' key='pair'>
-              <StyledInspectorFooterRowListValue className='value'>{description}</StyledInspectorFooterRowListValue>
+              <StyledInspectorFooterRowListValue className='value'>
+                {description}
+              </StyledInspectorFooterRowListValue>
             </StyledInspectorFooterRowListPair>
           </StyledInlineList>
         )
@@ -106,20 +151,41 @@ export class InspectorComponent extends Component {
           <StyledInlineList className='list-inline'>
             {mapLabels(item.labels)}
             <StyledInspectorFooterRowListPair key='pair' className='pair'>
-              <StyledInspectorFooterRowListKey className='key'>{'<id>:'}</StyledInspectorFooterRowListKey>
-              <StyledInspectorFooterRowListValue className='value'>{item.id}</StyledInspectorFooterRowListValue>
+              <StyledInspectorFooterRowListKey className='key'>
+                {'<id>:'}
+              </StyledInspectorFooterRowListKey>
+              <StyledInspectorFooterRowListValue className='value'>
+                {item.id}
+              </StyledInspectorFooterRowListValue>
             </StyledInspectorFooterRowListPair>
             {mapItemProperties(item.properties)}
           </StyledInlineList>
         )
       } else if (type === 'relationship') {
-        const style = {'backgroundColor': this.state.graphStyle.forRelationship(item).get('color'), 'color': this.state.graphStyle.forRelationship(item).get('text-color-internal')}
+        const style = {
+          backgroundColor: this.state.graphStyle
+            .forRelationship(item)
+            .get('color'),
+          color: this.state.graphStyle
+            .forRelationship(item)
+            .get('text-color-internal')
+        }
         inspectorContent = (
           <StyledInlineList className='list-inline'>
-            <StyledTokenRelationshipType key='token' style={style} className={'token' + ' ' + 'token-relationship-type'}>{item.type}</StyledTokenRelationshipType>
+            <StyledTokenRelationshipType
+              key='token'
+              style={style}
+              className={'token' + ' ' + 'token-relationship-type'}
+            >
+              {item.type}
+            </StyledTokenRelationshipType>
             <StyledInspectorFooterRowListPair key='pair' className='pair'>
-              <StyledInspectorFooterRowListKey className='key'>{'<id>:'}</StyledInspectorFooterRowListKey>
-              <StyledInspectorFooterRowListValue className='value'>{item.id}</StyledInspectorFooterRowListValue>
+              <StyledInspectorFooterRowListKey className='key'>
+                {'<id>:'}
+              </StyledInspectorFooterRowListKey>
+              <StyledInspectorFooterRowListValue className='value'>
+                {item.id}
+              </StyledInspectorFooterRowListValue>
             </StyledInspectorFooterRowListPair>
             {mapItemProperties(item.properties)}
           </StyledInlineList>
@@ -130,16 +196,39 @@ export class InspectorComponent extends Component {
     const toggleExpand = () => {
       this.setState({ contracted: !this.state.contracted }, () => {
         const inspectorHeight = this.footerRowElem.base.clientHeight
-        this.props.onExpandToggled && this.props.onExpandToggled(this.state.contracted, this.state.contracted ? 0 : inspectorHeight)
+        this.props.onExpandToggled &&
+          this.props.onExpandToggled(
+            this.state.contracted,
+            this.state.contracted ? 0 : inspectorHeight
+          )
       })
     }
 
     return (
-      <StyledStatusBar fullscreen={this.props.fullscreen} className='status-bar'>
+      <StyledStatusBar
+        fullscreen={this.props.fullscreen}
+        className='status-bar'
+      >
         <StyledStatus className='status'>
-          <StyledInspectorFooter className={this.state.contracted ? 'contracted inspector-footer' : 'inspector-footer'}>
-            <StyledInspectorFooterRow className='inspector-footer-row' ref={this.setFooterRowELem.bind(this)}>
-              { type === 'canvas' ? null : <RowExpandToggleComponent contracted={this.state.contracted} rowElem={this.footerRowElem} containerHeight={inspectorFooterContractedHeight} onClick={toggleExpand} /> }
+          <StyledInspectorFooter
+            className={
+              this.state.contracted
+                ? 'contracted inspector-footer'
+                : 'inspector-footer'
+            }
+          >
+            <StyledInspectorFooterRow
+              className='inspector-footer-row'
+              ref={this.setFooterRowELem.bind(this)}
+            >
+              {type === 'canvas'
+                ? null
+                : <RowExpandToggleComponent
+                  contracted={this.state.contracted}
+                  rowElem={this.footerRowElem}
+                  containerHeight={inspectorFooterContractedHeight}
+                  onClick={toggleExpand}
+                  />}
               {inspectorContent}
             </StyledInspectorFooterRow>
           </StyledInspectorFooter>
@@ -149,7 +238,8 @@ export class InspectorComponent extends Component {
   }
 
   componentWillReceiveProps (nextProps) {
-    if (this.props.selectedItem !== nextProps.selectedItem) { // || this.props.hoveredItem !== nextProps.hoveredItem){
+    if (this.props.selectedItem !== nextProps.selectedItem) {
+      // || this.props.hoveredItem !== nextProps.hoveredItem){
       this.setState({ contracted: true })
       this.props.onExpandToggled && this.props.onExpandToggled(true, 0)
     }

--- a/src/browser/modules/D3Visualization/components/Legend.jsx
+++ b/src/browser/modules/D3Visualization/components/Legend.jsx
@@ -18,9 +18,19 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {Component} from 'preact'
-import {legendRowHeight, StyledLegendRow, StyledTokenRelationshipType, StyledLegendInlineListItem, StyledLegend, StyledLegendContents, StyledLabelToken, StyledTokenCount, StyledLegendInlineList} from './styled'
-import {RowExpandToggleComponent} from './RowExpandToggle'
+import { Component } from 'preact'
+import {
+  legendRowHeight,
+  StyledLegendRow,
+  StyledTokenRelationshipType,
+  StyledLegendInlineListItem,
+  StyledLegend,
+  StyledLegendContents,
+  StyledLabelToken,
+  StyledTokenCount,
+  StyledLegendInlineList
+} from './styled'
+import { RowExpandToggleComponent } from './RowExpandToggle'
 
 export class LegendComponent extends Component {
   constructor (props) {
@@ -41,54 +51,114 @@ export class LegendComponent extends Component {
     }
   }
   render () {
-    const mapLabels = (labels) => {
+    const mapLabels = labels => {
       const labelList = Object.keys(labels).map((legendItemKey, i) => {
-        const styleForItem = this.props.graphStyle.forNode({labels: [legendItemKey]})
-        const onClick = () => { this.props.onSelectedLabel(legendItemKey, Object.keys(labels[legendItemKey].properties)) }
-        const style = {'backgroundColor': styleForItem.get('color'), 'color': styleForItem.get('text-color-internal')}
+        const styleForItem = this.props.graphStyle.forNode({
+          labels: [legendItemKey]
+        })
+        const onClick = () => {
+          this.props.onSelectedLabel(
+            legendItemKey,
+            Object.keys(labels[legendItemKey].properties)
+          )
+        }
+        const style = {
+          backgroundColor: styleForItem.get('color'),
+          color: styleForItem.get('text-color-internal')
+        }
         return (
           <StyledLegendInlineListItem key={i}>
             <StyledLegendContents className='contents'>
-              <StyledLabelToken onClick={onClick} style={style} className='token token-label'>
+              <StyledLabelToken
+                onClick={onClick}
+                style={style}
+                className='token token-label'
+              >
                 {legendItemKey}
-                <StyledTokenCount className='count'>{`(${labels[legendItemKey].count})`}</StyledTokenCount>
+                <StyledTokenCount className='count'>
+                  {`(${labels[legendItemKey].count})`}
+                </StyledTokenCount>
               </StyledLabelToken>
             </StyledLegendContents>
           </StyledLegendInlineListItem>
         )
       })
       return (
-        <StyledLegendRow className={this.state.labelRowContracted ? 'contracted' : ''}>
-          <StyledLegendInlineList className='list-inline' ref={this.setLabelRowELem.bind(this)}>
-            <RowExpandToggleComponent contracted={this.state.labelRowContracted} rowElem={this.state.labelRowELem} containerHeight={legendRowHeight} onClick={() => { this.setState({ labelRowContracted: !this.state.labelRowContracted }) }} />
+        <StyledLegendRow
+          className={this.state.labelRowContracted ? 'contracted' : ''}
+        >
+          <StyledLegendInlineList
+            className='list-inline'
+            ref={this.setLabelRowELem.bind(this)}
+          >
+            <RowExpandToggleComponent
+              contracted={this.state.labelRowContracted}
+              rowElem={this.state.labelRowELem}
+              containerHeight={legendRowHeight}
+              onClick={() => {
+                this.setState({
+                  labelRowContracted: !this.state.labelRowContracted
+                })
+              }}
+            />
             {labelList}
           </StyledLegendInlineList>
         </StyledLegendRow>
       )
     }
-    const mapRelTypes = (legendItems) => {
+    const mapRelTypes = legendItems => {
       if (!legendItems || !Object.keys(legendItems).length) {
         return null
       }
       const relTypeList = Object.keys(legendItems).map((legendItemKey, i) => {
-        const styleForItem = this.props.graphStyle.forRelationship({type: legendItemKey})
-        const onClick = () => { this.props.onSelectedRelType(legendItemKey, Object.keys(legendItems[legendItemKey].properties)) }
-        const style = {'backgroundColor': styleForItem.get('color'), 'color': styleForItem.get('text-color-internal')}
+        const styleForItem = this.props.graphStyle.forRelationship({
+          type: legendItemKey
+        })
+        const onClick = () => {
+          this.props.onSelectedRelType(
+            legendItemKey,
+            Object.keys(legendItems[legendItemKey].properties)
+          )
+        }
+        const style = {
+          backgroundColor: styleForItem.get('color'),
+          color: styleForItem.get('text-color-internal')
+        }
         return (
           <StyledLegendInlineListItem key={i}>
             <StyledLegendContents className='contents'>
-              <StyledTokenRelationshipType onClick={onClick} style={style} className='token token-relationship-type'>
+              <StyledTokenRelationshipType
+                onClick={onClick}
+                style={style}
+                className='token token-relationship-type'
+              >
                 {legendItemKey}
-                <StyledTokenCount className='count'>{`(${legendItems[legendItemKey].count})`}</StyledTokenCount>
+                <StyledTokenCount className='count'>
+                  {`(${legendItems[legendItemKey].count})`}
+                </StyledTokenCount>
               </StyledTokenRelationshipType>
             </StyledLegendContents>
           </StyledLegendInlineListItem>
         )
       })
       return (
-        <StyledLegendRow className={this.state.typeRowContracted ? 'contracted' : ''}>
-          <StyledLegendInlineList className='list-inline' ref={this.setTypeRowELem.bind(this)}>
-            <RowExpandToggleComponent contracted={this.state.typeRowContracted} rowElem={this.state.typeRowElem} containerHeight={legendRowHeight} onClick={() => { this.setState({ typeRowContracted: !this.state.typeRowContracted }) }} />
+        <StyledLegendRow
+          className={this.state.typeRowContracted ? 'contracted' : ''}
+        >
+          <StyledLegendInlineList
+            className='list-inline'
+            ref={this.setTypeRowELem.bind(this)}
+          >
+            <RowExpandToggleComponent
+              contracted={this.state.typeRowContracted}
+              rowElem={this.state.typeRowElem}
+              containerHeight={legendRowHeight}
+              onClick={() => {
+                this.setState({
+                  typeRowContracted: !this.state.typeRowContracted
+                })
+              }}
+            />
             {relTypeList}
           </StyledLegendInlineList>
         </StyledLegendRow>
@@ -100,7 +170,6 @@ export class LegendComponent extends Component {
         {mapLabels(this.props.stats.labels)}
         {relTypes}
       </StyledLegend>
-
     )
   }
 }

--- a/src/browser/modules/D3Visualization/components/RowExpandToggle.jsx
+++ b/src/browser/modules/D3Visualization/components/RowExpandToggle.jsx
@@ -21,11 +21,12 @@
 import { Component } from 'preact'
 import { StyledRowToggle, StyledCaret } from './styled'
 
-const getHeightFromElem = (rowElem) => (rowElem && rowElem.base) ? rowElem.base.clientHeight : 0
+const getHeightFromElem = rowElem =>
+  rowElem && rowElem.base ? rowElem.base.clientHeight : 0
 
 export class RowExpandToggleComponent extends Component {
   updateDimensions () {
-    this.setState({rowHeight: getHeightFromElem(this.props.rowElem)})
+    this.setState({ rowHeight: getHeightFromElem(this.props.rowElem) })
   }
 
   componentDidMount () {
@@ -47,7 +48,11 @@ export class RowExpandToggleComponent extends Component {
     if (this.props.containerHeight * 1.1 < this.state.rowHeight) {
       return (
         <StyledRowToggle onClick={this.props.onClick}>
-          <StyledCaret className={this.props.contracted ? 'fa fa-caret-left' : 'fa fa-caret-down'} />
+          <StyledCaret
+            className={
+              this.props.contracted ? 'fa fa-caret-left' : 'fa fa-caret-down'
+            }
+          />
         </StyledRowToggle>
       )
     } else {

--- a/src/browser/modules/D3Visualization/components/styled.jsx
+++ b/src/browser/modules/D3Visualization/components/styled.jsx
@@ -202,7 +202,8 @@ export const StyledStatusBar = styled.div`
   white-space: nowrap;
   overflow: hidden;
   border-top: 1px solid #e6e9ef;
-  ${props => props.fullscreen ? 'margin-top: -39px;' : 'margin-bottom: -39px;'};
+  ${props =>
+    props.fullscreen ? 'margin-top: -39px;' : 'margin-bottom: -39px;'};
 `
 
 export const StyledStatus = styled.div`
@@ -271,7 +272,7 @@ export const StyledLegendRow = styled.div`
 `
 export const StyledLegend = styled.div`
   background-color: ${props => props.theme.secondaryBackground};
-  margin-top: -${(legendRowHeight * 2) + 1}px;
+  margin-top: -${legendRowHeight * 2 + 1}px;
   &.one-row {
     margin-top: -${legendRowHeight}px;
   }
@@ -335,8 +336,11 @@ export const StyledCaptionSelector = styled.a`
 
 export const StyledFullSizeContainer = styled.div`
   height: 100%;
-  padding-top: ${(legendRowHeight * 2) + 1}px;
-  padding-bottom: ${props => props.forcePaddingBottom ? (props.forcePaddingBottom + 2 * pMarginTop) + 'px' : '39px'};
+  padding-top: ${legendRowHeight * 2 + 1}px;
+  padding-bottom: ${props =>
+    props.forcePaddingBottom
+      ? props.forcePaddingBottom + 2 * pMarginTop + 'px'
+      : '39px'};
   &.one-legend-row {
     padding-top: ${legendRowHeight}px;
   }

--- a/src/browser/modules/DatabaseInfo/DatabaseInfo.jsx
+++ b/src/browser/modules/DatabaseInfo/DatabaseInfo.jsx
@@ -25,7 +25,7 @@ import { executeCommand } from 'shared/modules/commands/commandsDuck'
 import { LabelItems, RelationshipItems, PropertyItems } from './MetaItems'
 import UserDetails from './UserDetails'
 import DatabaseKernelInfo from './DatabaseKernelInfo'
-import {Drawer, DrawerBody, DrawerHeader} from 'browser-components/drawer'
+import { Drawer, DrawerBody, DrawerHeader } from 'browser-components/drawer'
 
 export class DatabaseInfo extends Component {
   constructor (props) {
@@ -38,7 +38,7 @@ export class DatabaseInfo extends Component {
     }
   }
   onMoreClick (type) {
-    return (num) => {
+    return num => {
       this.setState({ [type + 'Max']: this.state[type + 'Max'] + num })
     }
   }
@@ -57,44 +57,53 @@ export class DatabaseInfo extends Component {
         <DrawerHeader>Database Information</DrawerHeader>
         <DrawerBody>
           <LabelItems
-            labels={labels.slice(0, this.state.labelsMax).map((l) => l.val)}
+            labels={labels.slice(0, this.state.labelsMax).map(l => l.val)}
             totalNumItems={labels.length}
             onItemClick={onItemClick}
             onMoreClick={this.onMoreClick.bind(this)('labels')}
             moreStep={this.state.moreStep}
           />
           <RelationshipItems
-            relationshipTypes={relationshipTypes.slice(0, this.state.relationshipsMax).map((l) => l.val)}
+            relationshipTypes={relationshipTypes
+              .slice(0, this.state.relationshipsMax)
+              .map(l => l.val)}
             onItemClick={onItemClick}
             totalNumItems={relationshipTypes.length}
             onMoreClick={this.onMoreClick.bind(this)('relationships')}
             moreStep={this.state.moreStep}
           />
           <PropertyItems
-            properties={properties.slice(0, this.state.propertiesMax).map((l) => l.val)}
+            properties={properties
+              .slice(0, this.state.propertiesMax)
+              .map(l => l.val)}
             onItemClick={onItemClick}
             totalNumItems={properties.length}
             onMoreClick={this.onMoreClick.bind(this)('properties')}
             moreStep={this.state.moreStep}
           />
           <UserDetails userDetails={userDetails} onItemClick={onItemClick} />
-          <DatabaseKernelInfo databaseKernelInfo={databaseKernelInfo} onItemClick={onItemClick} />
+          <DatabaseKernelInfo
+            databaseKernelInfo={databaseKernelInfo}
+            onItemClick={onItemClick}
+          />
         </DrawerBody>
       </Drawer>
     )
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return state.meta || {}
 }
 const mapDispatchToProps = (_, ownProps) => {
   return {
-    onItemClick: (cmd) => {
+    onItemClick: cmd => {
       const action = executeCommand(cmd)
       ownProps.bus.send(action.type, action)
     }
   }
 }
 
-export default withBus(connect(mapStateToProps, mapDispatchToProps)(DatabaseInfo))
+export default withBus(
+  connect(mapStateToProps, mapDispatchToProps)(DatabaseInfo)
+)

--- a/src/browser/modules/DatabaseInfo/DatabaseInfo.test.jsx
+++ b/src/browser/modules/DatabaseInfo/DatabaseInfo.test.jsx
@@ -45,48 +45,72 @@ describe('DatabaseInfo', () => {
       expect(wrapper.find('.token-label').length).toBe(0)
     })
     test('should show labels when there are labels', () => {
-      const labels = [{val: 'Person'}, {val: 'Movie'}]
+      const labels = [{ val: 'Person' }, { val: 'Movie' }]
       const wrapper = mount(<DatabaseInfoComponent labels={labels} />)
       expect(wrapper.find('.token-label').length).toBe(3)
       expect(wrapper.find('.token-label').first().text()).toEqual('*')
     })
     test('should call on click callback with correct cypher * label is clicked', () => {
-      const labels = [{val: 'Person'}]
-      const wrapper = mount(<DatabaseInfoComponent labels={labels} onItemClick={onItemClick} />)
+      const labels = [{ val: 'Person' }]
+      const wrapper = mount(
+        <DatabaseInfoComponent labels={labels} onItemClick={onItemClick} />
+      )
       simulateEvent(wrapper.find('.token-label').first(), 'click')
       expect(onItemClick).toHaveBeenCalledWith('MATCH (n) RETURN n LIMIT 25')
     })
     test('should call on click callback with correct cypher when a non * label is clicked', () => {
-      const labels = [{val: 'Person'}]
-      const wrapper = mount(<DatabaseInfoComponent labels={labels} onItemClick={onItemClick} />)
+      const labels = [{ val: 'Person' }]
+      const wrapper = mount(
+        <DatabaseInfoComponent labels={labels} onItemClick={onItemClick} />
+      )
       simulateEvent(wrapper.find('.token-label').last(), 'click')
-      expect(onItemClick).toHaveBeenCalledWith('MATCH (n:Person) RETURN n LIMIT 25')
+      expect(onItemClick).toHaveBeenCalledWith(
+        'MATCH (n:Person) RETURN n LIMIT 25'
+      )
     })
   })
 
   describe('relationshipTypes', () => {
     test('should not show relationshipTypes when there are no relationshipTypes', () => {
       const relationshipTypes = []
-      const wrapper = mount(<DatabaseInfoComponent relationshipTypes={relationshipTypes} />)
+      const wrapper = mount(
+        <DatabaseInfoComponent relationshipTypes={relationshipTypes} />
+      )
       expect(wrapper.find('.token-relationship').length).toBe(0)
     })
     test('should show relationshipTypes when there are relationshipTypes', () => {
-      const relationshipTypes = [{val: 'lives'}, {val: 'knows'}]
-      const wrapper = mount(<DatabaseInfoComponent relationshipTypes={relationshipTypes} />)
+      const relationshipTypes = [{ val: 'lives' }, { val: 'knows' }]
+      const wrapper = mount(
+        <DatabaseInfoComponent relationshipTypes={relationshipTypes} />
+      )
       expect(wrapper.find('.token-relationship').length).toBe(3)
       expect(wrapper.find('.token-relationship').first().text()).toEqual('*')
     })
     test('should call on click callback with correct cypher when * relationship is clicked', () => {
-      const relationshipTypes = [{val: 'DIRECTED'}]
-      const wrapper = mount(<DatabaseInfoComponent relationshipTypes={relationshipTypes} onItemClick={onItemClick} />)
+      const relationshipTypes = [{ val: 'DIRECTED' }]
+      const wrapper = mount(
+        <DatabaseInfoComponent
+          relationshipTypes={relationshipTypes}
+          onItemClick={onItemClick}
+        />
+      )
       simulateEvent(wrapper.find('.token-relationship').first(), 'click')
-      expect(onItemClick).toHaveBeenCalledWith('MATCH p=()-->() RETURN p LIMIT 25')
+      expect(onItemClick).toHaveBeenCalledWith(
+        'MATCH p=()-->() RETURN p LIMIT 25'
+      )
     })
     test('should call on click callback with correct cypher when a non * relationship is clicked', () => {
-      const relationshipTypes = [{val: 'DIRECTED'}]
-      const wrapper = mount(<DatabaseInfoComponent relationshipTypes={relationshipTypes} onItemClick={onItemClick} />)
+      const relationshipTypes = [{ val: 'DIRECTED' }]
+      const wrapper = mount(
+        <DatabaseInfoComponent
+          relationshipTypes={relationshipTypes}
+          onItemClick={onItemClick}
+        />
+      )
       simulateEvent(wrapper.find('.token-relationship').last(), 'click')
-      expect(onItemClick).toHaveBeenCalledWith('MATCH p=()-[r:DIRECTED]->() RETURN p LIMIT 25')
+      expect(onItemClick).toHaveBeenCalledWith(
+        'MATCH p=()-[r:DIRECTED]->() RETURN p LIMIT 25'
+      )
     })
   })
 
@@ -97,16 +121,23 @@ describe('DatabaseInfo', () => {
       expect(wrapper.find('.token-property').length).toBe(0)
     })
     test('should show properties when there are properties', () => {
-      const properties = [{val: 'born'}, {val: 'name'}]
+      const properties = [{ val: 'born' }, { val: 'name' }]
       const wrapper = mount(<DatabaseInfoComponent properties={properties} />)
       expect(wrapper.find('.token-property').length).toBe(2)
       expect(wrapper.find('.token-property').first().text()).toEqual('born')
     })
     test('should call on click callback with correct cypher when property is clicked', () => {
-      const properties = [{val: 'born'}]
-      const wrapper = mount(<DatabaseInfoComponent properties={properties} onItemClick={onItemClick} />)
+      const properties = [{ val: 'born' }]
+      const wrapper = mount(
+        <DatabaseInfoComponent
+          properties={properties}
+          onItemClick={onItemClick}
+        />
+      )
       simulateEvent(wrapper.find('.token-property').first(), 'click')
-      expect(onItemClick).toHaveBeenCalledWith('MATCH (n) WHERE EXISTS(n.born) RETURN DISTINCT "node" as element, n.born AS born LIMIT 25 UNION ALL MATCH ()-[r]-() WHERE EXISTS(r.born) RETURN DISTINCT "relationship" AS element, r.born AS born LIMIT 25')
+      expect(onItemClick).toHaveBeenCalledWith(
+        'MATCH (n) WHERE EXISTS(n.born) RETURN DISTINCT "node" as element, n.born AS born LIMIT 25 UNION ALL MATCH ()-[r]-() WHERE EXISTS(r.born) RETURN DISTINCT "relationship" AS element, r.born AS born LIMIT 25'
+      )
     })
   })
 })

--- a/src/browser/modules/DatabaseInfo/DatabaseKernelInfo.jsx
+++ b/src/browser/modules/DatabaseInfo/DatabaseKernelInfo.jsx
@@ -20,15 +20,38 @@
 
 import { connect } from 'preact-redux'
 import { withBus } from 'preact-suber'
-import { getVersion, getEdition, getDbName, getStoreSize, getClusterRole } from 'shared/modules/dbMeta/dbMetaDuck'
+import {
+  getVersion,
+  getEdition,
+  getDbName,
+  getStoreSize,
+  getClusterRole
+} from 'shared/modules/dbMeta/dbMetaDuck'
 import { executeCommand } from 'shared/modules/commands/commandsDuck'
 import { toHumanReadableBytes } from 'services/utils'
 
 import Render from 'browser-components/Render'
-import {DrawerSection, DrawerSectionBody, DrawerSubHeader} from 'browser-components/drawer'
-import {StyledTable, StyledKey, StyledValue, StyledValueUCFirst, Link} from './styled'
+import {
+  DrawerSection,
+  DrawerSectionBody,
+  DrawerSubHeader
+} from 'browser-components/drawer'
+import {
+  StyledTable,
+  StyledKey,
+  StyledValue,
+  StyledValueUCFirst,
+  Link
+} from './styled'
 
-export const DatabaseKernelInfo = ({role, version, edition, dbName, storeSize, onItemClick}) => {
+export const DatabaseKernelInfo = ({
+  role,
+  version,
+  edition,
+  dbName,
+  storeSize,
+  onItemClick
+}) => {
   return (
     <DrawerSection className='database-kernel-info'>
       <DrawerSubHeader>Database</DrawerSubHeader>
@@ -37,17 +60,20 @@ export const DatabaseKernelInfo = ({role, version, edition, dbName, storeSize, o
           <tbody>
             <Render if={role}>
               <tr>
-                <StyledKey>Cluster role: </StyledKey><StyledValue>{role}</StyledValue>
+                <StyledKey>Cluster role: </StyledKey>
+                <StyledValue>{role}</StyledValue>
               </tr>
             </Render>
             <Render if={version}>
               <tr>
-                <StyledKey>Version: </StyledKey><StyledValue>{version}</StyledValue>
+                <StyledKey>Version: </StyledKey>
+                <StyledValue>{version}</StyledValue>
               </tr>
             </Render>
             <Render if={edition}>
               <tr>
-                <StyledKey>Edition: </StyledKey><StyledValueUCFirst>{edition}</StyledValueUCFirst>
+                <StyledKey>Edition: </StyledKey>
+                <StyledValueUCFirst>{edition}</StyledValueUCFirst>
               </tr>
             </Render>
             <Render if={dbName}>
@@ -57,14 +83,21 @@ export const DatabaseKernelInfo = ({role, version, edition, dbName, storeSize, o
             </Render>
             <Render if={storeSize}>
               <tr>
-                <StyledKey>Size: </StyledKey><StyledValue>{toHumanReadableBytes(storeSize)}</StyledValue>
+                <StyledKey>Size: </StyledKey>
+                <StyledValue>{toHumanReadableBytes(storeSize)}</StyledValue>
               </tr>
             </Render>
             <tr>
-              <StyledKey>Information: </StyledKey><StyledValue><Link onClick={() => onItemClick(':sysinfo')}>:sysinfo</Link></StyledValue>
+              <StyledKey>Information: </StyledKey>
+              <StyledValue>
+                <Link onClick={() => onItemClick(':sysinfo')}>:sysinfo</Link>
+              </StyledValue>
             </tr>
             <tr>
-              <StyledKey>Query List: </StyledKey><StyledValue><Link onClick={() => onItemClick(':queries')}>:queries</Link></StyledValue>
+              <StyledKey>Query List: </StyledKey>
+              <StyledValue>
+                <Link onClick={() => onItemClick(':queries')}>:queries</Link>
+              </StyledValue>
             </tr>
           </tbody>
         </StyledTable>
@@ -73,7 +106,7 @@ export const DatabaseKernelInfo = ({role, version, edition, dbName, storeSize, o
   )
 }
 
-const mapStateToProps = (store) => {
+const mapStateToProps = store => {
   return {
     version: getVersion(store),
     edition: getEdition(store),
@@ -84,11 +117,13 @@ const mapStateToProps = (store) => {
 }
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    onItemClick: (cmd) => {
+    onItemClick: cmd => {
       const action = executeCommand(cmd)
       ownProps.bus.send(action.type, action)
     }
   }
 }
 
-export default withBus(connect(mapStateToProps, mapDispatchToProps)(DatabaseKernelInfo))
+export default withBus(
+  connect(mapStateToProps, mapDispatchToProps)(DatabaseKernelInfo)
+)

--- a/src/browser/modules/DatabaseInfo/DatabaseKernelInfo.test.jsx
+++ b/src/browser/modules/DatabaseInfo/DatabaseKernelInfo.test.jsx
@@ -26,7 +26,9 @@ import { shallow } from 'enzyme'
 describe('connected as', () => {
   test('should not show database kernal info if not connected', () => {
     const databaseKernelInfo = null
-    const wrapper = shallow(<DatabaseKernelInfo databaseKernelInfo={databaseKernelInfo} />)
+    const wrapper = shallow(
+      <DatabaseKernelInfo databaseKernelInfo={databaseKernelInfo} />
+    )
     expect(wrapper.find('.database-kernel-info').length).toBe(0)
   })
   test('should show verion and edition when connected', () => {
@@ -34,7 +36,9 @@ describe('connected as', () => {
       version: 'test',
       edition: ['3.1.0']
     }
-    const wrapper = shallow(<DatabaseKernelInfo databaseKernelInfo={databaseKernelInfo} />)
+    const wrapper = shallow(
+      <DatabaseKernelInfo databaseKernelInfo={databaseKernelInfo} />
+    )
     expect(wrapper.find('.database-kernel-info').length).toBeGreaterThan(0)
     expect(wrapper.find('.version').text()).toEqual('test')
     expect(wrapper.find('.edition').text()).toEqual('3.1.0')

--- a/src/browser/modules/DatabaseInfo/MetaItems.jsx
+++ b/src/browser/modules/DatabaseInfo/MetaItems.jsx
@@ -21,8 +21,18 @@
 import { ecsapeCypherMetaItem } from 'services/utils'
 import classNames from 'classnames'
 import styles from './style_meta.css'
-import {DrawerSubHeader, DrawerSection, DrawerSectionBody} from 'browser-components/drawer'
-import { StyledLabel, StyledRelationship, StyledProperty, StyledShowMoreContainer, StyledShowMoreLink } from './styled'
+import {
+  DrawerSubHeader,
+  DrawerSection,
+  DrawerSectionBody
+} from 'browser-components/drawer'
+import {
+  StyledLabel,
+  StyledRelationship,
+  StyledProperty,
+  StyledShowMoreContainer,
+  StyledShowMoreLink
+} from './styled'
 import Render from 'browser-components/Render'
 
 const ShowMore = ({ total, shown, moreStep, onMore }) => {
@@ -30,15 +40,25 @@ const ShowMore = ({ total, shown, moreStep, onMore }) => {
   return (
     <Render if={shown < total}>
       <StyledShowMoreContainer>
-        <StyledShowMoreLink onClick={() => onMore(numMore)}>Show {numMore} more</StyledShowMoreLink>
+        <StyledShowMoreLink onClick={() => onMore(numMore)}>
+          Show {numMore} more
+        </StyledShowMoreLink>
         &nbsp;|&nbsp;
-        <StyledShowMoreLink onClick={() => onMore(total)}>Show all</StyledShowMoreLink>
+        <StyledShowMoreLink onClick={() => onMore(total)}>
+          Show all
+        </StyledShowMoreLink>
       </StyledShowMoreContainer>
     </Render>
   )
 }
 
-const createItems = (originalList, onItemClick, RenderType, editorCommandTemplate, showStar = true) => {
+const createItems = (
+  originalList,
+  onItemClick,
+  RenderType,
+  editorCommandTemplate,
+  showStar = true
+) => {
   let items = [...originalList]
   if (showStar) {
     items.unshift('*')
@@ -48,81 +68,145 @@ const createItems = (originalList, onItemClick, RenderType, editorCommandTemplat
     return (
       <RenderType.component
         key={index}
-        onClick={() => onItemClick(getNodesCypher)}>
+        onClick={() => onItemClick(getNodesCypher)}
+      >
         {text}
       </RenderType.component>
     )
   })
 }
-const LabelItems = ({labels, totalNumItems, onItemClick, moreStep, onMoreClick}) => {
+const LabelItems = ({
+  labels,
+  totalNumItems,
+  onItemClick,
+  moreStep,
+  onMoreClick
+}) => {
   let labelItems = <p>There are no labels in database</p>
   if (labels.length) {
-    const editorCommandTemplate = (text) => {
+    const editorCommandTemplate = text => {
       if (text === '*') {
         return 'MATCH (n) RETURN n LIMIT 25'
       }
       return `MATCH (n:${ecsapeCypherMetaItem(text)}) RETURN n LIMIT 25`
     }
-    labelItems = createItems(labels, onItemClick, {component: StyledLabel}, editorCommandTemplate)
+    labelItems = createItems(
+      labels,
+      onItemClick,
+      { component: StyledLabel },
+      editorCommandTemplate
+    )
   }
   return (
     <DrawerSection>
       <DrawerSubHeader>Node Labels</DrawerSubHeader>
-      <DrawerSectionBody className={classNames({
-        [styles['wrapper']]: true
-      })}>
+      <DrawerSectionBody
+        className={classNames({
+          [styles['wrapper']]: true
+        })}
+      >
         {labelItems}
       </DrawerSectionBody>
-      <ShowMore total={totalNumItems} shown={labels.length} moreStep={moreStep} onMore={onMoreClick} />
+      <ShowMore
+        total={totalNumItems}
+        shown={labels.length}
+        moreStep={moreStep}
+        onMore={onMoreClick}
+      />
     </DrawerSection>
   )
 }
-const RelationshipItems = ({relationshipTypes, totalNumItems, onItemClick, moreStep, onMoreClick}) => {
+const RelationshipItems = ({
+  relationshipTypes,
+  totalNumItems,
+  onItemClick,
+  moreStep,
+  onMoreClick
+}) => {
   let relationshipItems = <p>No relationships in database</p>
   if (relationshipTypes.length > 0) {
-    const editorCommandTemplate = (text) => {
+    const editorCommandTemplate = text => {
       if (text === '*') {
         return 'MATCH p=()-->() RETURN p LIMIT 25'
       }
-      return `MATCH p=()-[r:${ecsapeCypherMetaItem(text)}]->() RETURN p LIMIT 25`
+      return `MATCH p=()-[r:${ecsapeCypherMetaItem(
+        text
+      )}]->() RETURN p LIMIT 25`
     }
-    relationshipItems = createItems(relationshipTypes, onItemClick, {component: StyledRelationship}, editorCommandTemplate)
+    relationshipItems = createItems(
+      relationshipTypes,
+      onItemClick,
+      { component: StyledRelationship },
+      editorCommandTemplate
+    )
   }
   return (
     <DrawerSection>
       <DrawerSubHeader>Relationship Types</DrawerSubHeader>
-      <DrawerSectionBody className={classNames({
-        [styles['wrapper']]: true
-      })}>
+      <DrawerSectionBody
+        className={classNames({
+          [styles['wrapper']]: true
+        })}
+      >
         {relationshipItems}
       </DrawerSectionBody>
-      <ShowMore total={totalNumItems} shown={relationshipTypes.length} moreStep={moreStep} onMore={onMoreClick} />
+      <ShowMore
+        total={totalNumItems}
+        shown={relationshipTypes.length}
+        moreStep={moreStep}
+        onMore={onMoreClick}
+      />
     </DrawerSection>
   )
 }
-const PropertyItems = ({properties, totalNumItems, onItemClick, moreStep, onMoreClick}) => {
+const PropertyItems = ({
+  properties,
+  totalNumItems,
+  onItemClick,
+  moreStep,
+  onMoreClick
+}) => {
   let propertyItems = <p>There are no properties in database</p>
   if (properties.length > 0) {
-    const editorCommandTemplate = (text) => {
-      return `MATCH (n) WHERE EXISTS(n.${ecsapeCypherMetaItem(text)}) RETURN DISTINCT "node" as entity, n.${ecsapeCypherMetaItem(text)} AS ${ecsapeCypherMetaItem(text)} LIMIT 25 UNION ALL MATCH ()-[r]-() WHERE EXISTS(r.${ecsapeCypherMetaItem(text)}) RETURN DISTINCT "relationship" AS entity, r.${ecsapeCypherMetaItem(text)} AS ${ecsapeCypherMetaItem(text)} LIMIT 25`
+    const editorCommandTemplate = text => {
+      return `MATCH (n) WHERE EXISTS(n.${ecsapeCypherMetaItem(
+        text
+      )}) RETURN DISTINCT "node" as entity, n.${ecsapeCypherMetaItem(
+        text
+      )} AS ${ecsapeCypherMetaItem(
+        text
+      )} LIMIT 25 UNION ALL MATCH ()-[r]-() WHERE EXISTS(r.${ecsapeCypherMetaItem(
+        text
+      )}) RETURN DISTINCT "relationship" AS entity, r.${ecsapeCypherMetaItem(
+        text
+      )} AS ${ecsapeCypherMetaItem(text)} LIMIT 25`
     }
-    propertyItems = createItems(properties, onItemClick, {component: StyledProperty}, editorCommandTemplate, false)
+    propertyItems = createItems(
+      properties,
+      onItemClick,
+      { component: StyledProperty },
+      editorCommandTemplate,
+      false
+    )
   }
   return (
     <DrawerSection>
       <DrawerSubHeader>Property Keys</DrawerSubHeader>
-      <DrawerSectionBody className={classNames({
-        [styles['wrapper']]: true
-      })}>
+      <DrawerSectionBody
+        className={classNames({
+          [styles['wrapper']]: true
+        })}
+      >
         {propertyItems}
       </DrawerSectionBody>
-      <ShowMore total={totalNumItems} shown={properties.length} moreStep={moreStep} onMore={onMoreClick} />
+      <ShowMore
+        total={totalNumItems}
+        shown={properties.length}
+        moreStep={moreStep}
+        onMore={onMoreClick}
+      />
     </DrawerSection>
   )
 }
 
-export {
-  LabelItems,
-  RelationshipItems,
-  PropertyItems
-}
+export { LabelItems, RelationshipItems, PropertyItems }

--- a/src/browser/modules/DatabaseInfo/UserDetails.jsx
+++ b/src/browser/modules/DatabaseInfo/UserDetails.jsx
@@ -25,7 +25,11 @@ import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
 import { executeCommand } from 'shared/modules/commands/commandsDuck'
 
 import Render from 'browser-components/Render'
-import { DrawerSubHeader, DrawerSection, DrawerSectionBody } from 'browser-components/drawer'
+import {
+  DrawerSubHeader,
+  DrawerSection,
+  DrawerSectionBody
+} from 'browser-components/drawer'
 import { StyledTable, StyledKey, StyledValue, Link } from './styled'
 
 export class UserDetails extends Component {
@@ -39,14 +43,18 @@ export class UserDetails extends Component {
     this.props.bus.self(
       CYPHER_REQUEST,
       { query: 'CALL dbms.security.showCurrentUser()' },
-      (response) => {
+      response => {
         if (!response.success) return
         const result = response.result
         const keys = result.records[0].keys
         this.setState({
           userDetails: {
-            username: (keys.includes('username')) ? result.records[0].get('username') : '-',
-            roles: (keys.includes('roles')) ? result.records[0].get('roles') : ['admin']
+            username: keys.includes('username')
+              ? result.records[0].get('username')
+              : '-',
+            roles: keys.includes('roles')
+              ? result.records[0].get('roles')
+              : ['admin']
           }
         })
       }
@@ -61,8 +69,12 @@ export class UserDetails extends Component {
   render () {
     const userDetails = this.state.userDetails
     if (userDetails.username) {
-      const mappedRoles = (userDetails.roles.length > 0) ? userDetails.roles.join(', ') : '-'
-      const hasAdminRole = userDetails.roles.map((role) => role.toLowerCase()).includes('admin')
+      const mappedRoles = userDetails.roles.length > 0
+        ? userDetails.roles.join(', ')
+        : '-'
+      const hasAdminRole = userDetails.roles
+        .map(role => role.toLowerCase())
+        .includes('admin')
       return (
         <DrawerSection className='user-details'>
           <DrawerSubHeader>Connected as</DrawerSubHeader>
@@ -70,14 +82,21 @@ export class UserDetails extends Component {
             <StyledTable>
               <tbody>
                 <tr>
-                  <StyledKey>Username:</StyledKey><StyledValue>{userDetails.username}</StyledValue>
+                  <StyledKey>Username:</StyledKey>
+                  <StyledValue>{userDetails.username}</StyledValue>
                 </tr>
                 <tr>
-                  <StyledKey>Roles:</StyledKey><StyledValue>{mappedRoles}</StyledValue>
+                  <StyledKey>Roles:</StyledKey>
+                  <StyledValue>{mappedRoles}</StyledValue>
                 </tr>
                 <Render if={hasAdminRole}>
                   <tr>
-                    <StyledKey className='user-list-button'>Admin:</StyledKey><Link onClick={() => this.props.onItemClick(':server user add')}>:server user add</Link>
+                    <StyledKey className='user-list-button'>Admin:</StyledKey>
+                    <Link
+                      onClick={() => this.props.onItemClick(':server user add')}
+                    >
+                      :server user add
+                    </Link>
                   </tr>
                 </Render>
               </tbody>
@@ -93,7 +112,7 @@ export class UserDetails extends Component {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    onItemClick: (cmd) => {
+    onItemClick: cmd => {
       const action = executeCommand(cmd)
       ownProps.bus.send(action.type, action)
     }

--- a/src/browser/modules/DatabaseInfo/styled.jsx
+++ b/src/browser/modules/DatabaseInfo/styled.jsx
@@ -89,8 +89,8 @@ export const StyledLink = styled.a`
     text-decoration: none;
   }
 `
-export const Link = (props) => {
-  const {children, ...rest} = props
+export const Link = props => {
+  const { children, ...rest } = props
   return <StyledLink {...rest}><PlainPlayIcon />&nbsp;{children}</StyledLink>
 }
 

--- a/src/browser/modules/Editor/Codemirror.jsx
+++ b/src/browser/modules/Editor/Codemirror.jsx
@@ -53,7 +53,10 @@ export default class CodeMirror extends Component {
 
   componentDidMount () {
     const textareaNode = this.editorReference
-    const { editor, editorSupport } = createCypherEditor(textareaNode, this.props.options)
+    const { editor, editorSupport } = createCypherEditor(
+      textareaNode,
+      this.props.options
+    )
     this.codeMirror = editor
     this.codeMirror.on('change', this.codemirrorValueChanged.bind(this))
     this.codeMirror.on('focus', this.focusChanged.bind(this, true))
@@ -79,13 +82,19 @@ export default class CodeMirror extends Component {
   }
 
   componentWillReceiveProps (nextProps) {
-    if (this.codeMirror &&
+    if (
+      this.codeMirror &&
       nextProps.value !== undefined &&
-      normalizeLineEndings(this.codeMirror.getValue()) !== normalizeLineEndings(nextProps.value)) {
+      normalizeLineEndings(this.codeMirror.getValue()) !==
+        normalizeLineEndings(nextProps.value)
+    ) {
       if (this.props.preserveScrollPosition) {
         const prevScrollPosition = this.codeMirror.getScrollInfo()
         this.codeMirror.setValue(nextProps.value)
-        this.codeMirror.scrollTo(prevScrollPosition.left, prevScrollPosition.top)
+        this.codeMirror.scrollTo(
+          prevScrollPosition.left,
+          prevScrollPosition.top
+        )
       } else {
         this.codeMirror.setValue(nextProps.value)
       }
@@ -136,11 +145,9 @@ export default class CodeMirror extends Component {
       this.props.classNames
     )
 
-    const setEditorReference = (ref) => {
+    const setEditorReference = ref => {
       this.editorReference = ref
     }
-    return (
-      <div className={editorClassNames} ref={setEditorReference} />
-    )
+    return <div className={editorClassNames} ref={setEditorReference} />
   }
 }

--- a/src/browser/modules/Editor/Editor.jsx
+++ b/src/browser/modules/Editor/Editor.jsx
@@ -22,11 +22,17 @@
 import { Component } from 'preact'
 import { connect } from 'preact-redux'
 import { withBus } from 'preact-suber'
-import { executeCommand, executeSystemCommand } from 'shared/modules/commands/commandsDuck'
+import {
+  executeCommand,
+  executeSystemCommand
+} from 'shared/modules/commands/commandsDuck'
 import * as favorites from 'shared/modules/favorites/favoritesDuck'
 import { SET_CONTENT, FOCUS, EXPAND } from 'shared/modules/editor/editorDuck'
 import { getHistory } from 'shared/modules/history/historyDuck'
-import { getCmdChar, shouldEditorAutocomplete } from 'shared/modules/settings/settingsDuck'
+import {
+  getCmdChar,
+  shouldEditorAutocomplete
+} from 'shared/modules/settings/settingsDuck'
 import { Bar, ActionButtonSection, EditorWrapper } from './styled'
 import { EditorButton } from 'browser-components/buttons'
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
@@ -108,7 +114,8 @@ export class Editor extends Component {
   historyPrev (cm) {
     if (!this.props.history.length) return
     if (this.state.historyIndex + 1 === this.props.history.length) return
-    if (this.state.historyIndex === -1) { // Save what's currently in the editor
+    if (this.state.historyIndex === -1) {
+      // Save what's currently in the editor
       this.setState({ buffer: cm.getValue() })
     }
     this.setState({
@@ -121,7 +128,8 @@ export class Editor extends Component {
   historyNext (cm) {
     if (!this.props.history.length) return
     if (this.state.historyIndex <= -1) return
-    if (this.state.historyIndex === 0) { // Should read from buffer
+    if (this.state.historyIndex === 0) {
+      // Should read from buffer
       this.setState({ historyIndex: -1 })
       this.setEditorValue(this.state.buffer)
       return
@@ -139,7 +147,8 @@ export class Editor extends Component {
     }
 
     const text = changed.text[0]
-    const triggerAutocompletion = text === '.' ||
+    const triggerAutocompletion =
+      text === '.' ||
       text === ':' ||
       text === '[]' ||
       text === '()' ||
@@ -153,7 +162,10 @@ export class Editor extends Component {
   }
 
   componentWillReceiveProps (nextProps) {
-    if (nextProps.content !== null && nextProps.content !== this.getEditorValue()) {
+    if (
+      nextProps.content !== null &&
+      nextProps.content !== this.getEditorValue()
+    ) {
       this.setEditorValue(nextProps.content)
     }
   }
@@ -168,7 +180,7 @@ export class Editor extends Component {
     }
 
     if (this.props.bus) {
-      this.props.bus.take(SET_CONTENT, (msg) => {
+      this.props.bus.take(SET_CONTENT, msg => {
         this.setEditorValue(msg.message)
       })
       this.props.bus.take(FOCUS, this.focusEditor.bind(this))
@@ -187,13 +199,14 @@ export class Editor extends Component {
     })
   }
 
-  updateCode (newCode, change, cb = () => {
-  }) {
-    const mode = this.props.cmdchar && newCode.trim().indexOf(this.props.cmdchar) === 0
+  updateCode (newCode, change, cb = () => {}) {
+    const mode = this.props.cmdchar &&
+      newCode.trim().indexOf(this.props.cmdchar) === 0
       ? 'text'
       : 'cypher'
     this.clearHints()
-    if (mode === 'cypher' &&
+    if (
+      mode === 'cypher' &&
       newCode.trim().length > 0 &&
       !newCode.trimLeft().toUpperCase().startsWith('EXPLAIN') &&
       !newCode.trimLeft().toUpperCase().startsWith('PROFILE')
@@ -203,20 +216,30 @@ export class Editor extends Component {
 
     const lastPosition = change && change.to
 
-    this.setState({
-      mode,
-      lastPosition: lastPosition ? { line: lastPosition.line, column: lastPosition.ch } : this.state.lastPosition,
-      editorHeight: this.editor && this.editor.base.clientHeight
-    }, cb)
+    this.setState(
+      {
+        mode,
+        lastPosition: lastPosition
+          ? { line: lastPosition.line, column: lastPosition.ch }
+          : this.state.lastPosition,
+        editorHeight: this.editor && this.editor.base.clientHeight
+      },
+      cb
+    )
   }
 
   checkForHints (code) {
     this.props.bus.self(
       CYPHER_REQUEST,
       { query: 'EXPLAIN ' + code },
-      (response) => {
-        if (response.success === true && response.result.summary.notifications.length > 0) {
-          this.setState({ notifications: response.result.summary.notifications })
+      response => {
+        if (
+          response.success === true &&
+          response.result.summary.notifications.length > 0
+        ) {
+          this.setState({
+            notifications: response.result.summary.notifications
+          })
         } else {
           this.clearHints()
         }
@@ -232,18 +255,25 @@ export class Editor extends Component {
     if (this.codeMirror) {
       this.codeMirror.clearGutter('cypher-hints')
       this.state.notifications.forEach(notification => {
-        this.codeMirror.setGutterMarker((notification.position.line || 1) - 1, 'cypher-hints', (() => {
-          let gutter = document.createElement('div')
-          gutter.style.color = '#822'
-          gutter.innerHTML = '<i class="fa fa-exclamation-triangle gutter-warning gutter-warning" aria-hidden="true"></i>'
-          gutter.title = `${notification.title}\n${notification.description}`
-          gutter.onclick = () => {
-            const action = executeSystemCommand(`EXPLAIN ${this.getEditorValue()}`)
-            action.forceView = viewTypes.WARNINGS
-            this.props.bus.send(action.type, action)
-          }
-          return gutter
-        })())
+        this.codeMirror.setGutterMarker(
+          (notification.position.line || 1) - 1,
+          'cypher-hints',
+          (() => {
+            let gutter = document.createElement('div')
+            gutter.style.color = '#822'
+            gutter.innerHTML =
+              '<i class="fa fa-exclamation-triangle gutter-warning gutter-warning" aria-hidden="true"></i>'
+            gutter.title = `${notification.title}\n${notification.description}`
+            gutter.onclick = () => {
+              const action = executeSystemCommand(
+                `EXPLAIN ${this.getEditorValue()}`
+              )
+              action.forceView = viewTypes.WARNINGS
+              this.props.bus.send(action.type, action)
+            }
+            return gutter
+          })()
+        )
       })
     }
   }
@@ -278,16 +308,16 @@ export class Editor extends Component {
       lint: true,
       extraKeys: {
         'Ctrl-Space': 'autocomplete',
-        'Enter': this.handleEnter.bind(this),
+        Enter: this.handleEnter.bind(this),
         'Shift-Enter': this.newlineAndIndent.bind(this),
         'Cmd-Enter': this.execCurrent.bind(this),
         'Ctrl-Enter': this.execCurrent.bind(this),
         'Cmd-Up': this.historyPrev.bind(this),
         'Ctrl-Up': this.historyPrev.bind(this),
-        'Up': this.handleUp.bind(this),
+        Up: this.handleUp.bind(this),
         'Cmd-Down': this.historyNext.bind(this),
         'Ctrl-Down': this.historyNext.bind(this),
-        'Down': this.handleDown.bind(this)
+        Down: this.handleDown.bind(this)
       },
       hintOptions: {
         completeSingle: false,
@@ -305,9 +335,12 @@ export class Editor extends Component {
 
     return (
       <Bar expanded={this.state.expanded} minHeight={this.state.editorHeight}>
-        <EditorWrapper expanded={this.state.expanded} minHeight={this.state.editorHeight}>
+        <EditorWrapper
+          expanded={this.state.expanded}
+          minHeight={this.state.editorHeight}
+        >
           <Codemirror
-            ref={(ref) => {
+            ref={ref => {
               this.editor = ref
             }}
             onChange={updateCode}
@@ -321,22 +354,22 @@ export class Editor extends Component {
             onClick={() => this.props.onFavortieClick(this.getEditorValue())}
             disabled={this.getEditorValue().length < 1}
             title='Favorite'
-            hoverIcon='"\58"'
-            icon='"\73"'
+            hoverIcon='&quot;\58&quot;'
+            icon='&quot;\73&quot;'
           />
           <EditorButton
             onClick={() => this.clearEditor()}
             disabled={this.getEditorValue().length < 1}
             title='Clear'
-            hoverIcon='"\e005"'
-            icon='"\5e"'
+            hoverIcon='&quot;\e005&quot;'
+            icon='&quot;\5e&quot;'
           />
           <EditorButton
             onClick={() => this.execCurrent()}
             disabled={this.getEditorValue().length < 1}
             title='Play'
-            hoverIcon='"\e002"'
-            icon='"\77"'
+            hoverIcon='&quot;\e002&quot;'
+            icon='&quot;\77&quot;'
           />
         </ActionButtonSection>
       </Bar>
@@ -346,18 +379,18 @@ export class Editor extends Component {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    onFavortieClick: (cmd) => {
+    onFavortieClick: cmd => {
       const action = favorites.addFavorite(cmd)
       ownProps.bus.send(action.type, action)
     },
-    onExecute: (cmd) => {
+    onExecute: cmd => {
       const action = executeCommand(cmd)
       ownProps.bus.send(action.type, action)
     }
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     enableEditorAutocomplete: shouldEditorAutocomplete(state),
     content: null,
@@ -366,7 +399,9 @@ const mapStateToProps = (state) => {
     schema: {
       consoleCommands: consoleCommands,
       labels: state.meta.labels.map(schemaConvert.toLabel),
-      relationshipTypes: state.meta.relationshipTypes.map(schemaConvert.toRelationshipType),
+      relationshipTypes: state.meta.relationshipTypes.map(
+        schemaConvert.toRelationshipType
+      ),
       propertyKeys: state.meta.properties.map(schemaConvert.toPropertyKey),
       functions: [
         ...cypherFunctions,

--- a/src/browser/modules/Editor/Editor.test.jsx
+++ b/src/browser/modules/Editor/Editor.test.jsx
@@ -32,24 +32,43 @@ describe('Editor', () => {
     onExecute = jest.fn()
   })
 
-  test.skip('should render Codemirror component with correct properties', () => {
-    const content = 'content-' + Math.random()
-    const wrapper = mount(
-      <EditorComponent bus={createBus()} onExecute={onExecute} content={content} history='' />
-    )
-    const codeMirror = wrapper.find(Codemirror)
-    expect(codeMirror.props().value).toEqual(content)
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Cmd-Enter'](codeMirror.get(0).getCodeMirror())
-    expect(onExecute).toHaveBeenCalled()
-  })
+  test.skip(
+    'should render Codemirror component with correct properties',
+    () => {
+      const content = 'content-' + Math.random()
+      const wrapper = mount(
+        <EditorComponent
+          bus={createBus()}
+          onExecute={onExecute}
+          content={content}
+          history=''
+        />
+      )
+      const codeMirror = wrapper.find(Codemirror)
+      expect(codeMirror.props().value).toEqual(content)
+      codeMirror
+        .get(0)
+        .getCodeMirrorInstance()
+        .keyMap['default']['Cmd-Enter'](codeMirror.get(0).getCodeMirror())
+      expect(onExecute).toHaveBeenCalled()
+    }
+  )
 
   test.skip('should execute current command on Cmd-Enter', () => {
     const content = 'content-' + Math.random()
     const wrapper = mount(
-      <EditorComponent bus={createBus()} onExecute={onExecute} content={content} history='' />
+      <EditorComponent
+        bus={createBus()}
+        onExecute={onExecute}
+        content={content}
+        history=''
+      />
     )
     const codeMirror = wrapper.find(Codemirror)
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Cmd-Enter'](codeMirror.get(0).getCodeMirror())
+    codeMirror
+      .get(0)
+      .getCodeMirrorInstance()
+      .keyMap['default']['Cmd-Enter'](codeMirror.get(0).getCodeMirror())
     expect(onExecute).toHaveBeenCalledWith(content)
     expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('')
   })
@@ -57,44 +76,92 @@ describe('Editor', () => {
   test.skip('should execute current command on Ctrl-Enter', () => {
     const content = 'content-' + Math.random()
     const wrapper = mount(
-      <EditorComponent bus={createBus()} onExecute={onExecute} content={content} history='' />
+      <EditorComponent
+        bus={createBus()}
+        onExecute={onExecute}
+        content={content}
+        history=''
+      />
     )
     const codeMirror = wrapper.find(Codemirror)
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Ctrl-Enter'](codeMirror.get(0).getCodeMirror())
+    codeMirror
+      .get(0)
+      .getCodeMirrorInstance()
+      .keyMap['default']['Ctrl-Enter'](codeMirror.get(0).getCodeMirror())
     expect(onExecute).toHaveBeenCalledWith(content)
     expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('')
   })
 
-  test.skip('should replace content as with history as user arrows up and down', () => {
-    const content = 'content-' + Math.random()
-    const history = [{cmd: 'latest'}, {cmd: 'middle'}, {cmd: 'oldest'}]
-    const wrapper = mount(
-      <EditorComponent bus={createBus()} onExecute={onExecute} content={content} history={history} />
-    )
-    const codeMirror = wrapper.find(Codemirror)
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Cmd-Up'](codeMirror.get(0).getCodeMirror())
-    expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('latest')
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Ctrl-Up'](codeMirror.get(0).getCodeMirror())
-    expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('middle')
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Ctrl-Up'](codeMirror.get(0).getCodeMirror())
-    expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('oldest')
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Cmd-Down'](codeMirror.get(0).getCodeMirror())
-    expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('middle')
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Ctrl-Down'](codeMirror.get(0).getCodeMirror())
-    expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('latest')
-  })
+  test.skip(
+    'should replace content as with history as user arrows up and down',
+    () => {
+      const content = 'content-' + Math.random()
+      const history = [{ cmd: 'latest' }, { cmd: 'middle' }, { cmd: 'oldest' }]
+      const wrapper = mount(
+        <EditorComponent
+          bus={createBus()}
+          onExecute={onExecute}
+          content={content}
+          history={history}
+        />
+      )
+      const codeMirror = wrapper.find(Codemirror)
+      codeMirror
+        .get(0)
+        .getCodeMirrorInstance()
+        .keyMap['default']['Cmd-Up'](codeMirror.get(0).getCodeMirror())
+      expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('latest')
+      codeMirror
+        .get(0)
+        .getCodeMirrorInstance()
+        .keyMap['default']['Ctrl-Up'](codeMirror.get(0).getCodeMirror())
+      expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('middle')
+      codeMirror
+        .get(0)
+        .getCodeMirrorInstance()
+        .keyMap['default']['Ctrl-Up'](codeMirror.get(0).getCodeMirror())
+      expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('oldest')
+      codeMirror
+        .get(0)
+        .getCodeMirrorInstance()
+        .keyMap['default']['Cmd-Down'](codeMirror.get(0).getCodeMirror())
+      expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('middle')
+      codeMirror
+        .get(0)
+        .getCodeMirrorInstance()
+        .keyMap['default']['Ctrl-Down'](codeMirror.get(0).getCodeMirror())
+      expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('latest')
+    }
+  )
 
   test.skip('should resest history after execution', () => {
-    const history = [{cmd: 'latest'}, {cmd: 'middle'}, {cmd: 'oldest'}]
+    const history = [{ cmd: 'latest' }, { cmd: 'middle' }, { cmd: 'oldest' }]
     const wrapper = mount(
-      <EditorComponent bus={createBus()} onExecute={onExecute} content='' history={history} />
+      <EditorComponent
+        bus={createBus()}
+        onExecute={onExecute}
+        content=''
+        history={history}
+      />
     )
     const codeMirror = wrapper.find(Codemirror)
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Cmd-Up'](codeMirror.get(0).getCodeMirror())
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Cmd-Up'](codeMirror.get(0).getCodeMirror())
+    codeMirror
+      .get(0)
+      .getCodeMirrorInstance()
+      .keyMap['default']['Cmd-Up'](codeMirror.get(0).getCodeMirror())
+    codeMirror
+      .get(0)
+      .getCodeMirrorInstance()
+      .keyMap['default']['Cmd-Up'](codeMirror.get(0).getCodeMirror())
     expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('middle')
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Cmd-Enter'](codeMirror.get(0).getCodeMirror())
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Cmd-Up'](codeMirror.get(0).getCodeMirror())
+    codeMirror
+      .get(0)
+      .getCodeMirrorInstance()
+      .keyMap['default']['Cmd-Enter'](codeMirror.get(0).getCodeMirror())
+    codeMirror
+      .get(0)
+      .getCodeMirrorInstance()
+      .keyMap['default']['Cmd-Up'](codeMirror.get(0).getCodeMirror())
     expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('latest')
   })
 })

--- a/src/browser/modules/Editor/styled.jsx
+++ b/src/browser/modules/Editor/styled.jsx
@@ -27,22 +27,25 @@ export const BaseBar = styled.div`
   display: flex;
   flex-direction: row;
   align-items: middle;
-  min-height: ${props => Math.max(dim.editorbarHeight, props.minHeight + editorPadding * 2)}px;
+  min-height: ${props =>
+    Math.max(dim.editorbarHeight, props.minHeight + editorPadding * 2)}px;
   overflow: hidden;
   box-shadow: 0 1px 4px rgba(0,0,0,.1);
   margin: 0 24px;
 `
 export const Bar = styled(BaseBar)`
-  ${(props => {
+  ${props => {
     if (props.expanded) {
-      return 'position: absolute;' +
-      'height: 100vh;' +
-      'z-index: 100;' +
-      'right: 0;' +
-      'left: 0;' +
-      'bottom: 0;'
+      return (
+        'position: absolute;' +
+        'height: 100vh;' +
+        'z-index: 100;' +
+        'right: 0;' +
+        'left: 0;' +
+        'bottom: 0;'
+      )
     }
-  })}
+  }}
 `
 export const ActionButtonSection = styled.div`
   flex: 0 0 130px;
@@ -59,7 +62,8 @@ const BaseEditorWrapper = styled.div`
   padding: ${editorPadding}px;
   background-color: ${props => props.theme.editorBarBackground};
   font-family: Monaco,"Courier New",Terminal,monospace;
-  min-Height: ${props => Math.max(dim.editorbarHeight, props.minHeight + editorPadding * 2)}px;
+  min-Height: ${props =>
+    Math.max(dim.editorbarHeight, props.minHeight + editorPadding * 2)}px;
   .CodeMirror {
     background-color: ${props => props.theme.editorBackground} !important;
     color: ${props => props.theme.editorCommandColor};
@@ -67,20 +71,22 @@ const BaseEditorWrapper = styled.div`
 `
 
 export const EditorWrapper = styled(BaseEditorWrapper)`
-  ${(props => {
+  ${props => {
     if (props.expanded) {
-      return 'height: 100%;' +
-      'z-index: 2;' +
-      '.CodeMirror {' +
-      '  position: absolute;' +
-      '  left: 12px;' +
-      '  right: 142px;' +
-      '  top: 12px;' +
-      '  bottom: 12px;' +
-      '}' +
-      '.CodeMirror-scroll {' +
-      '   max-height: initial !important;' +
-      '}'
+      return (
+        'height: 100%;' +
+        'z-index: 2;' +
+        '.CodeMirror {' +
+        '  position: absolute;' +
+        '  left: 12px;' +
+        '  right: 142px;' +
+        '  top: 12px;' +
+        '  bottom: 12px;' +
+        '}' +
+        '.CodeMirror-scroll {' +
+        '   max-height: initial !important;' +
+        '}'
+      )
     }
-  })}
+  }}
 `

--- a/src/browser/modules/Guides/Carousel.jsx
+++ b/src/browser/modules/Guides/Carousel.jsx
@@ -42,31 +42,45 @@ export default class Carousel extends Component {
     return this.state.firstRender
   }
   next () {
-    this.setState({visibleSlide: this.state.visibleSlide + 1})
+    this.setState({ visibleSlide: this.state.visibleSlide + 1 })
   }
   prev () {
-    this.setState({visibleSlide: this.state.visibleSlide - 1})
+    this.setState({ visibleSlide: this.state.visibleSlide - 1 })
   }
   getSlide (slideNumber) {
     return this.slides[slideNumber]
   }
   goToSlide (slideNumber) {
-    this.setState({visibleSlide: slideNumber})
+    this.setState({ visibleSlide: slideNumber })
   }
   render () {
     return (
       <StyledCarousel>
         <StyledCarouselButtonContainer>
           <Render if={this.state.visibleSlide !== 0}>
-            <StyledCarouselLeft><CarouselButton onClick={this.prev.bind(this)}>{'‹'}</CarouselButton></StyledCarouselLeft>
+            <StyledCarouselLeft>
+              <CarouselButton onClick={this.prev.bind(this)}>
+                {'‹'}
+              </CarouselButton>
+            </StyledCarouselLeft>
           </Render>
-          <Render if={this.state.visibleSlide !== (this.slides.length - 1)}>
-            <StyledCarouselRight><CarouselButton onClick={this.next.bind(this)}>{'›'}</CarouselButton></StyledCarouselRight>
+          <Render if={this.state.visibleSlide !== this.slides.length - 1}>
+            <StyledCarouselRight>
+              <CarouselButton onClick={this.next.bind(this)}>
+                {'›'}
+              </CarouselButton>
+            </StyledCarouselRight>
           </Render>
         </StyledCarouselButtonContainer>
-        <SlideContainer>{this.getSlide(this.state.visibleSlide)}</SlideContainer>
         <SlideContainer>
-          <CarouselSlidePicker slides={this.slides} visibleSlide={this.state.visibleSlide} onClickEvent={(slideNumber) => this.goToSlide(slideNumber)} />
+          {this.getSlide(this.state.visibleSlide)}
+        </SlideContainer>
+        <SlideContainer>
+          <CarouselSlidePicker
+            slides={this.slides}
+            visibleSlide={this.state.visibleSlide}
+            onClickEvent={slideNumber => this.goToSlide(slideNumber)}
+          />
         </SlideContainer>
       </StyledCarousel>
     )

--- a/src/browser/modules/Guides/CarouselSlidePicker.jsx
+++ b/src/browser/modules/Guides/CarouselSlidePicker.jsx
@@ -24,13 +24,14 @@ import {
   StyledUl
 } from './styled'
 
-const CarouselSlidePicker = ({slides, visibleSlide, onClickEvent}) => {
+const CarouselSlidePicker = ({ slides, visibleSlide, onClickEvent }) => {
   if (!slides || slides.length === 0) return null
-  const Indicators = slides.map((_, i) =>
-    (i !== visibleSlide)
-      ? <CarouselIndicatorInactive onClick={() => onClickEvent(i)} />
-      : <CarouselIndicatorActive onClick={() => onClickEvent(i)} />
-    )
+  const Indicators = slides.map(
+    (_, i) =>
+      i !== visibleSlide
+        ? <CarouselIndicatorInactive onClick={() => onClickEvent(i)} />
+        : <CarouselIndicatorActive onClick={() => onClickEvent(i)} />
+  )
   return <StyledUl>{Indicators}</StyledUl>
 }
 

--- a/src/browser/modules/Guides/Guides.jsx
+++ b/src/browser/modules/Guides/Guides.jsx
@@ -27,13 +27,13 @@ import Carousel from './Carousel'
 export default class Guides extends Component {
   constructor (props) {
     super(props)
-    this.state = {slides: null, firstRender: true}
+    this.state = { slides: null, firstRender: true }
   }
   componentDidMount () {
     const slides = this.base.getElementsByTagName('slide')
     let reactSlides = this
     if (slides.length > 0) {
-      reactSlides = Array.from(slides).map((slide) => {
+      reactSlides = Array.from(slides).map(slide => {
         return {
           html: slide
         }
@@ -43,8 +43,10 @@ export default class Guides extends Component {
   }
   render () {
     if (this.state.slides && Array.isArray(this.state.slides)) {
-      const ListOfSlides = this.state.slides.map((slide) => {
-        const slideComponent = <Slide key={uuid.v4()} html={slide.html.innerHTML} />
+      const ListOfSlides = this.state.slides.map(slide => {
+        const slideComponent = (
+          <Slide key={uuid.v4()} html={slide.html.innerHTML} />
+        )
         if (this.props.withDirectives) {
           return (
             <div key={uuid.v4()}>
@@ -59,16 +61,17 @@ export default class Guides extends Component {
           )
         }
       })
-      return (<Carousel slides={ListOfSlides} withDirectives={this.props.withDirectives} />)
+      return (
+        <Carousel
+          slides={ListOfSlides}
+          withDirectives={this.props.withDirectives}
+        />
+      )
     }
     if (this.props.withDirectives) {
-      return (
-        <Directives content={<Slide html={this.props.html} />} />
-      )
+      return <Directives content={<Slide html={this.props.html} />} />
     } else {
-      return (
-        <Slide html={this.props.html} />
-      )
+      return <Slide html={this.props.html} />
     }
   }
 }

--- a/src/browser/modules/Guides/Guides.test.jsx
+++ b/src/browser/modules/Guides/Guides.test.jsx
@@ -24,7 +24,7 @@ import React from 'react'
 import Guides from './Guides'
 import Slide from './Slide'
 
-import {mount} from 'enzyme'
+import { mount } from 'enzyme'
 
 describe('Guides', () => {
   test('should render Guides when html has `slide` tag', () => {

--- a/src/browser/modules/Guides/Slide.jsx
+++ b/src/browser/modules/Guides/Slide.jsx
@@ -21,8 +21,13 @@
 import styles from './style.css'
 import { StyledSlide } from './styled.jsx'
 
-const Slide = ({html}) => {
-  return (<StyledSlide className={styles.slide} dangerouslySetInnerHTML={{__html: html}} />)
+const Slide = ({ html }) => {
+  return (
+    <StyledSlide
+      className={styles.slide}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
 }
 
 export default Slide

--- a/src/browser/modules/Guides/Slide.test.jsx
+++ b/src/browser/modules/Guides/Slide.test.jsx
@@ -22,7 +22,7 @@
 import React from 'react'
 import Slide from './Slide'
 
-import {mount} from 'enzyme'
+import { mount } from 'enzyme'
 
 describe('Slide', () => {
   test('should render html', () => {

--- a/src/browser/modules/Guides/styled.jsx
+++ b/src/browser/modules/Guides/styled.jsx
@@ -70,7 +70,8 @@ export const StyledSlide = styled.div`
   }
   & a {
     color: ${props => props.theme.link};
-    text-decoration: ${props => props.theme.name === 'dark' ? 'underline' : 'none'};
+    text-decoration: ${props =>
+      props.theme.name === 'dark' ? 'underline' : 'none'};
   }
   & kbd {
     color: ${props => props.theme.primaryBackground} !important; /* inverted */

--- a/src/browser/modules/Intercom/index.jsx
+++ b/src/browser/modules/Intercom/index.jsx
@@ -36,7 +36,7 @@ export class Intercom extends Component {
       return
     }
     if (!window.Intercom) {
-      (function (w, d, id, s, x) {
+      ;(function (w, d, id, s, x) {
         function i () {
           i.c(arguments)
         }
@@ -81,9 +81,9 @@ export class Intercom extends Component {
   }
 }
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
-    updateData: (data) => dispatch(updateData(data))
+    updateData: data => dispatch(updateData(data))
   }
 }
 export default connect(null, mapDispatchToProps)(Intercom)

--- a/src/browser/modules/Main/Main.jsx
+++ b/src/browser/modules/Main/Main.jsx
@@ -18,15 +18,25 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { DISCONNECTED_STATE, PENDING_STATE } from 'shared/modules/connections/connectionsDuck'
+import {
+  DISCONNECTED_STATE,
+  PENDING_STATE
+} from 'shared/modules/connections/connectionsDuck'
 import Editor from '../Editor/Editor'
 import Stream from '../Stream/Stream'
 import Render from 'browser-components/Render'
 import ClickToCode from '../ClickToCode'
-import { StyledMain, WarningBanner, ErrorBanner, NotAuthedBanner, StyledCodeBlockAuthBar, StyledCodeBlockErrorBar } from './styled'
+import {
+  StyledMain,
+  WarningBanner,
+  ErrorBanner,
+  NotAuthedBanner,
+  StyledCodeBlockAuthBar,
+  StyledCodeBlockErrorBar
+} from './styled'
 import SyncReminderBanner from './SyncReminderBanner'
 
-const Main = (props) => {
+const Main = props => {
   return (
     <StyledMain>
       <Editor />

--- a/src/browser/modules/Main/SyncReminderBanner.jsx
+++ b/src/browser/modules/Main/SyncReminderBanner.jsx
@@ -20,8 +20,17 @@
 
 import { Component } from 'preact'
 import { connect } from 'preact-redux'
-import { SyncDisconnectedBanner, SyncSignInBarButton, StyledCancelLink, StyledSyncReminderSpan, StyledSyncReminderButtonContainer } from './styled'
-import { CONNECTED_STATE, getConnectionState } from 'shared/modules/connections/connectionsDuck'
+import {
+  SyncDisconnectedBanner,
+  SyncSignInBarButton,
+  StyledCancelLink,
+  StyledSyncReminderSpan,
+  StyledSyncReminderButtonContainer
+} from './styled'
+import {
+  CONNECTED_STATE,
+  getConnectionState
+} from 'shared/modules/connections/connectionsDuck'
 import Render from 'browser-components/Render'
 import BrowserSyncAuthWindow from '../Sync/BrowserSyncAuthWindow'
 import { getBrowserSyncConfig } from 'shared/modules/settings/settingsDuck'
@@ -37,25 +46,38 @@ class SyncReminderBanner extends Component {
     })
   }
   serviceReady (status) {
-    this.setState({status})
+    this.setState({ status })
   }
   logIn () {
-    BrowserSyncAuthWindow(this.props.browserSyncConfig.authWindowUrl, this.syncManager.authCallBack.bind(this.syncManager))
+    BrowserSyncAuthWindow(
+      this.props.browserSyncConfig.authWindowUrl,
+      this.syncManager.authCallBack.bind(this.syncManager)
+    )
   }
   render () {
     const { dbConnectionState, syncConsent, sync, optOutSync } = this.props
     const dbConnected = dbConnectionState === CONNECTED_STATE
     const syncDisconnected = !sync || !sync.authData
-    const syncConsentGiven = syncConsent && syncConsent.consented === true && !syncConsent.optedOut
+    const syncConsentGiven =
+      syncConsent && syncConsent.consented === true && !syncConsent.optedOut
 
-    const visible = dbConnected && syncDisconnected && syncConsentGiven && this.state.status === 'UP'
+    const visible =
+      dbConnected &&
+      syncDisconnected &&
+      syncConsentGiven &&
+      this.state.status === 'UP'
 
     return (
       <Render if={visible}>
         <SyncDisconnectedBanner height='100px'>
-          <StyledSyncReminderSpan>You are currently not signed into Neo4j Browser Sync. Connect through a simple social sign-in to get started.</StyledSyncReminderSpan>
+          <StyledSyncReminderSpan>
+            You are currently not signed into Neo4j Browser Sync. Connect
+            through a simple social sign-in to get started.
+          </StyledSyncReminderSpan>
           <StyledSyncReminderButtonContainer>
-            <SyncSignInBarButton onClick={this.logIn.bind(this)}>Sign In</SyncSignInBarButton>
+            <SyncSignInBarButton onClick={this.logIn.bind(this)}>
+              Sign In
+            </SyncSignInBarButton>
             <StyledCancelLink onClick={() => optOutSync()}>X</StyledCancelLink>
           </StyledSyncReminderButtonContainer>
         </SyncDisconnectedBanner>
@@ -64,7 +86,7 @@ class SyncReminderBanner extends Component {
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     syncConsent: state.syncConsent,
     sync: state.sync,
@@ -75,7 +97,7 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    onSync: (syncObject) => {
+    onSync: syncObject => {
       dispatch(setSync(syncObject))
     },
     optOutSync: () => {

--- a/src/browser/modules/Main/styled.jsx
+++ b/src/browser/modules/Main/styled.jsx
@@ -22,7 +22,7 @@ import styled, { keyframes } from 'styled-components'
 import { StyledCodeBlock } from '../ClickToCode/styled'
 import { SyncSignInButton } from 'browser-components/buttons'
 
-const grow = (height) => {
+const grow = height => {
   return keyframes`
     0% {
       max-height: 0px;

--- a/src/browser/modules/Sidebar/About.jsx
+++ b/src/browser/modules/Sidebar/About.jsx
@@ -19,7 +19,15 @@
  */
 
 import { version } from 'project-root/package.json'
-import {Drawer, DrawerBody, DrawerHeader, DrawerSubHeader, DrawerSection, DrawerSectionBody, DrawerFooter} from 'browser-components/drawer'
+import {
+  Drawer,
+  DrawerBody,
+  DrawerHeader,
+  DrawerSubHeader,
+  DrawerSection,
+  DrawerSectionBody,
+  DrawerFooter
+} from 'browser-components/drawer'
 
 const About = () => {
   return (
@@ -28,7 +36,8 @@ const About = () => {
       <DrawerBody>
         <DrawerSection>
           <DrawerSubHeader>
-            Made by <a target='_blank' href='http://neo4j.com/'>Neo Technology</a>
+            Made by{' '}
+            <a target='_blank' href='http://neo4j.com/'>Neo Technology</a>
           </DrawerSubHeader>
         </DrawerSection>
         <DrawerSection>
@@ -49,7 +58,16 @@ const About = () => {
             License
           </DrawerSubHeader>
           <DrawerSectionBody>
-            <a target='_blank' href='http://www.gnu.org/licenses/gpl.html'>GPLv3</a> or <a target='_blank' href='http://www.gnu.org/licenses/agpl-3.0.html'>AGPL</a> for Open Source, and <a target='_blank' href='https://neo4j.com/licensing/'>NTCL</a> Commercial.
+            <a target='_blank' href='http://www.gnu.org/licenses/gpl.html'>
+              GPLv3
+            </a>{' '}
+            or{' '}
+            <a target='_blank' href='http://www.gnu.org/licenses/agpl-3.0.html'>
+              AGPL
+            </a>{' '}
+            for Open Source, and{' '}
+            <a target='_blank' href='https://neo4j.com/licensing/'>NTCL</a>{' '}
+            Commercial.
           </DrawerSectionBody>
         </DrawerSection>
         <DrawerSection>
@@ -57,11 +75,33 @@ const About = () => {
             Participate
           </DrawerSubHeader>
           <DrawerSectionBody>
-            Ask questions at <a target='_blank' href='http://stackoverflow.com/questions/tagged/neo4j'>Stack Overflow</a><br />
-            Discuss Neo4j on <a target='_blank' href='http://neo4j.com/slack'>Slack</a> or <a target='_blank' href='http://groups.google.com/group/neo4j'>Google Groups</a><br />
-            Visit a local <a target='_blank' href='http://neo4j.meetup.com/'>Meetup Group</a><br />
-            Contribute code to <a target='_blank' href='http://github.com/neo4j'>Neo4j</a> or <a target='_blank' href='http://github.com/neo4j/neo4j-browser'>Neo4j Browser</a><br />
-            Send us your Browser feedback via <a href='mailto:browser@neotechnology.com?subject=Neo4j Browser feedback'>email</a>
+            Ask questions at{' '}
+            <a
+              target='_blank'
+              href='http://stackoverflow.com/questions/tagged/neo4j'
+            >
+              Stack Overflow
+            </a>
+            <br />
+            Discuss Neo4j on{' '}
+            <a target='_blank' href='http://neo4j.com/slack'>Slack</a> or{' '}
+            <a target='_blank' href='http://groups.google.com/group/neo4j'>
+              Google Groups
+            </a>
+            <br />
+            Visit a local{' '}
+            <a target='_blank' href='http://neo4j.meetup.com/'>Meetup Group</a>
+            <br />
+            Contribute code to{' '}
+            <a target='_blank' href='http://github.com/neo4j'>Neo4j</a> or{' '}
+            <a target='_blank' href='http://github.com/neo4j/neo4j-browser'>
+              Neo4j Browser
+            </a>
+            <br />
+            Send us your Browser feedback via{' '}
+            <a href='mailto:browser@neotechnology.com?subject=Neo4j Browser feedback'>
+              email
+            </a>
           </DrawerSectionBody>
         </DrawerSection>
         <DrawerSection>
@@ -69,11 +109,12 @@ const About = () => {
             Thanks
           </DrawerSubHeader>
           <DrawerSectionBody>
-            Neo4j wouldn't be possible without a fantastic community. Thanks for all the feedback, discussions and contributions.
+            Neo4j wouldn't be possible without a fantastic community. Thanks for
+            all the feedback, discussions and contributions.
           </DrawerSectionBody>
           <DrawerFooter>
             <DrawerSectionBody>
-             With &#9829; from Sweden.
+              With &#9829; from Sweden.
             </DrawerSectionBody>
           </DrawerFooter>
         </DrawerSection>

--- a/src/browser/modules/Sidebar/DocumentItems.jsx
+++ b/src/browser/modules/Sidebar/DocumentItems.jsx
@@ -21,22 +21,36 @@
 import { connect } from 'preact-redux'
 import { withBus } from 'preact-suber'
 import { SET_CONTENT, setContent } from 'shared/modules/editor/editorDuck'
-import {DrawerSubHeader, DrawerSection, DrawerSectionBody} from 'browser-components/drawer'
-import { StyledHelpLink, StyledHelpItem, StyledDocumentActionLink } from './styled'
+import {
+  DrawerSubHeader,
+  DrawerSection,
+  DrawerSectionBody
+} from 'browser-components/drawer'
+import {
+  StyledHelpLink,
+  StyledHelpItem,
+  StyledDocumentActionLink
+} from './styled'
 
-export const DocumentItems = ({header, items, onItemClick = null}) => {
-  const listOfItems = items.map((item) => {
+export const DocumentItems = ({ header, items, onItemClick = null }) => {
+  const listOfItems = items.map(item => {
     switch (item.type) {
       case 'link':
         return (
           <StyledHelpItem>
-            <StyledHelpLink href={item.command} target='_blank'>{item.name}</StyledHelpLink>
+            <StyledHelpLink href={item.command} target='_blank'>
+              {item.name}
+            </StyledHelpLink>
           </StyledHelpItem>
         )
       default:
         return (
           <StyledHelpItem>
-            <StyledDocumentActionLink onClick={() => onItemClick(item.command)} name={item.name} type={item.type} />
+            <StyledDocumentActionLink
+              onClick={() => onItemClick(item.command)}
+              name={item.name}
+              type={item.type}
+            />
           </StyledHelpItem>
         )
     }
@@ -55,7 +69,7 @@ export const DocumentItems = ({header, items, onItemClick = null}) => {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    onItemClick: (cmd) => {
+    onItemClick: cmd => {
       ownProps.bus.send(SET_CONTENT, setContent(cmd))
     }
   }

--- a/src/browser/modules/Sidebar/DocumentItems.test.jsx
+++ b/src/browser/modules/Sidebar/DocumentItems.test.jsx
@@ -24,8 +24,8 @@ import { shallow } from 'enzyme'
 import { DocumentItems as DocumentItemsComponent } from './DocumentItems'
 
 describe('DocumentItemsComponent', () => {
-  const link = {name: 'Link', command: 'url.com', type: 'link'}
-  const command = {name: 'Command', command: 'TEST'}
+  const link = { name: 'Link', command: 'url.com', type: 'link' }
+  const command = { name: 'Command', command: 'TEST' }
 
   test('should render href when link is provided', () => {
     const wrapper = shallow(<DocumentItemsComponent items={[link]} />)

--- a/src/browser/modules/Sidebar/Documents.jsx
+++ b/src/browser/modules/Sidebar/Documents.jsx
@@ -23,23 +23,47 @@ import { Drawer, DrawerBody, DrawerHeader } from 'browser-components/drawer'
 
 const staticItems = {
   intro: [
-    {name: 'Getting started', command: ':play intro', type: 'play'},
-    {name: 'Basic graph concepts', command: ':play graphs', type: 'play'},
-    {name: 'Writing Cypher queries', command: ':play cypher', type: 'play'}
+    { name: 'Getting started', command: ':play intro', type: 'play' },
+    { name: 'Basic graph concepts', command: ':play graphs', type: 'play' },
+    { name: 'Writing Cypher queries', command: ':play cypher', type: 'play' }
   ],
   help: [
-    {name: 'Help', command: ':help help', type: 'help'},
-    {name: 'Cypher syntax', command: ':help cypher', type: 'help'},
-    {name: 'Available commands', command: ':help commands', type: 'help'},
-    {name: 'Keyboard shortcuts', command: ':help keys', type: 'help'}
+    { name: 'Help', command: ':help help', type: 'help' },
+    { name: 'Cypher syntax', command: ':help cypher', type: 'help' },
+    { name: 'Available commands', command: ':help commands', type: 'help' },
+    { name: 'Keyboard shortcuts', command: ':help keys', type: 'help' }
   ],
   reference: [
-    {name: 'Developer Manual', command: 'https://neo4j.com/docs/developer-manual/3.2/', type: 'link'},
-    {name: 'Operations Manual', command: 'https://neo4j.com/docs/operations-manual/3.2/', type: 'link'},
-    {name: 'Cypher Refcard', command: 'https://neo4j.com/docs/cypher-refcard/3.2/', type: 'link'},
-    {name: 'GraphGists', command: 'https://neo4j.com/graphgists/', type: 'link'},
-    {name: 'Developer Site', command: 'https://www.neo4j.com/developer/', type: 'link'},
-    {name: 'Knowledge Base', command: 'https://neo4j.com/developer/kb/', type: 'link'}
+    {
+      name: 'Developer Manual',
+      command: 'https://neo4j.com/docs/developer-manual/3.2/',
+      type: 'link'
+    },
+    {
+      name: 'Operations Manual',
+      command: 'https://neo4j.com/docs/operations-manual/3.2/',
+      type: 'link'
+    },
+    {
+      name: 'Cypher Refcard',
+      command: 'https://neo4j.com/docs/cypher-refcard/3.2/',
+      type: 'link'
+    },
+    {
+      name: 'GraphGists',
+      command: 'https://neo4j.com/graphgists/',
+      type: 'link'
+    },
+    {
+      name: 'Developer Site',
+      command: 'https://www.neo4j.com/developer/',
+      type: 'link'
+    },
+    {
+      name: 'Knowledge Base',
+      command: 'https://neo4j.com/developer/kb/',
+      type: 'link'
+    }
   ]
 }
 

--- a/src/browser/modules/Sidebar/Documents.test.jsx
+++ b/src/browser/modules/Sidebar/Documents.test.jsx
@@ -26,7 +26,11 @@ import { shallow } from 'enzyme'
 
 describe('DocumentsComponent', () => {
   test('should show list of documents', () => {
-    const documents = {intro: [], help: [], reference: [{name: 'hello', command: 'test commands'}]}
+    const documents = {
+      intro: [],
+      help: [],
+      reference: [{ name: 'hello', command: 'test commands' }]
+    }
     const wrapper = shallow(<DocumentsComponent items={documents} />)
     expect(wrapper.find(DocumentItems).length).toBe(3)
   })

--- a/src/browser/modules/Sidebar/Favorite.jsx
+++ b/src/browser/modules/Sidebar/Favorite.jsx
@@ -18,12 +18,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {connect} from 'preact-redux'
+import { connect } from 'preact-redux'
 import * as favorite from 'shared/modules/favorites/favoritesDuck'
-import {StyledListItem, StyledFavoriteText, DeleteFavButton, ExecFavortieButton} from './styled'
-import {withBus} from 'preact-suber'
-import {Component} from 'preact'
-import {DragSource, DropTarget} from 'react-dnd'
+import {
+  StyledListItem,
+  StyledFavoriteText,
+  DeleteFavButton,
+  ExecFavortieButton
+} from './styled'
+import { withBus } from 'preact-suber'
+import { Component } from 'preact'
+import { DragSource, DropTarget } from 'react-dnd'
 import ItemTypes from './DragItemTypes'
 
 function extractNameFromCommand (input) {
@@ -72,7 +77,14 @@ const calculateNewPosition = (props, component, monitor) => {
     return null
   }
 
-  return { dragIndex, dragFolder: dragItem.folder, hoverIndex, hoverFolder: props.entry.folder, dragItem, hoveredItemProps: props }
+  return {
+    dragIndex,
+    dragFolder: dragItem.folder,
+    hoverIndex,
+    hoverFolder: props.entry.folder,
+    dragItem,
+    hoveredItemProps: props
+  }
 }
 
 const favoriteTarget = {
@@ -80,7 +92,7 @@ const favoriteTarget = {
     let newValues = calculateNewPosition(props, component, monitor)
 
     if (newValues) {
-      props.moveFavorite(Object.assign({...newValues}, {dropped: false}))
+      props.moveFavorite(Object.assign({ ...newValues }, { dropped: false }))
       monitor.getItem().index = newValues.hoverIndex
     }
   },
@@ -88,7 +100,15 @@ const favoriteTarget = {
     const dragItem = monitor.getItem()
     const dragIndex = dragItem.index
     const hoverIndex = props.index
-    props.moveFavorite({ dragIndex, dragFolder: dragItem.folder, hoverIndex, hoverFolder: props.entry.folder, dragItem, hoveredItemProps: props, dropped: true })
+    props.moveFavorite({
+      dragIndex,
+      dragFolder: dragItem.folder,
+      hoverIndex,
+      hoverFolder: props.entry.folder,
+      dragItem,
+      hoveredItemProps: props,
+      dropped: true
+    })
   }
 }
 
@@ -97,11 +117,20 @@ class FavoriteDp extends Component {
     const name = extractNameFromCommand(this.props.content)
     let favoriteContent = (
       <StyledListItem isChild={this.props.isChild}>
-        <ExecFavortieButton onClick={() => this.props.onExecClick(this.props.content)} />
-        <StyledFavoriteText {...this.props}
-          onClick={() => this.props.onItemClick(this.props.content)}>{name}</StyledFavoriteText>
-        <DeleteFavButton id={this.props.id} removeClick={() => this.props.removeClick(this.props.id)}
-          isStatic={this.props.isStatic} />
+        <ExecFavortieButton
+          onClick={() => this.props.onExecClick(this.props.content)}
+        />
+        <StyledFavoriteText
+          {...this.props}
+          onClick={() => this.props.onItemClick(this.props.content)}
+        >
+          {name}
+        </StyledFavoriteText>
+        <DeleteFavButton
+          id={this.props.id}
+          removeClick={() => this.props.removeClick(this.props.id)}
+          isStatic={this.props.isStatic}
+        />
       </StyledListItem>
     )
 
@@ -129,19 +158,27 @@ class FavoriteDg extends Component {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    removeClick: (id) => {
+    removeClick: id => {
       dispatch(favorite.removeFavorite(id))
     }
   }
 }
 
-const FavoriteDrop = DropTarget(ItemTypes.FAVORITE, favoriteTarget, connect => ({
-  connectDropTarget: connect.dropTarget()
-}))(FavoriteDg)
+const FavoriteDrop = DropTarget(
+  ItemTypes.FAVORITE,
+  favoriteTarget,
+  connect => ({
+    connectDropTarget: connect.dropTarget()
+  })
+)(FavoriteDg)
 
-const FavoriteDrag = DragSource(ItemTypes.FAVORITE, favoriteSource, (connect, monitor) => ({
-  connectDragSource: connect.dragSource(),
-  isDragging: monitor.isDragging()
-}))(FavoriteDrop)
+const FavoriteDrag = DragSource(
+  ItemTypes.FAVORITE,
+  favoriteSource,
+  (connect, monitor) => ({
+    connectDragSource: connect.dragSource(),
+    isDragging: monitor.isDragging()
+  })
+)(FavoriteDrop)
 
 export default withBus(connect(null, mapDispatchToProps)(FavoriteDrag))

--- a/src/browser/modules/Sidebar/Favorite.test.jsx
+++ b/src/browser/modules/Sidebar/Favorite.test.jsx
@@ -49,7 +49,9 @@ describe('FavoriteComponent', () => {
     ]
     testCases.forEach((testCase, i) => {
       test(`should extract name of script from case ${i}`, () => {
-        const wrapper = shallow(<FavoriteComponent content={testCase.command} />)
+        const wrapper = shallow(
+          <FavoriteComponent content={testCase.command} />
+        )
         const item = wrapper.find('.favorite')
         expect(item.length).toBe(1)
         expect(item.props().primaryText).toEqual(testCase.expected)
@@ -59,7 +61,9 @@ describe('FavoriteComponent', () => {
 
   test('should show tigger event with content of script', () => {
     const onItemClick = jest.fn()
-    const wrapper = shallow(<FavoriteComponent content={'Cypher'} onItemClick={onItemClick} />)
+    const wrapper = shallow(
+      <FavoriteComponent content={'Cypher'} onItemClick={onItemClick} />
+    )
     const favoriteElement = wrapper.find('.favorite')
     expect(favoriteElement.length).toBe(1)
     favoriteElement.first().simulate('click')
@@ -69,7 +73,9 @@ describe('FavoriteComponent', () => {
   test('should remove favorite that has been clicked', () => {
     const id = 'SomeId'
     const onRemoveClick = jest.fn()
-    const wrapper = mount(<FavoriteComponent id={id} content='hej' removeClick={onRemoveClick} />)
+    const wrapper = mount(
+      <FavoriteComponent id={id} content='hej' removeClick={onRemoveClick} />
+    )
     const favoriteElement = wrapper.find('.favorite')
     expect(favoriteElement.length).toBe(1)
     wrapper.find('.remove').simulate('click')

--- a/src/browser/modules/Sidebar/Favorites.jsx
+++ b/src/browser/modules/Sidebar/Favorites.jsx
@@ -18,54 +18,83 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {Component} from 'preact'
-import {connect} from 'preact-redux'
-import {withBus} from 'preact-suber'
+import { Component } from 'preact'
+import { connect } from 'preact-redux'
+import { withBus } from 'preact-suber'
 import * as editor from 'shared/modules/editor/editorDuck'
 import * as favorite from 'shared/modules/favorites/favoritesDuck'
 import * as folder from 'shared/modules/favorites/foldersDuck'
-import {getSettings} from 'shared/modules/settings/settingsDuck'
-import {executeCommand} from 'shared/modules/commands/commandsDuck'
+import { getSettings } from 'shared/modules/settings/settingsDuck'
+import { executeCommand } from 'shared/modules/commands/commandsDuck'
 
 import Render from 'browser-components/Render'
 import Favorite from './Favorite'
 import Folder from './Folder'
 import FileDrop from './FileDrop'
-import {Drawer, DrawerBody, DrawerHeader, DrawerSection, DrawerSubHeader} from 'browser-components/drawer'
-import {DragDropContext} from 'react-dnd'
+import {
+  Drawer,
+  DrawerBody,
+  DrawerHeader,
+  DrawerSection,
+  DrawerSubHeader
+} from 'browser-components/drawer'
+import { DragDropContext } from 'react-dnd'
 import HTML5Backend from 'react-dnd-html5-backend'
-import {NewFolderButton} from './styled'
+import { NewFolderButton } from './styled'
 
 const mapFavorites = (favorites, props, isChild, moveAction) => {
   return favorites.map((entry, index) => {
-    return <Favorite entry={entry} key={entry.id} id={entry.id} name={entry.name} content={entry.content}
-      onItemClick={props.onItemClick} onExecClick={props.onExecClick} removeClick={props.removeClick} isChild={isChild}
-      isStatic={entry.isStatic} index={index} moveFavorite={moveAction} />
+    return (
+      <Favorite
+        entry={entry}
+        key={entry.id}
+        id={entry.id}
+        name={entry.name}
+        content={entry.content}
+        onItemClick={props.onItemClick}
+        onExecClick={props.onExecClick}
+        removeClick={props.removeClick}
+        isChild={isChild}
+        isStatic={entry.isStatic}
+        index={index}
+        moveFavorite={moveAction}
+      />
+    )
   })
 }
 
 class Favorites extends Component {
   constructor (props) {
     super(props)
-    this.state = {...this.props}
+    this.state = { ...this.props }
   }
 
   componentWillReceiveProps (nextProps) {
-    this.setState({favorites: nextProps.favorites, folders: nextProps.folders})
+    this.setState({
+      favorites: nextProps.favorites,
+      folders: nextProps.folders
+    })
   }
 
   moveFavorite (dragDropValues) {
-    const {dropped} = dragDropValues
+    const { dropped } = dragDropValues
     let newFavorites = this.arrangeFavoriteList(dragDropValues)
 
     if (dropped) {
       this.props.updateFavorites(newFavorites)
     } else {
-      this.setState({favorites: newFavorites})
+      this.setState({ favorites: newFavorites })
     }
   }
 
-  arrangeFavoriteList ({dragIndex, dragFolder, hoverIndex, hoverFolder, dragItem, hoveredItemProps}) {
+  arrangeFavoriteList ({
+    dragIndex,
+    dragFolder,
+    hoverIndex,
+    hoverFolder,
+    dragItem,
+    hoveredItemProps
+  }) {
     let newFavorites
 
     if (dragFolder === hoverFolder || (!dragFolder && !hoverFolder)) {
@@ -74,16 +103,24 @@ class Favorites extends Component {
       let draggedFavIndex = favorites.findIndex(fav => fav.id === dragItem.id)
       let newIndex = draggedFavIndex + (hoverIndex - dragIndex)
       favorites.splice(draggedFavIndex, 1)
-      newFavorites = favorites.slice(0, newIndex).concat([draggedFav]).concat(favorites.slice(newIndex))
+      newFavorites = favorites
+        .slice(0, newIndex)
+        .concat([draggedFav])
+        .concat(favorites.slice(newIndex))
     } else {
       let favorites = this.state.favorites
       let draggedFav = favorites.find(fav => fav.id === dragItem.id)
       let draggedFavIndex = favorites.findIndex(fav => fav.id === dragItem.id)
-      let hoveredFavIndex = favorites.findIndex(fav => fav.id === hoveredItemProps.id)
+      let hoveredFavIndex = favorites.findIndex(
+        fav => fav.id === hoveredItemProps.id
+      )
       let newIndex = hoveredFavIndex
       favorites.splice(draggedFavIndex, 1)
       draggedFav.folder = hoverFolder
-      newFavorites = favorites.slice(0, newIndex).concat([draggedFav]).concat(favorites.slice(newIndex))
+      newFavorites = favorites
+        .slice(0, newIndex)
+        .concat([draggedFav])
+        .concat(favorites.slice(newIndex))
     }
 
     return newFavorites
@@ -96,7 +133,7 @@ class Favorites extends Component {
     if (dropped) {
       this.props.updateFavorites(this.state.favorites)
     } else {
-      this.setState({favorites: this.state.favorites})
+      this.setState({ favorites: this.state.favorites })
     }
   }
 
@@ -107,19 +144,45 @@ class Favorites extends Component {
   }
 
   render () {
-    const {favorites, folders} = {...this.state}
+    const { favorites, folders } = { ...this.state }
 
-    const ListOfFavorites = mapFavorites(favorites.filter(fav => !fav.isStatic && !fav.folder), this.props, false, this.moveFavorite.bind(this))
-    const ListOfFolders = folders.filter(folder => !folder.isStatic).map((folder) => {
-      const Favorites = mapFavorites(favorites.filter(fav => !fav.isStatic && fav.folder === folder.id), this.props, true, this.moveFavorite.bind(this))
-      return <Folder folder={folder} removeClick={this.props.removeFolderClick}
-        moveToFolder={this.moveToFolder.bind(this)}
-        updateFolder={this.updateFolder.bind(this)}>{Favorites}</Folder>
-    })
-    const ListOfSampleFolders = folders.filter(folder => folder.isStatic).map((folder) => {
-      const Favorites = mapFavorites(favorites.filter(fav => fav.isStatic && fav.folder === folder.id), this.props, true, this.moveFavorite.bind(this))
-      return <Folder folder={folder}>{Favorites}</Folder>
-    })
+    const ListOfFavorites = mapFavorites(
+      favorites.filter(fav => !fav.isStatic && !fav.folder),
+      this.props,
+      false,
+      this.moveFavorite.bind(this)
+    )
+    const ListOfFolders = folders
+      .filter(folder => !folder.isStatic)
+      .map(folder => {
+        const Favorites = mapFavorites(
+          favorites.filter(fav => !fav.isStatic && fav.folder === folder.id),
+          this.props,
+          true,
+          this.moveFavorite.bind(this)
+        )
+        return (
+          <Folder
+            folder={folder}
+            removeClick={this.props.removeFolderClick}
+            moveToFolder={this.moveToFolder.bind(this)}
+            updateFolder={this.updateFolder.bind(this)}
+          >
+            {Favorites}
+          </Folder>
+        )
+      })
+    const ListOfSampleFolders = folders
+      .filter(folder => folder.isStatic)
+      .map(folder => {
+        const Favorites = mapFavorites(
+          favorites.filter(fav => fav.isStatic && fav.folder === folder.id),
+          this.props,
+          true,
+          this.moveFavorite.bind(this)
+        )
+        return <Folder folder={folder}>{Favorites}</Folder>
+      })
 
     return (
       <Drawer id='db-favorites'>
@@ -149,7 +212,7 @@ class Favorites extends Component {
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     favorites: state.documents || [],
     folders: state.folders || [],
@@ -158,14 +221,14 @@ const mapStateToProps = (state) => {
 }
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    onItemClick: (cmd) => {
+    onItemClick: cmd => {
       ownProps.bus.send(editor.SET_CONTENT, editor.setContent(cmd))
     },
-    onExecClick: (cmd) => {
+    onExecClick: cmd => {
       const action = executeCommand(cmd)
       ownProps.bus.send(action.type, action)
     },
-    removeClick: (id) => {
+    removeClick: id => {
       const action = favorite.removeFavorite(id)
       dispatch(action)
     },
@@ -173,18 +236,20 @@ const mapDispatchToProps = (dispatch, ownProps) => {
       const action = folder.addFolder()
       dispatch(action)
     },
-    removeFolderClick: (id) => {
+    removeFolderClick: id => {
       const action = folder.removeFolder(id)
       dispatch(action)
     },
-    updateFavorites: (favorites) => {
+    updateFavorites: favorites => {
       const action = favorite.updateFavorites(favorites)
       dispatch(action)
     },
-    updateFolders: (folders) => {
+    updateFolders: folders => {
       const action = folder.updateFolders(folders)
       dispatch(action)
     }
   }
 }
-export default DragDropContext(HTML5Backend)(withBus(connect(mapStateToProps, mapDispatchToProps)(Favorites)))
+export default DragDropContext(HTML5Backend)(
+  withBus(connect(mapStateToProps, mapDispatchToProps)(Favorites))
+)

--- a/src/browser/modules/Sidebar/Favorites.test.jsx
+++ b/src/browser/modules/Sidebar/Favorites.test.jsx
@@ -27,8 +27,13 @@ import Favorite from './Favorite'
 
 describe('FavoritesComponent', () => {
   test('should show list of favorites', () => {
-    const favorites = [{id: '1', content: '//Test1 Hello'}, {id: '2', content: '//Test2 Again'}]
-    const wrapper = shallow(<FavoritesComponent scripts={favorites} dispatch={() => null} />)
+    const favorites = [
+      { id: '1', content: '//Test1 Hello' },
+      { id: '2', content: '//Test2 Again' }
+    ]
+    const wrapper = shallow(
+      <FavoritesComponent scripts={favorites} dispatch={() => null} />
+    )
     expect(wrapper.find(Favorite).length).toBe(2)
   })
 })

--- a/src/browser/modules/Sidebar/FileDrop.jsx
+++ b/src/browser/modules/Sidebar/FileDrop.jsx
@@ -42,7 +42,7 @@ export class FileDrop extends Component {
     this.fileReader = this.props.fileReader || new FileReader()
   }
   onDrop (files) {
-    this.setState({error: null, success: null})
+    this.setState({ error: null, success: null })
 
     const file = files[0]
     const fileExtension = file.name.split('.').pop()
@@ -53,31 +53,35 @@ export class FileDrop extends Component {
     } else if (this.grassExtenstions.includes(fileExtension)) {
       loader = this.props.onGrassFileDropped
     } else {
-      return this.setState({'error': `'.${fileExtension}' is not a valid file extension`})
+      return this.setState({
+        error: `'.${fileExtension}' is not a valid file extension`
+      })
     }
 
     this.fileReader.onload = () => {
       loader(this.fileReader.result)
-      this.setState({'success': `'${file.name}' has been added`})
+      this.setState({ success: `'${file.name}' has been added` })
     }
     this.fileReader.readAsText(file)
   }
   render () {
     return (
-      <Dropzone
-        disableClick
-        multiple={false}
-        onDrop={this.onDrop.bind(this)}>
-        <StyledDropzoneText>{this.state.error || this.state.success || 'Drop a file to import Cypher (*.cyp, *.cypher, *.cql, *.txt) or Grass (*.grass)'}</StyledDropzoneText>
-      </Dropzone>)
+      <Dropzone disableClick multiple={false} onDrop={this.onDrop.bind(this)}>
+        <StyledDropzoneText>
+          {this.state.error ||
+            this.state.success ||
+            'Drop a file to import Cypher (*.cyp, *.cypher, *.cql, *.txt) or Grass (*.grass)'}
+        </StyledDropzoneText>
+      </Dropzone>
+    )
   }
 }
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    onFavoriteFileDropped: (fileContent) => {
+    onFavoriteFileDropped: fileContent => {
       dispatch(addFavorite(fileContent))
     },
-    onGrassFileDropped: (fileContent) => {
+    onGrassFileDropped: fileContent => {
       const parsedGrass = parseGrass(fileContent)
       if (parsedGrass) {
         dispatch(updateGraphStyleData(parsedGrass))

--- a/src/browser/modules/Sidebar/FileDrop.test.jsx
+++ b/src/browser/modules/Sidebar/FileDrop.test.jsx
@@ -30,9 +30,11 @@ describe('FileDrop', () => {
   const readAsText = jest.fn()
   const stubFileReader = { readAsText, result: expectedFileContent }
 
-  test('should read file', (done) => {
+  test('should read file', done => {
     const onFileDropped = jest.fn()
-    const wrapper = shallow(<FileDrop fileReader={stubFileReader} onFileDropped={onFileDropped} />)
+    const wrapper = shallow(
+      <FileDrop fileReader={stubFileReader} onFileDropped={onFileDropped} />
+    )
     wrapper.instance().onDrop([file])
 
     try {
@@ -42,9 +44,11 @@ describe('FileDrop', () => {
       done.fail(error)
     }
   })
-  test('should not read file', (done) => {
+  test('should not read file', done => {
     const onFileDropped = jest.fn()
-    const wrapper = shallow(<FileDrop fileReader={stubFileReader} onFileDropped={onFileDropped} />)
+    const wrapper = shallow(
+      <FileDrop fileReader={stubFileReader} onFileDropped={onFileDropped} />
+    )
     wrapper.instance().onDrop([unknownFile])
 
     try {

--- a/src/browser/modules/Sidebar/Folder.jsx
+++ b/src/browser/modules/Sidebar/Folder.jsx
@@ -27,16 +27,19 @@ import {
   FolderButtonContainer,
   EditFolderInput
 } from './styled'
-import {Component} from 'preact'
-import {CollapseMenuIcon, ExpandMenuIcon} from 'browser-components/icons/Icons'
-import {DropTarget} from 'react-dnd'
+import { Component } from 'preact'
+import {
+  CollapseMenuIcon,
+  ExpandMenuIcon
+} from 'browser-components/icons/Icons'
+import { DropTarget } from 'react-dnd'
 import Render from 'browser-components/Render'
 import ItemTypes from './DragItemTypes'
 
 class Folder extends Component {
   constructor (props) {
     super(props)
-    this.state = {...props}
+    this.state = { ...props }
   }
 
   onFolderNameChanged (e) {
@@ -52,7 +55,7 @@ class Folder extends Component {
 
   handleKeyPress (e) {
     if (e.keyCode === 13) {
-      this.setState({editing: false})
+      this.setState({ editing: false })
     }
   }
 
@@ -67,24 +70,40 @@ class Folder extends Component {
         <StyledList>
           <StyledListHeaderItem>
             <Render if={!this.state.editing}>
-              <span onClick={() => this.setState({active: !this.state.active})}>{this.props.folder.name}</span>
+              <span
+                onClick={() => this.setState({ active: !this.state.active })}
+              >
+                {this.props.folder.name}
+              </span>
             </Render>
             <Render if={this.state.editing}>
-              <EditFolderInput type='text' onChange={this.onFolderNameChanged.bind(this)}
-                onBlur={() => this.setState({editing: false})}
-                value={this.props.folder.name} innerRef={this.folderNameInputSet.bind(this)} />
+              <EditFolderInput
+                type='text'
+                onChange={this.onFolderNameChanged.bind(this)}
+                onBlur={() => this.setState({ editing: false })}
+                value={this.props.folder.name}
+                innerRef={this.folderNameInputSet.bind(this)}
+              />
             </Render>
             <FolderButtonContainer>
-              <FoldersButton onClick={() => this.setState({active: !this.state.active})}>{icon}</FoldersButton>
+              <FoldersButton
+                onClick={() => this.setState({ active: !this.state.active })}
+              >
+                {icon}
+              </FoldersButton>
               <Render if={!this.props.folder.isStatic}>
-                <EditFolderButton editClick={() => {
-                  this.setState({editing: true})
-                  return false
-                }
-                } />
+                <EditFolderButton
+                  editClick={() => {
+                    this.setState({ editing: true })
+                    return false
+                  }}
+                />
               </Render>&nbsp;
-              <DeleteFavButton id={this.props.folder.id} removeClick={this.props.removeClick}
-                isStatic={this.props.folder.isStatic} />
+              <DeleteFavButton
+                id={this.props.folder.id}
+                removeClick={this.props.removeClick}
+                isStatic={this.props.folder.isStatic}
+              />
             </FolderButtonContainer>
           </StyledListHeaderItem>
           {this.state.active ? this.props.children : null}

--- a/src/browser/modules/Sidebar/Settings.jsx
+++ b/src/browser/modules/Sidebar/Settings.jsx
@@ -20,147 +20,182 @@
 
 import { connect } from 'preact-redux'
 import * as actions from 'shared/modules/settings/settingsDuck'
-import { Drawer, DrawerBody, DrawerHeader, DrawerSection, DrawerSectionBody, DrawerSubHeader } from 'browser-components/drawer'
+import {
+  Drawer,
+  DrawerBody,
+  DrawerHeader,
+  DrawerSection,
+  DrawerSectionBody,
+  DrawerSubHeader
+} from 'browser-components/drawer'
 import { RadioSelector, CheckboxSelector } from 'browser-components/Form'
-import { StyledSetting, StyledSettingLabel, StyledSettingTextInput } from './styled'
+import {
+  StyledSetting,
+  StyledSettingLabel,
+  StyledSettingTextInput
+} from './styled'
 
-const visualSettings =
-  [
-    {
-      title: 'User Interface',
-      settings: [
-        {
-          theme: {
-            displayName: 'Theme',
-            type: 'radio',
-            options: ['normal', 'outline', 'dark']
-          }
-        },
-        {
-          'editorAutocomplete': {
-            displayName: 'Trigger autocomplete when typing',
-            tooltip: 'Autocomplete written queries in editor (shortcut keys will still work)',
-            type: 'checkbox'
-          }
+const visualSettings = [
+  {
+    title: 'User Interface',
+    settings: [
+      {
+        theme: {
+          displayName: 'Theme',
+          type: 'radio',
+          options: ['normal', 'outline', 'dark']
         }
-      ]
-    },
-    {
-      title: 'Preferences',
-      settings: [
-        {
-          showSampleScripts: {
-            displayName: 'Show sample scripts',
-            tooltip: 'Show sample scripts in favorites drawer.',
-            type: 'checkbox'
-          }
+      },
+      {
+        editorAutocomplete: {
+          displayName: 'Trigger autocomplete when typing',
+          tooltip:
+            'Autocomplete written queries in editor (shortcut keys will still work)',
+          type: 'checkbox'
         }
-      ]
-    },
-    {
-      title: 'Network Connection',
-      settings: [
-        {
-          'useBoltRouting': {
-            displayName: 'Use bolt+routing',
-            tooltip: 'Use bolt+routing protocol when in a causal cluster.',
-            type: 'checkbox'
-          }
+      }
+    ]
+  },
+  {
+    title: 'Preferences',
+    settings: [
+      {
+        showSampleScripts: {
+          displayName: 'Show sample scripts',
+          tooltip: 'Show sample scripts in favorites drawer.',
+          type: 'checkbox'
         }
-      ]
-    },
-    {
-      title: 'Result Frames',
-      settings: [
-        {
-          maxFrames: {
-            displayName: 'Maximum number of result frames',
-            tooltip: 'Max number of result frames. When reached, old frames gets retired.'
-          }
-        },
-        {
-          maxHistory: {
-            displayName: 'Max History',
-            tooltip: 'Max number of history entries. When reached, old entries gets retired.'
-          }
-        },
-        {
-          scrollToTop: {
-            displayName: 'Scroll To Top',
-            tooltip: 'Automatically scroll stream to top on new frames.',
-            type: 'checkbox'
-          }
+      }
+    ]
+  },
+  {
+    title: 'Network Connection',
+    settings: [
+      {
+        useBoltRouting: {
+          displayName: 'Use bolt+routing',
+          tooltip: 'Use bolt+routing protocol when in a causal cluster.',
+          type: 'checkbox'
         }
-      ]
-    },
-    {
-      title: 'Graph Visualization',
-      settings: [
-        {
-          initialNodeDisplay: {
-            displayName: 'Initial Node Display',
-            tooltip: 'Limit number of nodes displayed on first load of the graph visualization.'
-          }
-        },
-        {
-          maxNeighbours: {
-            displayName: 'Max Neighbours',
-            tooltip: 'Limit exploratary queries to this limit.'
-          }
-        },
-        {
-          maxRows: {
-            displayName: 'Max Rows',
-            tooltip: "Max number of rows to render in 'Rows' result view"
-          }
-        },
-        {
-          autoComplete: {
-            displayName: 'Connect result nodes',
-            tooltip: 'If this is checked, after a cypher query result is retrieved, a second query is executed to fetch relationships between result nodes.',
-            type: 'checkbox'
-          }
+      }
+    ]
+  },
+  {
+    title: 'Result Frames',
+    settings: [
+      {
+        maxFrames: {
+          displayName: 'Maximum number of result frames',
+          tooltip:
+            'Max number of result frames. When reached, old frames gets retired.'
         }
-      ]
-    }
-  ]
+      },
+      {
+        maxHistory: {
+          displayName: 'Max History',
+          tooltip:
+            'Max number of history entries. When reached, old entries gets retired.'
+        }
+      },
+      {
+        scrollToTop: {
+          displayName: 'Scroll To Top',
+          tooltip: 'Automatically scroll stream to top on new frames.',
+          type: 'checkbox'
+        }
+      }
+    ]
+  },
+  {
+    title: 'Graph Visualization',
+    settings: [
+      {
+        initialNodeDisplay: {
+          displayName: 'Initial Node Display',
+          tooltip:
+            'Limit number of nodes displayed on first load of the graph visualization.'
+        }
+      },
+      {
+        maxNeighbours: {
+          displayName: 'Max Neighbours',
+          tooltip: 'Limit exploratary queries to this limit.'
+        }
+      },
+      {
+        maxRows: {
+          displayName: 'Max Rows',
+          tooltip: "Max number of rows to render in 'Rows' result view"
+        }
+      },
+      {
+        autoComplete: {
+          displayName: 'Connect result nodes',
+          tooltip:
+            'If this is checked, after a cypher query result is retrieved, a second query is executed to fetch relationships between result nodes.',
+          type: 'checkbox'
+        }
+      }
+    ]
+  }
+]
 
-export const Settings = ({settings, onSettingsSave = () => {}}) => {
+export const Settings = ({ settings, onSettingsSave = () => {} }) => {
   if (!settings) return null
   const mappedSettings = visualSettings.map((visualSetting, i) => {
     const title = <DrawerSubHeader>{visualSetting.title}</DrawerSubHeader>
-    const mapSettings = visualSetting.settings.map((settingObj, i) => {
-      const setting = Object.keys(settingObj)[0]
-      if (typeof settings[setting] === 'undefined') return false
-      const visual = settingObj[setting].displayName
-      const tooltip = settingObj[setting].tooltip || ''
+    const mapSettings = visualSetting.settings
+      .map((settingObj, i) => {
+        const setting = Object.keys(settingObj)[0]
+        if (typeof settings[setting] === 'undefined') return false
+        const visual = settingObj[setting].displayName
+        const tooltip = settingObj[setting].tooltip || ''
 
-      if (!settingObj[setting].type || settingObj[setting].type === 'input') {
-        return (<StyledSetting key={i}>
-          <StyledSettingLabel title={tooltip}>{visual}</StyledSettingLabel>
-          <StyledSettingTextInput onChange={(event) => {
-            settings[setting] = event.target.value
-            onSettingsSave(settings)
-          }} defaultValue={settings[setting]} title={[tooltip]} className={setting} />
-        </StyledSetting>)
-      } else if (settingObj[setting].type === 'radio') {
-        return (<StyledSetting key={i}>
-          <StyledSettingLabel title={tooltip}>{visual}</StyledSettingLabel>
-          <RadioSelector options={settingObj[setting].options} onChange={(event) => {
-            settings[setting] = event.target.value
-            onSettingsSave(settings)
-          }} selectedValue={settings[setting]} />
-        </StyledSetting>)
-      } else if (settingObj[setting].type === 'checkbox') {
-        return (<StyledSetting key={i}>
-          <CheckboxSelector onChange={(event) => {
-            settings[setting] = event.target.checked
-            onSettingsSave(settings)
-          }} checked={settings[setting]} />
-          <StyledSettingLabel title={tooltip}>{visual}</StyledSettingLabel>
-        </StyledSetting>)
-      }
-    }).filter((setting) => setting !== false)
+        if (!settingObj[setting].type || settingObj[setting].type === 'input') {
+          return (
+            <StyledSetting key={i}>
+              <StyledSettingLabel title={tooltip}>{visual}</StyledSettingLabel>
+              <StyledSettingTextInput
+                onChange={event => {
+                  settings[setting] = event.target.value
+                  onSettingsSave(settings)
+                }}
+                defaultValue={settings[setting]}
+                title={[tooltip]}
+                className={setting}
+              />
+            </StyledSetting>
+          )
+        } else if (settingObj[setting].type === 'radio') {
+          return (
+            <StyledSetting key={i}>
+              <StyledSettingLabel title={tooltip}>{visual}</StyledSettingLabel>
+              <RadioSelector
+                options={settingObj[setting].options}
+                onChange={event => {
+                  settings[setting] = event.target.value
+                  onSettingsSave(settings)
+                }}
+                selectedValue={settings[setting]}
+              />
+            </StyledSetting>
+          )
+        } else if (settingObj[setting].type === 'checkbox') {
+          return (
+            <StyledSetting key={i}>
+              <CheckboxSelector
+                onChange={event => {
+                  settings[setting] = event.target.checked
+                  onSettingsSave(settings)
+                }}
+                checked={settings[setting]}
+              />
+              <StyledSettingLabel title={tooltip}>{visual}</StyledSettingLabel>
+            </StyledSetting>
+          )
+        }
+      })
+      .filter(setting => setting !== false)
     return (
       <div>
         {title}
@@ -183,15 +218,15 @@ export const Settings = ({settings, onSettingsSave = () => {}}) => {
   )
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     settings: state.settings
   }
 }
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
-    onSettingsSave: (settings) => {
+    onSettingsSave: settings => {
       dispatch(actions.update(settings))
     }
   }

--- a/src/browser/modules/Sidebar/Sidebar.jsx
+++ b/src/browser/modules/Sidebar/Sidebar.jsx
@@ -27,7 +27,11 @@ import About from './About'
 import TabNavigation from 'browser-components/TabNavigation/Navigation'
 import Settings from './Settings'
 import BrowserSync from './../Sync/BrowserSync'
-import { PENDING_STATE, CONNECTED_STATE, DISCONNECTED_STATE } from 'shared/modules/connections/connectionsDuck'
+import {
+  PENDING_STATE,
+  CONNECTED_STATE,
+  DISCONNECTED_STATE
+} from 'shared/modules/connections/connectionsDuck'
 
 import {
   DatabaseIcon,
@@ -48,26 +52,66 @@ class Sidebar extends Component {
     const SettingsDrawer = Settings
     const AboutDrawer = About
     const topNavItemsList = [
-      {name: 'DB', title: 'Database', icon: (isOpen) => <DatabaseIcon isOpen={isOpen} connectionState={this.props.neo4jConnectionState} />, content: DatabaseDrawer},
-      {name: 'Favorites', title: 'Favorites', icon: (isOpen) => <FavoritesIcon isOpen={isOpen} />, content: FavoritesDrawer},
-      {name: 'Documents', title: 'Documentation', icon: (isOpen) => <DocumentsIcon isOpen={isOpen} />, content: DocumentsDrawer}
+      {
+        name: 'DB',
+        title: 'Database',
+        icon: isOpen =>
+          <DatabaseIcon
+            isOpen={isOpen}
+            connectionState={this.props.neo4jConnectionState}
+          />,
+        content: DatabaseDrawer
+      },
+      {
+        name: 'Favorites',
+        title: 'Favorites',
+        icon: isOpen => <FavoritesIcon isOpen={isOpen} />,
+        content: FavoritesDrawer
+      },
+      {
+        name: 'Documents',
+        title: 'Documentation',
+        icon: isOpen => <DocumentsIcon isOpen={isOpen} />,
+        content: DocumentsDrawer
+      }
     ]
     const bottomNavItemsList = [
-      {name: 'Sync', title: 'Cloud Services', icon: (isOpen) => <CloudSyncIcon isOpen={isOpen} connected={this.props.syncConnected} />, content: BrowserSync},
-      {name: 'Settings', title: 'Browser Settings', icon: (isOpen) => <SettingsIcon isOpen={isOpen} />, content: SettingsDrawer},
-      {name: 'About', title: 'About Neo4j', icon: (isOpen) => <AboutIcon isOpen={isOpen} />, content: AboutDrawer}
+      {
+        name: 'Sync',
+        title: 'Cloud Services',
+        icon: isOpen =>
+          <CloudSyncIcon
+            isOpen={isOpen}
+            connected={this.props.syncConnected}
+          />,
+        content: BrowserSync
+      },
+      {
+        name: 'Settings',
+        title: 'Browser Settings',
+        icon: isOpen => <SettingsIcon isOpen={isOpen} />,
+        content: SettingsDrawer
+      },
+      {
+        name: 'About',
+        title: 'About Neo4j',
+        icon: isOpen => <AboutIcon isOpen={isOpen} />,
+        content: AboutDrawer
+      }
     ]
 
-    return (<TabNavigation
-      openDrawer={openDrawer}
-      onNavClick={onNavClick}
-      topNavItems={topNavItemsList}
-      bottomNavItems={bottomNavItemsList}
-    />)
+    return (
+      <TabNavigation
+        openDrawer={openDrawer}
+        onNavClick={onNavClick}
+        topNavItems={topNavItemsList}
+        bottomNavItems={bottomNavItemsList}
+      />
+    )
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   let connectionState = 'disconnected'
   if (state.connections) {
     switch (state.connections.connectionState) {

--- a/src/browser/modules/Sidebar/Sidebar.test.jsx
+++ b/src/browser/modules/Sidebar/Sidebar.test.jsx
@@ -34,7 +34,7 @@ import settings from '../../../shared/modules/settings/settingsDuck'
 describe('Sidebar', () => {
   const reducer = combineReducers({
     favorites,
-    documents: (a) => a || null,
+    documents: a => a || null,
     settings
   })
   const store = createStore(reducer)

--- a/src/browser/modules/Sidebar/styled.jsx
+++ b/src/browser/modules/Sidebar/styled.jsx
@@ -19,7 +19,14 @@
  */
 
 import styled from 'styled-components'
-import {QuestionIcon, PlayIcon, PlainPlayIcon, PlusIcon, BinIcon, EditIcon} from 'browser-components/icons/Icons'
+import {
+  QuestionIcon,
+  PlayIcon,
+  PlainPlayIcon,
+  PlusIcon,
+  BinIcon,
+  EditIcon
+} from 'browser-components/icons/Icons'
 
 export const StyledSetting = styled.div`
   padding-bottom: 15px;
@@ -57,12 +64,13 @@ const StyledDocumentText = styled.a`
   }
 `
 
-export const StyledDocumentActionLink = (props) => {
-  const {name, ...rest} = props
+export const StyledDocumentActionLink = props => {
+  const { name, ...rest } = props
   return (
     <StyledHelpItem onClick={props.onClick}>
-      <StyledDocumentText {...rest}>{props.type === 'play' ? <PlayIcon />
-        : <QuestionIcon />}&nbsp;{name}</StyledDocumentText>
+      <StyledDocumentText {...rest}>
+        {props.type === 'play' ? <PlayIcon /> : <QuestionIcon />}&nbsp;{name}
+      </StyledDocumentText>
     </StyledHelpItem>
   )
 }
@@ -73,7 +81,7 @@ export const StyledList = styled.ul`
 `
 export const StyledListItem = styled.li`
   list-style-type: none;
-  margin: 8px 0px 8px ${props => props.isChild ? '16px' : '8px'};
+  margin: 8px 0px 8px ${props => (props.isChild ? '16px' : '8px')};
   cursor: pointer;
 `
 export const StyledListHeaderItem = styled.li`
@@ -136,7 +144,7 @@ const StyledExecFavoriteButton = styled.div`
     opacity: 1;
   }
 `
-export const ExecFavortieButton = (props) => {
+export const ExecFavortieButton = props => {
   return (
     <StyledExecFavoriteButton {...props}>
       <PlainPlayIcon />
@@ -144,7 +152,7 @@ export const ExecFavortieButton = (props) => {
   )
 }
 
-export const NewFolderButton = (props) => {
+export const NewFolderButton = props => {
   return (
     <NewFolderStyledButton onClick={props.onClick}>
       <PlusIcon />New Folder
@@ -152,15 +160,17 @@ export const NewFolderButton = (props) => {
   )
 }
 
-export const DeleteFavButton = (props) => {
-  const rightIcon = (props.removeClick && !props.isStatic) ? (<BinIcon className={'remove'} />) : null
+export const DeleteFavButton = props => {
+  const rightIcon = props.removeClick && !props.isStatic
+    ? <BinIcon className={'remove'} />
+    : null
   return (
-    <SytledFavFolderButtonSpan onClick={() => props.removeClick(props.id)}>{rightIcon}</SytledFavFolderButtonSpan>
+    <SytledFavFolderButtonSpan onClick={() => props.removeClick(props.id)}>
+      {rightIcon}
+    </SytledFavFolderButtonSpan>
   )
 }
 
-export const EditFolderButton = (props) => {
-  return (
-    <FoldersButton onClick={props.editClick}><EditIcon /></FoldersButton>
-  )
+export const EditFolderButton = props => {
+  return <FoldersButton onClick={props.editClick}><EditIcon /></FoldersButton>
 }

--- a/src/browser/modules/Stream/Auth/ChangePasswordForm.jsx
+++ b/src/browser/modules/Stream/Auth/ChangePasswordForm.jsx
@@ -20,7 +20,7 @@
 
 import { Component } from 'preact'
 
-import {FormButton} from 'browser-components/buttons'
+import { FormButton } from 'browser-components/buttons'
 import {
   StyledConnectionForm,
   StyledConnectionTextInput,
@@ -61,8 +61,17 @@ export default class ChangePasswordForm extends Component {
     this.props.onChange(this.state.newPassword, this.state.newPassword2)
   }
   validateSame () {
-    if (this.state.newPassword && this.state.newPassword !== '' && this.state.newPassword !== this.state.newPassword2) {
-      return this.props.onChangePasswordClick({error: {code: 'Mismatch', message: 'The two entered passwords must be the same.'}})
+    if (
+      this.state.newPassword &&
+      this.state.newPassword !== '' &&
+      this.state.newPassword !== this.state.newPassword2
+    ) {
+      return this.props.onChangePasswordClick({
+        error: {
+          code: 'Mismatch',
+          message: 'The two entered passwords must be the same.'
+        }
+      })
     }
     this.props.onChangePasswordClick({ newPassword: this.state.newPassword })
   }
@@ -74,13 +83,28 @@ export default class ChangePasswordForm extends Component {
         {this.props.children}
         <StyledConnectionFormEntry>
           <StyledConnectionLabel>New password</StyledConnectionLabel>
-          <StyledConnectionTextInput innerRef={(el) => this.formKeyHandler.registerInput(el, 1 + inputTabOffset)} type='password' onChange={this.onNewPasswordChange.bind(this)} value={this.state.newPassword} />
+          <StyledConnectionTextInput
+            innerRef={el =>
+              this.formKeyHandler.registerInput(el, 1 + inputTabOffset)}
+            type='password'
+            onChange={this.onNewPasswordChange.bind(this)}
+            value={this.state.newPassword}
+          />
         </StyledConnectionFormEntry>
         <StyledConnectionFormEntry>
           <StyledConnectionLabel>Repeat new password</StyledConnectionLabel>
-          <StyledConnectionTextInput innerRef={(el) => this.formKeyHandler.registerInput(el, 2 + inputTabOffset)} type='password' onChange={this.onNewPasswordChange2.bind(this)} value={this.state.newPassword2} />
+          <StyledConnectionTextInput
+            innerRef={el =>
+              this.formKeyHandler.registerInput(el, 2 + inputTabOffset)}
+            type='password'
+            onChange={this.onNewPasswordChange2.bind(this)}
+            value={this.state.newPassword2}
+          />
         </StyledConnectionFormEntry>
-        <FormButton onClick={this.validateSame.bind(this)} label='Change password' />
+        <FormButton
+          onClick={this.validateSame.bind(this)}
+          label='Change password'
+        />
       </StyledConnectionForm>
     )
   }

--- a/src/browser/modules/Stream/Auth/ChangePasswordFrame.jsx
+++ b/src/browser/modules/Stream/Auth/ChangePasswordFrame.jsx
@@ -57,16 +57,16 @@ export class ChangePasswordFrame extends Component {
     if (e.code === 'N/A') {
       e.message = 'Existing password is incorrect'
     }
-    this.setState({error: e})
+    this.setState({ error: e })
   }
   onPasswordChange (event) {
     const password = event.target.value
-    this.setState({password})
+    this.setState({ password })
     this.error({})
   }
   onSuccess () {
-    this.setState({password: ''})
-    this.setState({success: true})
+    this.setState({ password: '' })
+    this.setState({ success: true })
   }
   render () {
     const content = (
@@ -74,18 +74,33 @@ export class ChangePasswordFrame extends Component {
         <StyledConnectionAside>
           <H3>Password change</H3>
           <Render if={!this.state.success}>
-            <Lead>Enter your current password and the new twice to change your password.</Lead>
+            <Lead>
+              Enter your current password and the new twice to change your
+              password.
+            </Lead>
           </Render>
           <Render if={this.state.success}>
             <Lead>Password change successful</Lead>
           </Render>
         </StyledConnectionAside>
 
-        <ConnectionForm {...this.props} formKeyHandler={this.formKeyHandler} error={this.error.bind(this)} oldPassword={this.state.password} onSuccess={this.onSuccess.bind(this)} forcePasswordChange>
+        <ConnectionForm
+          {...this.props}
+          formKeyHandler={this.formKeyHandler}
+          error={this.error.bind(this)}
+          oldPassword={this.state.password}
+          onSuccess={this.onSuccess.bind(this)}
+          forcePasswordChange
+        >
           <Render if={!this.state.success}>
             <StyledConnectionFormEntry>
               <StyledConnectionLabel>Existing password</StyledConnectionLabel>
-              <StyledConnectionTextInput innerRef={(el) => this.formKeyHandler.registerInput(el, 1)} type='password' value={this.state.password} onChange={this.onPasswordChange.bind(this)} />
+              <StyledConnectionTextInput
+                innerRef={el => this.formKeyHandler.registerInput(el, 1)}
+                type='password'
+                value={this.state.password}
+                onChange={this.onPasswordChange.bind(this)}
+              />
             </StyledConnectionFormEntry>
           </Render>
         </ConnectionForm>
@@ -94,7 +109,12 @@ export class ChangePasswordFrame extends Component {
     return (
       <FrameTemplate
         header={this.props.frame}
-        statusbar={<FrameError code={this.state.error.code} message={this.state.error.message} />}
+        statusbar={
+          <FrameError
+            code={this.state.error.code}
+            message={this.state.error.message}
+          />
+        }
         contents={content}
       />
     )

--- a/src/browser/modules/Stream/Auth/ConnectForm.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectForm.jsx
@@ -20,7 +20,7 @@
 
 import { Component } from 'preact'
 import Render from 'browser-components/Render'
-import {FormButton} from 'browser-components/buttons'
+import { FormButton } from 'browser-components/buttons'
 import {
   StyledConnectionForm,
   StyledConnectionTextInput,
@@ -43,8 +43,8 @@ export default class ConnectForm extends Component {
     this.formKeyHandler.initialize(this.props.used === false)
   }
   onConnectClick () {
-    this.setState({connecting: true}, () => {
-      this.props.onConnectClick(() => this.setState({connecting: false}))
+    this.setState({ connecting: true }, () => {
+      this.props.onConnectClick(() => this.setState({ connecting: false }))
     })
   }
   render () {
@@ -52,18 +52,33 @@ export default class ConnectForm extends Component {
       <StyledConnectionForm>
         <StyledConnectionFormEntry>
           <StyledConnectionLabel>Host</StyledConnectionLabel>
-          <StyledConnectionTextInput innerRef={(el) => this.formKeyHandler.registerInput(el, 1)} onChange={this.props.onHostChange} value={this.props.host} />
+          <StyledConnectionTextInput
+            innerRef={el => this.formKeyHandler.registerInput(el, 1)}
+            onChange={this.props.onHostChange}
+            value={this.props.host}
+          />
         </StyledConnectionFormEntry>
         <StyledConnectionFormEntry>
           <StyledConnectionLabel>Username</StyledConnectionLabel>
-          <StyledConnectionTextInput innerRef={(el) => this.formKeyHandler.registerInput(el, 2)} onChange={this.props.onUsernameChange} value={this.props.username} />
+          <StyledConnectionTextInput
+            innerRef={el => this.formKeyHandler.registerInput(el, 2)}
+            onChange={this.props.onUsernameChange}
+            value={this.props.username}
+          />
         </StyledConnectionFormEntry>
         <StyledConnectionFormEntry>
           <StyledConnectionLabel>Password</StyledConnectionLabel>
-          <StyledConnectionTextInput innerRef={(el) => this.formKeyHandler.registerInput(el, 3)} onChange={this.props.onPasswordChange} value={this.props.password} type='password' />
+          <StyledConnectionTextInput
+            innerRef={el => this.formKeyHandler.registerInput(el, 3)}
+            onChange={this.props.onPasswordChange}
+            value={this.props.password}
+            type='password'
+          />
         </StyledConnectionFormEntry>
         <Render if={!this.state.connecting}>
-          <FormButton onClick={this.onConnectClick.bind(this)}>Connect</FormButton>
+          <FormButton onClick={this.onConnectClick.bind(this)}>
+            Connect
+          </FormButton>
         </Render>
         <Render if={this.state.connecting}>
           Connecting...

--- a/src/browser/modules/Stream/Auth/ConnectedView.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectedView.jsx
@@ -18,10 +18,19 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { StyledConnectionBody, StyledCode, StyledConnectionFooter } from './styled'
+import {
+  StyledConnectionBody,
+  StyledCode,
+  StyledConnectionFooter
+} from './styled'
 import Render from 'browser-components/Render'
 
-const ConnectedView = ({host, username, storeCredentials, showHost = true}) => {
+const ConnectedView = ({
+  host,
+  username,
+  storeCredentials,
+  showHost = true
+}) => {
   return (
     <StyledConnectionBody>
       You are connected as user <StyledCode>{username}</StyledCode><br />
@@ -29,7 +38,8 @@ const ConnectedView = ({host, username, storeCredentials, showHost = true}) => {
         <span>to the server <StyledCode>{host}</StyledCode><br /></span>
       </Render>
       <StyledConnectionFooter>
-        Connection credentials are {(storeCredentials ? '' : 'not ')}stored in your web browser.
+        Connection credentials are {storeCredentials ? '' : 'not '}stored in
+        your web browser.
       </StyledConnectionFooter>
     </StyledConnectionBody>
   )

--- a/src/browser/modules/Stream/Auth/ConnectionFrame.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectionFrame.jsx
@@ -23,7 +23,7 @@ import { Component } from 'preact'
 import FrameTemplate from '../FrameTemplate'
 import ConnectionForm from './ConnectionForm'
 import FrameError from '../FrameError'
-import {H3} from 'browser-components/headers'
+import { H3 } from 'browser-components/headers'
 import { Lead } from 'browser-components/Text'
 
 import Render from 'browser-components/Render'
@@ -41,23 +41,30 @@ export class ConnectionFrame extends Component {
     }
   }
   error (e) {
-    this.setState({error: e})
+    this.setState({ error: e })
   }
   success () {
-    this.setState({success: true})
+    this.setState({ success: true })
   }
   render () {
     return (
       <FrameTemplate
         header={this.props.frame}
-        statusbar={<FrameError code={this.state.error.code} message={this.state.error.message} />}
+        statusbar={
+          <FrameError
+            code={this.state.error.code}
+            message={this.state.error.message}
+          />
+        }
         contents={
           <StyledConnectionFrame>
             <StyledConnectionAside>
               <Render if={!this.state.success}>
                 <div>
                   <H3>Connect to Neo4j</H3>
-                  <Lead>Database access requires an authenticated connection.</Lead>
+                  <Lead>
+                    Database access requires an authenticated connection.
+                  </Lead>
                 </div>
               </Render>
               <Render if={this.state.success}>
@@ -68,10 +75,14 @@ export class ConnectionFrame extends Component {
               </Render>
             </StyledConnectionAside>
             <StyledConnectionBodyContainer>
-              <ConnectionForm {...this.props} onSuccess={this.success.bind(this)} error={this.error.bind(this)} />
+              <ConnectionForm
+                {...this.props}
+                onSuccess={this.success.bind(this)}
+                error={this.error.bind(this)}
+              />
             </StyledConnectionBodyContainer>
           </StyledConnectionFrame>
-          }
+        }
       />
     )
   }

--- a/src/browser/modules/Stream/Auth/DisconnectFrame.jsx
+++ b/src/browser/modules/Stream/Auth/DisconnectFrame.jsx
@@ -24,7 +24,7 @@ import { H3 } from 'browser-components/headers'
 import { Lead } from 'browser-components/Text'
 import Render from 'browser-components/Render'
 
-const Disconnect = ({frame, activeConnectionData}) => {
+const Disconnect = ({ frame, activeConnectionData }) => {
   return (
     <FrameTemplate
       header={frame}

--- a/src/browser/modules/Stream/Auth/ServerStatusFrame.jsx
+++ b/src/browser/modules/Stream/Auth/ServerStatusFrame.jsx
@@ -28,9 +28,12 @@ import {
   StyledConnectionBody
 } from './styled'
 import ConnectedView from './ConnectedView'
-import {H3} from 'browser-components/headers'
+import { H3 } from 'browser-components/headers'
 import Render from 'browser-components/Render'
-import { getActiveConnectionData, getActiveConnection } from 'shared/modules/connections/connectionsDuck'
+import {
+  getActiveConnectionData,
+  getActiveConnection
+} from 'shared/modules/connections/connectionsDuck'
 import { shouldRetainConnectionCredentials } from 'shared/modules/dbMeta/dbMetaDuck'
 
 class ServerStatusFrame extends Component {
@@ -50,15 +53,27 @@ class ServerStatusFrame extends Component {
             </StyledConnectionAside>
             <StyledConnectionBodyContainer>
               <Render if={!activeConnectionData}>
-                <StyledConnectionBody>You are not connected to the server.
+                <StyledConnectionBody>
+                  You are not connected to the server.
                 </StyledConnectionBody>
               </Render>
-              <Render if={activeConnectionData && activeConnectionData.authEnabled}>
-                <ConnectedView username={activeConnectionData && activeConnectionData.username}
-                  showHost={false} storeCredentials={storeCredentials} />
+              <Render
+                if={activeConnectionData && activeConnectionData.authEnabled}
+              >
+                <ConnectedView
+                  username={
+                    activeConnectionData && activeConnectionData.username
+                  }
+                  showHost={false}
+                  storeCredentials={storeCredentials}
+                />
               </Render>
-              <Render if={activeConnectionData && !activeConnectionData.authEnabled}>
-                <StyledConnectionBody>You have a working connection with the Neo4j database and server auth is disabled.
+              <Render
+                if={activeConnectionData && !activeConnectionData.authEnabled}
+              >
+                <StyledConnectionBody>
+                  You have a working connection with the Neo4j database and
+                  server auth is disabled.
                 </StyledConnectionBody>
               </Render>
             </StyledConnectionBodyContainer>
@@ -69,7 +84,7 @@ class ServerStatusFrame extends Component {
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     activeConnection: getActiveConnection(state),
     activeConnectionData: getActiveConnectionData(state),

--- a/src/browser/modules/Stream/CypherFrame.jsx
+++ b/src/browser/modules/Stream/CypherFrame.jsx
@@ -23,7 +23,18 @@ import FrameTemplate from './FrameTemplate'
 import { CypherFrameButton, FrameButton } from 'browser-components/buttons'
 import Centered from 'browser-components/Centered'
 import FrameSidebar from './FrameSidebar'
-import { VisualizationIcon, TableIcon, AsciiIcon, CodeIcon, PlanIcon, AlertIcon, ErrorIcon, DoubleUpIcon, DoubleDownIcon, Spinner } from 'browser-components/icons/Icons'
+import {
+  VisualizationIcon,
+  TableIcon,
+  AsciiIcon,
+  CodeIcon,
+  PlanIcon,
+  AlertIcon,
+  ErrorIcon,
+  DoubleUpIcon,
+  DoubleDownIcon,
+  Spinner
+} from 'browser-components/icons/Icons'
 import QueryPlan from './Planner/QueryPlan'
 import TableView from './Views/TableView'
 import AsciiView, { AsciiStatusbar } from './Views/AsciiView'
@@ -36,7 +47,13 @@ import FrameError from './FrameError'
 import Render from 'browser-components/Render'
 import Ellipsis from 'browser-components/Ellipsis'
 import * as viewTypes from 'shared/modules/stream/frameViewTypes'
-import { StyledFrameBody, StyledStatsBar, SpinnerContainer, FrameTitlebarButtonSection, StyledStatsBarContainer } from './styled'
+import {
+  StyledFrameBody,
+  StyledStatsBar,
+  SpinnerContainer,
+  FrameTitlebarButtonSection,
+  StyledStatsBarContainer
+} from './styled'
 
 class CypherFrame extends Component {
   constructor (props) {
@@ -52,13 +69,17 @@ class CypherFrame extends Component {
   }
 
   onNavClick (viewName) {
-    this.setState({openView: viewName})
+    this.setState({ openView: viewName })
   }
   getRecordsToDisplay (records) {
-    return records.length > this.props.maxRows ? records.slice(0, this.props.maxRows) : records
+    return records.length > this.props.maxRows
+      ? records.slice(0, this.props.maxRows)
+      : records
   }
   getRecordsToVisualise (records) {
-    return records.length > this.props.initialNodeDisplay ? records.slice(0, this.props.initialNodeDisplay) : records
+    return records.length > this.props.initialNodeDisplay
+      ? records.slice(0, this.props.initialNodeDisplay)
+      : records
   }
   componentWillReceiveProps (nextProps) {
     let rows
@@ -68,73 +89,131 @@ class CypherFrame extends Component {
     let warnings
     let errors
     if (nextProps.request.status === 'success') {
-      if (nextProps.request.result.records && nextProps.request.result.records.length > 0) {
-        nodesAndRelationships = bolt.extractNodesAndRelationshipsFromRecordsForOldVis(this.getRecordsToVisualise(nextProps.request.result.records))
-        rows = bolt.recordsToTableArray(this.getRecordsToDisplay(nextProps.request.result.records))
-        const untransformedRows = bolt.recordsToTableArray(this.getRecordsToDisplay(nextProps.request.result.records), false)
+      if (
+        nextProps.request.result.records &&
+        nextProps.request.result.records.length > 0
+      ) {
+        nodesAndRelationships = bolt.extractNodesAndRelationshipsFromRecordsForOldVis(
+          this.getRecordsToVisualise(nextProps.request.result.records)
+        )
+        rows = bolt.recordsToTableArray(
+          this.getRecordsToDisplay(nextProps.request.result.records)
+        )
+        const untransformedRows = bolt.recordsToTableArray(
+          this.getRecordsToDisplay(nextProps.request.result.records),
+          false
+        )
         serializedPropertiesRows = bolt.stringifyRows(untransformedRows)
       }
       plan = bolt.extractPlan(nextProps.request.result, true)
-      warnings = nextProps.request.result.summary ? nextProps.request.result.summary.notifications : null
+      warnings = nextProps.request.result.summary
+        ? nextProps.request.result.summary.notifications
+        : null
 
-      this.decideOpeningView({plan, nodesAndRelationships, warnings, props: nextProps})
+      this.decideOpeningView({
+        plan,
+        nodesAndRelationships,
+        warnings,
+        props: nextProps
+      })
       if (warnings && warnings.length > 0) {
-        this.setState({notifications: warnings, cypher: nextProps.request.result.summary.statement.text})
+        this.setState({
+          notifications: warnings,
+          cypher: nextProps.request.result.summary.statement.text
+        })
       }
-      this.setState({nodesAndRelationships, serializedPropertiesRows, rows, plan, errors})
-    } else if (nextProps.request.status !== 'success') { // Failed query
+      this.setState({
+        nodesAndRelationships,
+        serializedPropertiesRows,
+        rows,
+        plan,
+        errors
+      })
+    } else if (nextProps.request.status !== 'success') {
+      // Failed query
       errors = nextProps.request.result
       this.setState({ errors: errors, openView: viewTypes.ERRORS })
     }
   }
   componentWillMount () {
     if (this.props.request.status === 'error') {
-      this.setState({ errors: this.props.request.result, openView: viewTypes.ERRORS })
+      this.setState({
+        errors: this.props.request.result,
+        openView: viewTypes.ERRORS
+      })
     }
   }
   shouldComponentUpdate (nextProps, state) {
-    return state.openView !== this.state.openView ||
+    return (
+      state.openView !== this.state.openView ||
       state.fullscreen !== this.state.fullscreen ||
       state.frameHeight !== this.state.frameHeight ||
       nextProps.request.result !== this.props.request.result ||
       state.maxColWidth !== this.state.maxColWidth ||
       state.planAction !== this.state.planAction
+    )
   }
   setMaxColWidth (w) {
     this.setState({ maxColWidth: w })
   }
-  decideOpeningView ({plan, nodesAndRelationships, warnings, props}) {
+  decideOpeningView ({ plan, nodesAndRelationships, warnings, props }) {
     if (props.frame.forceView) {
-      this.setState({openView: props.frame.forceView})
+      this.setState({ openView: props.frame.forceView })
     } else if (plan) {
-      this.setState({openView: viewTypes.PLAN})
+      this.setState({ openView: viewTypes.PLAN })
     } else {
       let view = props.recentView || viewTypes.VISUALIZATION
-      this.setState({openView: this.returnRecentViewOrFallback({view, plan, nodesAndRelationships, warnings, props})})
+      this.setState({
+        openView: this.returnRecentViewOrFallback({
+          view,
+          plan,
+          nodesAndRelationships,
+          warnings,
+          props
+        })
+      })
     }
   }
 
-  returnRecentViewOrFallback ({view, plan, nodesAndRelationships, warnings, props}) {
+  returnRecentViewOrFallback ({
+    view,
+    plan,
+    nodesAndRelationships,
+    warnings,
+    props
+  }) {
     switch (view) {
-      case viewTypes.PLAN :
+      case viewTypes.PLAN:
         return plan != null
           ? viewTypes.PLAN
-          : this.returnRecentViewOrFallback({view: viewTypes.VISUALIZATION, plan, nodesAndRelationships, warnings, props})
-      case viewTypes.WARNINGS :
-        return (warnings != null && warnings.length > 0)
+          : this.returnRecentViewOrFallback({
+            view: viewTypes.VISUALIZATION,
+            plan,
+            nodesAndRelationships,
+            warnings,
+            props
+          })
+      case viewTypes.WARNINGS:
+        return warnings != null && warnings.length > 0
           ? viewTypes.WARNINGS
-          : this.returnRecentViewOrFallback({view: viewTypes.VISUALIZATION, plan, nodesAndRelationships, warnings, props})
-      case viewTypes.VISUALIZATION :
-        return (nodesAndRelationships && nodesAndRelationships.nodes.length > 0)
-            ? viewTypes.VISUALIZATION
-            : viewTypes.TABLE
+          : this.returnRecentViewOrFallback({
+            view: viewTypes.VISUALIZATION,
+            plan,
+            nodesAndRelationships,
+            warnings,
+            props
+          })
+      case viewTypes.VISUALIZATION:
+        return nodesAndRelationships && nodesAndRelationships.nodes.length > 0
+          ? viewTypes.VISUALIZATION
+          : viewTypes.TABLE
       default:
         return view
     }
   }
 
   changeView (view) {
-    this.setState({openView: view})
+    this.setState({ openView: view })
 
     if (this.props.onRecentViewChanged) {
       this.props.onRecentViewChanged(view)
@@ -142,7 +221,10 @@ class CypherFrame extends Component {
   }
 
   resultHasNodes () {
-    return (this.state.nodesAndRelationships) ? (this.state.nodesAndRelationships.nodes && this.state.nodesAndRelationships.nodes.length > 0) : false
+    return this.state.nodesAndRelationships
+      ? this.state.nodesAndRelationships.nodes &&
+          this.state.nodesAndRelationships.nodes.length > 0
+      : false
   }
 
   resultHasRows () {
@@ -153,53 +235,94 @@ class CypherFrame extends Component {
     return (
       <FrameSidebar>
         <Render if={this.resultHasNodes() && !this.state.errors}>
-          <CypherFrameButton selected={this.state.openView === viewTypes.VISUALIZATION} onClick={() => {
-            this.changeView(viewTypes.VISUALIZATION)
-          }}><VisualizationIcon /></CypherFrameButton>
+          <CypherFrameButton
+            selected={this.state.openView === viewTypes.VISUALIZATION}
+            onClick={() => {
+              this.changeView(viewTypes.VISUALIZATION)
+            }}
+          >
+            <VisualizationIcon />
+          </CypherFrameButton>
         </Render>
         <Render if={!this.state.errors}>
-          <CypherFrameButton selected={this.state.openView === viewTypes.TABLE} onClick={() => {
-            this.changeView(viewTypes.TABLE)
-          }}><TableIcon /></CypherFrameButton>
+          <CypherFrameButton
+            selected={this.state.openView === viewTypes.TABLE}
+            onClick={() => {
+              this.changeView(viewTypes.TABLE)
+            }}
+          >
+            <TableIcon />
+          </CypherFrameButton>
         </Render>
         <Render if={this.resultHasRows() && !this.state.errors}>
-          <CypherFrameButton selected={this.state.openView === viewTypes.TEXT} onClick={() => {
-            this.changeView(viewTypes.TEXT)
-          }}><AsciiIcon /></CypherFrameButton>
+          <CypherFrameButton
+            selected={this.state.openView === viewTypes.TEXT}
+            onClick={() => {
+              this.changeView(viewTypes.TEXT)
+            }}
+          >
+            <AsciiIcon />
+          </CypherFrameButton>
         </Render>
-        <Render if={(this.state.plan || bolt.extractPlan(this.props.request.result || false, true)) && !this.state.errors}>
-          <CypherFrameButton selected={this.state.openView === viewTypes.PLAN} onClick={() =>
-            this.changeView(viewTypes.PLAN)
-          }><PlanIcon /></CypherFrameButton>
+        <Render
+          if={
+            (this.state.plan ||
+              bolt.extractPlan(this.props.request.result || false, true)) &&
+            !this.state.errors
+          }
+        >
+          <CypherFrameButton
+            selected={this.state.openView === viewTypes.PLAN}
+            onClick={() => this.changeView(viewTypes.PLAN)}
+          >
+            <PlanIcon />
+          </CypherFrameButton>
         </Render>
         <Render if={this.state.notifications && !this.state.errors}>
-          <CypherFrameButton selected={this.state.openView === viewTypes.WARNINGS} onClick={() => {
-            this.changeView(viewTypes.WARNINGS)
-          }}><AlertIcon /></CypherFrameButton>
+          <CypherFrameButton
+            selected={this.state.openView === viewTypes.WARNINGS}
+            onClick={() => {
+              this.changeView(viewTypes.WARNINGS)
+            }}
+          >
+            <AlertIcon />
+          </CypherFrameButton>
         </Render>
         <Render if={this.state.errors}>
-          <CypherFrameButton selected={this.state.openView === viewTypes.ERRORS} onClick={() => {
-            this.changeView(viewTypes.ERRORS)
-          }}><ErrorIcon /></CypherFrameButton>
+          <CypherFrameButton
+            selected={this.state.openView === viewTypes.ERRORS}
+            onClick={() => {
+              this.changeView(viewTypes.ERRORS)
+            }}
+          >
+            <ErrorIcon />
+          </CypherFrameButton>
         </Render>
         <Render if={!this.state.errors}>
-          <CypherFrameButton selected={this.state.openView === viewTypes.CODE} onClick={() => {
-            this.changeView(viewTypes.CODE)
-          }}><CodeIcon /></CypherFrameButton>
+          <CypherFrameButton
+            selected={this.state.openView === viewTypes.CODE}
+            onClick={() => {
+              this.changeView(viewTypes.CODE)
+            }}
+          >
+            <CodeIcon />
+          </CypherFrameButton>
         </Render>
       </FrameSidebar>
     )
   }
 
   getDisplayStyle (viewType) {
-    return this.state.openView === viewType ? {display: 'block'} : {display: 'none'}
+    return this.state.openView === viewType
+      ? { display: 'block' }
+      : { display: 'none' }
   }
 
   onResize (fullscreen, collapse, frameHeight) {
     if (frameHeight) {
-      this.setState({fullscreen, collapse, frameHeight})
+      this.setState({ fullscreen, collapse, frameHeight })
     } else {
-      this.setState({fullscreen, collapse})
+      this.setState({ fullscreen, collapse })
     }
   }
 
@@ -208,23 +331,36 @@ class CypherFrame extends Component {
       return null
     }
 
-    const resultAvailableAfter = (result.summary.resultAvailableAfter.toNumber() === 0) ? 'in less than 1' : 'after ' + result.summary.resultAvailableAfter.toString()
-    const totalTime = result.summary.resultAvailableAfter.add(result.summary.resultConsumedAfter)
-    const totalTimeString = (totalTime.toNumber() === 0) ? 'in less than 1' : 'after ' + totalTime.toString()
-    const streamMessageTail = result.records.length > this.props.maxRows ? `ms, displaying first ${this.props.maxRows} rows.` : ' ms.'
+    const resultAvailableAfter = result.summary.resultAvailableAfter.toNumber() ===
+      0
+      ? 'in less than 1'
+      : 'after ' + result.summary.resultAvailableAfter.toString()
+    const totalTime = result.summary.resultAvailableAfter.add(
+      result.summary.resultConsumedAfter
+    )
+    const totalTimeString = totalTime.toNumber() === 0
+      ? 'in less than 1'
+      : 'after ' + totalTime.toString()
+    const streamMessageTail = result.records.length > this.props.maxRows
+      ? `ms, displaying first ${this.props.maxRows} rows.`
+      : ' ms.'
 
     let updateMessages = bolt.retrieveFormattedUpdateStatistics(result)
     let streamMessage = result.records.length > 0
-      ? `started streaming ${result.records.length} records ${resultAvailableAfter} ms and completed ${totalTimeString} ${streamMessageTail}`
+      ? `started streaming ${result.records
+          .length} records ${resultAvailableAfter} ms and completed ${totalTimeString} ${streamMessageTail}`
       : `completed ${totalTimeString} ${streamMessageTail}`
 
     if (updateMessages && updateMessages.length > 0) {
-      updateMessages = updateMessages[0].toUpperCase() + updateMessages.slice(1) + ', '
+      updateMessages =
+        updateMessages[0].toUpperCase() + updateMessages.slice(1) + ', '
     } else {
       streamMessage = streamMessage[0].toUpperCase() + streamMessage.slice(1)
     }
 
-    const bodyMessage = (updateMessages.length === 0 && result.records.length === 0) ? '(no changes, no records)'
+    const bodyMessage = updateMessages.length === 0 &&
+      result.records.length === 0
+      ? '(no changes, no records)'
       : updateMessages + `completed ${totalTimeString} ms.`
 
     return { statusBarMessage: updateMessages + streamMessage, bodyMessage }
@@ -247,7 +383,7 @@ class CypherFrame extends Component {
         statusBar = (
           <StyledStatsBar>
             <Ellipsis>
-              { messages && messages.statusBarMessage }
+              {messages && messages.statusBarMessage}
             </Ellipsis>
           </StyledStatsBar>
         )
@@ -257,19 +393,37 @@ class CypherFrame extends Component {
           <StyledStatsBarContainer>
             <StyledStatsBar>
               <Ellipsis>
-                Cypher version: {plan.root.version}, planner: {plan.root.planner}, runtime: {plan.root.runtime}.
-                { plan.root.totalDbHits ? ` ${plan.root.totalDbHits} total db hits in ${result.summary.resultAvailableAfter.add(result.summary.resultConsumedAfter).toNumber() || 0} ms.` : ``}
+                Cypher version: {plan.root.version}, planner:{' '}
+                {plan.root.planner}, runtime: {plan.root.runtime}.
+                {plan.root.totalDbHits
+                  ? ` ${plan.root
+                      .totalDbHits} total db hits in ${result.summary.resultAvailableAfter
+                      .add(result.summary.resultConsumedAfter)
+                      .toNumber() || 0} ms.`
+                  : ``}
               </Ellipsis>
             </StyledStatsBar>
             <FrameTitlebarButtonSection>
-              <FrameButton onClick={() => this.setState({planAction: 'COLLAPSE'})}><DoubleUpIcon /></FrameButton>
-              <FrameButton onClick={() => this.setState({planAction: 'EXPAND'})}><DoubleDownIcon /></FrameButton>
+              <FrameButton
+                onClick={() => this.setState({ planAction: 'COLLAPSE' })}
+              >
+                <DoubleUpIcon />
+              </FrameButton>
+              <FrameButton
+                onClick={() => this.setState({ planAction: 'EXPAND' })}
+              >
+                <DoubleDownIcon />
+              </FrameButton>
             </FrameTitlebarButtonSection>
           </StyledStatsBarContainer>
         )
       }
     }
-    if (this.state.openView === viewTypes.TEXT && this.state.serializedPropertiesRows && this.state.serializedPropertiesRows.length) {
+    if (
+      this.state.openView === viewTypes.TEXT &&
+      this.state.serializedPropertiesRows &&
+      this.state.serializedPropertiesRows.length
+    ) {
       statusBar = (
         <AsciiStatusbar
           rows={this.state.serializedPropertiesRows}
@@ -278,30 +432,67 @@ class CypherFrame extends Component {
       )
     }
     if (requestStatus !== 'pending') {
-      frameContents =
-        <StyledFrameBody fullscreen={this.state.fullscreen} collapsed={this.state.collapse}>
+      frameContents = (
+        <StyledFrameBody
+          fullscreen={this.state.fullscreen}
+          collapsed={this.state.collapse}
+        >
           <Render if={!this.state.errors}>
-            <Visualization style={this.getDisplayStyle(viewTypes.VISUALIZATION)} records={result.records} fullscreen={this.state.fullscreen} frameHeight={this.state.frameHeight} assignVisElement={(svgElement, graphElement) => { this.visElement = {svgElement, graphElement} }} />
+            <Visualization
+              style={this.getDisplayStyle(viewTypes.VISUALIZATION)}
+              records={result.records}
+              fullscreen={this.state.fullscreen}
+              frameHeight={this.state.frameHeight}
+              assignVisElement={(svgElement, graphElement) => {
+                this.visElement = { svgElement, graphElement }
+              }}
+            />
           </Render>
           <Render if={!this.state.errors}>
-            <TableView style={this.getDisplayStyle(viewTypes.TABLE)} data={this.state.rows} message={messages && messages.bodyMessage} />
+            <TableView
+              style={this.getDisplayStyle(viewTypes.TABLE)}
+              data={this.state.rows}
+              message={messages && messages.bodyMessage}
+            />
           </Render>
           <Render if={!this.state.errors}>
-            <AsciiView maxColWidth={this.state.maxColWidth} style={this.getDisplayStyle(viewTypes.TEXT)} rows={this.state.serializedPropertiesRows} message={messages && messages.bodyMessage} />
+            <AsciiView
+              maxColWidth={this.state.maxColWidth}
+              style={this.getDisplayStyle(viewTypes.TEXT)}
+              rows={this.state.serializedPropertiesRows}
+              message={messages && messages.bodyMessage}
+            />
           </Render>
           <Render if={!this.state.errors}>
-            <QueryPlan fullscreen={this.state.fullscreen} style={this.getDisplayStyle(viewTypes.PLAN)} plan={plan} action={this.state.planAction} />
+            <QueryPlan
+              fullscreen={this.state.fullscreen}
+              style={this.getDisplayStyle(viewTypes.PLAN)}
+              plan={plan}
+              action={this.state.planAction}
+            />
           </Render>
           <Render if={!this.state.errors}>
-            <WarningsView style={this.getDisplayStyle(viewTypes.WARNINGS)} notifications={this.state.notifications} cypher={this.state.cypher} />
+            <WarningsView
+              style={this.getDisplayStyle(viewTypes.WARNINGS)}
+              notifications={this.state.notifications}
+              cypher={this.state.cypher}
+            />
           </Render>
           <Render if={!this.state.errors}>
-            <CodeView style={this.getDisplayStyle(viewTypes.CODE)} query={this.props.frame.cmd} request={this.props.request} />
+            <CodeView
+              style={this.getDisplayStyle(viewTypes.CODE)}
+              query={this.props.frame.cmd}
+              request={this.props.request}
+            />
           </Render>
           <Render if={this.state.errors}>
-            <ErrorsView style={this.getDisplayStyle(viewTypes.ERRORS)} error={this.state.errors} />
+            <ErrorsView
+              style={this.getDisplayStyle(viewTypes.ERRORS)}
+              error={this.state.errors}
+            />
           </Render>
         </StyledFrameBody>
+      )
     } else if (requestStatus === 'pending') {
       frameContents = (
         <Centered>

--- a/src/browser/modules/Stream/ErrorFrame.jsx
+++ b/src/browser/modules/Stream/ErrorFrame.jsx
@@ -23,7 +23,7 @@ import * as e from 'services/exceptionMessages'
 import { getErrorMessage } from 'services/exceptions'
 import { PaddedDiv } from './styled'
 
-const ErrorFrame = ({frame}) => {
+const ErrorFrame = ({ frame }) => {
   const error = frame.error || false
   let errorContents = error.message || 'No error message found'
   if (error.type && typeof e[error.type] !== 'undefined') {

--- a/src/browser/modules/Stream/Frame.jsx
+++ b/src/browser/modules/Stream/Frame.jsx
@@ -20,7 +20,7 @@
 
 import FrameTemplate from './FrameTemplate'
 
-const Frame = ({frame}) => {
+const Frame = ({ frame }) => {
   const errors = frame.errors || false
   const contents = frame.contents || false
   let frameContents = contents
@@ -33,11 +33,6 @@ const Frame = ({frame}) => {
   } else if (frame.type === 'unknown') {
     frameContents = 'Unknown command'
   }
-  return (
-    <FrameTemplate
-      header={frame}
-      contents={frameContents}
-    />
-  )
+  return <FrameTemplate header={frame} contents={frameContents} />
 }
 export default Frame

--- a/src/browser/modules/Stream/FrameError.jsx
+++ b/src/browser/modules/Stream/FrameError.jsx
@@ -22,12 +22,15 @@ import { ExclamationTriangleIcon } from 'browser-components/icons/Icons'
 import Ellipsis from 'browser-components/Ellipsis'
 import { ErrorText } from './styled'
 
-const FrameError = (props) => {
+const FrameError = props => {
   if (!props || (!props.code && !props.message)) return null
-  const fullError = `${props.code}${(props.message ? ':' : '')} ${(props.message || '')}`
+  const fullError = `${props.code}${props.message ? ':' : ''} ${props.message ||
+    ''}`
   return (
     <Ellipsis>
-      <ErrorText title={fullError}><ExclamationTriangleIcon /> {fullError}</ErrorText>
+      <ErrorText title={fullError}>
+        <ExclamationTriangleIcon /> {fullError}
+      </ErrorText>
     </Ellipsis>
   )
 }

--- a/src/browser/modules/Stream/FrameSidebar.jsx
+++ b/src/browser/modules/Stream/FrameSidebar.jsx
@@ -20,7 +20,7 @@
 
 import { StyledFrameSidebar } from './styled'
 
-const FrameSidebar = (props) => {
+const FrameSidebar = props => {
   if (!props || !props.children) return null
   return <StyledFrameSidebar>{props.children}</StyledFrameSidebar>
 }

--- a/src/browser/modules/Stream/FrameSuccess.jsx
+++ b/src/browser/modules/Stream/FrameSuccess.jsx
@@ -18,9 +18,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const FrameSuccess = (props) => {
+const FrameSuccess = props => {
   if (!props || !props.message) return null
-  return <span style={{color: 'green'}}>{props.message}</span>
+  return <span style={{ color: 'green' }}>{props.message}</span>
 }
 
 export default FrameSuccess

--- a/src/browser/modules/Stream/FrameTemplate.jsx
+++ b/src/browser/modules/Stream/FrameTemplate.jsx
@@ -21,7 +21,13 @@
 import { Component } from 'preact'
 import FrameTitlebar from './FrameTitlebar'
 import Render from 'browser-components/Render'
-import { StyledFrame, StyledFrameBody, StyledFrameContents, StyledFrameStatusbar, StyledFrameMainSection } from './styled'
+import {
+  StyledFrame,
+  StyledFrameBody,
+  StyledFrameContents,
+  StyledFrameStatusbar,
+  StyledFrameMainSection
+} from './styled'
 
 class FrameTemplate extends Component {
   constructor (props) {
@@ -33,18 +39,53 @@ class FrameTemplate extends Component {
     }
   }
   toggleFullScreen () {
-    this.setState({fullscreen: !this.state.fullscreen}, () => this.props.onResize && this.props.onResize(this.state.fullscreen, this.state.collapse, this.lastHeight))
+    this.setState(
+      { fullscreen: !this.state.fullscreen },
+      () =>
+        this.props.onResize &&
+        this.props.onResize(
+          this.state.fullscreen,
+          this.state.collapse,
+          this.lastHeight
+        )
+    )
   }
   toggleCollapse () {
-    this.setState({collapse: !this.state.collapse}, () => this.props.onResize && this.props.onResize(this.state.fullscreen, this.state.collapse, this.lastHeight))
+    this.setState(
+      { collapse: !this.state.collapse },
+      () =>
+        this.props.onResize &&
+        this.props.onResize(
+          this.state.fullscreen,
+          this.state.collapse,
+          this.lastHeight
+        )
+    )
   }
   togglePin () {
-    this.setState({pinned: !this.state.pinned}, () => this.props.onResize && this.props.onResize(this.state.fullscreen, this.state.collapse, this.lastHeight))
+    this.setState(
+      { pinned: !this.state.pinned },
+      () =>
+        this.props.onResize &&
+        this.props.onResize(
+          this.state.fullscreen,
+          this.state.collapse,
+          this.lastHeight
+        )
+    )
   }
   componentDidUpdate () {
-    if (this.frameContentElement && this.lastHeight !== this.frameContentElement.base.clientHeight) {
+    if (
+      this.frameContentElement &&
+      this.lastHeight !== this.frameContentElement.base.clientHeight
+    ) {
       this.lastHeight = this.frameContentElement.base.clientHeight
-      this.props.onResize && this.props.onResize(this.state.fullscreen, this.state.collapse, this.lastHeight)
+      this.props.onResize &&
+        this.props.onResize(
+          this.state.fullscreen,
+          this.state.collapse,
+          this.lastHeight
+        )
     }
   }
   setFrameContentElement (el) {
@@ -63,15 +104,23 @@ class FrameTemplate extends Component {
           togglePin={this.togglePin.bind(this)}
           exportData={this.props.exportData}
           visElement={this.props.visElement}
-          />
-        <StyledFrameBody fullscreen={this.state.fullscreen} collapsed={this.state.collapse}>
-          {(this.props.sidebar) ? this.props.sidebar() : null}
+        />
+        <StyledFrameBody
+          fullscreen={this.state.fullscreen}
+          collapsed={this.state.collapse}
+        >
+          {this.props.sidebar ? this.props.sidebar() : null}
           <StyledFrameMainSection>
-            <StyledFrameContents fullscreen={this.state.fullscreen} ref={this.setFrameContentElement.bind(this)}>
+            <StyledFrameContents
+              fullscreen={this.state.fullscreen}
+              ref={this.setFrameContentElement.bind(this)}
+            >
               {this.props.contents}
             </StyledFrameContents>
             <Render if={this.props.statusbar}>
-              <StyledFrameStatusbar fullscreen={this.state.fullscreen}>{this.props.statusbar}</StyledFrameStatusbar>
+              <StyledFrameStatusbar fullscreen={this.state.fullscreen}>
+                {this.props.statusbar}
+              </StyledFrameStatusbar>
             </Render>
           </StyledFrameMainSection>
         </StyledFrameBody>

--- a/src/browser/modules/Stream/FrameTitlebar.jsx
+++ b/src/browser/modules/Stream/FrameTitlebar.jsx
@@ -29,11 +29,29 @@ import { removeComments } from 'shared/services/utils'
 import { FrameButton } from 'browser-components/buttons'
 import Render from 'browser-components/Render'
 import { CSVSerializer } from 'services/serializer'
-import { ExpandIcon, ContractIcon, RefreshIcon, CloseIcon, UpIcon, DownIcon, PinIcon, DownloadIcon } from 'browser-components/icons/Icons'
-import { StyledFrameTitleBar, StyledFrameCommand, DottedLineHover, FrameTitlebarButtonSection, DropdownList, DropdownContent, DropdownButton, DropdownItem } from './styled'
+import {
+  ExpandIcon,
+  ContractIcon,
+  RefreshIcon,
+  CloseIcon,
+  UpIcon,
+  DownIcon,
+  PinIcon,
+  DownloadIcon
+} from 'browser-components/icons/Icons'
+import {
+  StyledFrameTitleBar,
+  StyledFrameCommand,
+  DottedLineHover,
+  FrameTitlebarButtonSection,
+  DropdownList,
+  DropdownContent,
+  DropdownButton,
+  DropdownItem
+} from './styled'
 import { downloadPNGFromSVG } from 'shared/services/exporting/pngUtils'
 
-const getCsvData = (exportData) => {
+const getCsvData = exportData => {
   if (exportData && exportData.length > 0) {
     let data = exportData.slice()
     const csv = CSVSerializer(data.shift())
@@ -54,12 +72,14 @@ class FrameTitlebar extends Component {
 
   componentWillReceiveProps (nextProps) {
     if (this.props.exportData !== nextProps.exportData) {
-      this.setState({csvData: nextProps.exportData ? getCsvData(nextProps.exportData) : null})
+      this.setState({
+        csvData: nextProps.exportData ? getCsvData(nextProps.exportData) : null
+      })
     }
   }
 
   exportPNG () {
-    const {svgElement, graphElement} = this.props.visElement
+    const { svgElement, graphElement } = this.props.visElement
     const fileName = 'graph'
     downloadPNGFromSVG(svgElement, graphElement, fileName)
   }
@@ -67,8 +87,8 @@ class FrameTitlebar extends Component {
   render () {
     let props = this.props
     const { frame } = props
-    const fullscreenIcon = (props.fullscreen) ? <ContractIcon /> : <ExpandIcon />
-    const expandCollapseIcon = (props.collapse) ? <DownIcon /> : <UpIcon />
+    const fullscreenIcon = props.fullscreen ? <ContractIcon /> : <ExpandIcon />
+    const expandCollapseIcon = props.collapse ? <DownIcon /> : <UpIcon />
     const cmd = removeComments(frame.cmd)
     return (
       <StyledFrameTitleBar>
@@ -83,24 +103,57 @@ class FrameTitlebar extends Component {
               <DownloadIcon />
               <DropdownList>
                 <DropdownContent>
-                  <DropdownItem onClick={() => this.exportPNG()}>Export PNG</DropdownItem>
-                  <DropdownItem download='export.csv' href={this.state.csvData}>Export CSV</DropdownItem>
+                  <DropdownItem onClick={() => this.exportPNG()}>
+                    Export PNG
+                  </DropdownItem>
+                  <DropdownItem download='export.csv' href={this.state.csvData}>
+                    Export CSV
+                  </DropdownItem>
                 </DropdownContent>
               </DropdownList>
             </DropdownButton>
           </Render>
-          <FrameButton title='Pin at top' onClick={() => {
-            props.togglePin()
-            props.togglePinning(frame.id, frame.isPinned)
-          }} pressed={props.pinned}><PinIcon /></FrameButton>
-          <Render if={['cypher', 'play', 'play-remote'].indexOf(frame.type) > -1}>
-            <FrameButton title={(props.fullscreen) ? 'Close fullscreen' : 'Fullscreen'} onClick={() => props.fullscreenToggle()}>{fullscreenIcon}</FrameButton>
+          <FrameButton
+            title='Pin at top'
+            onClick={() => {
+              props.togglePin()
+              props.togglePinning(frame.id, frame.isPinned)
+            }}
+            pressed={props.pinned}
+          >
+            <PinIcon />
+          </FrameButton>
+          <Render
+            if={['cypher', 'play', 'play-remote'].indexOf(frame.type) > -1}
+          >
+            <FrameButton
+              title={props.fullscreen ? 'Close fullscreen' : 'Fullscreen'}
+              onClick={() => props.fullscreenToggle()}
+            >
+              {fullscreenIcon}
+            </FrameButton>
           </Render>
-          <FrameButton title={(props.collapse) ? 'Expand' : 'Collapse'}onClick={() => props.collapseToggle()}>{expandCollapseIcon}</FrameButton>
+          <FrameButton
+            title={props.collapse ? 'Expand' : 'Collapse'}
+            onClick={() => props.collapseToggle()}
+          >
+            {expandCollapseIcon}
+          </FrameButton>
           <Render if={frame.type === 'cypher'}>
-            <FrameButton title='Rerun' onClick={() => props.onReRunClick(frame.cmd, frame.id, frame.requestId)}><RefreshIcon /></FrameButton>
+            <FrameButton
+              title='Rerun'
+              onClick={() =>
+                props.onReRunClick(frame.cmd, frame.id, frame.requestId)}
+            >
+              <RefreshIcon />
+            </FrameButton>
           </Render>
-          <FrameButton title='Close' onClick={() => props.onCloseClick(frame.id, frame.requestId)}><CloseIcon /></FrameButton>
+          <FrameButton
+            title='Close'
+            onClick={() => props.onCloseClick(frame.id, frame.requestId)}
+          >
+            <CloseIcon />
+          </FrameButton>
         </FrameTitlebarButtonSection>
       </StyledFrameTitleBar>
     )
@@ -109,7 +162,7 @@ class FrameTitlebar extends Component {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    onTitlebarClick: (cmd) => {
+    onTitlebarClick: cmd => {
       ownProps.bus.send(editor.SET_CONTENT, editor.setContent(cmd))
     },
     onCloseClick: (id, requestId) => {
@@ -121,9 +174,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
       dispatch(commands.executeCommand(cmd, id))
     },
     togglePinning: (id, isPinned) => {
-      isPinned
-        ? dispatch(unpin(id))
-        : dispatch(pin(id))
+      isPinned ? dispatch(unpin(id)) : dispatch(pin(id))
     }
   }
 }

--- a/src/browser/modules/Stream/HelpFrame.jsx
+++ b/src/browser/modules/Stream/HelpFrame.jsx
@@ -24,7 +24,7 @@ import Directives from 'browser-components/Directives'
 import FrameTemplate from './FrameTemplate'
 import { transformCommandToHelpTopic } from 'services/commandUtils'
 
-const HelpFrame = ({frame}) => {
+const HelpFrame = ({ frame }) => {
   let help = 'Help topic not specified'
   if (frame.result) {
     help = <Slide html={frame.result} />

--- a/src/browser/modules/Stream/HistoryFrame.jsx
+++ b/src/browser/modules/Stream/HistoryFrame.jsx
@@ -24,13 +24,15 @@ import FrameTemplate from './FrameTemplate'
 import { StyledHistoryList } from './styled'
 import HistoryRow from './HistoryRow'
 
-export const HistoryFrame = (props) => {
-  const {frame, bus} = props
-  const onHistoryClick = (cmd) => {
+export const HistoryFrame = props => {
+  const { frame, bus } = props
+  const onHistoryClick = cmd => {
     bus.send(editor.SET_CONTENT, editor.setContent(cmd))
   }
   const historyRows = frame.result.map((entry, index) => {
-    return <HistoryRow key={index} handleEntryClick={onHistoryClick} entry={entry} />
+    return (
+      <HistoryRow key={index} handleEntryClick={onHistoryClick} entry={entry} />
+    )
   })
   return (
     <FrameTemplate

--- a/src/browser/modules/Stream/HistoryRow.jsx
+++ b/src/browser/modules/Stream/HistoryRow.jsx
@@ -20,7 +20,11 @@
 
 import { StyledHistoryRow } from './styled'
 
-const HistoryRow = ({entry, handleEntryClick}) => {
-  return <StyledHistoryRow onClick={() => handleEntryClick(entry)}>{entry}</StyledHistoryRow>
+const HistoryRow = ({ entry, handleEntryClick }) => {
+  return (
+    <StyledHistoryRow onClick={() => handleEntryClick(entry)}>
+      {entry}
+    </StyledHistoryRow>
+  )
 }
 export default HistoryRow

--- a/src/browser/modules/Stream/ParamFrame.jsx
+++ b/src/browser/modules/Stream/ParamFrame.jsx
@@ -21,14 +21,22 @@
 import Render from 'browser-components/Render'
 import FrameTemplate from './FrameTemplate'
 
-const ParamFrame = ({frame, params}) => {
+const ParamFrame = ({ frame, params }) => {
   return (
     <FrameTemplate
       header={frame}
-      contents={<Render if={frame.success}><pre>{JSON.stringify(frame.params, null, 2)}</pre></Render>}
+      contents={
+        <Render if={frame.success}>
+          <pre>{JSON.stringify(frame.params, null, 2)}</pre>
+        </Render>
+      }
     >
-      <Render if={frame.success}><span>Successfully set your parameter</span></Render>
-      <Render if={!frame.success}><span>Something went wrong. Read help pages.</span></Render>
+      <Render if={frame.success}>
+        <span>Successfully set your parameter</span>
+      </Render>
+      <Render if={!frame.success}>
+        <span>Something went wrong. Read help pages.</span>
+      </Render>
     </FrameTemplate>
   )
 }

--- a/src/browser/modules/Stream/ParamsFrame.jsx
+++ b/src/browser/modules/Stream/ParamsFrame.jsx
@@ -21,14 +21,22 @@
 import Render from 'browser-components/Render'
 import FrameTemplate from './FrameTemplate'
 
-const ParamsFrame = ({frame, params}) => {
+const ParamsFrame = ({ frame, params }) => {
   return (
     <FrameTemplate
       header={frame}
-      contents={<Render if={frame.success !== false}><pre>{JSON.stringify(frame.params, null, 2)}</pre></Render>}
+      contents={
+        <Render if={frame.success !== false}>
+          <pre>{JSON.stringify(frame.params, null, 2)}</pre>
+        </Render>
+      }
     >
-      <Render if={frame.success}><span>Successfully set your parameters</span></Render>
-      <Render if={frame.success === false}><span>Something went wrong. Read help pages.</span></Render>
+      <Render if={frame.success}>
+        <span>Successfully set your parameters</span>
+      </Render>
+      <Render if={frame.success === false}>
+        <span>Something went wrong. Read help pages.</span>
+      </Render>
     </FrameTemplate>
   )
 }

--- a/src/browser/modules/Stream/Planner/QueryPlan.jsx
+++ b/src/browser/modules/Stream/Planner/QueryPlan.jsx
@@ -31,10 +31,10 @@ class QueryPlan extends Component {
     }
   }
   toggleExpanded (expanded) {
-    const visit = (operator) => {
+    const visit = operator => {
       operator.expanded = expanded
       if (operator.children) {
-        operator.children.forEach((child) => {
+        operator.children.forEach(child => {
           visit(child)
         })
       }
@@ -62,7 +62,16 @@ class QueryPlan extends Component {
     }
 
     return (
-      <svg display={this.props.style.display} className='neod3plan' style={(this.props.fullscreen) ? {'padding-bottom': dim.frameStatusbarHeight + 'px'} : {}} ref={this.planInit.bind(this)} />
+      <svg
+        display={this.props.style.display}
+        className='neod3plan'
+        style={
+          this.props.fullscreen
+            ? { 'padding-bottom': dim.frameStatusbarHeight + 'px' }
+            : {}
+        }
+        ref={this.planInit.bind(this)}
+      />
     )
   }
 }

--- a/src/browser/modules/Stream/PlayFrame.jsx
+++ b/src/browser/modules/Stream/PlayFrame.jsx
@@ -36,31 +36,56 @@ export class PlayFrame extends Component {
     }
   }
   componentDidMount () {
-    if (this.props.frame.result) { // Found remote guide
-      this.setState({ guide: <Guides withDirectives html={this.props.frame.result} /> })
+    if (this.props.frame.result) {
+      // Found remote guide
+      this.setState({
+        guide: <Guides withDirectives html={this.props.frame.result} />
+      })
       return
     }
-    if (this.props.frame.response && this.props.frame.error && this.props.frame.error.error) { // Not found remotely (or other error)
-      if (this.props.frame.response.status === 404) return this.setState({ guide: <Guides withDirectives html={html['unfound']} /> })
+    if (
+      this.props.frame.response &&
+      this.props.frame.error &&
+      this.props.frame.error.error
+    ) {
+      // Not found remotely (or other error)
+      if (this.props.frame.response.status === 404) {
+        return this.setState({
+          guide: <Guides withDirectives html={html['unfound']} />
+        })
+      }
       return this.setState({
         guide: (
           <ErrorsView
             error={{
-              message: 'Error: The remote server responded with the following error: ' + this.props.frame.response.status,
+              message:
+                'Error: The remote server responded with the following error: ' +
+                  this.props.frame.response.status,
               code: 'Remote guide error'
             }}
-          />)
+          />
+        )
       })
     }
-    if (this.props.frame.error && this.props.frame.error.error) { // Some other error. Whitelist error etc.
-      return this.setState({ guide: <ErrorsView error={{
-        message: this.props.frame.error.error,
-        code: 'Remote guide error'
-      }} /> })
+    if (this.props.frame.error && this.props.frame.error.error) {
+      // Some other error. Whitelist error etc.
+      return this.setState({
+        guide: (
+          <ErrorsView
+            error={{
+              message: this.props.frame.error.error,
+              code: 'Remote guide error'
+            }}
+          />
+        )
+      })
     }
-    const topicInput = (splitStringOnFirst(this.props.frame.cmd, ' ')[1] || 'start').trim()
+    const topicInput = (splitStringOnFirst(this.props.frame.cmd, ' ')[1] ||
+      'start')
+      .trim()
     const guideName = topicInput.toLowerCase().replace(/\s|-/g, '')
-    if (html[guideName] !== undefined) { // Found it locally
+    if (html[guideName] !== undefined) {
+      // Found it locally
       this.setState({ guide: <Guides withDirectives html={html[guideName]} /> })
       return
     }
@@ -68,14 +93,20 @@ export class PlayFrame extends Component {
     // Try to find it remotely by name
     if (this.props.bus) {
       const action = fetchGuideFromWhitelistAction(topicInput)
-      this.props.bus.self(action.type, action, (res) => {
-        if (!res.success) { // No luck
-          return this.setState({ guide: <Guides withDirectives html={html['unfound']} /> })
+      this.props.bus.self(action.type, action, res => {
+        if (!res.success) {
+          // No luck
+          return this.setState({
+            guide: <Guides withDirectives html={html['unfound']} />
+          })
         }
         this.setState({ guide: <Guides withDirectives html={res.result} /> })
       })
-    } else { // No bus. Give up
-      return this.setState({ guide: <Guides withDirectives html={html['unfound']} /> })
+    } else {
+      // No bus. Give up
+      return this.setState({
+        guide: <Guides withDirectives html={html['unfound']} />
+      })
     }
   }
   render () {

--- a/src/browser/modules/Stream/PlayFrame.test.jsx
+++ b/src/browser/modules/Stream/PlayFrame.test.jsx
@@ -26,25 +26,30 @@ import Guides from '../Guides/Guides'
 
 describe('PlayFrame', () => {
   test.skip('should render PlayFrame', () => {
-    const wrapper = shallow(<PlayFrame frame={{cmd: ':play movies'}} />)
+    const wrapper = shallow(<PlayFrame frame={{ cmd: ':play movies' }} />)
     expect(wrapper.find('.playFrame').length).toBe(1)
   })
   test.skip('should render play guide when not guide name is provided', () => {
-    const wrapper = shallow(<PlayFrame frame={{cmd: ':play'}} />)
+    const wrapper = shallow(<PlayFrame frame={{ cmd: ':play' }} />)
     expect(wrapper.find('.playFrame').length).toBe(1)
     const card = shallow(wrapper.find('.playFrame').node)
     expect(card.find('.frame-contents').text()).to.match(/not\sspecified/)
   })
   test.skip('should render play guide not found', () => {
-    const wrapper = shallow(<PlayFrame frame={{cmd: ':play i-do-not-exist'}} />)
+    const wrapper = shallow(
+      <PlayFrame frame={{ cmd: ':play i-do-not-exist' }} />
+    )
     expect(wrapper.find('.playFrame').length).toBe(1)
     const card = shallow(wrapper.find('.playFrame').node)
     expect(card.find('.frame-contents').text()).to.match(/not\sfound/)
   })
-  test.skip('should render contents when contents is passed to PlayFrame', () => {
-    const wrapper = shallow(<PlayFrame frame={{result: 'Hello'}} />)
-    expect(wrapper.find('.playFrame').length).toBe(1)
-    const card = shallow(wrapper.find('.playFrame').node)
-    expect(card.find(Guides).props().html).to.eql('Hello')
-  })
+  test.skip(
+    'should render contents when contents is passed to PlayFrame',
+    () => {
+      const wrapper = shallow(<PlayFrame frame={{ result: 'Hello' }} />)
+      expect(wrapper.find('.playFrame').length).toBe(1)
+      const card = shallow(wrapper.find('.playFrame').node)
+      expect(card.find(Guides).props().html).to.eql('Hello')
+    }
+  )
 })

--- a/src/browser/modules/Stream/PreFrame.jsx
+++ b/src/browser/modules/Stream/PreFrame.jsx
@@ -21,11 +21,13 @@
 import FrameTemplate from './FrameTemplate'
 import { PaddedDiv } from './styled'
 
-const PreFrame = ({frame}) => {
+const PreFrame = ({ frame }) => {
   return (
     <FrameTemplate
       header={frame}
-      contents={<PaddedDiv><pre>{frame.result || frame.contents}</pre></PaddedDiv>}
+      contents={
+        <PaddedDiv><pre>{frame.result || frame.contents}</pre></PaddedDiv>
+      }
     />
   )
 }

--- a/src/browser/modules/Stream/Queries/QueriesFrame.jsx
+++ b/src/browser/modules/Stream/Queries/QueriesFrame.jsx
@@ -18,19 +18,40 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {Component} from 'preact'
-import {connect} from 'preact-redux'
-import {withBus} from 'preact-suber'
+import { Component } from 'preact'
+import { connect } from 'preact-redux'
+import { withBus } from 'preact-suber'
 import FrameTemplate from '../FrameTemplate'
 import bolt from 'services/bolt/bolt'
-import {listQueriesProcedure, killQueriesProcedure} from 'shared/modules/cypher/queriesProcedureHelper'
-import {getAvailableProcedures} from 'shared/modules/features/featuresDuck'
-import {CYPHER_REQUEST, CLUSTER_CYPHER_REQUEST, AD_HOC_CYPHER_REQUEST} from 'shared/modules/cypher/cypherDuck'
-import {getConnectionState, CONNECTED_STATE} from 'shared/modules/connections/connectionsDuck'
-import {ConfirmationButton} from 'browser-components/buttons/ConfirmationButton'
-import {StyledTh, StyledHeaderRow, StyledTable, StyledTd, Code, StyledStatusBar, AutoRefreshToogle, RefreshQueriesButton, AutoRefreshSpan, StatusbarWrapper} from './styled'
-import {EnterpriseOnlyFrame} from 'browser-components/EditionView'
-import {RefreshIcon} from 'browser-components/icons/Icons'
+import {
+  listQueriesProcedure,
+  killQueriesProcedure
+} from 'shared/modules/cypher/queriesProcedureHelper'
+import { getAvailableProcedures } from 'shared/modules/features/featuresDuck'
+import {
+  CYPHER_REQUEST,
+  CLUSTER_CYPHER_REQUEST,
+  AD_HOC_CYPHER_REQUEST
+} from 'shared/modules/cypher/cypherDuck'
+import {
+  getConnectionState,
+  CONNECTED_STATE
+} from 'shared/modules/connections/connectionsDuck'
+import { ConfirmationButton } from 'browser-components/buttons/ConfirmationButton'
+import {
+  StyledTh,
+  StyledHeaderRow,
+  StyledTable,
+  StyledTd,
+  Code,
+  StyledStatusBar,
+  AutoRefreshToogle,
+  RefreshQueriesButton,
+  AutoRefreshSpan,
+  StatusbarWrapper
+} from './styled'
+import { EnterpriseOnlyFrame } from 'browser-components/EditionView'
+import { RefreshIcon } from 'browser-components/icons/Icons'
 import Render from 'browser-components/Render'
 import FrameError from '../FrameError'
 
@@ -51,14 +72,17 @@ export class QueriesFrame extends Component {
     if (this.props.connectionState === CONNECTED_STATE) {
       this.getRunningQueries()
     } else {
-      this.setState({errors: ['Unable to connect to bolt server']})
+      this.setState({ errors: ['Unable to connect to bolt server'] })
     }
   }
 
   componentDidUpdate (prevProps, prevState) {
     if (prevState.autoRefresh !== this.state.autoRefresh) {
       if (this.state.autoRefresh) {
-        this.timer = setInterval(this.getRunningQueries.bind(this), this.state.autoRefreshInterval * 1000)
+        this.timer = setInterval(
+          this.getRunningQueries.bind(this),
+          this.state.autoRefreshInterval * 1000
+        )
       } else {
         clearInterval(this.timer)
       }
@@ -74,19 +98,28 @@ export class QueriesFrame extends Component {
 
   getRunningQueries (suppressQuerySuccessMessage = false) {
     this.props.bus.self(
-      (this.isCC()) ? CLUSTER_CYPHER_REQUEST : CYPHER_REQUEST,
-      {query: listQueriesProcedure()},
-      (response) => {
+      this.isCC() ? CLUSTER_CYPHER_REQUEST : CYPHER_REQUEST,
+      { query: listQueriesProcedure() },
+      response => {
         if (response.success) {
           let queries = this.extractQueriesFromBoltResult(response.result)
           let resultMessage = this.constructSuccessMessage(queries)
 
           this.setState((prevState, props) => {
-            return {queries: queries, errors: null, success: suppressQuerySuccessMessage ? prevState.success : resultMessage}
+            return {
+              queries: queries,
+              errors: null,
+              success: suppressQuerySuccessMessage
+                ? prevState.success
+                : resultMessage
+            }
           })
         } else {
           let errors = this.state.errors || []
-          this.setState({errors: errors.concat([response.error]), success: false})
+          this.setState({
+            errors: errors.concat([response.error]),
+            success: false
+          })
         }
       }
     )
@@ -94,22 +127,28 @@ export class QueriesFrame extends Component {
 
   killQueries (host, queryIdList) {
     this.props.bus.self(
-      (this.isCC()) ? AD_HOC_CYPHER_REQUEST : CYPHER_REQUEST,
-      {host, query: killQueriesProcedure(queryIdList)},
-      (response) => {
+      this.isCC() ? AD_HOC_CYPHER_REQUEST : CYPHER_REQUEST,
+      { host, query: killQueriesProcedure(queryIdList) },
+      response => {
         if (response.success) {
-          this.setState({success: 'Query successfully cancelled', errors: null})
+          this.setState({
+            success: 'Query successfully cancelled',
+            errors: null
+          })
           this.getRunningQueries(true)
         } else {
           let errors = this.state.errors || []
-          this.setState({errors: errors.concat([response.error]), success: false})
+          this.setState({
+            errors: errors.concat([response.error]),
+            success: false
+          })
         }
       }
     )
   }
 
   extractQueriesFromBoltResult (result) {
-    return result.records.map((queryRecord) => {
+    return result.records.map(queryRecord => {
       let queryInfo = {}
       queryRecord.keys.forEach((key, idx) => {
         queryInfo[key] = bolt.itemIntToNumber(queryRecord._fields[idx])
@@ -129,13 +168,16 @@ export class QueriesFrame extends Component {
 
   constructSuccessMessage (queries) {
     let hosts = queries.map(query => query.host).reduce((acc, host) => {
-      if (acc.host) { return acc } else {
+      if (acc.host) {
+        return acc
+      } else {
         acc[host] = 1
         return acc
       }
     }, {})
 
-    let clusterCount = Object.keys(hosts).map(key => hosts.hasOwnProperty(key)).length
+    let clusterCount = Object.keys(hosts).map(key => hosts.hasOwnProperty(key))
+      .length
     let numMachinesMsg = 'running on one server'
 
     if (clusterCount > 1) {
@@ -160,18 +202,36 @@ export class QueriesFrame extends Component {
       ['Elapsed time', '95px'],
       ['Kill', '95px']
     ]
-    const tableRows = queries.map((query) => {
+    const tableRows = queries.map(query => {
       return (
         <tr>
-          <StyledTd title={query.host} width={tableHeaderSizes[0][1]}><Code>{query.host}</Code></StyledTd>
+          <StyledTd title={query.host} width={tableHeaderSizes[0][1]}>
+            <Code>{query.host}</Code>
+          </StyledTd>
           <StyledTd width={tableHeaderSizes[1][1]}>{query.username}</StyledTd>
-          <StyledTd title={query.query} width={tableHeaderSizes[2][1]}><Code>{query.query}</Code></StyledTd>
-          <StyledTd width={tableHeaderSizes[3][1]}><Code>{query.parameters}</Code></StyledTd>
-          <StyledTd width={tableHeaderSizes[4][1]}><Code>{query.metaData}</Code></StyledTd>
-          <StyledTd width={tableHeaderSizes[5][1]}>{query.elapsedTimeMillis} ms</StyledTd>
-          <StyledTd width={tableHeaderSizes[6][1]}><ConfirmationButton
-            onConfirmed={this.onCancelQuery.bind(this, query.host, query.queryId)} /></StyledTd>
-        </tr>)
+          <StyledTd title={query.query} width={tableHeaderSizes[2][1]}>
+            <Code>{query.query}</Code>
+          </StyledTd>
+          <StyledTd width={tableHeaderSizes[3][1]}>
+            <Code>{query.parameters}</Code>
+          </StyledTd>
+          <StyledTd width={tableHeaderSizes[4][1]}>
+            <Code>{query.metaData}</Code>
+          </StyledTd>
+          <StyledTd width={tableHeaderSizes[5][1]}>
+            {query.elapsedTimeMillis} ms
+          </StyledTd>
+          <StyledTd width={tableHeaderSizes[6][1]}>
+            <ConfirmationButton
+              onConfirmed={this.onCancelQuery.bind(
+                this,
+                query.host,
+                query.queryId
+              )}
+            />
+          </StyledTd>
+        </tr>
+      )
     })
 
     const tableHeaders = tableHeaderSizes.map((heading, i) => {
@@ -192,7 +252,7 @@ export class QueriesFrame extends Component {
   }
 
   setAutoRefresh (autoRefresh) {
-    this.setState({autoRefresh: autoRefresh})
+    this.setState({ autoRefresh: autoRefresh })
 
     if (autoRefresh) {
       this.getRunningQueries()
@@ -213,16 +273,21 @@ export class QueriesFrame extends Component {
           <Render if={this.state.success}>
             <StyledStatusBar>
               {this.state.success}
-              <RefreshQueriesButton onClick={() => this.getRunningQueries()}><RefreshIcon /></RefreshQueriesButton>
+              <RefreshQueriesButton onClick={() => this.getRunningQueries()}>
+                <RefreshIcon />
+              </RefreshQueriesButton>
               <AutoRefreshSpan>
-                <AutoRefreshToogle checked={this.state.autoRefresh} onClick={(e) => this.setAutoRefresh(e.target.checked)} />
+                <AutoRefreshToogle
+                  checked={this.state.autoRefresh}
+                  onClick={e => this.setAutoRefresh(e.target.checked)}
+                />
               </AutoRefreshSpan>
             </StyledStatusBar>
           </Render>
         </StatusbarWrapper>
       )
     } else {
-      frameContents = (<EnterpriseOnlyFrame command={this.props.frame.cmd} />)
+      frameContents = <EnterpriseOnlyFrame command={this.props.frame.cmd} />
     }
     return (
       <FrameTemplate
@@ -234,7 +299,7 @@ export class QueriesFrame extends Component {
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     availableProcedures: getAvailableProcedures(state) || [],
     connectionState: getConnectionState(state)

--- a/src/browser/modules/Stream/Queries/styled.jsx
+++ b/src/browser/modules/Stream/Queries/styled.jsx
@@ -19,7 +19,7 @@
  */
 
 import styled from 'styled-components'
-import {FrameButton} from 'browser-components/buttons'
+import { FrameButton } from 'browser-components/buttons'
 import styles from './toggleStyles.css'
 
 export const Code = styled.code`
@@ -86,11 +86,16 @@ const ToggleLabel = styled.label`
   cursor: pointer;
 `
 
-export const AutoRefreshToogle = (props) => {
+export const AutoRefreshToogle = props => {
   return (
     <ToggleLabel>
       AUTO-REFRESH &nbsp;
-      <input type='checkbox' checked={props.checked} onClick={props.onClick} className={styles['toggle-check-input']} />
+      <input
+        type='checkbox'
+        checked={props.checked}
+        onClick={props.onClick}
+        className={styles['toggle-check-input']}
+      />
       <span className={styles['toggle-check-text']} />
     </ToggleLabel>
   )

--- a/src/browser/modules/Stream/SchemaFrame.jsx
+++ b/src/browser/modules/Stream/SchemaFrame.jsx
@@ -33,15 +33,17 @@ export class SchemaFrame extends Component {
     }
   }
   responseHandler (name) {
-    return (res) => {
+    return res => {
       if (!res.success || !res.result || !res.result.records.length) {
         this.setState({ [name]: [] })
         return
       }
-      const out = res.result.records.map((rec) => rec.keys.reduce((acc, key) => {
-        acc[key] = rec.get(key)
-        return acc
-      }, {}))
+      const out = res.result.records.map(rec =>
+        rec.keys.reduce((acc, key) => {
+          acc[key] = rec.get(key)
+          return acc
+        }, {})
+      )
       this.setState({ [name]: out })
     }
   }
@@ -70,10 +72,17 @@ export class SchemaFrame extends Component {
     let indexString
     let constraintsString
 
-    if (indexes.length === 0) { indexString = 'No indexes' } else {
+    if (indexes.length === 0) {
+      indexString = 'No indexes'
+    } else {
       indexString = 'Indexes'
       indexString += indexes.reduce((acc, index) => {
-        acc += `\n  ${index.description.replace('INDEX', '')} ${index.state.toUpperCase()} ${index.type === 'node_unique_property' ? ' (for uniqueness constraint)' : ''}`
+        acc += `\n  ${index.description.replace(
+          'INDEX',
+          ''
+        )} ${index.state.toUpperCase()} ${index.type === 'node_unique_property'
+          ? ' (for uniqueness constraint)'
+          : ''}`
         return acc
       }, '')
     }
@@ -92,14 +101,16 @@ export class SchemaFrame extends Component {
   }
 
   render () {
-    const contents = <StyledSchemaBody>{this.formatIndexAndConstraints(this.state.indexes, this.state.constraints)}</StyledSchemaBody>
-
-    return (
-      <FrameTemplate
-        header={this.props.frame}
-        contents={contents}
-      />
+    const contents = (
+      <StyledSchemaBody>
+        {this.formatIndexAndConstraints(
+          this.state.indexes,
+          this.state.constraints
+        )}
+      </StyledSchemaBody>
     )
+
+    return <FrameTemplate header={this.props.frame} contents={contents} />
   }
 }
 export default withBus(SchemaFrame)

--- a/src/browser/modules/Stream/Stream.jsx
+++ b/src/browser/modules/Stream/Stream.jsx
@@ -40,12 +40,20 @@ import ChangePasswordFrame from './Auth/ChangePasswordFrame'
 import QueriesFrame from './Queries/QueriesFrame'
 import UserList from '../User/UserList'
 import UserAdd from '../User/UserAdd'
-import { getFrames, setRecentView, getRecentView } from 'shared/modules/stream/streamDuck'
+import {
+  getFrames,
+  setRecentView,
+  getRecentView
+} from 'shared/modules/stream/streamDuck'
 import { getRequests } from 'shared/modules/requests/requestsDuck'
 import { getActiveConnectionData } from 'shared/modules/connections/connectionsDuck'
-import { getMaxRows, getInitialNodeDisplay, getScrollToTop } from 'shared/modules/settings/settingsDuck'
+import {
+  getMaxRows,
+  getInitialNodeDisplay,
+  getScrollToTop
+} from 'shared/modules/settings/settingsDuck'
 
-const getFrame = (type) => {
+const getFrame = type => {
   const trans = {
     error: ErrorFrame,
     cypher: CypherFrame,
@@ -74,7 +82,8 @@ class Stream extends Component {
   shouldComponentUpdate (nextProps, nextState) {
     const frameHasBeenAdded = this.props.frames.length < nextProps.frames.length
 
-    if (this.props.activeConnectionData === nextProps.activeConnectionData &&
+    if (
+      this.props.activeConnectionData === nextProps.activeConnectionData &&
       this.props.requests === nextProps.requests &&
       (this.props.children.length === nextProps.children.length &&
         this.props.children.every((child, idx) => {
@@ -97,13 +106,13 @@ class Stream extends Component {
   render () {
     return (
       <StyledStream>
-        {this.props.frames.map((frame) => {
+        {this.props.frames.map(frame => {
           const frameProps = {
             frame,
             activeConnectionData: this.props.activeConnectionData,
             request: this.props.requests[frame.requestId],
             recentView: this.props.recentView,
-            onRecentViewChanged: (view) => {
+            onRecentViewChanged: view => {
               this.props.onRecentViewChanged(view)
             },
             maxRows: this.props.maxRows,
@@ -117,7 +126,7 @@ class Stream extends Component {
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     frames: getFrames(state),
     requests: getRequests(state),
@@ -131,7 +140,7 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    onRecentViewChanged: (view) => {
+    onRecentViewChanged: view => {
       dispatch(setRecentView(view))
     }
   }

--- a/src/browser/modules/Stream/Stream.test.jsx
+++ b/src/browser/modules/Stream/Stream.test.jsx
@@ -25,7 +25,10 @@ import { Stream as StreamComponent } from './Stream'
 
 describe('Stream', () => {
   test('should render a stream of frames', () => {
-    const frames = [{id: 1, cmd: ':first', type: 'x'}, {id: 2, cmd: ':second', type: 'x'}]
+    const frames = [
+      { id: 1, cmd: ':first', type: 'x' },
+      { id: 2, cmd: ':second', type: 'x' }
+    ]
     const wrapper = shallow(<StreamComponent frames={frames} />)
     expect(wrapper.find('Frame').length).toBe(frames.length)
   })

--- a/src/browser/modules/Stream/Views/AsciiView.jsx
+++ b/src/browser/modules/Stream/Views/AsciiView.jsx
@@ -21,12 +21,21 @@
 import { Component } from 'preact'
 import asciitable from 'ascii-data-table'
 import { debounce } from 'services/utils'
-import { StyledStatsBar, PaddedDiv, StyledBodyMessage, StyledRightPartial, StyledWidthSliderContainer, StyledWidthSlider } from '../styled'
+import {
+  StyledStatsBar,
+  PaddedDiv,
+  StyledBodyMessage,
+  StyledRightPartial,
+  StyledWidthSliderContainer,
+  StyledWidthSlider
+} from '../styled'
 
-const AsciiView = ({rows, style, message, maxColWidth = 70}) => {
+const AsciiView = ({ rows, style, message, maxColWidth = 70 }) => {
   let contents = <StyledBodyMessage>{message}</StyledBodyMessage>
   if (rows !== undefined && rows.length) {
-    contents = <pre>{asciitable.tableFromSerializedData(rows, maxColWidth)}</pre>
+    contents = (
+      <pre>{asciitable.tableFromSerializedData(rows, maxColWidth)}</pre>
+    )
   }
   return <PaddedDiv style={style}>{contents}</PaddedDiv>
 }
@@ -48,7 +57,11 @@ export class AsciiStatusbar extends Component {
     }
   }
   componentWillMount () {
-    this.debouncedMaxColWidthChanged = debounce(this.maxColWidthChanged, 25, this)
+    this.debouncedMaxColWidthChanged = debounce(
+      this.maxColWidthChanged,
+      25,
+      this
+    )
     this.setMaxSliderWidth(asciitable.maxColumnWidth(this.props.rows))
   }
   maxColWidthChanged (w) {

--- a/src/browser/modules/Stream/Views/CodeView.jsx
+++ b/src/browser/modules/Stream/Views/CodeView.jsx
@@ -18,9 +18,16 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { PaddedDiv, StyledTable, StyledTBody, StyledAlteringTr, StyledStrongTd, StyledTd } from '../styled'
+import {
+  PaddedDiv,
+  StyledTable,
+  StyledTBody,
+  StyledAlteringTr,
+  StyledStrongTd,
+  StyledTd
+} from '../styled'
 
-const CodeView = ({request, query, style: displayStyle}) => {
+const CodeView = ({ request, query, style: displayStyle }) => {
   if (request.status !== 'success') return null
   return (
     <PaddedDiv style={displayStyle}>

--- a/src/browser/modules/Stream/Views/ErrorsView.jsx
+++ b/src/browser/modules/Stream/Views/ErrorsView.jsx
@@ -36,7 +36,7 @@ import {
   StyledHelpFrame
 } from '../styled'
 
-const ErrorsView = ({error, style, bus}) => {
+const ErrorsView = ({ error, style, bus }) => {
   if (!error) {
     return null
   }
@@ -52,14 +52,17 @@ const ErrorsView = ({error, style, bus}) => {
         </StyledDiv>
         <Render if={isUnknownProcedureError(error)}>
           <StyledLinkContainer>
-            <StyledLink onClick={() => onItemClick(bus)}><PlayIcon />&nbsp;List available procedures</StyledLink>
+            <StyledLink onClick={() => onItemClick(bus)}>
+              <PlayIcon />&nbsp;List available procedures
+            </StyledLink>
           </StyledLinkContainer>
         </Render>
       </StyledHelpContent>
-    </StyledHelpFrame>)
+    </StyledHelpFrame>
+  )
 }
 
-const onItemClick = (bus) => {
+const onItemClick = bus => {
   const action = executeCommand(listAvailableProcedures)
   bus.send(action.type, action)
 }

--- a/src/browser/modules/Stream/Views/TableView.jsx
+++ b/src/browser/modules/Stream/Views/TableView.jsx
@@ -21,7 +21,13 @@
 import { Component } from 'preact'
 import { v4 } from 'uuid'
 import { PaddedTableViewDiv, StyledBodyMessage } from '../styled'
-import {StyledTable, StyledBodyTr, StyledTh, StyledTd, StyledJsonPre} from 'browser-components/DataTables'
+import {
+  StyledTable,
+  StyledBodyTr,
+  StyledTh,
+  StyledTd,
+  StyledJsonPre
+} from 'browser-components/DataTables'
 
 class TableView extends Component {
   constructor (props) {
@@ -35,7 +41,11 @@ class TableView extends Component {
   }
   renderCell (entry) {
     if (Array.isArray(entry)) {
-      const children = entry.map((item, index) => <span>{this.renderCell(item)}{index === entry.length - 1 ? null : ', '}</span>)
+      const children = entry.map((item, index) =>
+        <span>
+          {this.renderCell(item)}{index === entry.length - 1 ? null : ', '}
+        </span>
+      )
       return <span>[{children}]</span>
     } else if (typeof entry === 'object') {
       return this.renderObject(entry)
@@ -51,19 +61,31 @@ class TableView extends Component {
     }
   }
   render () {
-    if (!this.props.data) return (<PaddedTableViewDiv style={this.props.style}><StyledBodyMessage>{this.props.message}</StyledBodyMessage></PaddedTableViewDiv>)
-    const tableHeader = this.state.columns.map((column, i) => (
-      <StyledTh className='table-header' key={i}>{column}</StyledTh>)
+    if (!this.props.data) {
+      return (
+        <PaddedTableViewDiv style={this.props.style}>
+          <StyledBodyMessage>{this.props.message}</StyledBodyMessage>
+        </PaddedTableViewDiv>
+      )
+    }
+    const tableHeader = this.state.columns.map((column, i) =>
+      <StyledTh className='table-header' key={i}>{column}</StyledTh>
     )
-    const buildData = (entries) => {
-      return entries.map((entry) => {
+    const buildData = entries => {
+      return entries.map(entry => {
         if (entry !== null) {
-          return <StyledTd className='table-properties' key={v4()}>{this.renderCell(entry)}</StyledTd>
+          return (
+            <StyledTd className='table-properties' key={v4()}>
+              {this.renderCell(entry)}
+            </StyledTd>
+          )
         }
-        return <StyledTd className='table-properties' key={v4()}>(empty)</StyledTd>
+        return (
+          <StyledTd className='table-properties' key={v4()}>(empty)</StyledTd>
+        )
       })
     }
-    const buildRow = (item) => {
+    const buildRow = item => {
       return (
         <StyledBodyTr className='table-row' key={v4()}>
           {buildData(item)}
@@ -72,11 +94,7 @@ class TableView extends Component {
     }
     const tableBody = (
       <tbody>
-        {
-          this.state.data.map((item) => (
-            buildRow(item)
-          ))
-        }
+        {this.state.data.map(item => buildRow(item))}
       </tbody>
     )
     return (

--- a/src/browser/modules/Stream/Views/TableView.test.jsx
+++ b/src/browser/modules/Stream/Views/TableView.test.jsx
@@ -23,57 +23,47 @@ import React from 'react'
 import { shallow } from 'enzyme'
 import TableView from './TableView'
 
-const testData =
+const testData = [
+  ['a', 'n'],
   [
-    [
-      'a',
-      'n'
-    ],
-    [
-      {
-        'identity': '7',
-        'start': '8',
-        'end': '0',
-        'type': 'ACTED_IN',
-        'properties': {
-          'roles': [
-            'Emil'
-          ]
-        }
-      },
-      {
-        'identity': '0',
-        'labels': [
-          'Movie'
-        ],
-        'properties': {
-          'tagline': 'Welcome to the Real World',
-          'title': 'The Matrix',
-          'released': '1999'
-        }
+    {
+      identity: '7',
+      start: '8',
+      end: '0',
+      type: 'ACTED_IN',
+      properties: {
+        roles: ['Emil']
       }
-    ],
-    [
-      {
-        'identity': '6',
-        'start': '7',
-        'end': '0',
-        'type': 'PRODUCED',
-        'properties': {}
-      },
-      {
-        'identity': '0',
-        'labels': [
-          'Movie'
-        ],
-        'properties': {
-          'tagline': 'Welcome to the Real World',
-          'title': 'The Matrix',
-          'released': '1999'
-        }
+    },
+    {
+      identity: '0',
+      labels: ['Movie'],
+      properties: {
+        tagline: 'Welcome to the Real World',
+        title: 'The Matrix',
+        released: '1999'
       }
-    ]
+    }
+  ],
+  [
+    {
+      identity: '6',
+      start: '7',
+      end: '0',
+      type: 'PRODUCED',
+      properties: {}
+    },
+    {
+      identity: '0',
+      labels: ['Movie'],
+      properties: {
+        tagline: 'Welcome to the Real World',
+        title: 'The Matrix',
+        released: '1999'
+      }
+    }
   ]
+]
 
 describe('TableView', () => {
   test('should render headings', () => {
@@ -87,20 +77,24 @@ describe('TableView', () => {
   })
   test('should render properties', () => {
     const wrapper = shallow(<TableView data={testData} />)
-    expect(wrapper.find('.table-properties').first().text()).toBe(JSON.stringify({
-      'roles': [
-        'Emil'
-      ]
-    }))
-    expect(wrapper.find('.table-properties').at(1).text()).toBe(JSON.stringify({
-      'tagline': 'Welcome to the Real World',
-      'title': 'The Matrix',
-      'released': '1999'
-    }))
+    expect(wrapper.find('.table-properties').first().text()).toBe(
+      JSON.stringify({
+        roles: ['Emil']
+      })
+    )
+    expect(wrapper.find('.table-properties').at(1).text()).toBe(
+      JSON.stringify({
+        tagline: 'Welcome to the Real World',
+        title: 'The Matrix',
+        released: '1999'
+      })
+    )
   })
   test('should render when properties are projected', () => {
     const newTestData = [['a'], ['testData']]
     const wrapper = shallow(<TableView data={newTestData} />)
-    expect(wrapper.find('.table-properties').text()).toBe(JSON.stringify('testData'))
+    expect(wrapper.find('.table-properties').text()).toBe(
+      JSON.stringify('testData')
+    )
   })
 })

--- a/src/browser/modules/Stream/Views/WarningsView.jsx
+++ b/src/browser/modules/Stream/Views/WarningsView.jsx
@@ -18,20 +18,30 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { StyledCypherMessage, StyledCypherWarningMessage, StyledCypherErrorMessage, StyledHelpContent,
-  StyledH4, StyledPreformattedArea, StyledHelpDescription, StyledDiv, StyledBr, StyledHelpFrame} from '../styled'
+import {
+  StyledCypherMessage,
+  StyledCypherWarningMessage,
+  StyledCypherErrorMessage,
+  StyledHelpContent,
+  StyledH4,
+  StyledPreformattedArea,
+  StyledHelpDescription,
+  StyledDiv,
+  StyledBr,
+  StyledHelpFrame
+} from '../styled'
 
-const getWarningComponent = (severity) => {
+const getWarningComponent = severity => {
   if (severity === 'ERROR') {
-    return (<StyledCypherErrorMessage>{severity}</StyledCypherErrorMessage>)
+    return <StyledCypherErrorMessage>{severity}</StyledCypherErrorMessage>
   } else if (severity === 'WARNING') {
-    return (<StyledCypherWarningMessage>{severity}</StyledCypherWarningMessage>)
+    return <StyledCypherWarningMessage>{severity}</StyledCypherWarningMessage>
   } else {
-    return (<StyledCypherMessage>{severity}</StyledCypherMessage>)
+    return <StyledCypherMessage>{severity}</StyledCypherMessage>
   }
 }
 
-const WarningsView = ({notifications, cypher, style}) => {
+const WarningsView = ({ notifications, cypher, style }) => {
   if (!notifications || !cypher) {
     return null
   }
@@ -39,7 +49,7 @@ const WarningsView = ({notifications, cypher, style}) => {
   let cypherLines = cypher.split('\n')
   cypherLines[0] = cypherLines[0].replace(/^EXPLAIN /, '')
 
-  let notificationsList = notifications.map((notification) => {
+  let notificationsList = notifications.map(notification => {
     return (
       <StyledHelpContent>
         <StyledHelpDescription>
@@ -47,9 +57,12 @@ const WarningsView = ({notifications, cypher, style}) => {
           <StyledH4>{notification.title}</StyledH4>
         </StyledHelpDescription>
         <StyledDiv>
-          <StyledHelpDescription>{notification.description}</StyledHelpDescription>
+          <StyledHelpDescription>
+            {notification.description}
+          </StyledHelpDescription>
           <StyledDiv>
-            <StyledPreformattedArea>{cypherLines[notification.position.line - 1]}
+            <StyledPreformattedArea>
+              {cypherLines[notification.position.line - 1]}
               <StyledBr />{Array(notification.position.column).join(' ')}^
             </StyledPreformattedArea>
           </StyledDiv>
@@ -60,7 +73,8 @@ const WarningsView = ({notifications, cypher, style}) => {
   return (
     <StyledHelpFrame style={style}>
       {notificationsList}
-    </StyledHelpFrame>)
+    </StyledHelpFrame>
+  )
 }
 
 export default WarningsView

--- a/src/browser/modules/Stream/Visualization.jsx
+++ b/src/browser/modules/Stream/Visualization.jsx
@@ -25,7 +25,11 @@ import bolt from 'services/bolt/bolt'
 import { withBus } from 'preact-suber'
 import { ExplorerComponent } from '../D3Visualization/components/Explorer'
 import { StyledVisContainer } from './styled'
-import { getMaxNeighbours, getSettings, shouldAutoComplete } from 'shared/modules/settings/settingsDuck'
+import {
+  getMaxNeighbours,
+  getSettings,
+  shouldAutoComplete
+} from 'shared/modules/settings/settingsDuck'
 
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
 
@@ -49,9 +53,11 @@ export class Visualization extends Component {
   }
 
   shouldComponentUpdate (nextProps) {
-    return nextProps.style !== this.props.style ||
+    return (
+      nextProps.style !== this.props.style ||
       nextProps.records !== this.props.records ||
       nextProps.graphStyleData !== this.props.graphStyleData
+    )
   }
 
   componentWillReceiveProps (nextProps) {
@@ -60,16 +66,25 @@ export class Visualization extends Component {
     }
 
     if (nextProps.style.display !== this.props.style.display) {
-      this.setState({justInitiated: false})
+      this.setState({ justInitiated: false })
     }
   }
 
   populateDataToStateFromProps (props) {
-    this.setState({ nodesAndRelationships: bolt.extractNodesAndRelationshipsFromRecordsForOldVis(props.records) })
+    this.setState({
+      nodesAndRelationships: bolt.extractNodesAndRelationshipsFromRecordsForOldVis(
+        props.records
+      )
+    })
   }
 
   mergeToList (list1, list2) {
-    return list1.concat(list2.filter(itemInList2 => list1.findIndex(itemInList1 => itemInList1.id === itemInList2.id) < 0))
+    return list1.concat(
+      list2.filter(
+        itemInList2 =>
+          list1.findIndex(itemInList1 => itemInList1.id === itemInList2.id) < 0
+      )
+    )
   }
 
   autoCompleteRelationships (existingNodes, newNodes) {
@@ -78,10 +93,11 @@ export class Visualization extends Component {
       const newNodeIds = newNodes.map(node => parseInt(node.id))
 
       this.getInternalRelationships(existingNodeIds, newNodeIds)
-        .then((graph) => {
-          this.autoCompleteCallback && this.autoCompleteCallback(graph.relationships)
+        .then(graph => {
+          this.autoCompleteCallback &&
+            this.autoCompleteCallback(graph.relationships)
         })
-        .catch((e) => {})
+        .catch(e => {})
     }
   }
 
@@ -91,22 +107,24 @@ export class Visualization extends Component {
                    AND NOT (id(o) IN[${currentNeighbourIds.join(',')}])
                    RETURN path, size((a)--()) as c
                    ORDER BY id(o)
-                   LIMIT ${this.props.maxNeighbours - currentNeighbourIds.length}`
+                   LIMIT ${this.props.maxNeighbours -
+                     currentNeighbourIds.length}`
     return new Promise((resolve, reject) => {
-      this.props.bus.self(
-        CYPHER_REQUEST,
-        {query: query},
-        (response) => {
-          if (!response.success) {
-            reject(new Error('Non successful response'))
-          } else {
-            let count = response.result.records.length > 0 ? parseInt(response.result.records[0].get('c').toString()) : 0
-            const resultGraph = bolt.extractNodesAndRelationshipsFromRecordsForOldVis(response.result.records, false)
-            this.autoCompleteRelationships(this.graph._nodes, resultGraph.nodes)
-            resolve({...resultGraph, count: count})
-          }
+      this.props.bus.self(CYPHER_REQUEST, { query: query }, response => {
+        if (!response.success) {
+          reject(new Error('Non successful response'))
+        } else {
+          let count = response.result.records.length > 0
+            ? parseInt(response.result.records[0].get('c').toString())
+            : 0
+          const resultGraph = bolt.extractNodesAndRelationshipsFromRecordsForOldVis(
+            response.result.records,
+            false
+          )
+          this.autoCompleteRelationships(this.graph._nodes, resultGraph.nodes)
+          resolve({ ...resultGraph, count: count })
         }
-      )
+      })
     })
   }
 
@@ -114,16 +132,22 @@ export class Visualization extends Component {
     newNodeIds = newNodeIds.map(bolt.neo4j.int)
     existingNodeIds = existingNodeIds.map(bolt.neo4j.int)
     existingNodeIds = existingNodeIds.concat(newNodeIds)
-    const query = 'MATCH (a)-[r]->(b) WHERE id(a) IN $existingNodeIds AND id(b) IN $newNodeIds RETURN r;'
+    const query =
+      'MATCH (a)-[r]->(b) WHERE id(a) IN $existingNodeIds AND id(b) IN $newNodeIds RETURN r;'
     return new Promise((resolve, reject) => {
       this.props.bus.self(
         CYPHER_REQUEST,
-        {query, params: {existingNodeIds, newNodeIds}},
-        (response) => {
+        { query, params: { existingNodeIds, newNodeIds } },
+        response => {
           if (!response.success) {
             reject(new Error('Non successful response'))
           } else {
-            resolve({...bolt.extractNodesAndRelationshipsFromRecordsForOldVis(response.result.records, false)})
+            resolve({
+              ...bolt.extractNodesAndRelationshipsFromRecordsForOldVis(
+                response.result.records,
+                false
+              )
+            })
           }
         }
       )
@@ -142,7 +166,10 @@ export class Visualization extends Component {
     }
 
     return (
-      <StyledVisContainer fullscreen={this.props.fullscreen} style={this.props.style} >
+      <StyledVisContainer
+        fullscreen={this.props.fullscreen}
+        style={this.props.style}
+      >
         <ExplorerComponent
           maxNeighbours={this.props.maxNeighbours}
           initialNodeDisplay={this.props.initialNodeDisplay}
@@ -154,7 +181,9 @@ export class Visualization extends Component {
           fullscreen={this.props.fullscreen}
           frameHeight={this.props.frameHeight}
           assignVisElement={this.props.assignVisElement}
-          getAutoCompleteCallback={(callback) => { this.autoCompleteCallback = callback }}
+          getAutoCompleteCallback={callback => {
+            this.autoCompleteCallback = callback
+          }}
           setGraph={this.setGraph.bind(this)}
         />
       </StyledVisContainer>
@@ -162,7 +191,7 @@ export class Visualization extends Component {
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     graphStyleData: grassActions.getGraphStyleData(state),
     initialNodeDisplay: getSettings(state).initialNodeDisplay,
@@ -171,12 +200,14 @@ const mapStateToProps = (state) => {
   }
 }
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
-    updateStyle: (graphStyleData) => {
+    updateStyle: graphStyleData => {
       dispatch(grassActions.updateGraphStyleData(graphStyleData))
     }
   }
 }
 
-export default withBus(connect(mapStateToProps, mapDispatchToProps)(Visualization))
+export default withBus(
+  connect(mapStateToProps, mapDispatchToProps)(Visualization)
+)

--- a/src/browser/modules/Stream/styled.jsx
+++ b/src/browser/modules/Stream/styled.jsx
@@ -52,25 +52,33 @@ export const StyledFrame = styled.article`
   box-shadow: 0 1px 4px rgba(0,0,0,.1);
   animation: ${rollDownAnimation} .2s linear;
   border: ${props => props.theme.frameBorder};
-  margin: ${props => props.fullscreen ? '0' : '10px 0px 10px 0px'};
-  ${props => props.fullscreen ? 'position: fixed' : null};
-  ${props => props.fullscreen ? 'left: 0' : null};
-  ${props => props.fullscreen ? 'top: 0' : null};
-  ${props => props.fullscreen ? 'bottom: 0' : null};
-  ${props => props.fullscreen ? 'right: 0' : null};
-  ${props => props.fullscreen ? 'z-index: 1030' : null};
+  margin: ${props => (props.fullscreen ? '0' : '10px 0px 10px 0px')};
+  ${props => (props.fullscreen ? 'position: fixed' : null)};
+  ${props => (props.fullscreen ? 'left: 0' : null)};
+  ${props => (props.fullscreen ? 'top: 0' : null)};
+  ${props => (props.fullscreen ? 'bottom: 0' : null)};
+  ${props => (props.fullscreen ? 'right: 0' : null)};
+  ${props => (props.fullscreen ? 'z-index: 1030' : null)};
 `
 
 export const StyledVisContainer = styled.div`
   width: 100%;
-  height: ${props => (props.fullscreen ? '100vh' : (dim.frameBodyHeight - (dim.frameTitlebarHeight * 2)) + 'px')};
+  height: ${props =>
+    props.fullscreen
+      ? '100vh'
+      : dim.frameBodyHeight - dim.frameTitlebarHeight * 2 + 'px'};
   display : ${props => props.style.display};
 `
 
 export const StyledFrameBody = styled.div`
   min-height: ${dim.frameBodyHeight / 2}px;
-  max-height: ${props => props.collapsed ? 0 : (props.fullscreen ? '100%' : (dim.frameBodyHeight - dim.frameStatusbarHeight) + 1 + 'px')};
-  display: ${props => props.collapsed ? 'none' : 'flex'};
+  max-height: ${props =>
+    props.collapsed
+      ? 0
+      : props.fullscreen
+        ? '100%'
+        : dim.frameBodyHeight - dim.frameStatusbarHeight + 1 + 'px'};
+  display: ${props => (props.collapsed ? 'none' : 'flex')};
   flex-direction: row;
 `
 
@@ -83,13 +91,17 @@ export const StyledFrameMainSection = styled.div`
 export const StyledFrameContents = styled.div`
   overflow: auto;
   min-height: ${dim.frameBodyHeight / 2}px;
-  max-height: ${props => (props.fullscreen ? '100vh' : (dim.frameBodyHeight - (dim.frameStatusbarHeight * 2)) + 'px')};
-  ${props => props.fullscreen ? 'height: 100vh' : null};
+  max-height: ${props =>
+    props.fullscreen
+      ? '100vh'
+      : dim.frameBodyHeight - dim.frameStatusbarHeight * 2 + 'px'};
+  ${props => (props.fullscreen ? 'height: 100vh' : null)};
 `
 
 export const PaddedDiv = styled.div`
   padding: 0 20px 20px 20px;
-  padding-bottom: ${props => (props.fullscreen ? (dim.frameTitlebarHeight + 20) + 'px' : '20px')};
+  padding-bottom: ${props =>
+    props.fullscreen ? dim.frameTitlebarHeight + 20 + 'px' : '20px'};
 `
 
 export const PaddedTableViewDiv = styled(PaddedDiv)`
@@ -111,7 +123,7 @@ export const StyledFrameSidebar = styled.ul`
 export const StyledFrameStatusbar = styled.div`
   border-top: ${props => props.theme.inFrameBorder};
   height: ${dim.frameStatusbarHeight + 1}px;
-  ${props => props.fullscreen ? 'margin-top: -78px;' : ''};
+  ${props => (props.fullscreen ? 'margin-top: -78px;' : '')};
   display: flex;
   flex-direction: row;
 `

--- a/src/browser/modules/Sync/BrowserSync.jsx
+++ b/src/browser/modules/Sync/BrowserSync.jsx
@@ -23,14 +23,34 @@ import { connect } from 'preact-redux'
 import { withBus } from 'preact-suber'
 import TimeAgo from 'react-timeago'
 
-import { setSync, clearSync, clearSyncAndLocal, consentSync, authorizedAs } from 'shared/modules/sync/syncDuck'
+import {
+  setSync,
+  clearSync,
+  clearSyncAndLocal,
+  consentSync,
+  authorizedAs
+} from 'shared/modules/sync/syncDuck'
 import { signOut } from 'services/browserSyncService'
 import { setContent as setEditorContent } from 'shared/modules/editor/editorDuck'
 import { getBrowserSyncConfig } from 'shared/modules/settings/settingsDuck'
-import {Drawer, DrawerBody, DrawerHeader, DrawerSection, DrawerSubHeader, DrawerSectionBody, DrawerToppedHeader} from 'browser-components/drawer'
+import {
+  Drawer,
+  DrawerBody,
+  DrawerHeader,
+  DrawerSection,
+  DrawerSubHeader,
+  DrawerSectionBody,
+  DrawerToppedHeader
+} from 'browser-components/drawer'
 import { FormButton, SyncSignInButton } from 'browser-components/buttons'
 import { BinIcon } from 'browser-components/icons/Icons'
-import {ConsentCheckBox, AlertBox, ClearLocalConfirmationBox, StyledSyncLink, SmallHeaderText} from './styled'
+import {
+  ConsentCheckBox,
+  AlertBox,
+  ClearLocalConfirmationBox,
+  StyledSyncLink,
+  SmallHeaderText
+} from './styled'
 import BrowserSyncAuthWindow from './BrowserSyncAuthWindow'
 import SyncSignInManager from 'shared/modules/sync/SyncSignInManager'
 
@@ -52,38 +72,58 @@ export class BrowserSync extends Component {
   componentWillMount () {
     this.syncManager = new SyncSignInManager({
       dbConfig: this.props.browserSyncConfig.firebaseConfig,
-      serviceReadyCallback: (status) => this.setState({status}),
+      serviceReadyCallback: status => this.setState({ status }),
       onSyncCallback: this.props.onSync
     })
   }
   logIn () {
     if (this.state.userConsented === true) {
       const { onSignIn } = this.props
-      const signInCallback = (data) => onSignIn(data.profile)
-      BrowserSyncAuthWindow(this.props.browserSyncConfig.authWindowUrl, (data, error) => {
-        this.syncManager.authCallBack.bind(this.syncManager)(data, error, signInCallback)
-      })
+      const signInCallback = data => onSignIn(data.profile)
+      BrowserSyncAuthWindow(
+        this.props.browserSyncConfig.authWindowUrl,
+        (data, error) => {
+          this.syncManager.authCallBack.bind(this.syncManager)(
+            data,
+            error,
+            signInCallback
+          )
+        }
+      )
     } else {
-      this.setState({showConsentAlert: true})
+      this.setState({ showConsentAlert: true })
     }
   }
   signOutAndClearLocalStorage () {
     if (this.state.clearLocalRequested) {
-      this.setState({clearLocalRequested: false, authData: null, serviceAuthenticated: false, userConsented: false})
+      this.setState({
+        clearLocalRequested: false,
+        authData: null,
+        serviceAuthenticated: false,
+        userConsented: false
+      })
       this.props.onSignOutAndClear()
     } else {
-      this.setState({clearLocalRequested: true})
+      this.setState({ clearLocalRequested: true })
     }
   }
   signOutFromSync () {
-    this.setState({authData: null, serviceAuthenticated: false})
+    this.setState({ authData: null, serviceAuthenticated: false })
     this.props.onSignOut()
   }
   render () {
     if (this.state.status === 'PENDING') {
-      return <Drawer id='sync-drawer'><DrawerHeader>Connecting sync service... </DrawerHeader></Drawer>
+      return (
+        <Drawer id='sync-drawer'>
+          <DrawerHeader>Connecting sync service... </DrawerHeader>
+        </Drawer>
+      )
     } else if (this.state.status === 'DOWN') {
-      return <Drawer id='sync-drawer'><DrawerHeader>Sync service is down</DrawerHeader></Drawer>
+      return (
+        <Drawer id='sync-drawer'>
+          <DrawerHeader>Sync service is down</DrawerHeader>
+        </Drawer>
+      )
     }
 
     let offlineContent = null
@@ -95,26 +135,41 @@ export class BrowserSync extends Component {
     const serviceAuthenticated = this.props.authData !== null
 
     if (serviceAuthenticated) {
-      headerContent =
+      headerContent = (
         <DrawerToppedHeader>
           {this.props.authData.profile.name}<br />
           <SmallHeaderText>Connected</SmallHeaderText><br />
           <SmallHeaderText>
-            Synced <TimeAgo date={new Date(this.props.lastSyncedAt)} minPeriod='5' />
+            Synced{' '}
+            <TimeAgo date={new Date(this.props.lastSyncedAt)} minPeriod='5' />
           </SmallHeaderText>
         </DrawerToppedHeader>
+      )
     } else {
       headerContent = <DrawerHeader>Neo4j Browser Sync</DrawerHeader>
     }
 
     if (this.state.clearLocalRequested === true) {
-      clearLocalDataContent = <ClearLocalConfirmationBox onClick={() => { this.setState({clearLocalRequested: false}) }} />
+      clearLocalDataContent = (
+        <ClearLocalConfirmationBox
+          onClick={() => {
+            this.setState({ clearLocalRequested: false })
+          }}
+        />
+      )
     } else {
-      clearLocalDataContent = 'This will reset your local storage, clearing favorite scripts, grass, command history and settings.'
+      clearLocalDataContent =
+        'This will reset your local storage, clearing favorite scripts, grass, command history and settings.'
     }
 
     if (this.state.showConsentAlert) {
-      consentAlertContent = <AlertBox onClick={() => { this.setState({showConsentAlert: false}) }} />
+      consentAlertContent = (
+        <AlertBox
+          onClick={() => {
+            this.setState({ showConsentAlert: false })
+          }}
+        />
+      )
     }
 
     if (serviceAuthenticated === true) {
@@ -124,11 +179,22 @@ export class BrowserSync extends Component {
             <DrawerSubHeader>Manage local data</DrawerSubHeader>
             <DrawerSectionBody>
               <DrawerSection>{clearLocalDataContent}</DrawerSection>
-              <FormButton label={this.state.clearLocalRequested ? 'Sign out + clear' : 'Clear local data'} onClick={() => this.signOutAndClearLocalStorage()}
-                icon={<BinIcon suppressIconStyles='true' />} buttonType='drawer' />
+              <FormButton
+                label={
+                  this.state.clearLocalRequested
+                    ? 'Sign out + clear'
+                    : 'Clear local data'
+                }
+                onClick={() => this.signOutAndClearLocalStorage()}
+                icon={<BinIcon suppressIconStyles='true' />}
+                buttonType='drawer'
+              />
               <p>&nbsp;</p>
-              <FormButton label='Sign Out' onClick={() => this.signOutFromSync()}
-                buttonType='drawer' />
+              <FormButton
+                label='Sign Out'
+                onClick={() => this.signOutFromSync()}
+                buttonType='drawer'
+              />
             </DrawerSectionBody>
           </DrawerSection>
         </DrawerBody>
@@ -140,21 +206,31 @@ export class BrowserSync extends Component {
             <DrawerSubHeader>Sign In or Register</DrawerSubHeader>
             <DrawerSectionBody>
               <DrawerSection>
-                Neo4j Browser Sync is a companion cloud service for Neo4j Browser. Connect through a simple social
-                sign-in to get started. <StyledSyncLink onClick={() => this.props.onSyncHelpClick()}>About Neo4j Browser Sync</StyledSyncLink>
+                Neo4j Browser Sync is a companion cloud service for Neo4j
+                Browser. Connect through a simple social
+                sign-in to get started.{' '}
+                <StyledSyncLink onClick={() => this.props.onSyncHelpClick()}>
+                  About Neo4j Browser Sync
+                </StyledSyncLink>
               </DrawerSection>
               <DrawerSection>
-                <ConsentCheckBox checked={this.state.userConsented === true} onChange={(e) => {
-                  this.setState({
-                    userConsented: e.target.checked,
-                    showConsentAlert: this.state.showConsentAlert && !e.target.checked
-                  })
-                  this.props.onConsentSyncChanged(e.target.checked)
-                }} />
+                <ConsentCheckBox
+                  checked={this.state.userConsented === true}
+                  onChange={e => {
+                    this.setState({
+                      userConsented: e.target.checked,
+                      showConsentAlert:
+                        this.state.showConsentAlert && !e.target.checked
+                    })
+                    this.props.onConsentSyncChanged(e.target.checked)
+                  }}
+                />
                 {consentAlertContent}
               </DrawerSection>
               <DrawerSection>
-                <SyncSignInButton onClick={this.logIn.bind(this)}>Sign In / Register</SyncSignInButton>
+                <SyncSignInButton onClick={this.logIn.bind(this)}>
+                  Sign In / Register
+                </SyncSignInButton>
               </DrawerSection>
             </DrawerSectionBody>
           </DrawerSection>
@@ -162,8 +238,12 @@ export class BrowserSync extends Component {
             <DrawerSubHeader>Manage local data</DrawerSubHeader>
             <DrawerSectionBody>
               <DrawerSection>{clearLocalDataContent}</DrawerSection>
-              <FormButton label='Clear local data' onClick={this.signOutAndClearLocalStorage.bind(this)}
-                icon={<BinIcon suppressIconStyles='true' />} buttonType='drawer' />
+              <FormButton
+                label='Clear local data'
+                onClick={this.signOutAndClearLocalStorage.bind(this)}
+                icon={<BinIcon suppressIconStyles='true' />}
+                buttonType='drawer'
+              />
             </DrawerSectionBody>
           </DrawerSection>
         </DrawerBody>
@@ -180,7 +260,7 @@ export class BrowserSync extends Component {
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     lastSyncedAt: state.sync ? state.sync.lastSyncedAt : null,
     authData: state.sync ? state.sync.authData : null,
@@ -191,14 +271,14 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    onSignIn: (data) => {
+    onSignIn: data => {
       const action = authorizedAs(data)
       ownProps.bus.send(action.type, action)
     },
-    onSync: (syncObject) => {
+    onSync: syncObject => {
       dispatch(setSync(syncObject))
     },
-    onSyncHelpClick: (play) => {
+    onSyncHelpClick: play => {
       const action = setEditorContent(':play neo4j sync')
       ownProps.bus.send(action.type, action)
     },
@@ -212,9 +292,11 @@ const mapDispatchToProps = (dispatch, ownProps) => {
       const action = clearSync()
       ownProps.bus.send(action.type, action)
     },
-    onConsentSyncChanged: (consent) => {
+    onConsentSyncChanged: consent => {
       dispatch(consentSync(consent))
     }
   }
 }
-export default withBus(connect(mapStateToProps, mapDispatchToProps)(BrowserSync))
+export default withBus(
+  connect(mapStateToProps, mapDispatchToProps)(BrowserSync)
+)

--- a/src/browser/modules/Sync/BrowserSyncAuthWindow.jsx
+++ b/src/browser/modules/Sync/BrowserSyncAuthWindow.jsx
@@ -19,7 +19,11 @@
  */
 
 const BrowserSyncAuthWindow = (url, callback) => {
-  const win = window.open(url, 'loginWindow', 'location=0,status=0,scrollbars=0, width=1080,height=720')
+  const win = window.open(
+    url,
+    'loginWindow',
+    'location=0,status=0,scrollbars=0, width=1080,height=720'
+  )
   const pollInterval = setInterval(() => {
     win.postMessage('Polling for results', url)
   }, 6000)
@@ -28,11 +32,15 @@ const BrowserSyncAuthWindow = (url, callback) => {
   } catch (e) {
     callback(null, e)
   }
-  window.addEventListener('message', (event) => {
-    clearInterval(pollInterval)
-    callback(event.data)
-    win.close()
-  }, false)
+  window.addEventListener(
+    'message',
+    event => {
+      clearInterval(pollInterval)
+      callback(event.data)
+      win.close()
+    },
+    false
+  )
 }
 
 export default BrowserSyncAuthWindow

--- a/src/browser/modules/Sync/styled.jsx
+++ b/src/browser/modules/Sync/styled.jsx
@@ -21,36 +21,60 @@
 import styled from 'styled-components'
 import { PlayIcon } from 'browser-components/icons/Icons'
 
-export const ConsentCheckBox = (props) => {
+export const ConsentCheckBox = props => {
   return (
     <StyledP>
       <CheckBoxLabel for='syncConsentCheckbox'>
-        <StyledCheckBox {...props} type='checkbox' id='syncConsentCheckbox' value='first_checkbox' />
+        <StyledCheckBox
+          {...props}
+          type='checkbox'
+          id='syncConsentCheckbox'
+          value='first_checkbox'
+        />
         &nbsp; By checking this box you are agreeing to the &nbsp;
-        <StyledSimpleLink href='http://neo4j.com/terms/neo4j-browser-sync/' target='blank'>Neo4j Browser Sync Terms of Use</StyledSimpleLink>
+        <StyledSimpleLink
+          href='http://neo4j.com/terms/neo4j-browser-sync/'
+          target='blank'
+        >
+          Neo4j Browser Sync Terms of Use
+        </StyledSimpleLink>
         &nbsp; and our &nbsp;
-        <StyledSimpleLink href='http://neo4j.com/privacy-policy/' target='blank'>Privacy Policy</StyledSimpleLink>.
+        <StyledSimpleLink
+          href='http://neo4j.com/privacy-policy/'
+          target='blank'
+        >
+          Privacy Policy
+        </StyledSimpleLink>.
       </CheckBoxLabel>
     </StyledP>
   )
 }
 
-export const AlertBox = (props) => {
+export const AlertBox = props => {
   return (
     <AlertDiv>
       <CloseButton {...props}>×</CloseButton>
-      <span>Before you can sign in, please check the box above to agree to the terms of use and privacy policy.</span>
+      <span>
+        Before you can sign in, please check the box above to agree to the terms
+        of use and privacy policy.
+      </span>
     </AlertDiv>
   )
 }
 
-export const ClearLocalConfirmationBox = (props) => {
+export const ClearLocalConfirmationBox = props => {
   return (
     <div>
-      <AlertP><strong>WARNING</strong>: This WILL erase your data stored in this web browsers local storage</AlertP>
+      <AlertP>
+        <strong>WARNING</strong>: This WILL erase your data stored in this web
+        browsers local storage
+      </AlertP>
       <AlertP>
         What do you want to do?<br />
-        <SmallText>(nothing, <StyledSimpleLink onClick={props.onClick}>cancel</StyledSimpleLink>)</SmallText>
+        <SmallText>
+          (nothing,{' '}
+          <StyledSimpleLink onClick={props.onClick}>cancel</StyledSimpleLink>)
+        </SmallText>
       </AlertP>
     </div>
   )
@@ -97,7 +121,7 @@ const AlertP = styled.p`
   margin: 10px;
 `
 
-export const StyledSyncLink = (props) => {
+export const StyledSyncLink = props => {
   return (
     <StyledSimpleLink onClick={props.onClick}>
       <PlayIcon />&nbsp;{props.children}

--- a/src/browser/modules/User/RolesSelector.jsx
+++ b/src/browser/modules/User/RolesSelector.jsx
@@ -18,10 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const RolesSelector = ({roles = [], onChange = null, selectedValue = undefined}) => {
+const RolesSelector = ({
+  roles = [],
+  onChange = null,
+  selectedValue = undefined
+}) => {
   if (roles.length > 0) {
     const options = roles.map((role, i) => {
-      return (<option key={i} value={role}>{role}</option>)
+      return <option key={i} value={role}>{role}</option>
     })
     return (
       <select
@@ -33,6 +37,8 @@ const RolesSelector = ({roles = [], onChange = null, selectedValue = undefined})
         {options}
       </select>
     )
-  } else { return null }
+  } else {
+    return null
+  }
 }
 export default RolesSelector

--- a/src/browser/modules/User/UserAdd.jsx
+++ b/src/browser/modules/User/UserAdd.jsx
@@ -22,7 +22,11 @@ import { Component } from 'preact'
 import { withBus } from 'preact-suber'
 
 import bolt from 'services/bolt/bolt'
-import { listRolesQuery, createDatabaseUser, addRoleToUser } from 'shared/modules/cypher/boltUserHelper'
+import {
+  listRolesQuery,
+  createDatabaseUser,
+  addRoleToUser
+} from 'shared/modules/cypher/boltUserHelper'
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
 
 import RolesSelector from './RolesSelector'
@@ -32,7 +36,12 @@ import FrameSuccess from '../Stream/FrameSuccess'
 
 import { CloseIcon } from 'browser-components/icons/Icons'
 import { FormButton, StyledLink } from 'browser-components/buttons'
-import {StyledTable, StyledBodyTr, StyledTh, StyledTd} from 'browser-components/DataTables'
+import {
+  StyledTable,
+  StyledBodyTr,
+  StyledTh,
+  StyledTd
+} from 'browser-components/DataTables'
 
 export class UserAdd extends Component {
   constructor (props) {
@@ -64,19 +73,24 @@ export class UserAdd extends Component {
   listRoles () {
     return this.state.roles.map((role, i) => {
       return (
-        <FormButton key={i} label={role} icon={<CloseIcon />} onClick={() => {
-          this.setState({roles: this.removeRole(role)})
-        }} />
+        <FormButton
+          key={i}
+          label={role}
+          icon={<CloseIcon />}
+          onClick={() => {
+            this.setState({ roles: this.removeRole(role) })
+          }}
+        />
       )
     })
   }
   addRoles () {
     let errors = []
-    this.state.roles.forEach((role) => {
+    this.state.roles.forEach(role => {
       this.props.bus.self(
         CYPHER_REQUEST,
-        {query: addRoleToUser(this.state.username, role)},
-        (response) => {
+        { query: addRoleToUser(this.state.username, role) },
+        response => {
           if (!response.success) {
             return errors.add(response.error)
           }
@@ -84,60 +98,77 @@ export class UserAdd extends Component {
       )
     })
     if (errors.length > 0) {
-      return this.setState({errors: errors})
+      return this.setState({ errors: errors })
     }
-    return this.setState({success: `${this.state.username} created`})
+    return this.setState({ success: `${this.state.username} created` })
   }
   getRoles () {
     this.props.bus.self(
       CYPHER_REQUEST,
-      {query: listRolesQuery()},
-      (response) => {
+      { query: listRolesQuery() },
+      response => {
         if (!response.success) {
-          return this.setState({errors: ['Unable to create user', response.error]})
+          return this.setState({
+            errors: ['Unable to create user', response.error]
+          })
         }
-        const flatten = arr => arr.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), [])
-        return this.setState({availableRoles: flatten(this.extractUserNameAndRolesFromBolt(response.result))})
-      })
+        const flatten = arr =>
+          arr.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), [])
+        return this.setState({
+          availableRoles: flatten(
+            this.extractUserNameAndRolesFromBolt(response.result)
+          )
+        })
+      }
+    )
   }
   submit () {
-    this.setState({success: null, errors: null})
+    this.setState({ success: null, errors: null })
     let errors = []
     if (!this.state.username) errors.push('Missing username')
     if (!this.state.password) errors.push('Missing password')
-    if (!(this.state.password === this.state.confirmPassword)) errors.push('Passwords are not the same')
+    if (!(this.state.password === this.state.confirmPassword)) {
+      errors.push('Passwords are not the same')
+    }
     if (errors.length !== 0) {
-      return this.setState({errors: errors})
+      return this.setState({ errors: errors })
     } else {
-      this.setState({errors: null})
+      this.setState({ errors: null })
       return this.createUser()
     }
   }
   createUser () {
     this.props.bus.self(
       CYPHER_REQUEST,
-      {query: createDatabaseUser(this.state)},
-      (response) => {
+      { query: createDatabaseUser(this.state) },
+      response => {
         if (!response.success) {
-          return this.setState({errors: ['Unable to create user', response.error]})
+          return this.setState({
+            errors: ['Unable to create user', response.error]
+          })
         }
         return this.addRoles.bind(this)
-      })
+      }
+    )
   }
   updateUsername (event) {
-    return this.setState({username: event.target.value})
+    return this.setState({ username: event.target.value })
   }
   updatePassword (event) {
-    return this.setState({password: event.target.value})
+    return this.setState({ password: event.target.value })
   }
   confirmUpdatePassword (event) {
-    return this.setState({confirmPassword: event.target.value})
+    return this.setState({ confirmPassword: event.target.value })
   }
   updateForcePasswordChange (event) {
-    return this.setState({forcePasswordChange: !this.state.forcePasswordChange})
+    return this.setState({
+      forcePasswordChange: !this.state.forcePasswordChange
+    })
   }
   availableRoles () {
-    return this.state.availableRoles.filter(role => this.state.roles.indexOf(role) < 0)
+    return this.state.availableRoles.filter(
+      role => this.state.roles.indexOf(role) < 0
+    )
   }
 
   openListUsersFrame () {
@@ -146,15 +177,26 @@ export class UserAdd extends Component {
   }
 
   render () {
-    const listOfAvailableRoles = (this.state.availableRoles)
-      ? (<RolesSelector roles={this.availableRoles()} onChange={(event) => {
-        this.setState({roles: this.state.roles.concat([event.target.value])})
-      }} />)
+    const listOfAvailableRoles = this.state.availableRoles
+      ? <RolesSelector
+        roles={this.availableRoles()}
+        onChange={event => {
+          this.setState({
+            roles: this.state.roles.concat([event.target.value])
+          })
+        }}
+        />
       : '-'
-    const tableHeaders = ['Username', 'Roles(s)', 'Set Password', 'Confirm Password', 'Force Password Change'].map((heading, i) => {
-      return (<StyledTh key={i}>{heading}</StyledTh>)
+    const tableHeaders = [
+      'Username',
+      'Roles(s)',
+      'Set Password',
+      'Confirm Password',
+      'Force Password Change'
+    ].map((heading, i) => {
+      return <StyledTh key={i}>{heading}</StyledTh>
     })
-    const errors = (this.state.errors) ? this.state.errors.join(', ') : null
+    const errors = this.state.errors ? this.state.errors.join(', ') : null
     const table = (
       <StyledTable>
         <thead>
@@ -165,20 +207,32 @@ export class UserAdd extends Component {
         <tbody>
           <StyledBodyTr>
             <StyledTd>
-              <input className='username' onChange={this.updateUsername.bind(this)} />
+              <input
+                className='username'
+                onChange={this.updateUsername.bind(this)}
+              />
             </StyledTd>
             <StyledTd>
               {listOfAvailableRoles}
               {this.listRoles()}
             </StyledTd>
             <StyledTd>
-              <input onChange={this.updatePassword.bind(this)} type='password' />
+              <input
+                onChange={this.updatePassword.bind(this)}
+                type='password'
+              />
             </StyledTd>
             <StyledTd>
-              <input onChange={this.confirmUpdatePassword.bind(this)} type='password' />
+              <input
+                onChange={this.confirmUpdatePassword.bind(this)}
+                type='password'
+              />
             </StyledTd>
             <StyledTd>
-              <input onClick={this.updateForcePasswordChange.bind(this)} type='checkbox' />
+              <input
+                onClick={this.updateForcePasswordChange.bind(this)}
+                type='checkbox'
+              />
             </StyledTd>
           </StyledBodyTr>
           <StyledBodyTr>
@@ -199,14 +253,10 @@ export class UserAdd extends Component {
       </div>
     )
     return (
-      <FrameTemplate
-        header={this.props.frame}
-        contents={frameContents}
-      >
+      <FrameTemplate header={this.props.frame} contents={frameContents}>
         <FrameError message={errors} />
         <FrameSuccess message={this.state.success} />
       </FrameTemplate>
-
     )
   }
 }

--- a/src/browser/modules/User/UserAdd.test.jsx
+++ b/src/browser/modules/User/UserAdd.test.jsx
@@ -23,18 +23,34 @@ import React from 'react'
 import { UserAdd } from './UserAdd'
 import { shallow } from 'enzyme'
 
-const mockBus = {self: () => {}}
+const mockBus = { self: () => {} }
 
 describe('UserAdd', () => {
   test('should show filtered list of roles', () => {
-    const user = {username: 'user', roles: ['a', 'b'], status: []}
-    const wrapper = shallow(<UserAdd bus={mockBus} username={user.username} availableRoles={['a', 'b', 'c']} roles={user.roles} status={user.status} />)
+    const user = { username: 'user', roles: ['a', 'b'], status: [] }
+    const wrapper = shallow(
+      <UserAdd
+        bus={mockBus}
+        username={user.username}
+        availableRoles={['a', 'b', 'c']}
+        roles={user.roles}
+        status={user.status}
+      />
+    )
     expect(wrapper.instance().availableRoles()).toEqual(['c'])
     expect(wrapper.state().roles).toEqual(['a', 'b'])
   })
   test('should remove role from the users assigned roles', () => {
-    const user = {username: 'user', roles: ['a', 'b', 'c'], status: []}
-    const wrapper = shallow(<UserAdd bus={mockBus} username={user.username} availableRoles={user.roles} roles={user.roles} status={user.status} />)
+    const user = { username: 'user', roles: ['a', 'b', 'c'], status: [] }
+    const wrapper = shallow(
+      <UserAdd
+        bus={mockBus}
+        username={user.username}
+        availableRoles={user.roles}
+        roles={user.roles}
+        status={user.status}
+      />
+    )
     expect(wrapper.instance().removeRole('a')).toEqual(['b', 'c'])
   })
 })

--- a/src/browser/modules/User/UserInfo.jsx
+++ b/src/browser/modules/User/UserInfo.jsx
@@ -22,12 +22,15 @@ import { Component } from 'preact'
 import { connect } from 'preact-redux'
 import { withBus } from 'preact-suber'
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
-import { getCurrentUser, updateCurrentUser } from 'shared/modules/currentUser/currentUserDuck'
+import {
+  getCurrentUser,
+  updateCurrentUser
+} from 'shared/modules/currentUser/currentUserDuck'
 
 export class UserInfoComponent extends Component {
   constructor (props) {
     super(props)
-    this.state = {user: this.props.info}
+    this.state = { user: this.props.info }
   }
   extractUserNameAndRolesFromBolt (r) {
     return {
@@ -36,13 +39,13 @@ export class UserInfoComponent extends Component {
     }
   }
   componentWillReceiveProps (newProps) {
-    this.setState({user: newProps.info})
+    this.setState({ user: newProps.info })
   }
   componentWillMount () {
     this.props.bus.self(
       CYPHER_REQUEST,
       'CALL dbms.showCurrentUser',
-      (response) => {
+      response => {
         if (!response.success) return
         const user = this.extractUserNameAndRolesFromBolt(response)
         this.props.updateCurrentUser(user.username, user.roles)
@@ -51,7 +54,7 @@ export class UserInfoComponent extends Component {
   }
   render () {
     const currentUser = this.state.user
-    const result = (currentUser == null) ? null : JSON.stringify(currentUser)
+    const result = currentUser == null ? null : JSON.stringify(currentUser)
     return (
       <div id='db-user'>
         <h4>User Information</h4>
@@ -61,13 +64,13 @@ export class UserInfoComponent extends Component {
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     info: getCurrentUser(state)
   }
 }
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     updateCurrentUser: (username, roles) => {
       dispatch(updateCurrentUser(username, roles))
@@ -75,5 +78,7 @@ const mapDispatchToProps = (dispatch) => {
   }
 }
 
-const UserInfo = withBus(connect(mapStateToProps, mapDispatchToProps)(UserInfoComponent))
+const UserInfo = withBus(
+  connect(mapStateToProps, mapDispatchToProps)(UserInfoComponent)
+)
 export default UserInfo

--- a/src/browser/modules/User/UserInfo.test.jsx
+++ b/src/browser/modules/User/UserInfo.test.jsx
@@ -26,7 +26,7 @@ import { shallow } from 'enzyme'
 describe('UserInfo', () => {
   const mockBus = { self: () => {} }
   test('should show username and role of logged in user', () => {
-    const info = {username: 'Admin', roles: ['admin']}
+    const info = { username: 'Admin', roles: ['admin'] }
     const wrapper = shallow(<UserInfoComponent bus={mockBus} info={info} />)
     expect(wrapper.find('#db-user').length).toBe(1)
     expect(wrapper.find('#db-user').text()).toMatch(info.username)

--- a/src/browser/modules/User/UserInformation.jsx
+++ b/src/browser/modules/User/UserInformation.jsx
@@ -19,15 +19,21 @@
  */
 
 import { Component } from 'preact'
-import {v4} from 'uuid'
+import { v4 } from 'uuid'
 
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
 import { withBus } from 'preact-suber'
-import { deleteUser, addRoleToUser, removeRoleFromUser, activateUser, suspendUser } from 'shared/modules/cypher/boltUserHelper'
+import {
+  deleteUser,
+  addRoleToUser,
+  removeRoleFromUser,
+  activateUser,
+  suspendUser
+} from 'shared/modules/cypher/boltUserHelper'
 
 import { FormButton } from 'browser-components/buttons'
 import { CloseIcon } from 'browser-components/icons/Icons'
-import {StyledBodyTr, StyledTd} from 'browser-components/DataTables'
+import { StyledBodyTr, StyledTd } from 'browser-components/DataTables'
 
 import RolesSelector from './RolesSelector'
 
@@ -44,67 +50,84 @@ export class UserInformation extends Component {
   removeClick (thing) {
     this.props.bus.self(
       CYPHER_REQUEST,
-      {query: deleteUser(this.state.username)},
+      { query: deleteUser(this.state.username) },
       this.handleResponse.bind(this)
     )
   }
   suspendUser () {
     this.props.bus.self(
       CYPHER_REQUEST,
-      {query: suspendUser(this.state.username)},
+      { query: suspendUser(this.state.username) },
       this.handleResponse.bind(this)
     )
   }
   activateUser () {
     this.props.bus.self(
       CYPHER_REQUEST,
-      {query: activateUser(this.state.username)},
+      { query: activateUser(this.state.username) },
       this.handleResponse.bind(this)
     )
   }
   statusButton (statusList) {
     if (statusList.indexOf('is_suspended') !== -1) {
-      return (<FormButton label='Suspend user' onClick={this.activateUser.bind(this)} />)
+      return (
+        <FormButton
+          label='Suspend user'
+          onClick={this.activateUser.bind(this)}
+        />
+      )
     } else {
-      return (<FormButton label='Active user' onClick={this.suspendUser.bind(this)} />)
+      return (
+        <FormButton label='Active user' onClick={this.suspendUser.bind(this)} />
+      )
     }
   }
   passwordChange () {
     return '-'
   }
   listRoles () {
-    return this.state.roles.map((role) => {
+    return this.state.roles.map(role => {
       return (
-        <FormButton key={v4()} label={role} icon={<CloseIcon />} onClick={() => {
-          this.props.bus.self(
-            CYPHER_REQUEST,
-            {query: removeRoleFromUser(role, this.state.username)},
-            this.handleResponse.bind(this)
-          )
-        }} />
+        <FormButton
+          key={v4()}
+          label={role}
+          icon={<CloseIcon />}
+          onClick={() => {
+            this.props.bus.self(
+              CYPHER_REQUEST,
+              { query: removeRoleFromUser(role, this.state.username) },
+              this.handleResponse.bind(this)
+            )
+          }}
+        />
       )
     })
   }
   onRoleSelect (event) {
     this.props.bus.self(
       CYPHER_REQUEST,
-      {query: addRoleToUser(this.state.username, event.target.value)},
+      { query: addRoleToUser(this.state.username, event.target.value) },
       this.handleResponse.bind(this)
     )
   }
   handleResponse (response) {
-    if (!response.success) return this.setState({errors: [response.error]})
+    if (!response.success) return this.setState({ errors: [response.error] })
     return this.props.refresh()
   }
   availableRoles () {
-    return this.state.availableRoles.filter((role) => this.props.roles.indexOf(role) < 0)
+    return this.state.availableRoles.filter(
+      role => this.props.roles.indexOf(role) < 0
+    )
   }
   render () {
     return (
       <StyledBodyTr className='user-info'>
         <StyledTd className='username'>{this.props.username}</StyledTd>
         <StyledTd className='roles'>
-          <RolesSelector roles={this.availableRoles()} onChange={this.onRoleSelect.bind(this)} />
+          <RolesSelector
+            roles={this.availableRoles()}
+            onChange={this.onRoleSelect.bind(this)}
+          />
           <span>
             {this.listRoles()}
           </span>
@@ -116,7 +139,11 @@ export class UserInformation extends Component {
           {this.passwordChange()}
         </StyledTd>
         <StyledTd>
-          <FormButton className='delete' label='Remove' onClick={this.removeClick.bind(this)} />
+          <FormButton
+            className='delete'
+            label='Remove'
+            onClick={this.removeClick.bind(this)}
+          />
         </StyledTd>
       </StyledBodyTr>
     )

--- a/src/browser/modules/User/UserInformation.test.jsx
+++ b/src/browser/modules/User/UserInformation.test.jsx
@@ -23,12 +23,19 @@ import React from 'react'
 import { UserInformation } from './UserInformation'
 import { shallow } from 'enzyme'
 
-const mockBus = {self: () => {}}
+const mockBus = { self: () => {} }
 
 describe('UserInformation', () => {
   test('should show username and role of a user', () => {
-    const user = {username: 'user', roles: ['roles'], status: []}
-    const wrapper = shallow(<UserInformation bus={mockBus} username={user.username} roles={user.roles} status={user.status} />)
+    const user = { username: 'user', roles: ['roles'], status: [] }
+    const wrapper = shallow(
+      <UserInformation
+        bus={mockBus}
+        username={user.username}
+        roles={user.roles}
+        status={user.status}
+      />
+    )
     expect(wrapper.find('.user-info').length).toBe(1)
     expect(wrapper.find('.user-info .username').text()).toMatch(user.username)
     expect(wrapper.find('.roles').first().html()).toMatch(user.roles[0])

--- a/src/browser/modules/User/UserList.jsx
+++ b/src/browser/modules/User/UserList.jsx
@@ -22,12 +22,15 @@ import { executeCommand } from 'shared/modules/commands/commandsDuck'
 import { Component } from 'preact'
 import uuid from 'uuid'
 import { withBus } from 'preact-suber'
-import { listUsersQuery, listRolesQuery } from 'shared/modules/cypher/boltUserHelper'
+import {
+  listUsersQuery,
+  listRolesQuery
+} from 'shared/modules/cypher/boltUserHelper'
 import UserInformation from './UserInformation'
 import bolt from 'services/bolt/bolt'
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
 import { StyledLink } from 'browser-components/buttons'
-import {StyledTable, StyledTh} from 'browser-components/DataTables'
+import { StyledTable, StyledTh } from 'browser-components/DataTables'
 
 import FrameTemplate from '../Stream/FrameTemplate'
 
@@ -47,27 +50,54 @@ export class UserList extends Component {
   getUserList () {
     this.props.bus.self(
       CYPHER_REQUEST,
-      {query: listUsersQuery()},
-      (response) => {
-        if (response.success) this.setState({userList: this.extractUserNameAndRolesFromBolt(response.result)})
-      })
+      { query: listUsersQuery() },
+      response => {
+        if (response.success) {
+          this.setState({
+            userList: this.extractUserNameAndRolesFromBolt(response.result)
+          })
+        }
+      }
+    )
   }
   getRoles () {
     this.props.bus.self(
       CYPHER_REQUEST,
-      {query: listRolesQuery()},
-      (response) => {
-        const flatten = arr => arr.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), [])
-        if (response.success) this.setState({listRoles: flatten(this.extractUserNameAndRolesFromBolt(response.result))})
-      })
+      { query: listRolesQuery() },
+      response => {
+        const flatten = arr =>
+          arr.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), [])
+        if (response.success) {
+          this.setState({
+            listRoles: flatten(
+              this.extractUserNameAndRolesFromBolt(response.result)
+            )
+          })
+        }
+      }
+    )
   }
   makeTable (data) {
-    const items = data.map((row) => {
+    const items = data.map(row => {
       return (
-        <UserInformation className='user-information' key={uuid.v4()} username={row[0]} roles={row[1]} status={row[2]} refresh={this.getUserList.bind(this)} availableRoles={this.state.listRoles} />
+        <UserInformation
+          className='user-information'
+          key={uuid.v4()}
+          username={row[0]}
+          roles={row[1]}
+          status={row[2]}
+          refresh={this.getUserList.bind(this)}
+          availableRoles={this.state.listRoles}
+        />
       )
     })
-    const tableHeaders = ['Username', 'Roles(s)', 'Status', 'Password Change', 'Delete'].map((heading, i) => {
+    const tableHeaders = [
+      'Username',
+      'Roles(s)',
+      'Status',
+      'Password Change',
+      'Delete'
+    ].map((heading, i) => {
       return <StyledTh key={i}>{heading}</StyledTh>
     })
     return (
@@ -92,7 +122,9 @@ export class UserList extends Component {
     this.getRoles()
   }
   render () {
-    const renderedListOfUsers = (this.state.userList) ? this.makeTable(this.state.userList) : 'No users'
+    const renderedListOfUsers = this.state.userList
+      ? this.makeTable(this.state.userList)
+      : 'No users'
     const frameContents = (
       <div className='db-list-users'>
         {renderedListOfUsers}
@@ -101,12 +133,7 @@ export class UserList extends Component {
         </StyledLink>
       </div>
     )
-    return (
-      <FrameTemplate
-        header={this.props.frame}
-        contents={frameContents}
-      />
-    )
+    return <FrameTemplate header={this.props.frame} contents={frameContents} />
   }
 }
 

--- a/src/browser/modules/User/UserList.test.jsx
+++ b/src/browser/modules/User/UserList.test.jsx
@@ -24,24 +24,25 @@ import { shallow } from 'enzyme'
 
 import { UserList } from './UserList'
 
-const mockBus = {self: () => {}}
+const mockBus = { self: () => {} }
 
 describe('UserList', () => {
   test('should show list of database users by username', () => {
     const props = {
-      users: [
-        ['Admin', ['admin'], []],
-        ['Thing', ['thing'], []]
-      ]
+      users: [['Admin', ['admin'], []], ['Thing', ['thing'], []]]
     }
-    const wrapper = shallow(shallow(<UserList bus={mockBus} {...props} />).props().contents)
+    const wrapper = shallow(
+      shallow(<UserList bus={mockBus} {...props} />).props().contents
+    )
     expect(wrapper.find('.user-information').length).toBe(2)
   })
 
   test.skip('should show list of database users by role', () => {
     const roles = ['user1', 'user2']
-    const props = {roles: roles}
-    const wrapper = shallow(shallow(<UserList bus={mockBus} {...props} />).contents)
+    const props = { roles: roles }
+    const wrapper = shallow(
+      shallow(<UserList bus={mockBus} {...props} />).contents
+    )
     expect(wrapper.find('.roles').text()).toEqual('user1, user2')
   })
 })

--- a/src/browser/modules/UserInteraction/index.jsx
+++ b/src/browser/modules/UserInteraction/index.jsx
@@ -23,7 +23,7 @@ import { withBus } from 'preact-suber'
 import { throttle } from 'services/utils'
 import { USER_INTERACTION } from 'shared/modules/userInteraction/userInteractionDuck'
 
-const reportInteraction = (bus) => {
+const reportInteraction = bus => {
   if (!bus) return
   bus.send(USER_INTERACTION)
 }
@@ -31,12 +31,20 @@ const throttledReportInteraction = throttle(reportInteraction, 5000)
 
 export class UserInteraction extends Component {
   componentDidMount () {
-    document.addEventListener('keyup', () => throttledReportInteraction(this.props.bus))
-    document.addEventListener('click', () => throttledReportInteraction(this.props.bus))
+    document.addEventListener('keyup', () =>
+      throttledReportInteraction(this.props.bus)
+    )
+    document.addEventListener('click', () =>
+      throttledReportInteraction(this.props.bus)
+    )
   }
   componentWillUnmount () {
-    document.removeEventListener('keyup', () => throttledReportInteraction(this.props.bus))
-    document.removeEventListener('click', () => throttledReportInteraction(this.props.bus))
+    document.removeEventListener('keyup', () =>
+      throttledReportInteraction(this.props.bus)
+    )
+    document.removeEventListener('click', () =>
+      throttledReportInteraction(this.props.bus)
+    )
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,7 +85,7 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-ansi-escapes@^1.1.0, ansi-escapes@^1.4.0:
+ansi-escapes@^1.0.0, ansi-escapes@^1.1.0, ansi-escapes@^1.4.0:
   version "1.4.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
@@ -121,6 +121,10 @@ anymatch@^1.3.0:
   dependencies:
     arrify "^1.0.0"
     micromatch "^2.1.5"
+
+app-root-path@^2.0.0:
+  version "2.0.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
 
 append-transform@^0.4.0:
   version "0.4.0"
@@ -1226,11 +1230,22 @@ clean-css@4.1.x:
   dependencies:
     source-map "0.5.x"
 
-cli-cursor@^1.0.1:
+cli-cursor@^1.0.1, cli-cursor@^1.0.2:
   version "1.0.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
   dependencies:
     restore-cursor "^1.0.1"
+
+cli-spinners@^0.1.2:
+  version "0.1.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
+
+cli-truncate@^0.2.1:
+  version "0.2.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
+  dependencies:
+    slice-ansi "0.0.4"
+    string-width "^1.0.1"
 
 cli-width@^2.0.0:
   version "2.1.0"
@@ -1463,6 +1478,19 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cosmiconfig@^1.1.0:
+  version "1.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/cosmiconfig/-/cosmiconfig-1.1.0.tgz#0dea0f9804efdfb929fbb1b188e25553ea053d37"
+  dependencies:
+    graceful-fs "^4.1.2"
+    js-yaml "^3.4.3"
+    minimist "^1.2.0"
+    object-assign "^4.0.1"
+    os-homedir "^1.0.1"
+    parse-json "^2.2.0"
+    pinkie-promise "^2.0.0"
+    require-from-string "^1.1.0"
+
 cosmiconfig@^2.1.0, cosmiconfig@^2.1.1:
   version "2.1.3"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/cosmiconfig/-/cosmiconfig-2.1.3.tgz#952771eb0dddc1cb3fa2f6fbe51a522e93b3ee0a"
@@ -1507,6 +1535,14 @@ cross-spawn@^4.0.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/cross-spawn/-/cross-spawn-4.0.2.tgz#7b9247621c23adfdd3856004a823cbe397424d41"
   dependencies:
     lru-cache "^4.0.1"
+    which "^1.2.9"
+
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
     which "^1.2.9"
 
 cryptiles@2.x.x:
@@ -1678,6 +1714,10 @@ dashdash@^1.12.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
+
+date-fns@^1.27.2:
+  version "1.28.5"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/date-fns/-/date-fns-1.28.5.tgz#257cfc45d322df45ef5658665967ee841cd73faf"
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -1937,6 +1977,10 @@ ejs@^2.5.6:
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.11:
   version "1.3.13"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/electron-to-chromium/-/electron-to-chromium-1.3.13.tgz#1b3a5eace6e087bb5e257a100b0cbfe81b2891fc"
+
+elegant-spinner@^1.0.1:
+  version "1.0.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
 
 elliptic@^6.0.0:
   version "6.4.0"
@@ -2369,6 +2413,18 @@ exec-sh@^0.2.0:
   dependencies:
     merge "^1.1.3"
 
+execa@^0.7.0:
+  version "0.7.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
@@ -2491,7 +2547,7 @@ fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-figures@^1.3.5:
+figures@^1.3.5, figures@^1.7.0:
   version "1.7.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
   dependencies:
@@ -2566,6 +2622,10 @@ find-cache-dir@^0.1.1:
     commondir "^1.0.1"
     mkdirp "^0.5.1"
     pkg-dir "^1.0.0"
+
+find-parent-dir@^0.3.0:
+  version "0.3.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
 
 find-root@^1.0.0:
   version "1.0.0"
@@ -2744,6 +2804,10 @@ get-func-name@^2.0.0:
 get-stdin@^5.0.1:
   version "5.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+
+get-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
 getpass@^0.1.1:
   version "0.1.7"
@@ -3068,6 +3132,15 @@ https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
+husky@^0.13.4:
+  version "0.13.4"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/husky/-/husky-0.13.4.tgz#48785c5028de3452a51c48c12c4f94b2124a1407"
+  dependencies:
+    chalk "^1.1.3"
+    find-parent-dir "^0.3.0"
+    is-ci "^1.0.9"
+    normalize-path "^1.0.0"
+
 hyphenate-style-name@^1.0.1:
   version "1.0.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz#31160a36930adaf1fc04c6074f7eb41465d4ec4b"
@@ -3107,6 +3180,16 @@ immutability-helper@^2.1.2:
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
+
+indent-string@^2.1.0:
+  version "2.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
+  dependencies:
+    repeating "^2.0.0"
+
+indent-string@^3.0.0:
+  version "3.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/indent-string/-/indent-string-3.1.0.tgz#08ff4334603388399b329e6b9538dc7a3cf5de7d"
 
 indexes-of@^1.0.1:
   version "1.0.1"
@@ -3206,7 +3289,7 @@ is-callable@^1.1.1, is-callable@^1.1.2, is-callable@^1.1.3:
   version "1.1.3"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
 
-is-ci@^1.0.10:
+is-ci@^1.0.10, is-ci@^1.0.9:
   version "1.0.10"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/is-ci/-/is-ci-1.0.10.tgz#f739336b2632365061a9d48270cd56ae3369318e"
   dependencies:
@@ -3323,6 +3406,10 @@ is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+
 is-property@^1.0.0:
   version "1.0.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
@@ -3339,7 +3426,7 @@ is-resolvable@^1.0.0:
   dependencies:
     tryit "^1.0.1"
 
-is-stream@^1.0.1:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -3866,6 +3953,67 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lint-staged@^4.0.0:
+  version "4.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/lint-staged/-/lint-staged-4.0.0.tgz#c15669f598614a6e68090303e175a799d48e0d85"
+  dependencies:
+    app-root-path "^2.0.0"
+    cosmiconfig "^1.1.0"
+    execa "^0.7.0"
+    listr "^0.12.0"
+    lodash.chunk "^4.2.0"
+    minimatch "^3.0.0"
+    npm-which "^3.0.1"
+    p-map "^1.1.1"
+    staged-git-files "0.0.4"
+
+listr-silent-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
+
+listr-update-renderer@^0.2.0:
+  version "0.2.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz#ca80e1779b4e70266807e8eed1ad6abe398550f9"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    strip-ansi "^3.0.1"
+
+listr-verbose-renderer@^0.4.0:
+  version "0.4.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/listr-verbose-renderer/-/listr-verbose-renderer-0.4.0.tgz#44dc01bb0c34a03c572154d4d08cde9b1dc5620f"
+  dependencies:
+    chalk "^1.1.3"
+    cli-cursor "^1.0.2"
+    date-fns "^1.27.2"
+    figures "^1.7.0"
+
+listr@^0.12.0:
+  version "0.12.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/listr/-/listr-0.12.0.tgz#6bce2c0f5603fa49580ea17cd6a00cc0e5fa451a"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    figures "^1.7.0"
+    indent-string "^2.1.0"
+    is-promise "^2.1.0"
+    is-stream "^1.1.0"
+    listr-silent-renderer "^1.1.1"
+    listr-update-renderer "^0.2.0"
+    listr-verbose-renderer "^0.4.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    ora "^0.2.3"
+    p-map "^1.1.1"
+    rxjs "^5.0.0-beta.11"
+    stream-to-observable "^0.1.0"
+    strip-ansi "^3.0.1"
+
 load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
@@ -3936,6 +4084,10 @@ lodash.bind@^4.1.4:
 lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+
+lodash.chunk@^4.2.0:
+  version "4.2.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/lodash.chunk/-/lodash.chunk-4.2.0.tgz#66e5ce1f76ed27b4303d8c6512e8d1216e8106bc"
 
 lodash.cond@^4.3.0:
   version "4.5.2"
@@ -4027,6 +4179,19 @@ lodash.uniq@^4.5.0:
 lodash@4.17.4, lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@~4.17.2:
   version "4.17.4"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+log-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  dependencies:
+    chalk "^1.0.0"
+
+log-update@^1.0.2:
+  version "1.0.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/log-update/-/log-update-1.0.2.tgz#19929f64c4093d2d2e7075a1dad8af59c296b8d1"
+  dependencies:
+    ansi-escapes "^1.0.0"
+    cli-cursor "^1.0.2"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -4312,6 +4477,10 @@ normalize-package-data@^2.3.2:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
+normalize-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
+
 normalize-path@^2.0.1:
   version "2.1.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
@@ -4330,6 +4499,26 @@ normalize-url@^1.4.0:
     prepend-http "^1.0.0"
     query-string "^4.1.0"
     sort-keys "^1.0.0"
+
+npm-path@^2.0.2:
+  version "2.0.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/npm-path/-/npm-path-2.0.3.tgz#15cff4e1c89a38da77f56f6055b24f975dfb2bbe"
+  dependencies:
+    which "^1.2.10"
+
+npm-run-path@^2.0.0:
+  version "2.0.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
+  dependencies:
+    path-key "^2.0.0"
+
+npm-which@^3.0.1:
+  version "3.0.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa"
+  dependencies:
+    commander "^2.9.0"
+    npm-path "^2.0.2"
+    which "^1.2.10"
 
 npmlog@^4.0.2:
   version "4.1.0"
@@ -4476,6 +4665,15 @@ options@>=0.0.5:
   version "0.0.6"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/options/-/options-0.0.6.tgz#ec22d312806bb53e731773e7cdaefcf1c643128f"
 
+ora@^0.2.3:
+  version "0.2.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/ora/-/ora-0.2.3.tgz#37527d220adcd53c39b73571d754156d5db657a4"
+  dependencies:
+    chalk "^1.1.1"
+    cli-cursor "^1.0.2"
+    cli-spinners "^0.1.2"
+    object-assign "^4.0.1"
+
 original@>=0.0.5:
   version "1.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/original/-/original-1.0.0.tgz#9147f93fa1696d04be61e01bd50baeaca656bd3b"
@@ -4506,6 +4704,10 @@ osenv@^0.1.4:
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+p-finally@^1.0.0:
+  version "1.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
 
 p-limit@^1.1.0:
   version "1.1.0"
@@ -4607,6 +4809,10 @@ path-is-absolute@^1.0.0:
 path-is-inside@^1.0.1:
   version "1.0.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/path-is-inside/-/path-is-inside-1.0.2.tgz#365417dede44430d1c11af61027facf074bdfc53"
+
+path-key@^2.0.0:
+  version "2.0.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
 path-parse@^1.0.5:
   version "1.0.5"
@@ -5360,6 +5566,10 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@^1.4.4:
+  version "1.4.4"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/prettier/-/prettier-1.4.4.tgz#a8d1447b14c9bf67e6d420dcadd10fb9a4fad65a"
+
 pretty-error@^2.0.2:
   version "2.1.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/pretty-error/-/pretty-error-2.1.0.tgz#87f4e9d706a24c87d6cbee9fabec001fcf8c75d8"
@@ -5954,7 +6164,7 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
-rxjs@^5.0.3:
+rxjs@^5.0.0-beta.11, rxjs@^5.0.3:
   version "5.4.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/rxjs/-/rxjs-5.4.0.tgz#a7db14ab157f9d7aac6a56e655e7a3860d39bf26"
   dependencies:
@@ -6060,6 +6270,16 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/sha.js/-/sha.js-2.4.8.tgz#37068c2c476b6baf402d14a49c67f597921f634f"
   dependencies:
     inherits "^2.0.1"
+
+shebang-command@^1.2.0:
+  version "1.2.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
+  dependencies:
+    shebang-regex "^1.0.0"
+
+shebang-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
 
 shelljs@^0.7.5:
   version "0.7.7"
@@ -6251,6 +6471,10 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+staged-git-files@0.0.4:
+  version "0.0.4"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/staged-git-files/-/staged-git-files-0.0.4.tgz#d797e1b551ca7a639dec0237dc6eb4bb9be17d35"
+
 standalone-react-addons-pure-render-mixin@^0.1.1:
   version "0.1.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/standalone-react-addons-pure-render-mixin/-/standalone-react-addons-pure-render-mixin-0.1.1.tgz#3c7409f4c79c40de9ac72c616cf679a994f37551"
@@ -6298,6 +6522,10 @@ stream-http@^2.3.1:
     readable-stream "^2.2.6"
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
+
+stream-to-observable@^0.1.0:
+  version "0.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/stream-to-observable/-/stream-to-observable-0.1.0.tgz#45bf1d9f2d7dc09bed81f1c307c430e68b84cffe"
 
 strict-uri-encode@^1.0.0:
   version "1.1.0"
@@ -6357,6 +6585,10 @@ strip-bom@^2.0.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
   dependencies:
     is-utf8 "^0.2.0"
+
+strip-eof@^1.0.0:
+  version "1.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -6918,7 +7150,7 @@ which-module@^1.0.0:
   version "1.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/which-module/-/which-module-1.0.0.tgz#bba63ca861948994ff307736089e3b96026c2a4f"
 
-which@^1.2.12, which@^1.2.9:
+which@^1.2.10, which@^1.2.12, which@^1.2.9:
   version "1.2.14"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
   dependencies:


### PR DESCRIPTION
The [prettier](https://github.com/prettier/prettier) project is spreading like a virus, for good reasons.
I wanted to try it on our codebase (but still keep the format within the standardJS rules).
The `standard --fix` command is very limited in what it can do.
Prettier takes the AST and walks backwards to create code.
Read this blogpost for more info: http://jlongster.com/A-Prettier-Formatter

I've created a precommit hook so the code is auto formatted on every commit. 
You don't have to think about it. Write code in what ever format you want, it'll be fixed into standardJS compatible format that's easy to read. No more linter errors, ever.

In my opinion the code is **a lot** easier to read formatted this way.

Thoughts on this @pe4cey @irfannuri?