### PR TITLE
Honor url whitelist when fetching remote grass files

### DIFF
--- a/src/shared/modules/commands/helpers/grass.js
+++ b/src/shared/modules/commands/helpers/grass.js
@@ -28,7 +28,6 @@ export const fetchRemoteGrass = (url, whitelist = null) => {
     }
     resolve()
   }).then(() => {
-    console.log(remote.get(url))
     return remote.get(url).then((r) => {
       return r
     })
@@ -36,7 +35,7 @@ export const fetchRemoteGrass = (url, whitelist = null) => {
 }
 
 export function parseGrass (string) {
-  var result
+  let result
   try {
     result = JSON.parse(string)
   } catch (e) {
@@ -46,17 +45,17 @@ export function parseGrass (string) {
 }
 
 function parseGrassCSS (string) {
-  var chars = string.split('')
-  var insideString = false
-  var insideProps = false
-  var insideBinding = false
-  var keyword = ''
-  var props = ''
-  var rules = {}
-  var i, j
+  let chars = string.split('')
+  let insideString = false
+  let insideProps = false
+  let insideBinding = false
+  let keyword = ''
+  let props = ''
+  let rules = {}
+  let i, j
 
   for (i = 0; i < chars.length; i++) {
-    let c = chars[i]
+    const c = chars[i]
     let skipThis = true
     switch (c) {
       case '{':
@@ -102,14 +101,14 @@ function parseGrassCSS (string) {
 
   const keys = Object.keys(rules)
   for (i = 0; i < keys.length; i++) {
-    let val = rules[keys[i]]
+    const val = rules[keys[i]]
     rules[keys[i]] = {}
-    let props = val.split(';')
+    const props = val.split(';')
     for (j = 0; j < props.length; j++) {
-      let propKeyVal = props[j].split(':')
+      const propKeyVal = props[j].split(':')
       if (propKeyVal && propKeyVal.length === 2) {
-        let prop = propKeyVal[0].trim()
-        let value = propKeyVal[1].trim()
+        const prop = propKeyVal[0].trim()
+        const value = propKeyVal[1].trim()
         rules[keys[i]][prop] = value
       }
     }

--- a/src/shared/modules/commands/helpers/grass.js
+++ b/src/shared/modules/commands/helpers/grass.js
@@ -18,6 +18,23 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { hostIsAllowed } from 'services/utils'
+import remote from 'services/remote'
+
+export const fetchRemoteGrass = (url, whitelist = null) => {
+  return new Promise((resolve, reject) => {
+    if (!hostIsAllowed(url, whitelist)) {
+      return reject(new Error('Hostname is not allowed according to server whitelist'))
+    }
+    resolve()
+  }).then(() => {
+    console.log(remote.get(url))
+    return remote.get(url).then((r) => {
+      return r
+    })
+  })
+}
+
 export function parseGrass (string) {
   var result
   try {

--- a/src/shared/modules/commands/helpers/grass.test.js
+++ b/src/shared/modules/commands/helpers/grass.test.js
@@ -36,18 +36,14 @@ describe('Grass remote fetch', () => {
   test('should not fetch from url not in the whitelist', () => {
     const whitelist = 'foo'
     const urlNotInWhitelist = 'bar'
-    return fetchRemoteGrass(urlNotInWhitelist, whitelist)
-    .catch((error) => {
-      expect(error).not.toBe(null)
+    return expect(fetchRemoteGrass(urlNotInWhitelist, whitelist)).rejects.toMatchObject({
+      message: 'Hostname is not allowed according to server whitelist'
     })
   })
   test('should fetch from url in the whitelist', () => {
     const whitelist = 'foo'
     const urlInWhitelist = 'foo'
-    return fetchRemoteGrass(urlInWhitelist, whitelist)
-    .then((res) => {
-      expect(res).toBe(urlInWhitelist)
-    })
+    return expect(fetchRemoteGrass(urlInWhitelist, whitelist)).resolves.toBe(urlInWhitelist)
   })
 })
 

--- a/src/shared/modules/commands/helpers/grass.test.js
+++ b/src/shared/modules/commands/helpers/grass.test.js
@@ -53,24 +53,24 @@ describe('Grass remote fetch', () => {
 
 describe('Grass parser', () => {
   test('Can parse simple grass data', () => {
-    var data = 'node {color: red;} relationship {shaft-width: 10px;}'
-    var parsed = parseGrass(data)
+    const data = 'node {color: red;} relationship {shaft-width: 10px;}'
+    const parsed = parseGrass(data)
     expect(parsed.node.color).toEqual('red')
     expect(parsed.relationship['shaft-width']).toEqual('10px')
   })
 
   test('Returns empty object on strange data', () => {
-    var data = 'this is not grass data! : { . / , > <'
-    var parsed = parseGrass(data)
+    const data = 'this is not grass data! : { . / , > <'
+    const parsed = parseGrass(data)
     expect(parsed).toEqual({})
   })
 
   test('Handles id and type captions correctly', () => {
-    var data = `node {caption: {title};}
+    const data = `node {caption: {title};}
                 node.PERSON {caption: <id>;}
                 relationship {caption: <type>;}
                 relationship.KNOWS {caption: {how};}`
-    var parsed = parseGrass(data)
+    const parsed = parseGrass(data)
     expect(parsed.node.caption).toEqual('title')
     expect(parsed['node.PERSON'].caption).toEqual('<id>')
     expect(parsed.relationship.caption).toEqual('<type>')
@@ -78,24 +78,24 @@ describe('Grass parser', () => {
   })
 
   test('Parsing does not generate any junk', () => {
-    var data = `node {caption: {title};}
+    const data = `node {caption: {title};}
                 relationship {caption: <type>;}`
-    var parsed = parseGrass(data)
+    const parsed = parseGrass(data)
     expect(Object.keys(parsed).length).toEqual(2)
     expect(Object.keys(parsed.node).length).toEqual(1)
     expect(Object.keys(parsed.relationship).length).toEqual(1)
   })
 
   test('Parsing grass with odd whitespace', () => {
-    var data = 'node {border-color : #9AA1AC ; \n\r\t  diameter:50px;color:#A5ABB6; border-width : 2px ; } relationship{ color : #A5ABB6 ; shaft-width : 1px ; font-size : 8px ; padding : 3px ; text-color-external : #000000 ; text-color-internal : #FFFFFF ; caption : <type>; }'
-    var parsed = parseGrass(data)
+    const data = 'node {border-color : #9AA1AC ; \n\r\t  diameter:50px;color:#A5ABB6; border-width : 2px ; } relationship{ color : #A5ABB6 ; shaft-width : 1px ; font-size : 8px ; padding : 3px ; text-color-external : #000000 ; text-color-internal : #FFFFFF ; caption : <type>; }'
+    const parsed = parseGrass(data)
     expect(parsed.node.diameter).toEqual('50px')
     expect(parsed.relationship.color).toEqual('#A5ABB6')
   })
 
   test('Handles JSON data', () => {
-    var data = '{"node": {"diameter":"50px", "color":"#A5ABB6"}, "relationship":{"color":"#A5ABB6","shaft-width":"1px"}}'
-    var parsed = parseGrass(data)
+    const data = '{"node": {"diameter":"50px", "color":"#A5ABB6"}, "relationship":{"color":"#A5ABB6","shaft-width":"1px"}}'
+    const parsed = parseGrass(data)
     expect(parsed.node.diameter).toEqual('50px')
     expect(parsed.relationship.color).toEqual('#A5ABB6')
   })

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -207,7 +207,9 @@ const availableCommands = [{
       if (!param.startsWith('http')) {
         param = 'http://' + param
       }
-      fetchRemoteGrass(param)
+
+      const whitelist = getRemoteContentHostnameWhitelist(store.getState())
+      fetchRemoteGrass(param, whitelist)
       .then((response) => {
         const parsedGrass = parseGrass(response)
         if (parsedGrass) {

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -36,7 +36,7 @@ import { handleParamCommand, handleParamsCommand } from 'shared/modules/commands
 import { handleGetConfigCommand, handleUpdateConfigCommand } from 'shared/modules/commands/helpers/config'
 import { CouldNotFetchRemoteGuideError, FetchURLError } from 'services/exceptions'
 import { parseHttpVerbCommand, isValidURL } from 'shared/modules/commands/helpers/http'
-import { parseGrass } from 'shared/modules/commands/helpers/grass'
+import { fetchRemoteGrass, parseGrass } from 'shared/modules/commands/helpers/grass'
 
 const availableCommands = [{
   name: 'clear',
@@ -207,7 +207,7 @@ const availableCommands = [{
       if (!param.startsWith('http')) {
         param = 'http://' + param
       }
-      remote.get(param)
+      fetchRemoteGrass(param)
       .then((response) => {
         const parsedGrass = parseGrass(response)
         if (parsedGrass) {


### PR DESCRIPTION
The url param when loading remote grass using `:style` needs to be present in the whitelist returned by the neo4j server