### PR TITLE
Fix display of zero length paths

### DIFF
--- a/__mocks__/neo4j.js
+++ b/__mocks__/neo4j.js
@@ -21,13 +21,29 @@
 var out = {
   v1: {
     types: {
-      Node: function Node (id) {
+      Node: function Node (id, labels, properties) {
         this.identity = id
+        this.labels = labels
+        this.properties = properties
       },
-      Relationship: function Relationship (id) {
+      Relationship: function Relationship (id, start, end, type, properties) {
         this.identity = id
+        this.start = start
+        this.end = end
+        this.type = type
+        this.properties = properties
       },
-      Path: function Path () {}
+      Path: function Path (start, end, segments) {
+        this.start = start
+        this.end = end
+        this.segments = segments
+        this.length = segments.length
+      },
+      PathSegment: function PathSegment (start, relationship, end) {
+        this.start = start
+        this.relationship = relationship
+        this.end = end
+      }
     }
   }
 }
@@ -35,5 +51,6 @@ var out = {
 out.v1.types.Node.prototype.toString = function () { return 'node' }
 out.v1.types.Relationship.prototype.toString = function () { return 'rel' }
 out.v1.types.Path.prototype.toString = function () { return 'path' }
+out.v1.types.PathSegment.prototype.toString = function () { return 'pathsegment' }
 
 module.exports = out

--- a/src/shared/services/bolt/boltMappings.js
+++ b/src/shared/services/bolt/boltMappings.js
@@ -50,11 +50,11 @@ export function arrayIntToString (arr, converters) {
 
 export function objIntToString (obj, converters) {
   let entry = converters.objectConverter(obj, converters)
-
-  let newObj = {}
+  let newObj = null
   if (Array.isArray(entry)) {
     newObj = entry.map(item => itemIntToString(item, converters))
-  } else {
+  } else if (entry !== null && typeof entry === 'object') {
+    newObj = {}
     Object.keys(entry).forEach((key) => {
       newObj[key] = itemIntToString(entry[key], converters)
     })
@@ -72,10 +72,17 @@ export function extractFromNeoObjects (obj, converters) {
 }
 
 const extractPathForRows = (path, converters) => {
-  return path.segments.map(function (segment) {
-    return [objIntToString(segment.start, converters),
+  let segments = path.segments
+  // Zero length path. No relationship, end === start
+  if (!Array.isArray(path.segments) || path.segments.length < 1) {
+    segments = [{...path, end: null}]
+  }
+  return segments.map(function (segment) {
+    return [
+      objIntToString(segment.start, converters),
       objIntToString(segment.relationship, converters),
-      objIntToString(segment.end, converters)]
+      objIntToString(segment.end, converters)
+    ].filter((part) => part !== null)
   })
 }
 

--- a/src/shared/services/bolt/boltMappings.js
+++ b/src/shared/services/bolt/boltMappings.js
@@ -207,10 +207,15 @@ const flattenArray = (arr) => {
 const extractNodesAndRelationshipsFromPath = (item, rawNodes, rawRels) => {
   let paths = Array.isArray(item) ? item : [item]
   paths.forEach((path) => {
-    path.segments.forEach((segment) => {
-      rawNodes.push(segment.start)
-      rawNodes.push(segment.end)
-      rawRels.push(segment.relationship)
+    let segments = path.segments
+    // Zero length path. No relationship, end === start
+    if (!Array.isArray(path.segments) || path.segments.length < 1) {
+      segments = [{...path, end: null}]
+    }
+    segments.forEach((segment) => {
+      if (segment.start) rawNodes.push(segment.start)
+      if (segment.end) rawNodes.push(segment.end)
+      if (segment.relationship) rawRels.push(segment.relationship)
     })
   })
 }

--- a/src/shared/services/bolt/boltMappings.test.js
+++ b/src/shared/services/bolt/boltMappings.test.js
@@ -367,6 +367,73 @@ describe('boltMappings', () => {
       // Then
       expect(out.nodes.length).toEqual(4)
     })
+    test('should find items in paths with segments', () => {
+      // Given
+      const converters = {
+        intChecker: () => false,
+        intConverter: (a) => a,
+        objectConverter: extractFromNeoObjects
+      }
+      const start = new neo4j.types.Node(1, ['X'], {x: 1})
+      const rel1 = new neo4j.types.Relationship(3, 1, 2, 'REL', {rel: 1})
+      const end1 = new neo4j.types.Node(2, ['Y'], {y: 1})
+      const rel2 = new neo4j.types.Relationship(6, 4, 5, 'REL2', {rel: 2})
+      const end = new neo4j.types.Node(5, ['Y'], {y: 2})
+      const segments = [
+        new neo4j.types.PathSegment(start, rel1, end1),
+        new neo4j.types.PathSegment(end1, rel2, end)
+      ]
+      const path = new neo4j.types.Path(start, end, segments)
+      const boltRecord = {
+        keys: ['p'],
+        get: (key) => {
+          if (key === 'p') return path
+        }
+      }
+      const records = [boltRecord]
+
+      // When
+      const out = extractNodesAndRelationshipsFromRecordsForOldVis(
+        records,
+        neo4j.types,
+        false,
+        converters
+      )
+
+      // Then
+      expect(out.nodes.length).toEqual(4)
+    })
+    test('should find items in paths zero segments', () => {
+      // Given
+      const converters = {
+        intChecker: () => false,
+        intConverter: (a) => a,
+        objectConverter: extractFromNeoObjects
+      }
+      const start = new neo4j.types.Node(1, ['X'], {x: 2})
+      const end = start
+      const segments = []
+      const path = new neo4j.types.Path(start, end, segments)
+      const boltRecord = {
+        keys: ['p'],
+        get: (key) => {
+          if (key === 'p') return path
+        }
+      }
+      const records = [boltRecord]
+
+      // When
+      const out = extractNodesAndRelationshipsFromRecordsForOldVis(
+        records,
+        neo4j.types,
+        false,
+        converters
+      )
+
+      // Then
+      expect(out.nodes.length).toEqual(1)
+      expect(out.nodes[0].properties.x).toEqual(2)
+    })
   })
   describe('extractFromNeoObjects', () => {
     test('should extract objects from paths with zero segments', () => {


### PR DESCRIPTION
In the code a path assumed to have segments. That assumption is wrong, a path can be of zero length and just be a node.

To illustrate, load movie dataset and run this query before and after this fix:

```
MATCH path=(n:Person)-[*0]-()
WHERE n.name='Keanu Reeves' 
RETURN path
```

Nothing is displayed in viz or table view. When viewing the response in the code view it's clear that we get a node back.

**For the reviewer**: I have tested this manually many times for different kinds of path queries and found no regressions. Please do so you as well. 
There were no existing tests covering object extraction from paths.

![oskar4j 2017-06-27 at 12 57 14](https://user-images.githubusercontent.com/570998/27584881-389bef68-5b3a-11e7-8777-09f967722dc6.png)
![oskar4j 2017-06-27 at 12 57 20](https://user-images.githubusercontent.com/570998/27584882-38c0c0fe-5b3a-11e7-9b8a-14df00fa70cb.png)
![oskar4j 2017-06-27 at 12 57 25](https://user-images.githubusercontent.com/570998/27584883-38c29320-5b3a-11e7-93aa-a856534efdb9.png)



Fixes #351 