### PR TITLE
Bring back `:style` command

### DIFF
--- a/src/shared/modules/commands/commandsDuck.test.js
+++ b/src/shared/modules/commands/commandsDuck.test.js
@@ -50,7 +50,12 @@ describe('commandsDuck', () => {
       },
       history: [':xxx'],
       connections: {},
-      params: {}
+      params: {},
+      grass: {
+        node: {
+          color: '#000'
+        }
+      }
     })
   })
   afterEach(() => {
@@ -245,6 +250,31 @@ describe('commandsDuck', () => {
           addHistory(cmdString, maxHistory),
           { type: commands.KNOWN_COMMAND },
           frames.add({...action, type: 'pre', result: JSON.stringify({cmdchar: ':', maxHistory: 20}, null, 2)}),
+          { type: 'NOOP' }
+        ])
+        done()
+      })
+
+      // When
+      store.dispatch(action)
+
+      // Then
+      // See above
+    })
+
+    test('does the right thing for :style', (done) => {
+      // Given
+      const cmd = store.getState().settings.cmdchar + 'style'
+      const cmdString = cmd
+      const id = 1
+      const action = commands.executeCommand(cmdString, id)
+      bus.take('NOOP', (currentAction) => {
+        // Then
+        expect(store.getActions()).toEqual([
+          action,
+          addHistory(cmdString, maxHistory),
+          { type: commands.KNOWN_COMMAND },
+          frames.add({...action, type: 'pre', result: JSON.stringify({ node: { color: '#000' } }, null, 2)}),
           { type: 'NOOP' }
         ])
         done()

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -24,7 +24,7 @@ import { getHistory } from 'shared/modules/history/historyDuck'
 import { update as updateQueryResult } from 'shared/modules/requests/requestsDuck'
 import { getActiveConnectionData } from 'shared/modules/connections/connectionsDuck'
 import { getParams } from 'shared/modules/params/paramsDuck'
-import { updateGraphStyleData } from 'shared/modules/grass/grassDuck'
+import { updateGraphStyleData, getGraphStyleData } from 'shared/modules/grass/grassDuck'
 import { getRemoteContentHostnameWhitelist } from 'shared/modules/dbMeta/dbMetaDuck'
 import { fetchRemoteGuide } from 'shared/modules/commands/helpers/play'
 import remote from 'services/remote'
@@ -199,8 +199,8 @@ const availableCommands = [{
     let param = match && match[1] ? match[1] : ''
 
     if (param === '') {
-      // Todo: show popup
-      put(showErrorMessage(':style command missing a parameter - grass url, grass style data or reset'))
+      const grassData = JSON.stringify(getGraphStyleData(store.getState()), null, 2)
+      put(frames.add({...action, type: 'pre', result: grassData}))
     } else if (param === 'reset') {
       put(updateGraphStyleData(null))
     } else if (isValidURL(param)) {


### PR DESCRIPTION
In it's simplest form, outputting the style data into a `<pre>` frame.

To "edit", users can copy the json, edit it locally och upload a file with the new styling (or upload it somewhere and use `:style http://myurl.com/grass.json`.

![oskar4j 2017-06-26 at 10 04 04](https://user-images.githubusercontent.com/570998/27530028-0d17490c-5a57-11e7-8dbc-379a4a50164e.png)

Fixes #562 