### PR TITLE
Update cypher-codemirror to 1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "ascii-data-table": "^2.1.1",
     "classnames": "^2.2.5",
     "codemirror": "^5.25.2",
-    "cypher-codemirror": "1.0.4",
+    "cypher-codemirror": "1.0.5",
     "dnd-core": "^2.2.4",
     "file-saver": "^1.3.3",
     "firebase": "^3.6.5",

--- a/src/browser/modules/Editor/Editor.jsx
+++ b/src/browser/modules/Editor/Editor.jsx
@@ -200,9 +200,7 @@ export class Editor extends Component {
 
   updateCode (newCode, change, cb = () => {
   }) {
-    const mode = this.props.cmdchar && newCode.trim().indexOf(this.props.cmdchar) === 0
-      ? 'text'
-      : 'cypher'
+    const mode = 'cypher'
     this.clearHints()
     if (mode === 'cypher' &&
       newCode.trim().length > 0 &&
@@ -392,6 +390,7 @@ const mapStateToProps = (state) => {
     cmdchar: getCmdChar(state),
     schema: {
       consoleCommands: consoleCommands,
+      parameters: Object.keys(state.params),
       labels: state.meta.labels.map(schemaConvert.toLabel),
       relationshipTypes: state.meta.relationshipTypes.map(schemaConvert.toRelationshipType),
       propertyKeys: state.meta.properties.map(schemaConvert.toPropertyKey),


### PR DESCRIPTION
**Warning: DO NOT MERGE this until Cypher Editor 1.0.5 will be released.**

Changes:
- Errors in console commands are suppressed. Therefore autocompletion & syntax highlight is enabled now for console commands
- Add schema-based parameter autocompletion
- Fixed various Cypher parser bugs

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/neo4j/neo4j-browser/615)
<!-- Reviewable:end -->
