### PR TITLE
Fix display of Neo4j integers in Cypher result frames

### DIFF
--- a/__mocks__/neo4j.js
+++ b/__mocks__/neo4j.js
@@ -18,10 +18,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+function integerFn (val) {
+  this.val = val
+}
+integerFn.prototype.toString = function () {
+  return this.val.toString()
+}
+
 var out = {
   v1: {
-    isInt: function () {
-      return false
+    Int: integerFn,
+    isInt: function (val) {
+      return val instanceof integerFn
     },
     types: {
       Node: function Node (id, labels, properties) {

--- a/src/browser/modules/Stream/CypherFrame/AsciiView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/AsciiView.jsx
@@ -25,13 +25,7 @@ import Render from 'browser-components/Render'
 import Ellipsis from 'browser-components/Ellipsis'
 import { debounce, shallowEquals, deepEquals } from 'services/utils'
 import { StyledStatsBar, PaddedDiv, StyledBodyMessage, StyledRightPartial, StyledWidthSliderContainer, StyledWidthSlider } from '../styled'
-import { getBodyAndStatusBarMessages, getRecordsToDisplayInTable, extractRecordsToResultArray, stringifyResultArray, flattenGraphItemsInResultArray } from './helpers'
-
-const toTable = (records) => records && records.length
-  ? [records]
-      .map(extractRecordsToResultArray)
-      .map(flattenGraphItemsInResultArray.bind(null, neo4j.types, neo4j.isInt))[0]
-  : undefined
+import { getBodyAndStatusBarMessages, getRecordsToDisplayInTable, transformResultRecordsToResultArray, stringifyResultArray } from './helpers'
 
 export class AsciiView extends Component {
   constructor (props) {
@@ -71,7 +65,7 @@ export class AsciiView extends Component {
     this.setState({ bodyMessage })
     if (!result || !result.records) return
     const records = getRecordsToDisplayInTable(props.result, props.maxRows)
-    const serializedRows = stringifyResultArray(neo4j.isInt, toTable(records)) || []
+    const serializedRows = stringifyResultArray(neo4j.isInt, transformResultRecordsToResultArray(records)) || []
     this.setState({ serializedRows })
     this.props.setParentState && this.props.setParentState({ _asciiSerializedRows: serializedRows })
   }

--- a/src/browser/modules/Stream/CypherFrame/AsciiView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/AsciiView.jsx
@@ -20,15 +20,18 @@
 
 import { Component } from 'preact'
 import asciitable from 'ascii-data-table'
-import bolt from 'services/bolt/bolt'
+import { v1 as neo4j } from 'neo4j-driver-alias'
 import Render from 'browser-components/Render'
 import Ellipsis from 'browser-components/Ellipsis'
 import { debounce, shallowEquals, deepEquals } from 'services/utils'
 import { StyledStatsBar, PaddedDiv, StyledBodyMessage, StyledRightPartial, StyledWidthSliderContainer, StyledWidthSlider } from '../styled'
-import { getBodyAndStatusBarMessages, getRecordsToDisplayInTable } from './helpers'
+import { getBodyAndStatusBarMessages, getRecordsToDisplayInTable, extractRecordsToResultArray, stringifyResultArray, flattenGraphItemsInResultArray } from './helpers'
 
-const toTable = (records) => records && records.length ? bolt.recordsToTableArray(records) : undefined
-const stringify = bolt.stringifyRows || undefined
+const toTable = (records) => records && records.length
+  ? [records]
+      .map(extractRecordsToResultArray)
+      .map(flattenGraphItemsInResultArray.bind(null, neo4j.types, neo4j.isInt))[0]
+  : undefined
 
 export class AsciiView extends Component {
   constructor (props) {
@@ -68,7 +71,7 @@ export class AsciiView extends Component {
     this.setState({ bodyMessage })
     if (!result || !result.records) return
     const records = getRecordsToDisplayInTable(props.result, props.maxRows)
-    const serializedRows = stringify(toTable(records))
+    const serializedRows = stringifyResultArray(neo4j.isInt, toTable(records)) || []
     this.setState({ serializedRows })
     this.props.setParentState && this.props.setParentState({ _asciiSerializedRows: serializedRows })
   }

--- a/src/browser/modules/Stream/CypherFrame/TableView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/TableView.jsx
@@ -25,13 +25,7 @@ import Ellipsis from 'browser-components/Ellipsis'
 import {StyledTable, StyledBodyTr, StyledTh, StyledTd, StyledJsonPre} from 'browser-components/DataTables'
 import { deepEquals, shallowEquals, stringifyMod } from 'services/utils'
 import { v1 as neo4j } from 'neo4j-driver-alias'
-import { getBodyAndStatusBarMessages, getRecordsToDisplayInTable, extractRecordsToResultArray, flattenGraphItemsInResultArray } from './helpers'
-
-const toTable = (records) => records && records.length
-? [records]
-    .map(extractRecordsToResultArray)
-    .map(flattenGraphItemsInResultArray.bind(null, neo4j.types, neo4j.isInt))[0]
-: undefined
+import { getBodyAndStatusBarMessages, getRecordsToDisplayInTable, transformResultRecordsToResultArray } from './helpers'
 
 const intToString = (val) => {
   if (neo4j.isInt(val)) return val.toString()
@@ -96,7 +90,7 @@ export class TableView extends Component {
   }
   makeState (props) {
     const records = getRecordsToDisplayInTable(props.result, props.maxRows)
-    const table = toTable(records) || []
+    const table = transformResultRecordsToResultArray(records) || []
     const data = table ? table.slice() : []
     const columns = data.length > 0 ? data.shift() : []
     const { bodyMessage } = getBodyAndStatusBarMessages(props.result, props.maxRows)

--- a/src/browser/modules/Stream/CypherFrame/helpers.js
+++ b/src/browser/modules/Stream/CypherFrame/helpers.js
@@ -134,6 +134,14 @@ export const stringifyResultArray = (intChecker = neo4j.isInt, arr = []) => {
   })
 }
 
+export const transformResultRecordsToResultArray = (records) => {
+  return records && records.length
+  ? [records]
+      .map(extractRecordsToResultArray)
+      .map(flattenGraphItemsInResultArray.bind(null, neo4j.types, neo4j.isInt))[0]
+  : undefined
+}
+
 export const extractRecordsToResultArray = (records = []) => {
   records = Array.isArray(records) ? records : []
   const keys = records[0] ? [records[0].keys] : undefined

--- a/src/browser/modules/Stream/CypherFrame/helpers.js
+++ b/src/browser/modules/Stream/CypherFrame/helpers.js
@@ -19,8 +19,10 @@
  */
 
 import bolt from 'services/bolt/bolt'
+import { v1 as neo4j } from 'neo4j-driver-alias'
 import * as viewTypes from 'shared/modules/stream/frameViewTypes'
 import { recursivelyExtractGraphItems, flattenArray } from 'services/bolt/boltMappings'
+import { stringifyMod } from 'services/utils'
 
 export function getBodyAndStatusBarMessages (result, maxRows) {
   if (!result || !result.summary || !result.summary.resultAvailableAfter) {
@@ -119,4 +121,76 @@ export const initialView = (props, state = {}) => {
   // If the response have viz elements, we show the viz
   if (resultHasNodes(props.request)) return viewTypes.VISUALIZATION
   return viewTypes.TABLE
+}
+
+export const stringifyResultArray = (intChecker = neo4j.isInt, arr = []) => {
+  return arr.map((col) => {
+    if (!col) return col
+    return col.map((fVal) => {
+      return stringifyMod(fVal, (val) => {
+        if (intChecker(val)) return val.toString()
+      })
+    })
+  })
+}
+
+export const extractRecordsToResultArray = (records = []) => {
+  records = Array.isArray(records) ? records : []
+  const keys = records[0] ? [records[0].keys] : undefined
+  return (keys || []).concat(
+    records.map((record) => {
+      return record.keys.map((key, i) => record._fields[i])
+    })
+  )
+}
+
+export const flattenGraphItemsInResultArray = (types = neo4j.types, intChecker = neo4j.isInt, result = []) => {
+  return result.map(flattenGraphItems.bind(null, types, intChecker))
+}
+
+export const flattenGraphItems = (types = neo4j.types, intChecker = neo4j.isInt, item) => {
+  if (Array.isArray(item)) return item.map(flattenGraphItems.bind(null, types, intChecker))
+  if (typeof item === 'object' && item !== null && !isGraphItem(types, item) && !intChecker(item)) {
+    let out = {}
+    const keys = Object.keys(item)
+    for (let i = 0; i < keys.length; i++) {
+      out[keys[i]] = flattenGraphItems(types, intChecker, item[keys[i]])
+    }
+    return out
+  }
+  if (isGraphItem(types, item)) return extractPropertiesFromGraphItems(types, item)
+  return item
+}
+
+export const isGraphItem = (types = neo4j.types, item) => {
+  return (
+    item instanceof types.Node ||
+    item instanceof types.Relationship ||
+    item instanceof types.Path ||
+    item instanceof types.PathSegment
+  )
+}
+
+export function extractPropertiesFromGraphItems (types = neo4j.types, obj) {
+  if (obj instanceof types.Node || obj instanceof types.Relationship) {
+    return obj.properties
+  } else if (obj instanceof types.Path) {
+    return [].concat.apply([], arrayifyPath(types, obj))
+  }
+  return obj
+}
+
+const arrayifyPath = (types = neo4j.types, path) => {
+  let segments = path.segments
+  // Zero length path. No relationship, end === start
+  if (!Array.isArray(path.segments) || path.segments.length < 1) {
+    segments = [{...path, end: null}]
+  }
+  return segments.map(function (segment) {
+    return [
+      extractPropertiesFromGraphItems(types, segment.start),
+      extractPropertiesFromGraphItems(types, segment.relationship),
+      extractPropertiesFromGraphItems(types, segment.end)
+    ].filter((part) => part !== null)
+  })
 }

--- a/src/browser/modules/Stream/CypherFrame/helpers.js
+++ b/src/browser/modules/Stream/CypherFrame/helpers.js
@@ -123,6 +123,12 @@ export const initialView = (props, state = {}) => {
   return viewTypes.TABLE
 }
 
+/**
+ * Takes an array of objects and stringifies it using a
+ * modified version of JSON.stringify.
+ * It takes a replacer without enforcing quoting rules to it.
+ * Used so we can have Neo4j integers as string without quotes.
+ */
 export const stringifyResultArray = (intChecker = neo4j.isInt, arr = []) => {
   return arr.map((col) => {
     if (!col) return col
@@ -134,6 +140,11 @@ export const stringifyResultArray = (intChecker = neo4j.isInt, arr = []) => {
   })
 }
 
+/**
+ * Transformes an array of neo4j driver records to an array of objects.
+ * Flattens graph items so only their props are left.
+ * Leaves Neo4j Integers as they were.
+ */
 export const transformResultRecordsToResultArray = (records) => {
   return records && records.length
   ? [records]
@@ -142,6 +153,10 @@ export const transformResultRecordsToResultArray = (records) => {
   : undefined
 }
 
+/**
+ * Transformes an array of neo4j driver records to an array of objects.
+ * Leaves all values as they were, just changing the data structure.
+ */
 export const extractRecordsToResultArray = (records = []) => {
   records = Array.isArray(records) ? records : []
   const keys = records[0] ? [records[0].keys] : undefined
@@ -156,6 +171,10 @@ export const flattenGraphItemsInResultArray = (types = neo4j.types, intChecker =
   return result.map(flattenGraphItems.bind(null, types, intChecker))
 }
 
+/**
+ * Recursively looks for graph items and elevates their properties if found.
+ * Leaves everything else (including neo4j integers) as is
+ */
 export const flattenGraphItems = (types = neo4j.types, intChecker = neo4j.isInt, item) => {
   if (Array.isArray(item)) return item.map(flattenGraphItems.bind(null, types, intChecker))
   if (typeof item === 'object' && item !== null && !isGraphItem(types, item) && !intChecker(item)) {

--- a/src/browser/modules/Stream/CypherFrame/helpers.test.js
+++ b/src/browser/modules/Stream/CypherFrame/helpers.test.js
@@ -28,7 +28,9 @@ import {
   resultHasPlan,
   resultIsError,
   getRecordsToDisplayInTable,
-  initialView
+  initialView,
+  extractRecordsToResultArray,
+  flattenGraphItemsInResultArray
 } from './helpers'
 
 describe('helpers', () => {
@@ -472,6 +474,77 @@ describe('helpers', () => {
 
       // Then
       expect(view).toEqual(viewTypes.TABLE)
+    })
+  })
+  describe('record transformations', () => {
+    test('extractRecordsToResultArray handles empty records', () => {
+      // Given
+      const records = null
+
+      // When
+      const res = extractRecordsToResultArray(records)
+
+      // Then
+      expect(res).toEqual([])
+    })
+    test('extractRecordsToResultArray handles regular records', () => {
+      // Given
+      const start = new neo4j.types.Node(1, ['X'], {x: 1})
+      const end = new neo4j.types.Node(2, ['Y'], {y: 1})
+      const rel = new neo4j.types.Relationship(3, 1, 2, 'REL', {rel: 1})
+      const segments = [new neo4j.types.PathSegment(start, rel, end)]
+      const path = new neo4j.types.Path(start, end, segments)
+
+      const records = [
+        {
+          keys: ['"x"', '"y"', '"n"'],
+          _fields: ['x', 'y', new neo4j.types.Node('1', ['Person'], {prop1: 'prop1'})]
+        },
+        {
+          keys: ['"x"', '"y"', '"n"'],
+          _fields: ['xx', 'yy', path]
+        }
+      ]
+
+      // When
+      const res = extractRecordsToResultArray(records)
+
+      // Then
+      expect(res).toEqual([
+        ['"x"', '"y"', '"n"'],
+        ['x', 'y', new neo4j.types.Node('1', ['Person'], {prop1: 'prop1'})],
+        ['xx', 'yy', path]
+      ])
+    })
+    test('flattenGraphItemsInResultArray extracts props from graph items', () => {
+      // Given
+      const start = new neo4j.types.Node(1, ['X'], {x: 1})
+      const end = new neo4j.types.Node(2, ['Y'], {y: 1})
+      const rel = new neo4j.types.Relationship(3, 1, 2, 'REL', {rel: 1})
+      const segments = [new neo4j.types.PathSegment(start, rel, end)]
+      const path = new neo4j.types.Path(start, end, segments)
+
+      const records = [
+        {
+          keys: ['"x"', '"y"', '"n"'],
+          _fields: ['x', 'y', new neo4j.types.Node('1', ['Person'], {prop1: 'prop1'})]
+        },
+        {
+          keys: ['"x"', '"y"', '"n"'],
+          _fields: ['xx', 'yy', {prop: path}]
+        }
+      ]
+
+      // When
+      const step1 = extractRecordsToResultArray(records)
+      const res = flattenGraphItemsInResultArray(neo4j.types, neo4j.isInt, step1)
+
+      // Then
+      expect(res).toEqual([
+        ['"x"', '"y"', '"n"'],
+        ['x', 'y', {prop1: 'prop1'}],
+        ['xx', 'yy', {prop: [{x: 1}, {rel: 1}, {y: 1}]}]
+      ])
     })
   })
 })

--- a/src/browser/modules/Stream/CypherFrame/index.jsx
+++ b/src/browser/modules/Stream/CypherFrame/index.jsx
@@ -23,7 +23,7 @@ import { Component } from 'preact'
 import FrameTemplate from '../FrameTemplate'
 import { CypherFrameButton } from 'browser-components/buttons'
 import Centered from 'browser-components/Centered'
-import bolt from 'services/bolt/bolt'
+import { v1 as neo4j } from 'neo4j-driver-alias'
 import { deepEquals } from 'services/utils'
 import FrameSidebar from '../FrameSidebar'
 import { VisualizationIcon, TableIcon, AsciiIcon, CodeIcon, PlanIcon, AlertIcon, ErrorIcon, Spinner } from 'browser-components/icons/Icons'
@@ -37,7 +37,7 @@ import { VisualizationConnectedBus } from './VisualizationView'
 import Render from 'browser-components/Render'
 import Display from 'browser-components/Display'
 import * as viewTypes from 'shared/modules/stream/frameViewTypes'
-import { resultHasRows, resultHasWarnings, resultHasPlan, resultIsError, resultHasNodes, initialView } from './helpers'
+import { resultHasRows, resultHasWarnings, resultHasPlan, resultIsError, resultHasNodes, initialView, transformResultRecordsToResultArray, stringifyResultArray } from './helpers'
 import { StyledFrameBody, SpinnerContainer, StyledStatsBarContainer } from '../styled'
 import { getMaxRows, getInitialNodeDisplay, getMaxNeighbours, shouldAutoComplete } from 'shared/modules/settings/settingsDuck'
 import { setRecentView, getRecentView } from 'shared/modules/stream/streamDuck'
@@ -49,6 +49,9 @@ export class CypherFrame extends Component {
       openView: undefined,
       exportData: null
     }
+  }
+  makeExportData (records) {
+    return stringifyResultArray(neo4j.isInt, transformResultRecordsToResultArray(records))
   }
   changeView (view) {
     this.setState({openView: view})
@@ -74,7 +77,7 @@ export class CypherFrame extends Component {
     }
     if (this.props.request === undefined || !deepEquals(props.request.result, this.props.request.result)) {
       if (props.request.result && props.request.result.records && props.request.result.records.length) {
-        newState['exportData'] = bolt.recordsToTableArray(props.request.result.records)
+        newState['exportData'] = this.makeExportData(props.request.result.records)
       } else {
         newState['exportData'] = null
       }
@@ -85,7 +88,7 @@ export class CypherFrame extends Component {
     const view = initialView(this.props, this.state)
     if (view) this.setState({ openView: view })
     if (this.props.request && this.props.request.result && this.props.request.result.records && this.props.request.result.records.length) {
-      this.setState({ exportData: bolt.recordsToTableArray(this.props.request.result.records) })
+      this.setState({ exportData: this.makeExportData(this.props.request.result.records) })
     }
   }
   sidebar () {

--- a/src/shared/services/bolt/bolt.js
+++ b/src/shared/services/bolt/bolt.js
@@ -20,7 +20,6 @@
 
 import { v4 } from 'uuid'
 import { v1 as neo4j } from 'neo4j-driver-alias'
-import { stringifyMod } from 'services/utils'
 import * as mappings from './boltMappings'
 import { BoltConnectionError, createErrorObject } from '../exceptions'
 

--- a/src/shared/services/bolt/bolt.js
+++ b/src/shared/services/bolt/bolt.js
@@ -202,19 +202,6 @@ export default {
     const intConverter = convertInts ? (item) => mappings.itemIntToString(item, { intChecker: neo4j.isInt, intConverter: (val) => val.toNumber() }) : (val) => val
     return mappings.recordsToTableArray(records, { intChecker, intConverter, objectConverter: mappings.extractFromNeoObjects })
   },
-  stringifyRows: (rows) => {
-    if (!Array.isArray(rows)) return rows
-    const flat = mappings.flattenProperties(rows)
-    if (!Array.isArray(flat)) return rows
-    return flat.map((col) => {
-      if (!col) return col
-      return col.map((fVal) => {
-        return stringifyMod()(fVal, (val) => {
-          if (neo4j.isInt(val)) return val.toString()
-        })
-      })
-    })
-  },
   extractNodesAndRelationshipsFromRecords: (records) => {
     return mappings.extractNodesAndRelationshipsFromRecords(records, neo4j.types)
   },

--- a/src/shared/services/utils.js
+++ b/src/shared/services/utils.js
@@ -204,39 +204,45 @@ export const parseTimeMillis = (timeWithOrWithoutUnit) => {
   }
 }
 
-export const stringifyMod = () => {
+export const stringifyMod = (value, modFn = null, prettyLevel = false, skipOpeningIndentation = false) => {
+  prettyLevel = !prettyLevel ? false : (prettyLevel === true ? 1 : parseInt(prettyLevel))
+  const nextPrettyLevel = prettyLevel ? prettyLevel + 1 : false
+  const newLine = prettyLevel ? '\n' : ''
+  const indentation = prettyLevel && !skipOpeningIndentation ? Array(prettyLevel).join('  ') : ''
+  const endIndentation = prettyLevel ? Array(prettyLevel).join('  ') : ''
+  const propSpacing = prettyLevel ? ' ' : ''
   const toString = Object.prototype.toString
   const isArray = Array.isArray || function (a) { return toString.call(a) === '[object Array]' }
   const escMap = {'"': '\\"', '\\': '\\\\', '\b': '\\b', '\f': '\\f', '\n': '\\n', '\r': '\\r', '\t': '\\t'}
   const escFunc = function (m) { return escMap[m] || '\\u' + (m.charCodeAt(0) + 0x10000).toString(16).substr(1) }
   const escRE = /[\\"\u0000-\u001F\u2028\u2029]/g
-  return function stringify (value, modFn = null) {
-    if (modFn) {
-      const modVal = modFn && modFn(value)
-      if (typeof modVal !== 'undefined') return modVal
-    }
-    if (value == null) return 'null'
-    if (typeof value === 'number') return isFinite(value) ? value.toString() : 'null'
-    if (typeof value === 'boolean') return value.toString()
-    if (typeof value === 'object') {
-      if (typeof value.toJSON === 'function') {
-        return stringify(value.toJSON(), modFn)
-      } else if (isArray(value)) {
-        let res = '['
-        for (let i = 0; i < value.length; i++) {
-          res += (i ? ',' : '') + stringify(value[i], modFn)
-        }
-        return res + ']'
-      } else if (toString.call(value) === '[object Object]') {
-        let tmp = []
-        for (const k in value) {
-          if (value.hasOwnProperty(k)) tmp.push(stringify(k, modFn) + ':' + stringify(value[k], modFn))
-        }
-        return '{' + tmp.join(',') + '}'
-      }
-    }
-    return '"' + value.toString().replace(escRE, escFunc) + '"'
+  if (modFn) {
+    const modVal = modFn && modFn(value)
+    if (typeof modVal !== 'undefined') return indentation + modVal
   }
+  if (value == null) return indentation + 'null'
+  if (typeof value === 'number') return indentation + (isFinite(value) ? value.toString() : 'null')
+  if (typeof value === 'boolean') return indentation + value.toString()
+  if (typeof value === 'object') {
+    if (typeof value.toJSON === 'function') {
+      return stringifyMod(value.toJSON(), modFn, nextPrettyLevel)
+    } else if (isArray(value)) {
+      let hasValues = false
+      let res = ''
+      for (let i = 0; i < value.length; i++) {
+        hasValues = true
+        res += (i ? ',' : '') + newLine + stringifyMod(value[i], modFn, nextPrettyLevel)
+      }
+      return indentation + '[' + res + (hasValues ? newLine + endIndentation : '') + ']'
+    } else if (toString.call(value) === '[object Object]') {
+      let tmp = []
+      for (const k in value) {
+        if (value.hasOwnProperty(k)) tmp.push(stringifyMod(k, modFn, nextPrettyLevel) + ':' + propSpacing + stringifyMod(value[k], modFn, nextPrettyLevel, true))
+      }
+      return indentation + '{' + newLine + tmp.join(',' + newLine) + newLine + endIndentation + '}'
+    }
+  }
+  return indentation + '"' + value.toString().replace(escRE, escFunc) + '"'
 }
 
 // Epic helpers

--- a/src/shared/services/utils.test.js
+++ b/src/shared/services/utils.test.js
@@ -303,7 +303,7 @@ describe('utils', () => {
 
     // When & Then
     tests.forEach((t) => {
-      expect(utils.stringifyMod()(t)).toEqual(JSON.stringify(t))
+      expect(utils.stringifyMod(t)).toEqual(JSON.stringify(t))
     })
   })
 
@@ -324,13 +324,43 @@ describe('utils', () => {
       'null',
       'false',
       JSON.stringify([[], [1]]),
-      5,
+      '5',
       '[string]'
     ]
 
     // When & Then
     tests.forEach((t, index) => {
-      expect(utils.stringifyMod()(t, modFn)).toEqual(expects[index])
+      expect(utils.stringifyMod(t, modFn)).toEqual(expects[index])
+    })
+  })
+  test('stringifyMod can add spaces on the output', () => {
+    // Given
+    const tests = [
+      false,
+      [[], [0]],
+      {
+        prop1: 1,
+        prop2: [
+          {innerProp: 'innerVal', innerProp2: [{innerInner: 'innerVal2', innerInner2: 'innerInnerVal2'}]}
+        ]
+      },
+      ['string']
+    ]
+    const expects = [
+      'false',
+      JSON.stringify([[], [0]], null, 2),
+      JSON.stringify({
+        prop1: 1,
+        prop2: [
+          {innerProp: 'innerVal', innerProp2: [{innerInner: 'innerVal2', innerInner2: 'innerInnerVal2'}]}
+        ]
+      }, null, 2),
+      JSON.stringify(['string'], null, 2)
+    ]
+
+    // When & Then
+    tests.forEach((t, index) => {
+      expect(utils.stringifyMod(t, null, true)).toEqual(expects[index])
     })
   })
   test('parseTimeMillis correctly parses human readable units correctly', () => {

--- a/src/shared/services/utils.test.js
+++ b/src/shared/services/utils.test.js
@@ -310,22 +310,23 @@ describe('utils', () => {
   test('stringifyMod works just as JSON.stringify with modFn', () => {
     // Given
     const modFn = (val) => {
-      if (Number.isInteger(val)) return val + 1
-      if (typeof val === 'string') return val.toString()
+      if (Number.isInteger(val)) return val.toString()
     }
     const tests = [
       null,
       false,
       [[], [0]],
+      '4',
       4,
       ['string']
     ]
     const expects = [
       'null',
       'false',
-      JSON.stringify([[], [1]]),
-      '5',
-      '[string]'
+      JSON.stringify([[], [0]]),
+      '"4"',
+      '4',
+      '["string"]'
     ]
 
     // When & Then


### PR DESCRIPTION
This regression was introduced with the cypher frame refactoring.
Rather than filling up `boltMappings` with more functions I decided to place the mappings and transforms close to where they are used.
Opens for code duplication, but makes the code more safe to make changes to.

![oskarhane-mbpt 2017-08-01 at 10 55 35](https://user-images.githubusercontent.com/570998/28817588-faaee7de-76a8-11e7-8cf6-bc8464a4e22a.png)

Fixes #618 