### PR TITLE
Don't add repeated executed commands to history

### DIFF
--- a/src/shared/modules/history/historyDuck.js
+++ b/src/shared/modules/history/historyDuck.js
@@ -27,7 +27,11 @@ export const ADD = 'history/ADD'
 export const getHistory = (state) => state[NAME]
 
 function addHistoryHelper (state, newState, maxHistory) {
-  let newHistory = [].concat(state)
+  // If it's the same as the last entry, don't add it
+  if (state && state.length && state[0] === newState) {
+    return state
+  }
+  let newHistory = [...state]
   newHistory.unshift(newState)
   return newHistory.slice(0, maxHistory)
 }

--- a/src/shared/modules/history/historyDuck.test.js
+++ b/src/shared/modules/history/historyDuck.test.js
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/* global test, expect */
+/* global describe, test, expect */
 import reducer, * as actions from './historyDuck'
 
 describe('editor reducer', () => {
@@ -31,6 +31,24 @@ describe('editor reducer', () => {
     const historyAction = actions.addHistory(':history', 20)
     const nextnextState = reducer(nextState, historyAction)
     expect(nextnextState).toEqual([':history', ':help'])
+  })
+  test('editor.actionTypes.ADD_HISTORY does not repeat two entries in a row', () => {
+    // Given
+    const helpAction = actions.addHistory(':help', 20)
+    const historyAction = actions.addHistory(':history', 20)
+    const initalState = [':help']
+
+    // When
+    const nextState = reducer(initalState, helpAction)
+
+    // Then
+    expect(nextState).toEqual([':help'])
+
+    // When
+    const nextState1 = reducer(nextState, historyAction)
+
+    // Then
+    expect(nextState1).toEqual([':history', ':help'])
   })
 
   test('takes editor.actionTypes.SET_MAX_HISTORY into account', () => {


### PR DESCRIPTION
Fix regression where repeated commands were added to history multiple times.

![oskar4j 2017-06-29 at 07 34 48](https://user-images.githubusercontent.com/570998/27672800-7fdd871a-5c9d-11e7-9700-8aa8b4fc7a2a.png)
