### PR TITLE
Instantiate NeoConstructor in plan view

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/PlanView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/PlanView.jsx
@@ -65,7 +65,7 @@ export class PlanView extends Component {
   planInit (el) {
     if (el != null && !this.plan) {
       const NeoConstructor = neo.queryPlan
-      this.plan = NeoConstructor(el)
+      this.plan = new NeoConstructor(el)
       this.plan.display(this.state.extractedPlan)
     }
   }


### PR DESCRIPTION
This is so each plan view will have access to it's own plan class (as opposed to a global singleton)