### PR TITLE
Enable code autoformatting with prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "webpack-dashboard -t 'Neo4j Browser' -- webpack-dev-server --colors --no-info",
     "starts": "webpack-dashboard -t 'Neo4j Browser' -- webpack-dev-server --https --colors --no-info",
+    "precommit": "lint-staged",
     "format": "prettier-standard 'src/**/!(*.min).js' 'src/**/*.jsx'",
     "lint": "standard --fix",
     "test": "npm run lint && jest",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "start": "webpack-dashboard -t 'Neo4j Browser' -- webpack-dev-server --colors --no-info",
     "starts": "webpack-dashboard -t 'Neo4j Browser' -- webpack-dev-server --https --colors --no-info",
+    "format": "prettier-standard 'src/**/!(*.min).js' 'src/**/*.jsx'",
     "lint": "standard --fix",
     "test": "npm run lint && jest",
     "e2e": "cypress run --config fixturesFolder=e2e_tests/fixtures,integrationFolder=e2e_tests/integration,screenshotsFolder=e2e_tests/screenshots,supportFile=e2e_tests/support,videosFolder=e2e_tests/videos",
@@ -14,6 +15,14 @@
     "jar": "yarn build && mvn package",
     "version-pom": "node ./scripts/set-pom-version.js -f ./pom.xml -v $npm_package_version",
     "version": "npm run version-pom && git add ./pom.xml"
+  },
+  "lint-staged": {
+    "linters": {
+      "*.{js,jsx}": [
+        "prettier-standard",
+        "git add"
+      ]
+    }
   },
   "jest": {
     "testPathIgnorePatterns": [
@@ -108,6 +117,7 @@
     "preact-render-to-string": "^3.6.3",
     "preact-test-utils": "^0.1.3",
     "precss": "^2.0.0",
+    "prettier-standard": "^6.0.0",
     "react-addons-test-utils": "^15.0.2",
     "react-hot-loader": "^1.3.0",
     "redux-devtools": "^3.2.0",
@@ -131,8 +141,10 @@
     "dnd-core": "^2.2.4",
     "file-saver": "^1.3.3",
     "firebase": "^4.2.0",
+    "husky": "^0.14.3",
     "isomorphic-fetch": "^2.2.1",
     "jsonic": "^0.3.0",
+    "lint-staged": "^4.0.3",
     "lodash.debounce": "^4.0.8",
     "neo4j-driver": "~1.2.0",
     "node-noop": "^1.0.0",

--- a/src/browser/components/Directives.jsx
+++ b/src/browser/components/Directives.jsx
@@ -24,63 +24,72 @@ import { executeCommand } from 'shared/modules/commands/commandsDuck'
 import * as editor from 'shared/modules/editor/editorDuck'
 import { addClass, prependIcon } from 'shared/services/dom-helpers'
 
-const directives = [{
-  selector: '[exec-topic]',
-  valueExtractor: (elem) => {
-    return `:${elem.getAttribute('exec-topic')}`
+const directives = [
+  {
+    selector: '[exec-topic]',
+    valueExtractor: elem => {
+      return `:${elem.getAttribute('exec-topic')}`
+    },
+    autoExec: true
   },
-  autoExec: true
-}, {
-  selector: '[play-topic]',
-  valueExtractor: (elem) => {
-    return `:play ${elem.getAttribute('play-topic')}`
+  {
+    selector: '[play-topic]',
+    valueExtractor: elem => {
+      return `:play ${elem.getAttribute('play-topic')}`
+    },
+    autoExec: true
   },
-  autoExec: true
-}, {
-  selector: '[server-topic]',
-  valueExtractor: (elem) => {
-    return `:server ${elem.getAttribute('server-topic')}`
+  {
+    selector: '[server-topic]',
+    valueExtractor: elem => {
+      return `:server ${elem.getAttribute('server-topic')}`
+    },
+    autoExec: true
   },
-  autoExec: true
-}, {
-  selector: '[help-topic]',
-  valueExtractor: (elem) => {
-    return `:help ${elem.getAttribute('help-topic')}`
+  {
+    selector: '[help-topic]',
+    valueExtractor: elem => {
+      return `:help ${elem.getAttribute('help-topic')}`
+    },
+    autoExec: true
   },
-  autoExec: true
-}, {
-  selector: '.runnable pre',
-  valueExtractor: (elem) => {
-    return elem.textContent.trim()
+  {
+    selector: '.runnable pre',
+    valueExtractor: elem => {
+      return elem.textContent.trim()
+    },
+    autoExec: false
   },
-  autoExec: false
-}, {
-  selector: 'pre.runnable',
-  valueExtractor: (elem) => {
-    return elem.textContent.trim()
-  },
-  autoExec: false
-}]
+  {
+    selector: 'pre.runnable',
+    valueExtractor: elem => {
+      return elem.textContent.trim()
+    },
+    autoExec: false
+  }
+]
 
-const prependHelpIcon = (element) => {
+const prependHelpIcon = element => {
   prependIcon(element, 'fa fa-question-circle-o')
 }
 
-const prependPlayIcon = (element) => {
+const prependPlayIcon = element => {
   prependIcon(element, 'fa fa-play-circle-o')
 }
 
-const bindDynamicInputToDom = (element) => {
+const bindDynamicInputToDom = element => {
   const valueForElems = element.querySelectorAll('[value-for]')
   const valueKeyElems = element.querySelectorAll('[value-key]')
   if (valueForElems.length > 0 && valueKeyElems.length > 0) {
-    valueForElems.forEach((valueForElem) => {
+    valueForElems.forEach(valueForElem => {
       const newArray = [...valueKeyElems]
-      const filteredValueKeyElems = newArray.filter((e) => {
-        return e.getAttribute('value-key') === valueForElem.getAttribute('value-for')
+      const filteredValueKeyElems = newArray.filter(e => {
+        return (
+          e.getAttribute('value-key') === valueForElem.getAttribute('value-for')
+        )
       })
       if (filteredValueKeyElems.length > 0) {
-        valueForElem.onkeyup = (event) => {
+        valueForElem.onkeyup = event => {
           filteredValueKeyElems[0].innerText = event.target.value
         }
       }
@@ -88,19 +97,24 @@ const bindDynamicInputToDom = (element) => {
   }
 }
 
-export const Directives = (props) => {
-  const callback = (elem) => {
+export const Directives = props => {
+  const callback = elem => {
     if (elem) {
-      directives.forEach((directive) => {
+      directives.forEach(directive => {
         const elems = elem.querySelectorAll(directive.selector)
-        Array.from(elems).forEach((e) => {
+        Array.from(elems).forEach(e => {
           if (e.firstChild.nodeName !== 'I') {
-            directive.selector === '[help-topic]' ? prependHelpIcon(e) : prependPlayIcon(e)
+            directive.selector === '[help-topic]'
+              ? prependHelpIcon(e)
+              : prependPlayIcon(e)
           }
 
           e.onclick = () => {
             addClass(e, 'clicked')
-            return props.onItemClick(directive.valueExtractor(e), directive.autoExec)
+            return props.onItemClick(
+              directive.valueExtractor(e),
+              directive.autoExec
+            )
           }
         })
       })

--- a/src/browser/components/Directives.test.js
+++ b/src/browser/components/Directives.test.js
@@ -26,10 +26,10 @@ import { mount } from 'services/testUtils'
 describe('Directives', () => {
   test('should attach play topic directive when contents has a play-topic attribute', () => {
     const clickEvent = jest.fn()
-    const html = (<a play-topic='hello'>foobar</a>)
+    const html = <a play-topic='hello'>foobar</a>
     const result = mount(DirectivesComponent)
       .withProps({ content: html, onItemClick: clickEvent })
-      .then((wrapper) => {
+      .then(wrapper => {
         const actual = wrapper.find('a').get(0)
         actual.click()
         expect(clickEvent).toHaveBeenCalled()
@@ -39,10 +39,10 @@ describe('Directives', () => {
   })
   test('should attach help topic directive when contents has a help-topic attribute', () => {
     const clickEvent = jest.fn()
-    const html = (<a help-topic='hello'>foobar</a>)
+    const html = <a help-topic='hello'>foobar</a>
     const result = mount(DirectivesComponent)
       .withProps({ content: html, onItemClick: clickEvent })
-      .then((wrapper) => {
+      .then(wrapper => {
         const actual = wrapper.find('a').get(0)
         actual.click()
         expect(clickEvent).toHaveBeenCalled()
@@ -52,10 +52,10 @@ describe('Directives', () => {
   })
   test('should attach runnable directive when element has a tag of `pre.runnable`', () => {
     const clickEvent = jest.fn()
-    const html = (<pre className='runnable'>foobar</pre>)
+    const html = <pre className='runnable'>foobar</pre>
     const result = mount(DirectivesComponent)
       .withProps({ content: html, onItemClick: clickEvent })
-      .then((wrapper) => {
+      .then(wrapper => {
         const actual = wrapper.find('pre.runnable').get(0)
         actual.click()
         expect(clickEvent).toHaveBeenCalled()
@@ -65,10 +65,14 @@ describe('Directives', () => {
   })
   test('should attach runnable directive when element has a class name of `.runnable pre`', () => {
     const clickEvent = jest.fn()
-    const html = (<span className='runnable'><pre>foobar</pre></span>)
+    const html = (
+      <span className='runnable'>
+        <pre>foobar</pre>
+      </span>
+    )
     const result = mount(DirectivesComponent)
       .withProps({ content: html, onItemClick: clickEvent })
-      .then((wrapper) => {
+      .then(wrapper => {
         const actual = wrapper.find('.runnable pre').get(0)
         actual.click()
         expect(clickEvent).toHaveBeenCalled()
@@ -79,10 +83,10 @@ describe('Directives', () => {
 
   test('should not attach any directives when contents does not have any directive attributes', () => {
     const clickEvent = jest.fn()
-    const html = (<a>foobar</a>)
+    const html = <a>foobar</a>
     const result = mount(DirectivesComponent)
       .withProps({ content: html, onItemClick: clickEvent })
-      .then((wrapper) => {
+      .then(wrapper => {
         const actual = wrapper.find('a').get(0)
         actual.click()
         expect(clickEvent).not.toHaveBeenCalled()
@@ -94,13 +98,17 @@ describe('Directives', () => {
     const clickEvent = jest.fn()
     const html = (
       <div>
-        <a class='help' is help-topic='help'>foobar</a>
-        <a class='play' is play-topic='play'>foobar</a>
+        <a class='help' is help-topic='help'>
+          foobar
+        </a>
+        <a class='play' is play-topic='play'>
+          foobar
+        </a>
       </div>
     )
     const result = mount(DirectivesComponent)
       .withProps({ content: html, onItemClick: clickEvent })
-      .then((wrapper) => {
+      .then(wrapper => {
         const actualHelp = wrapper.find('a.help').get(0)
         const actualPlay = wrapper.find('a.play').get(0)
         actualPlay.click()

--- a/src/browser/components/Display.jsx
+++ b/src/browser/components/Display.jsx
@@ -30,7 +30,9 @@ export default class Display extends Component {
     }
   }
   componentDidMount () {
-    if (this.props.if === true) this.setState({ displayed: true, mounted: true })
+    if (this.props.if === true) {
+      this.setState({ displayed: true, mounted: true })
+    }
   }
   componentWillReceiveProps (props) {
     if (props.if && this.state.displayed === false) {
@@ -43,12 +45,26 @@ export default class Display extends Component {
   }
   shouldComponentUpdate (props, state) {
     if (props.if === false && this.props.if === false) return false // Never rerender non displayed components
-    return !(shallowEquals(props, this.props) && shallowEquals(state, this.state))
+    return !(
+      shallowEquals(props, this.props) && shallowEquals(state, this.state)
+    )
   }
   render () {
-    if (!this.state.displayed && !this.state.mounted && this.props.lazy) return null // Lazy load it
+    if (!this.state.displayed && !this.state.mounted && this.props.lazy) {
+      return null
+    } // Lazy load it
     const { style = {}, children = [] } = this.props
-    const modStyle = { ...style, width: 'inherit', display: (!this.state.displayed ? 'none' : (this.props.inline ? 'inline' : 'block')) }
-    return <div style={modStyle}>{children}</div>
+    const modStyle = {
+      ...style,
+      width: 'inherit',
+      display: !this.state.displayed
+        ? 'none'
+        : this.props.inline ? 'inline' : 'block'
+    }
+    return (
+      <div style={modStyle}>
+        {children}
+      </div>
+    )
   }
 }

--- a/src/browser/components/Display.test.js
+++ b/src/browser/components/Display.test.js
@@ -31,10 +31,9 @@ describe('<Display>', () => {
     const val = false
     const children = [<span>Hello</span>]
     const result = mount(Display)
-      .withProps({if: val, lazy: 1, children})
-
+      .withProps({ if: val, lazy: 1, children })
       // Then
-      .then((wrapper) => {
+      .then(wrapper => {
         expect(wrapper.text()).toEqual('')
       })
 
@@ -46,10 +45,9 @@ describe('<Display>', () => {
     const val = false
     const children = [<span>Hello</span>]
     const result = mount(Display)
-      .withProps({if: val, children})
-
+      .withProps({ if: val, children })
       // Then
-      .then((wrapper) => {
+      .then(wrapper => {
         expect(wrapper.text()).toEqual('Hello')
         expect(wrapper.html()).toContain('display: none')
       })
@@ -62,10 +60,9 @@ describe('<Display>', () => {
     const val = true
     const children = [<span>Hello</span>]
     const result = mount(Display)
-      .withProps({if: val, children})
-
+      .withProps({ if: val, children })
       // Then
-      .then((wrapper) => {
+      .then(wrapper => {
         expect(wrapper.text()).toEqual('Hello')
         expect(wrapper.html()).toContain('display: block')
       })
@@ -78,10 +75,9 @@ describe('<Display>', () => {
     const val = true
     const children = [<span>Hello</span>]
     const result = mount(Display)
-      .withProps({if: val, inline: 1, children})
-
+      .withProps({ if: val, inline: 1, children })
       // Then
-      .then((wrapper) => {
+      .then(wrapper => {
         expect(wrapper.text()).toEqual('Hello')
         expect(wrapper.html()).toContain('display: inline')
       })
@@ -95,15 +91,14 @@ describe('<Display>', () => {
     const secondVal = true
     const children = [<span>Hello</span>]
     const result = mount(Display)
-      .withProps({if: firstVal, lazy: 1, children})
-
+      .withProps({ if: firstVal, lazy: 1, children })
       // Then
-      .then((wrapper) => {
+      .then(wrapper => {
         expect(wrapper.text()).toEqual('')
         return wrapper
       })
-      .then((wrapper) => {
-        wrapper.setProps({if: secondVal, lazy: 1, children})
+      .then(wrapper => {
+        wrapper.setProps({ if: secondVal, lazy: 1, children })
         wrapper.update()
         expect(wrapper.text()).toEqual('Hello')
         expect(wrapper.html()).toContain('display: block')
@@ -116,22 +111,21 @@ describe('<Display>', () => {
     // Given
     const children = [<span>Hello</span>]
     const result = mount(Display)
-      .withProps({if: false, lazy: 1, children})
-
+      .withProps({ if: false, lazy: 1, children })
       // Then
-      .then((wrapper) => {
+      .then(wrapper => {
         expect(wrapper.text()).toEqual('')
         return wrapper
       })
-      .then((wrapper) => {
-        wrapper.setProps({if: true, lazy: 1, children})
+      .then(wrapper => {
+        wrapper.setProps({ if: true, lazy: 1, children })
         wrapper.update()
         expect(wrapper.text()).toEqual('Hello')
         expect(wrapper.html()).toContain('display: block')
         return wrapper
       })
-      .then((wrapper) => {
-        wrapper.setProps({if: false, lazy: 1, children})
+      .then(wrapper => {
+        wrapper.setProps({ if: false, lazy: 1, children })
         wrapper.update()
         expect(wrapper.text()).toEqual('Hello')
         expect(wrapper.html()).toContain('display: none')

--- a/src/browser/components/EditionView.jsx
+++ b/src/browser/components/EditionView.jsx
@@ -19,7 +19,7 @@
  */
 
 import styled from 'styled-components'
-import {H3} from 'browser-components/headers'
+import { H3 } from 'browser-components/headers'
 
 const Aside = styled.div`
   display: table-cell;
@@ -30,17 +30,13 @@ const Aside = styled.div`
   font-weight: 300;
   color: ${props => props.theme.asideText};
 `
-const PaddedDiv = styled.div`
-  padding: 30px 45px;
-`
+const PaddedDiv = styled.div`padding: 30px 45px;`
 const StyledConnectionBody = styled.div`
   font-size: 1.3em;
   line-height: 1.6em;
   padding-left: 50px;
 `
-const BodyContainer = styled.div`
-  display: table-cell;
-`
+const BodyContainer = styled.div`display: table-cell;`
 const Code = styled.code`
   white-space: nowrap;
   overflow: hidden;
@@ -48,12 +44,10 @@ const Code = styled.code`
   background-color: #f9f2f4;
   border-radius: 4px;
 `
-const P = styled.p`
-  margin: 20px 0;
-`
+const P = styled.p`margin: 20px 0;`
 
-export const EnterpriseOnlyFrame = (props) => {
-  const {command, ...rest} = props
+export const EnterpriseOnlyFrame = props => {
+  const { command, ...rest } = props
   return (
     <PaddedDiv {...rest}>
       <Aside>
@@ -62,8 +56,17 @@ export const EnterpriseOnlyFrame = (props) => {
       </Aside>
       <BodyContainer>
         <StyledConnectionBody>
-          <P>Unable to display <Code>{command}</Code> because the procedures required to run this frame are missing. These procedures are usually found in Neo4j Enterprise edition.</P>
-          <P>Find out more over at <a href='https://neo4j.com/editions/' target='_blank'>neo4j.com/editions</a></P>
+          <P>
+            Unable to display <Code>{command}</Code> because the procedures
+            required to run this frame are missing. These procedures are usually
+            found in Neo4j Enterprise edition.
+          </P>
+          <P>
+            Find out more over at{' '}
+            <a href='https://neo4j.com/editions/' target='_blank'>
+              neo4j.com/editions
+            </a>
+          </P>
         </StyledConnectionBody>
       </BodyContainer>
     </PaddedDiv>

--- a/src/browser/components/FileImporter/FileDrop.jsx
+++ b/src/browser/components/FileImporter/FileDrop.jsx
@@ -19,7 +19,7 @@
  */
 
 import { Component } from 'preact'
-import {NativeTypes} from 'react-dnd-html5-backend'
+import { NativeTypes } from 'react-dnd-html5-backend'
 import { DropTarget } from 'react-dnd'
 import { wrapWithDndContext } from './dndGlobalContext'
 
@@ -28,13 +28,15 @@ const fileTarget = {
     const file = monitor.getItem().files[0]
     if (file.name.endsWith(`.${props.expectedExtension}`)) {
       const fileReader = new FileReader()
-      fileReader.onloadend = (evt) => {
+      fileReader.onloadend = evt => {
         props.onImportSuccess(evt.target.result)
       }
       fileReader.readAsText(file)
-      return {message: `Imported file: ${file.name}`}
+      return { message: `Imported file: ${file.name}` }
     } else {
-      return {message: `File not imported. Expected File to have an extension of '${props.expectedExtension}'`}
+      return {
+        message: `File not imported. Expected File to have an extension of '${props.expectedExtension}'`
+      }
     }
   }
 }
@@ -50,7 +52,7 @@ class FileDropZone extends Component {
   componentWillUpdate () {
     const result = this.props.getDropResult
     if (result && result.message) {
-      this.setState({text: result.message})
+      this.setState({ text: result.message })
     }
   }
   render () {
@@ -63,13 +65,17 @@ class FileDropZone extends Component {
 }
 
 export const FileDrop = (Component, applyContext) => {
-  let WrappedComponent = (props) => {
-    return (<FileDropZone {...props} Component={Component} />)
+  let WrappedComponent = props => {
+    return <FileDropZone {...props} Component={Component} />
   }
-  const Target = DropTarget(NativeTypes.FILE, fileTarget, (connect, monitor) => ({
-    connectDropTarget: connect.dropTarget(),
-    canDrop: monitor.canDrop(),
-    getDropResult: monitor.getDropResult()
-  }))(WrappedComponent)
+  const Target = DropTarget(
+    NativeTypes.FILE,
+    fileTarget,
+    (connect, monitor) => ({
+      connectDropTarget: connect.dropTarget(),
+      canDrop: monitor.canDrop(),
+      getDropResult: monitor.getDropResult()
+    })
+  )(WrappedComponent)
   return wrapWithDndContext(Target)
 }

--- a/src/browser/components/FileImporter/FileDrop.test.jsx
+++ b/src/browser/components/FileImporter/FileDrop.test.jsx
@@ -21,12 +21,12 @@
 /* global test, expect */
 import React from 'react'
 import { mount } from 'enzyme'
-import {FileDrop} from './FileDrop'
+import { FileDrop } from './FileDrop'
 
 describe('FileDrop', () => {
   test('should render child component', () => {
-    const ChildComponent = (props) => {
-      return (<div className='child' />)
+    const ChildComponent = props => {
+      return <div className='child' />
     }
     const FileDropComp = FileDrop(ChildComponent, true)
     const wrapper = mount(<FileDropComp />)

--- a/src/browser/components/FileImporter/FileDropBar.jsx
+++ b/src/browser/components/FileImporter/FileDropBar.jsx
@@ -18,10 +18,14 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {FileDrop} from './FileDrop'
+import { FileDrop } from './FileDrop'
 
-const DropBar = (props) => {
-  return (<div>{props.text}</div>)
+const DropBar = props => {
+  return (
+    <div>
+      {props.text}
+    </div>
+  )
 }
 
 export const FileDropBar = FileDrop(DropBar, true)

--- a/src/browser/components/FileImporter/dndGlobalContext.js
+++ b/src/browser/components/FileImporter/dndGlobalContext.js
@@ -47,16 +47,14 @@ class DndContextWrapping extends Component {
     }
   }
   render () {
-    let childProps = {...this.props}
+    let childProps = { ...this.props }
     delete childProps.Component
-    return (
-      <this.props.Component {...childProps} />
-    )
+    return <this.props.Component {...childProps} />
   }
 }
 
-export const wrapWithDndContext = (Component) => {
-  return (props) => {
-    return (<DndContextWrapping {...props} Component={Component} />)
+export const wrapWithDndContext = Component => {
+  return props => {
+    return <DndContextWrapping {...props} Component={Component} />
   }
 }

--- a/src/browser/components/Form.jsx
+++ b/src/browser/components/Form.jsx
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {Component} from 'preact'
+import { Component } from 'preact'
 import styled from 'styled-components'
 
 const StyledSettingTextInput = styled.input`
@@ -32,9 +32,7 @@ const StyledSettingTextInput = styled.input`
   width: 192px;
 `
 
-const StyledCheckbox = styled.input`
-  margin-right: 10px;
-`
+const StyledCheckbox = styled.input`margin-right: 10px;`
 const StyledLabel = styled.label`
   margin-left: 10px;
   display: inline-block;
@@ -42,17 +40,21 @@ const StyledLabel = styled.label`
     text-transform: uppercase;
   }
 `
-const StyledRadioEntry = styled.div`
-  margin: 10px 0;
-`
+const StyledRadioEntry = styled.div`margin: 10px 0;`
 
-export const TextInput = (props) => {
-  const {children, ...rest} = props
-  return <StyledSettingTextInput {...rest}>{children}</StyledSettingTextInput>
+export const TextInput = props => {
+  const { children, ...rest } = props
+  return (
+    <StyledSettingTextInput {...rest}>
+      {children}
+    </StyledSettingTextInput>
+  )
 }
 
-export const CheckboxSelector = (props) => {
-  return (props.checked) ? <StyledCheckbox type='checkbox' {...props} /> : <StyledCheckbox type='checkbox' {...props} />
+export const CheckboxSelector = props => {
+  return props.checked
+    ? <StyledCheckbox type='checkbox' {...props} />
+    : <StyledCheckbox type='checkbox' {...props} />
 }
 
 export class RadioSelector extends Component {
@@ -66,14 +68,23 @@ export class RadioSelector extends Component {
   render () {
     return (
       <form>
-        {this.props.options.map((option) => {
-          return (<StyledRadioEntry>
-            <input type='radio' value={option} checked={this.isSelectedValue(option)} onClick={(event) => {
-              this.state.selectedValue = option
-              this.props.onChange(event)
-            }} />
-            <StyledLabel>{option}</StyledLabel>
-          </StyledRadioEntry>)
+        {this.props.options.map(option => {
+          return (
+            <StyledRadioEntry>
+              <input
+                type='radio'
+                value={option}
+                checked={this.isSelectedValue(option)}
+                onClick={event => {
+                  this.state.selectedValue = option
+                  this.props.onChange(event)
+                }}
+              />
+              <StyledLabel>
+                {option}
+              </StyledLabel>
+            </StyledRadioEntry>
+          )
         })}
       </form>
     )

--- a/src/browser/components/Render/index.jsx
+++ b/src/browser/components/Render/index.jsx
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const Render = ({if: cond, children}) => {
+const Render = ({ if: cond, children }) => {
   return cond ? children[0] : null
 }
 export default Render

--- a/src/browser/components/Render/index.test.js
+++ b/src/browser/components/Render/index.test.js
@@ -31,10 +31,9 @@ describe('<Render>', () => {
     const val = false
     const children = [<span>Hello</span>]
     const result = mount(Render)
-      .withProps({if: val, children})
-
+      .withProps({ if: val, children })
       // Then
-      .then((wrapper) => {
+      .then(wrapper => {
         expect(wrapper.text()).toEqual('')
       })
 
@@ -46,10 +45,9 @@ describe('<Render>', () => {
     const val = true
     const children = [<span>Hello</span>]
     const result = mount(Render)
-      .withProps({if: val, children})
-
+      .withProps({ if: val, children })
       // Then
-      .then((wrapper) => {
+      .then(wrapper => {
         expect(wrapper.text()).toEqual('Hello')
       })
 

--- a/src/browser/components/TabNavigation/Navigation.jsx
+++ b/src/browser/components/TabNavigation/Navigation.jsx
@@ -19,8 +19,17 @@
  */
 
 import { Component } from 'preact'
-import { StyledNavigationButton, NavigationButtonContainer } from 'browser-components/buttons'
-import { StyledSidebar, StyledDrawer, StyledTabsWrapper, StyledTopNav, StyledBottomNav } from './styled'
+import {
+  StyledNavigationButton,
+  NavigationButtonContainer
+} from 'browser-components/buttons'
+import {
+  StyledSidebar,
+  StyledDrawer,
+  StyledTabsWrapper,
+  StyledTopNav,
+  StyledBottomNav
+} from './styled'
 
 const Closing = 'CLOSING'
 const Closed = 'CLOSED'
@@ -41,12 +50,18 @@ class Navigation extends Component {
       var newState = {}
       if (nextProps.openDrawer) {
         newState.drawerContent = nextProps.openDrawer
-        if (this.state.transitionState === Closed || this.state.transitionState === Closing) {
+        if (
+          this.state.transitionState === Closed ||
+          this.state.transitionState === Closing
+        ) {
           newState.transitionState = Opening
         }
       } else {
         newState.drawerContent = ''
-        if (this.state.transitionState === Open || this.state.transitionState === Opening) {
+        if (
+          this.state.transitionState === Open ||
+          this.state.transitionState === Opening
+        ) {
           newState.transitionState = Closing
         }
       }
@@ -69,11 +84,7 @@ class Navigation extends Component {
   }
 
   render () {
-    let {
-      onNavClick,
-      topNavItems,
-      bottomNavItems = []
-    } = this.props
+    let { onNavClick, topNavItems, bottomNavItems = [] } = this.props
 
     const buildNavList = (list, selected) => {
       return list.map((item, index) => {
@@ -85,14 +96,16 @@ class Navigation extends Component {
             onClick={() => onNavClick(item.name.toLowerCase())}
             isOpen={isOpen}
           >
-            <StyledNavigationButton name={item.name}>{item.icon(isOpen)}</StyledNavigationButton>
+            <StyledNavigationButton name={item.name}>
+              {item.icon(isOpen)}
+            </StyledNavigationButton>
           </NavigationButtonContainer>
         )
       })
     }
-    const getContentToShow = (openDrawer) => {
+    const getContentToShow = openDrawer => {
       if (openDrawer) {
-        let filteredList = topNavItems.concat(bottomNavItems).filter((item) => {
+        let filteredList = topNavItems.concat(bottomNavItems).filter(item => {
           return item.name.toLowerCase() === openDrawer
         })
         let TabContent = filteredList[0].content
@@ -101,17 +114,27 @@ class Navigation extends Component {
       return null
     }
     const topNavItemsList = buildNavList(topNavItems, this.state.drawerContent)
-    const bottomNavItemsList = buildNavList(bottomNavItems, this.state.drawerContent)
+    const bottomNavItemsList = buildNavList(
+      bottomNavItems,
+      this.state.drawerContent
+    )
 
     return (
       <StyledSidebar>
         <StyledTabsWrapper>
-          <StyledTopNav>{topNavItemsList}</StyledTopNav>
-          <StyledBottomNav>{bottomNavItemsList}</StyledBottomNav>
+          <StyledTopNav>
+            {topNavItemsList}
+          </StyledTopNav>
+          <StyledBottomNav>
+            {bottomNavItemsList}
+          </StyledBottomNav>
         </StyledTabsWrapper>
         <StyledDrawer
-          open={this.state.transitionState === Open || this.state.transitionState === Opening}
-          innerRef={(ref) => {
+          open={
+            this.state.transitionState === Open ||
+            this.state.transitionState === Opening
+          }
+          innerRef={ref => {
             if (ref) {
               // Remove old listeners so we don't get multiple callbacks.
               // This function is called more than once with same html element

--- a/src/browser/components/TabNavigation/Navigation.test.jsx
+++ b/src/browser/components/TabNavigation/Navigation.test.jsx
@@ -32,7 +32,10 @@ describe('Navigation', () => {
   }
   const navItem1 = 'item1' + Math.random()
   const navItem2 = 'item2' + Math.random()
-  const navItems = [{name: navItem1, icon: null, content: Tab1Content}, {name: navItem2, icon: null, content: Tab2Content}]
+  const navItems = [
+    { name: navItem1, icon: null, content: Tab1Content },
+    { name: navItem2, icon: null, content: Tab2Content }
+  ]
 
   test('renders a list of navigation links', () => {
     const wrapper = mount(<Navigation topNavItems={navItems} />)
@@ -41,19 +44,25 @@ describe('Navigation', () => {
 
   test('hides drawer when no drawer should be open', () => {
     const drawer = null
-    const wrapper = mount(<Navigation openDrawer={drawer} topNavItems={navItems} />)
+    const wrapper = mount(
+      <Navigation openDrawer={drawer} topNavItems={navItems} />
+    )
     expect(wrapper.find('.tab').at(0).hasClass('hidden')).toEqual(true)
   })
 
   test('shows drawer when drawer should be open', () => {
     const drawer = navItem1
-    const wrapper = mount(<Navigation openDrawer={drawer} topNavItems={navItems} />)
+    const wrapper = mount(
+      <Navigation openDrawer={drawer} topNavItems={navItems} />
+    )
     expect(wrapper.find('.tab').at(0).hasClass('hidden')).toEqual(false)
   })
 
   test('should render the selected tab', () => {
     const drawer = navItem1
-    const wrapper = mount(<Navigation openDrawer={drawer} topNavItems={navItems} />)
+    const wrapper = mount(
+      <Navigation openDrawer={drawer} topNavItems={navItems} />
+    )
     expect(wrapper.find('.tab').at(0).hasClass('hidden')).toEqual(false)
     expect(wrapper.find('#thing').length).toBe(1)
     expect(wrapper.find('#thing2').length).toBe(0)

--- a/src/browser/components/TabNavigation/styled.jsx
+++ b/src/browser/components/TabNavigation/styled.jsx
@@ -22,7 +22,7 @@ import styled from 'styled-components'
 
 export const StyledSidebar = styled.div`
   flex: 0 0 auto;
-  background-color: #4C4957;
+  background-color: #4c4957;
   display: flex;
   flex-direction: row;
   border-right: 1px solid black;
@@ -31,10 +31,10 @@ export const StyledSidebar = styled.div`
 
 export const StyledDrawer = styled.div`
   flex: 0 0 auto;
-  background-color: #30333A;
+  background-color: #30333a;
   overflow-x: hidden;
   overflow-y: auto;
-  width: ${props => props.open ? '300px' : '0px'};
+  width: ${props => (props.open ? '300px' : '0px')};
   transition: .2s ease-out;
   z-index: 1;
 `

--- a/src/browser/components/Tables.jsx
+++ b/src/browser/components/Tables.jsx
@@ -23,9 +23,9 @@ import styled from 'styled-components'
 const StyledTable = styled.table`
   border-radius: 4px;
   margin: 0 15px 20px 15px;
-  -webkit-box-shadow: 0 1px 1px rgba(0,0,0,.05);
-  box-shadow: 0 1px 1px rgba(0,0,0,.05);
-  `
+  -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
+  box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
+`
 const StyledTr = styled.tr`
   padding: 10px 15px;
   border: 1px solid #ddd;
@@ -41,9 +41,7 @@ const StyledTh = styled.th`
   border-color: #ddd;
   padding: 10px 15px;
 `
-const StyledTd = styled.td`
-  padding: 5px;
-`
+const StyledTd = styled.td`padding: 5px;`
 const StyledTdKey = styled(StyledTd)`
   font-weight: bold;
 `
@@ -53,12 +51,14 @@ export const SysInfoTableContainer = styled.div`
   padding: 30px;
   width: 100%;
 `
-export const SysInfoTable = ({header, colspan, children}) => {
+export const SysInfoTable = ({ header, colspan, children }) => {
   return (
     <StyledTable>
       <thead>
         <StyledTr>
-          <StyledTh colSpan={colspan || 2}>{header}</StyledTh>
+          <StyledTh colSpan={colspan || 2}>
+            {header}
+          </StyledTh>
         </StyledTr>
       </thead>
       <tbody>
@@ -68,25 +68,37 @@ export const SysInfoTable = ({header, colspan, children}) => {
   )
 }
 
-export const SysInfoTableEntry = ({label, value, values, headers}) => {
+export const SysInfoTableEntry = ({ label, value, values, headers }) => {
   if (headers) {
     return (
       <StyledTr>
-        {headers.map((value) => <StyledTdKey>{value || '-'}</StyledTdKey>)}
+        {headers.map(value =>
+          <StyledTdKey>
+            {value || '-'}
+          </StyledTdKey>
+        )}
       </StyledTr>
     )
   }
   if (values) {
     return (
       <StyledTr>
-        {values.map((value) => <StyledTd>{value || '-'}</StyledTd>)}
+        {values.map(value =>
+          <StyledTd>
+            {value || '-'}
+          </StyledTd>
+        )}
       </StyledTr>
     )
   }
   return (
     <StyledTr>
-      <StyledTdKey>{label}</StyledTdKey>
-      <StyledTd>{value || '-'}</StyledTd>
+      <StyledTdKey>
+        {label}
+      </StyledTdKey>
+      <StyledTd>
+        {value || '-'}
+      </StyledTd>
     </StyledTr>
   )
 }

--- a/src/browser/components/badge/index.jsx
+++ b/src/browser/components/badge/index.jsx
@@ -20,11 +20,15 @@
 
 import style from './style.css'
 
-const Badge = ({children = null, status = 'ok', size = 'medium'}) => {
+const Badge = ({ children = null, status = 'ok', size = 'medium' }) => {
   let cn = style.badge
   if (status) cn += ' ' + style[status]
   if (size) cn += ' ' + style[size]
-  return <div className={cn}>{children}</div>
+  return (
+    <div className={cn}>
+      {children}
+    </div>
+  )
 }
 
 export default Badge

--- a/src/browser/components/buttons/ConfirmationButton.jsx
+++ b/src/browser/components/buttons/ConfirmationButton.jsx
@@ -18,9 +18,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {Component} from 'preact'
+import { Component } from 'preact'
 import styles from './style.css'
-import { MinusIcon, RightArrowIcon, CancelIcon } from 'browser-components/icons/Icons'
+import {
+  MinusIcon,
+  RightArrowIcon,
+  CancelIcon
+} from 'browser-components/icons/Icons'
 
 export class ConfirmationButton extends Component {
   constructor (props) {
@@ -32,21 +36,41 @@ export class ConfirmationButton extends Component {
   }
 
   componentWillMount () {
-    this.confirmIcon = this.props.confirmIcon || (<RightArrowIcon />)
-    this.cancelIcon = this.props.cancelIcon || (<CancelIcon />)
-    this.requestIcon = this.props.requestIcon || (<MinusIcon />)
+    this.confirmIcon = this.props.confirmIcon || <RightArrowIcon />
+    this.cancelIcon = this.props.cancelIcon || <CancelIcon />
+    this.requestIcon = this.props.requestIcon || <MinusIcon />
   }
 
   render () {
     if (this.state.requested) {
       return (
         <div>
-          <button className={styles.icon} onClick={() => { this.setState({ requested: false }); this.props.onConfirmed() }}>{this.confirmIcon}</button>
-          <button className={styles.icon} onClick={() => this.setState({ requested: false })}>{this.cancelIcon}</button>
+          <button
+            className={styles.icon}
+            onClick={() => {
+              this.setState({ requested: false })
+              this.props.onConfirmed()
+            }}
+          >
+            {this.confirmIcon}
+          </button>
+          <button
+            className={styles.icon}
+            onClick={() => this.setState({ requested: false })}
+          >
+            {this.cancelIcon}
+          </button>
         </div>
       )
     } else {
-      return (<button className={styles.icon} onClick={() => this.setState({ requested: true })}>{this.requestIcon}</button>)
+      return (
+        <button
+          className={styles.icon}
+          onClick={() => this.setState({ requested: true })}
+        >
+          {this.requestIcon}
+        </button>
+      )
     }
   }
 }

--- a/src/browser/components/buttons/index.jsx
+++ b/src/browser/components/buttons/index.jsx
@@ -36,15 +36,18 @@ export class ToolTip extends Component {
     }
   }
   onMouseEnterHandler () {
-    this.setState({mouseover: true})
+    this.setState({ mouseover: true })
   }
   onMouseLeaveHandler () {
-    this.setState({mouseover: false})
+    this.setState({ mouseover: false })
   }
   render () {
     const tooltip = null
     return (
-      <div onMouseLeave={this.onMouseLeaveHandler.bind(this)} onMouseEnter={this.onMouseEnterHandler.bind(this)}>
+      <div
+        onMouseLeave={this.onMouseLeaveHandler.bind(this)}
+        onMouseEnter={this.onMouseEnterHandler.bind(this)}
+      >
         {this.props.children}
         {tooltip}
       </div>
@@ -52,18 +55,16 @@ export class ToolTip extends Component {
   }
 }
 
-export const CloseButton = (props) => {
-  return (
-    <button {...props}>×</button>
-  )
+export const CloseButton = props => {
+  return <button {...props}>×</button>
 }
 
 export const EditorButton = styled.span`
   font-family: ${props => props.theme.streamlineFontFamily};
-  font-style: normal!important;
-  font-weight: 400!important;
-  font-variant: normal!important;
-  text-transform: none!important;
+  font-style: normal !important;
+  font-weight: 400 !important;
+  font-variant: normal !important;
+  text-transform: none !important;
   speak: none;
   -webkit-font-smoothing: antialiased;
   color: ${props => props.theme.secondaryButtonText};
@@ -105,7 +106,8 @@ export const StyledNavigationButton = styled.button`
 export const NavigationButtonContainer = styled.li`
   min-height: 70px;
   height: 70px;
-  background-color: ${props => !props.isOpen ? 'transparent' : props.theme.drawerBackground};
+  background-color: ${props =>
+    !props.isOpen ? 'transparent' : props.theme.drawerBackground};
   &:focus {
     outline: none;
   }
@@ -158,19 +160,43 @@ const buttonTypes = {
   drawer: StyledDrawerFormButton
 }
 
-export const FormButton = (props) => {
-  const {icon, label, children, ...rest} = props
+export const FormButton = props => {
+  const { icon, label, children, ...rest } = props
   const ButtonType = buttonTypes[props.buttonType] || buttonTypes.primary
 
-  if (icon && label) return (<ButtonType {...rest} type='button'>{label} {icon}</ButtonType>)
-  if (icon) return (<ButtonType {...rest} type='button'>{icon}</ButtonType>)
-  if (label) return (<ButtonType {...rest} type='button'>{label}</ButtonType>)
-  return (<ButtonType {...props} type='button'>{children}</ButtonType>)
+  if (icon && label) {
+    return (
+      <ButtonType {...rest} type='button'>
+        {label} {icon}
+      </ButtonType>
+    )
+  }
+  if (icon) {
+    return (
+      <ButtonType {...rest} type='button'>
+        {icon}
+      </ButtonType>
+    )
+  }
+  if (label) {
+    return (
+      <ButtonType {...rest} type='button'>
+        {label}
+      </ButtonType>
+    )
+  }
+  return (
+    <ButtonType {...props} type='button'>
+      {children}
+    </ButtonType>
+  )
 }
 
-export const CypherFrameButton = (props) => {
-  const {selected, ...rest} = props
-  return (selected) ? <StyledSelectedCypherFrameButton {...rest} /> : <StyledCypherFrameButton {...rest} />
+export const CypherFrameButton = props => {
+  const { selected, ...rest } = props
+  return selected
+    ? <StyledSelectedCypherFrameButton {...rest} />
+    : <StyledCypherFrameButton {...rest} />
 }
 
 const StyledCypherFrameButton = styled.li`
@@ -197,9 +223,15 @@ const StyledSelectedCypherFrameButton = styled(StyledCypherFrameButton)`
   color: ${props => props.theme.secondaryButtonTextHover};
   fill: ${props => props.theme.secondaryButtonTextHover};
 `
-export const FrameButton = (props) => {
-  const {pressed, children, ...rest} = props
-  return (pressed) ? <StyledFrameButtonPressed {...rest}>{children}</StyledFrameButtonPressed> : <StyledFrameButton {...rest}>{children}</StyledFrameButton>
+export const FrameButton = props => {
+  const { pressed, children, ...rest } = props
+  return pressed
+    ? <StyledFrameButtonPressed {...rest}>
+      {children}
+    </StyledFrameButtonPressed>
+    : <StyledFrameButton {...rest}>
+      {children}
+    </StyledFrameButton>
 }
 const StyledFrameButton = styled.li`
   color: ${props => props.theme.secondaryButtonText};
@@ -240,9 +272,9 @@ export const FrameButtonAChild = styled(DefaultA)`
   }
 `
 
-export const ActionButton = (props) => {
-  const {className, ...rest} = props
-  return (<button className={className + ' ' + styles.action} {...rest} />)
+export const ActionButton = props => {
+  const { className, ...rest } = props
+  return <button className={className + ' ' + styles.action} {...rest} />
 }
 
 const BaseCarouselButton = styled.button`
@@ -285,11 +317,13 @@ const CarouselButtonOverlay = styled.span`
   top: 13px;
   left: 9px;
 `
-export const CarouselButton = (props) => {
-  const {children, ...rest} = props
+export const CarouselButton = props => {
+  const { children, ...rest } = props
   return (
     <BaseCarouselButton {...rest}>
-      <CarouselButtonOverlay>{children}</CarouselButtonOverlay>
+      <CarouselButtonOverlay>
+        {children}
+      </CarouselButtonOverlay>
     </BaseCarouselButton>
   )
 }

--- a/src/browser/components/drawer/Drawer.jsx
+++ b/src/browser/components/drawer/Drawer.jsx
@@ -20,9 +20,7 @@
 
 import styled from 'styled-components'
 
-export const Drawer = styled.div`
-  width: 285px;
-`
+export const Drawer = styled.div`width: 285px;`
 
 export const DrawerHeader = styled.h4`
   color: ${props => props.theme.primaryHeaderText};
@@ -54,9 +52,7 @@ export const DrawerSubHeader = styled.h5`
   font-family: ${props => props.theme.drawerHeaderFontFamily};
 `
 
-export const DrawerSection = styled.div`
-  margin-bottom: 12px;
-`
+export const DrawerSection = styled.div`margin-bottom: 12px;`
 
 export const DrawerSectionBody = styled.div`
   font-family: ${props => props.theme.primaryFontFamily};
@@ -64,9 +60,7 @@ export const DrawerSectionBody = styled.div`
   color: #bcc0c9;
 `
 
-export const DrawerBody = styled.div`
-  padding: 0 24px;
-`
+export const DrawerBody = styled.div`padding: 0 24px;`
 
 export const DrawerFooter = styled.div`
   position: absolute;

--- a/src/browser/components/drawer/index.js
+++ b/src/browser/components/drawer/index.js
@@ -18,6 +18,24 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {Drawer, DrawerBody, DrawerHeader, DrawerSubHeader, DrawerSection, DrawerSectionBody, DrawerToppedHeader, DrawerFooter} from './Drawer'
+import {
+  Drawer,
+  DrawerBody,
+  DrawerHeader,
+  DrawerSubHeader,
+  DrawerSection,
+  DrawerSectionBody,
+  DrawerToppedHeader,
+  DrawerFooter
+} from './Drawer'
 
-export {Drawer, DrawerBody, DrawerHeader, DrawerSubHeader, DrawerSection, DrawerSectionBody, DrawerToppedHeader, DrawerFooter}
+export {
+  Drawer,
+  DrawerBody,
+  DrawerHeader,
+  DrawerSubHeader,
+  DrawerSection,
+  DrawerSectionBody,
+  DrawerToppedHeader,
+  DrawerFooter
+}

--- a/src/browser/components/headers/Headers.jsx
+++ b/src/browser/components/headers/Headers.jsx
@@ -26,15 +26,15 @@ export const H3 = styled.h3`
   font-family: ${props => props.theme.primaryFontFamily};
   color: ${props => props.theme.headerText};
 `
-export const H2 = (props) => {
-  return (<h2 {...props} />)
+export const H2 = props => {
+  return <h2 {...props} />
 }
-export const H1 = (props) => {
-  return (<h1 {...props} />)
+export const H1 = props => {
+  return <h1 {...props} />
 }
-export const H4 = (props) => {
-  return (<h4 {...props} />)
+export const H4 = props => {
+  return <h4 {...props} />
 }
-export const H5 = (props) => {
-  return (<h5 {...props} />)
+export const H5 = props => {
+  return <h5 {...props} />
 }

--- a/src/browser/components/headers/index.js
+++ b/src/browser/components/headers/index.js
@@ -18,6 +18,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {H1, H2, H3, H4, H5} from './Headers'
+import { H1, H2, H3, H4, H5 } from './Headers'
 
-export {H1, H2, H3, H4, H5}
+export { H1, H2, H3, H4, H5 }

--- a/src/browser/components/icons/Icons.jsx
+++ b/src/browser/components/icons/Icons.jsx
@@ -30,19 +30,44 @@ class IconContainer extends Component {
     }
   }
   mouseover () {
-    this.setState({mouseover: true})
+    this.setState({ mouseover: true })
   }
   mouseout () {
-    this.setState({mouseover: false})
+    this.setState({ mouseover: false })
   }
   render () {
-    const {activeStyle, inactiveStyle, isOpen, text, regulateSize, ...rest} = this.props
-    const state = (this.state.mouseover || isOpen) ? activeStyle || '' : inactiveStyle || ''
-    const newClass = this.props.suppressIconStyles ? this.props.className : state + ' ' + this.props.className
-    const regulateSizeStyle = (regulateSize) ? {'font-size': regulateSize + 'em'} : null
-    const icon = <i {...rest} className={newClass} onMouseEnter={this.mouseover.bind(this)} onMouseLeave={this.mouseout.bind(this)} style={regulateSizeStyle} />
+    const {
+      activeStyle,
+      inactiveStyle,
+      isOpen,
+      text,
+      regulateSize,
+      ...rest
+    } = this.props
+    const state =
+      this.state.mouseover || isOpen ? activeStyle || '' : inactiveStyle || ''
+    const newClass = this.props.suppressIconStyles
+      ? this.props.className
+      : state + ' ' + this.props.className
+    const regulateSizeStyle = regulateSize
+      ? { 'font-size': regulateSize + 'em' }
+      : null
+    const icon = (
+      <i
+        {...rest}
+        className={newClass}
+        onMouseEnter={this.mouseover.bind(this)}
+        onMouseLeave={this.mouseout.bind(this)}
+        style={regulateSizeStyle}
+      />
+    )
     return text
-      ? <span>{icon}<StyledText>{text}</StyledText></span>
+      ? <span>
+        {icon}
+        <StyledText>
+          {text}
+        </StyledText>
+      </span>
       : icon
   }
 }
@@ -72,54 +97,166 @@ const databaseConnectionStateStyles = {
   }
 }
 
-export const DatabaseIcon = ({isOpen, connectionState}) => (<IconContainer isOpen={isOpen}
-  activeStyle={databaseConnectionStateStyles[connectionState].active}
-  inactiveStyle={databaseConnectionStateStyles[connectionState].inactive}
-  className={'sl sl-database-' + databaseConnectionStateStyles[connectionState].classModifier}
-/>)
-export const FavoritesIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.white} inactiveStyle={styles.inactive} className='sl sl-star' />)
-export const DocumentsIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.white} inactiveStyle={styles.inactive} className='sl sl-book' />)
+export const DatabaseIcon = ({ isOpen, connectionState }) =>
+  <IconContainer
+    isOpen={isOpen}
+    activeStyle={databaseConnectionStateStyles[connectionState].active}
+    inactiveStyle={databaseConnectionStateStyles[connectionState].inactive}
+    className={
+      'sl sl-database-' +
+      databaseConnectionStateStyles[connectionState].classModifier
+    }
+  />
+export const FavoritesIcon = ({ isOpen }) =>
+  <IconContainer
+    isOpen={isOpen}
+    activeStyle={styles.white}
+    inactiveStyle={styles.inactive}
+    className='sl sl-star'
+  />
+export const DocumentsIcon = ({ isOpen }) =>
+  <IconContainer
+    isOpen={isOpen}
+    activeStyle={styles.white}
+    inactiveStyle={styles.inactive}
+    className='sl sl-book'
+  />
 
-export const CloudIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.successGreen} inactiveStyle={styles.inactive} className='sl sl-cloud-checked' />)
-export const CloudDisconnectedIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.warningRed} inactiveStyle={styles.warningRed} className='sl sl-cloud-delete' />)
-export const CloudSyncIcon = ({isOpen, connected}) => (<IconContainer isOpen={isOpen} activeStyle={connected ? styles.successGreen : styles.warningRed} inactiveStyle={connected ? styles.inactive : styles.warningRed} className={'sl sl-cloud' + (connected ? '-checked' : '-delete')} />)
+export const CloudIcon = ({ isOpen }) =>
+  <IconContainer
+    isOpen={isOpen}
+    activeStyle={styles.successGreen}
+    inactiveStyle={styles.inactive}
+    className='sl sl-cloud-checked'
+  />
+export const CloudDisconnectedIcon = ({ isOpen }) =>
+  <IconContainer
+    isOpen={isOpen}
+    activeStyle={styles.warningRed}
+    inactiveStyle={styles.warningRed}
+    className='sl sl-cloud-delete'
+  />
+export const CloudSyncIcon = ({ isOpen, connected }) =>
+  <IconContainer
+    isOpen={isOpen}
+    activeStyle={connected ? styles.successGreen : styles.warningRed}
+    inactiveStyle={connected ? styles.inactive : styles.warningRed}
+    className={'sl sl-cloud' + (connected ? '-checked' : '-delete')}
+  />
 
-export const SettingsIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.white} inactiveStyle={styles.inactive} className='sl sl-setting-gear' />)
-export const AboutIcon = ({isOpen}) => (<IconContainer isOpen={isOpen} activeStyle={styles.credits} inactiveStyle={styles.inactive} className='nw nw-neo4j-outline-32px' />)
+export const SettingsIcon = ({ isOpen }) =>
+  <IconContainer
+    isOpen={isOpen}
+    activeStyle={styles.white}
+    inactiveStyle={styles.inactive}
+    className='sl sl-setting-gear'
+  />
+export const AboutIcon = ({ isOpen }) =>
+  <IconContainer
+    isOpen={isOpen}
+    activeStyle={styles.credits}
+    inactiveStyle={styles.inactive}
+    className='nw nw-neo4j-outline-32px'
+  />
 
-export const TableIcon = () => (<IconContainer className='fa fa-table' text='Table' />)
-export const VisualizationIcon = () => (<IconContainer className='nw nw-neo4j-outline-16px' text='Graph' />)
-export const AsciiIcon = () => (<IconContainer className='fa fa-font' text='Text' />)
-export const CodeIcon = () => (<IconContainer className='fa fa-code' text='Code' />)
-export const PlanIcon = () => (<IconContainer className='sl-hierarchy' text='Plan' />)
-export const AlertIcon = () => (<IconContainer className='sl-alert' text='Warn' />)
-export const ErrorIcon = () => (<IconContainer className='fa fa-file-text-o' text='Error' />)
+export const TableIcon = () =>
+  <IconContainer className='fa fa-table' text='Table' />
+export const VisualizationIcon = () =>
+  <IconContainer className='nw nw-neo4j-outline-16px' text='Graph' />
+export const AsciiIcon = () =>
+  <IconContainer className='fa fa-font' text='Text' />
+export const CodeIcon = () =>
+  <IconContainer className='fa fa-code' text='Code' />
+export const PlanIcon = () =>
+  <IconContainer className='sl-hierarchy' text='Plan' />
+export const AlertIcon = () =>
+  <IconContainer className='sl-alert' text='Warn' />
+export const ErrorIcon = () =>
+  <IconContainer className='fa fa-file-text-o' text='Error' />
 
-export const ZoomInIcon = () => (<IconContainer activeStyle={styles.active} inactiveStyle={styles.inactive} className='sl-zoom-in' />)
-export const ZoomOutIcon = () => (<IconContainer activeStyle={styles.active} inactiveStyle={styles.inactive} className='sl-zoom-out' />)
+export const ZoomInIcon = () =>
+  <IconContainer
+    activeStyle={styles.active}
+    inactiveStyle={styles.inactive}
+    className='sl-zoom-in'
+  />
+export const ZoomOutIcon = () =>
+  <IconContainer
+    activeStyle={styles.active}
+    inactiveStyle={styles.inactive}
+    className='sl-zoom-out'
+  />
 
-export const BinIcon = (props) => (<IconContainer activeStyle={styles.white} inactiveStyle={styles.inactive} {...props} className='sl-bin' />)
+export const BinIcon = props =>
+  <IconContainer
+    activeStyle={styles.white}
+    inactiveStyle={styles.inactive}
+    {...props}
+    className='sl-bin'
+  />
 
-export const ExpandIcon = () => (<IconContainer className='sl-scale-spread' />)
-export const ContractIcon = () => (<IconContainer className='sl-scale-reduce' />)
-export const RefreshIcon = () => (<IconContainer className='sl-loop' />)
-export const CloseIcon = () => (<IconContainer className='sl-delete' regulateSize='0.85' />)
-export const UpIcon = () => (<IconContainer className='sl-chevron-up' />)
-export const DownIcon = () => (<IconContainer className='sl-chevron-down' />)
-export const DoubleUpIcon = () => (<IconContainer className='sl-double-up' />)
-export const DoubleDownIcon = () => (<IconContainer className='sl-double-down' />)
-export const PinIcon = () => (<IconContainer className='sl-pin' />)
-export const MinusIcon = () => (<IconContainer activeStyle={styles.blue} inactiveStyle={styles.inactive} className='sl-minus-circle' />)
-export const RightArrowIcon = () => (<IconContainer activeStyle={styles.blue} inactiveStyle={styles.inactive} className='sl-arrow-circle-right' />)
-export const CancelIcon = () => (<IconContainer activeStyle={styles.blue} inactiveStyle={styles.inactive} className='sl-delete-circle' />)
-export const DownloadIcon = () => (<IconContainer className='sl-download-drive' />)
-export const ExpandMenuIcon = () => (<IconContainer activeStyle={styles.blue} className='fa fa-caret-right' />)
-export const CollapseMenuIcon = () => (<IconContainer activeStyle={styles.blue} className='fa fa-caret-down' />)
-export const PlayIcon = () => (<IconContainer activeStyle={styles.lightBlue} inactiveStyle={styles.blue} className='fa fa-play-circle-o' />)
-export const PlainPlayIcon = () => (<IconContainer className='fa fa-play-circle' />)
-export const QuestionIcon = () => (<IconContainer activeStyle={styles.lightBlue} inactiveStyle={styles.blue} className='fa fa-question-circle-o' />)
-export const PlusIcon = () => (<IconContainer activeStyle={styles.white} inactiveStyle={styles.white} className='fa fa-plus' />)
-export const EditIcon = () => (<IconContainer activeStyle={styles.white} inactiveStyle={styles.white} className='sl-pencil' />)
-export const Spinner = () => (<IconContainer className='fa fa-spinner fa-spin fa-2x' />)
+export const ExpandIcon = () => <IconContainer className='sl-scale-spread' />
+export const ContractIcon = () => <IconContainer className='sl-scale-reduce' />
+export const RefreshIcon = () => <IconContainer className='sl-loop' />
+export const CloseIcon = () =>
+  <IconContainer className='sl-delete' regulateSize='0.85' />
+export const UpIcon = () => <IconContainer className='sl-chevron-up' />
+export const DownIcon = () => <IconContainer className='sl-chevron-down' />
+export const DoubleUpIcon = () => <IconContainer className='sl-double-up' />
+export const DoubleDownIcon = () => <IconContainer className='sl-double-down' />
+export const PinIcon = () => <IconContainer className='sl-pin' />
+export const MinusIcon = () =>
+  <IconContainer
+    activeStyle={styles.blue}
+    inactiveStyle={styles.inactive}
+    className='sl-minus-circle'
+  />
+export const RightArrowIcon = () =>
+  <IconContainer
+    activeStyle={styles.blue}
+    inactiveStyle={styles.inactive}
+    className='sl-arrow-circle-right'
+  />
+export const CancelIcon = () =>
+  <IconContainer
+    activeStyle={styles.blue}
+    inactiveStyle={styles.inactive}
+    className='sl-delete-circle'
+  />
+export const DownloadIcon = () =>
+  <IconContainer className='sl-download-drive' />
+export const ExpandMenuIcon = () =>
+  <IconContainer activeStyle={styles.blue} className='fa fa-caret-right' />
+export const CollapseMenuIcon = () =>
+  <IconContainer activeStyle={styles.blue} className='fa fa-caret-down' />
+export const PlayIcon = () =>
+  <IconContainer
+    activeStyle={styles.lightBlue}
+    inactiveStyle={styles.blue}
+    className='fa fa-play-circle-o'
+  />
+export const PlainPlayIcon = () =>
+  <IconContainer className='fa fa-play-circle' />
+export const QuestionIcon = () =>
+  <IconContainer
+    activeStyle={styles.lightBlue}
+    inactiveStyle={styles.blue}
+    className='fa fa-question-circle-o'
+  />
+export const PlusIcon = () =>
+  <IconContainer
+    activeStyle={styles.white}
+    inactiveStyle={styles.white}
+    className='fa fa-plus'
+  />
+export const EditIcon = () =>
+  <IconContainer
+    activeStyle={styles.white}
+    inactiveStyle={styles.white}
+    className='sl-pencil'
+  />
+export const Spinner = () =>
+  <IconContainer className='fa fa-spinner fa-spin fa-2x' />
 
-export const ExclamationTriangleIcon = () => <IconContainer suppressIconStyles className='fa fa-exclamation-triangle' />
+export const ExclamationTriangleIcon = () =>
+  <IconContainer suppressIconStyles className='fa fa-exclamation-triangle' />

--- a/src/browser/external/canvg/StackBlur.js
+++ b/src/browser/external/canvg/StackBlur.js
@@ -40,48 +40,528 @@ OTHER DEALINGS IN THE SOFTWARE.
 */
 
 var mul_table = [
-  512, 512, 456, 512, 328, 456, 335, 512, 405, 328, 271, 456, 388, 335, 292, 512,
-  454, 405, 364, 328, 298, 271, 496, 456, 420, 388, 360, 335, 312, 292, 273, 512,
-  482, 454, 428, 405, 383, 364, 345, 328, 312, 298, 284, 271, 259, 496, 475, 456,
-  437, 420, 404, 388, 374, 360, 347, 335, 323, 312, 302, 292, 282, 273, 265, 512,
-  497, 482, 468, 454, 441, 428, 417, 405, 394, 383, 373, 364, 354, 345, 337, 328,
-  320, 312, 305, 298, 291, 284, 278, 271, 265, 259, 507, 496, 485, 475, 465, 456,
-  446, 437, 428, 420, 412, 404, 396, 388, 381, 374, 367, 360, 354, 347, 341, 335,
-  329, 323, 318, 312, 307, 302, 297, 292, 287, 282, 278, 273, 269, 265, 261, 512,
-  505, 497, 489, 482, 475, 468, 461, 454, 447, 441, 435, 428, 422, 417, 411, 405,
-  399, 394, 389, 383, 378, 373, 368, 364, 359, 354, 350, 345, 341, 337, 332, 328,
-  324, 320, 316, 312, 309, 305, 301, 298, 294, 291, 287, 284, 281, 278, 274, 271,
-  268, 265, 262, 259, 257, 507, 501, 496, 491, 485, 480, 475, 470, 465, 460, 456,
-  451, 446, 442, 437, 433, 428, 424, 420, 416, 412, 408, 404, 400, 396, 392, 388,
-  385, 381, 377, 374, 370, 367, 363, 360, 357, 354, 350, 347, 344, 341, 338, 335,
-  332, 329, 326, 323, 320, 318, 315, 312, 310, 307, 304, 302, 299, 297, 294, 292,
-  289, 287, 285, 282, 280, 278, 275, 273, 271, 269, 267, 265, 263, 261, 259]
+  512,
+  512,
+  456,
+  512,
+  328,
+  456,
+  335,
+  512,
+  405,
+  328,
+  271,
+  456,
+  388,
+  335,
+  292,
+  512,
+  454,
+  405,
+  364,
+  328,
+  298,
+  271,
+  496,
+  456,
+  420,
+  388,
+  360,
+  335,
+  312,
+  292,
+  273,
+  512,
+  482,
+  454,
+  428,
+  405,
+  383,
+  364,
+  345,
+  328,
+  312,
+  298,
+  284,
+  271,
+  259,
+  496,
+  475,
+  456,
+  437,
+  420,
+  404,
+  388,
+  374,
+  360,
+  347,
+  335,
+  323,
+  312,
+  302,
+  292,
+  282,
+  273,
+  265,
+  512,
+  497,
+  482,
+  468,
+  454,
+  441,
+  428,
+  417,
+  405,
+  394,
+  383,
+  373,
+  364,
+  354,
+  345,
+  337,
+  328,
+  320,
+  312,
+  305,
+  298,
+  291,
+  284,
+  278,
+  271,
+  265,
+  259,
+  507,
+  496,
+  485,
+  475,
+  465,
+  456,
+  446,
+  437,
+  428,
+  420,
+  412,
+  404,
+  396,
+  388,
+  381,
+  374,
+  367,
+  360,
+  354,
+  347,
+  341,
+  335,
+  329,
+  323,
+  318,
+  312,
+  307,
+  302,
+  297,
+  292,
+  287,
+  282,
+  278,
+  273,
+  269,
+  265,
+  261,
+  512,
+  505,
+  497,
+  489,
+  482,
+  475,
+  468,
+  461,
+  454,
+  447,
+  441,
+  435,
+  428,
+  422,
+  417,
+  411,
+  405,
+  399,
+  394,
+  389,
+  383,
+  378,
+  373,
+  368,
+  364,
+  359,
+  354,
+  350,
+  345,
+  341,
+  337,
+  332,
+  328,
+  324,
+  320,
+  316,
+  312,
+  309,
+  305,
+  301,
+  298,
+  294,
+  291,
+  287,
+  284,
+  281,
+  278,
+  274,
+  271,
+  268,
+  265,
+  262,
+  259,
+  257,
+  507,
+  501,
+  496,
+  491,
+  485,
+  480,
+  475,
+  470,
+  465,
+  460,
+  456,
+  451,
+  446,
+  442,
+  437,
+  433,
+  428,
+  424,
+  420,
+  416,
+  412,
+  408,
+  404,
+  400,
+  396,
+  392,
+  388,
+  385,
+  381,
+  377,
+  374,
+  370,
+  367,
+  363,
+  360,
+  357,
+  354,
+  350,
+  347,
+  344,
+  341,
+  338,
+  335,
+  332,
+  329,
+  326,
+  323,
+  320,
+  318,
+  315,
+  312,
+  310,
+  307,
+  304,
+  302,
+  299,
+  297,
+  294,
+  292,
+  289,
+  287,
+  285,
+  282,
+  280,
+  278,
+  275,
+  273,
+  271,
+  269,
+  267,
+  265,
+  263,
+  261,
+  259
+]
 
 var shg_table = [
-	     9, 11, 12, 13, 13, 14, 14, 15, 15, 15, 15, 16, 16, 16, 16, 17,
-  17, 17, 17, 17, 17, 17, 18, 18, 18, 18, 18, 18, 18, 18, 18, 19,
-  19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 19, 20, 20, 20,
-  20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 20, 21,
-  21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 21,
-  21, 21, 21, 21, 21, 21, 21, 21, 21, 21, 22, 22, 22, 22, 22, 22,
-  22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22,
-  22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 22, 23,
-  23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23,
-  23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23,
-  23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23, 23,
-  23, 23, 23, 23, 23, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-  24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-  24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-  24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24,
-  24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24, 24 ]
+  9,
+  11,
+  12,
+  13,
+  13,
+  14,
+  14,
+  15,
+  15,
+  15,
+  15,
+  16,
+  16,
+  16,
+  16,
+  17,
+  17,
+  17,
+  17,
+  17,
+  17,
+  17,
+  18,
+  18,
+  18,
+  18,
+  18,
+  18,
+  18,
+  18,
+  18,
+  19,
+  19,
+  19,
+  19,
+  19,
+  19,
+  19,
+  19,
+  19,
+  19,
+  19,
+  19,
+  19,
+  19,
+  20,
+  20,
+  20,
+  20,
+  20,
+  20,
+  20,
+  20,
+  20,
+  20,
+  20,
+  20,
+  20,
+  20,
+  20,
+  20,
+  20,
+  20,
+  21,
+  21,
+  21,
+  21,
+  21,
+  21,
+  21,
+  21,
+  21,
+  21,
+  21,
+  21,
+  21,
+  21,
+  21,
+  21,
+  21,
+  21,
+  21,
+  21,
+  21,
+  21,
+  21,
+  21,
+  21,
+  21,
+  21,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  22,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  23,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24,
+  24
+]
 
 function premultiplyAlpha (imageData) {
   var pixels = imageData.data
   var size = imageData.width * imageData.height * 4
 
-  for (var i = 0; i < size; i += 4)	{
+  for (var i = 0; i < size; i += 4) {
     var a = pixels[i + 3] / 255
-    pixels[i ] *= a
+    pixels[i] *= a
     pixels[i + 1] *= a
     pixels[i + 2] *= a
   }
@@ -91,11 +571,11 @@ function unpremultiplyAlpha (imageData) {
   var pixels = imageData.data
   var size = imageData.width * imageData.height * 4
 
-  for (var i = 0; i < size; i += 4)	{
+  for (var i = 0; i < size; i += 4) {
     var a = pixels[i + 3]
-    if (a != 0)		{
+    if (a != 0) {
       a = 255 / a
-      pixels[i ] *= a
+      pixels[i] *= a
       pixels[i + 1] *= a
       pixels[i + 2] *= a
     }
@@ -103,7 +583,7 @@ function unpremultiplyAlpha (imageData) {
 }
 
 function stackBlurImage (imageID, canvasID, radius, blurAlphaChannel) {
- 	var img = document.getElementById(imageID)
+  var img = document.getElementById(imageID)
   var w = img.naturalWidth
   var h = img.naturalHeight
 
@@ -122,7 +602,7 @@ function stackBlurImage (imageID, canvasID, radius, blurAlphaChannel) {
 
   if (blurAlphaChannel) {
     stackBlurCanvasRGBA(canvasID, 0, 0, w, h, radius)
-  } else		{
+  } else {
     stackBlurCanvasRGB(canvasID, 0, 0, w, h, radius)
   }
 }
@@ -136,34 +616,55 @@ function stackBlurCanvasRGBA (id, top_x, top_y, width, height, radius) {
   var imageData
 
   try {
-	  try {
-    imageData = context.getImageData(top_x, top_y, width, height)
-	  } catch (e) {
-		// NOTE: this part is supposedly only needed if you want to work with local files
-		// so it might be okay to remove the whole try/catch block and just use
-		// imageData = context.getImageData( top_x, top_y, width, height );
     try {
-      netscape.security.PrivilegeManager.enablePrivilege('UniversalBrowserRead')
       imageData = context.getImageData(top_x, top_y, width, height)
     } catch (e) {
-      alert('Cannot access local image')
-      throw new Error('unable to access local image data: ' + e)
-      return
+      // NOTE: this part is supposedly only needed if you want to work with local files
+      // so it might be okay to remove the whole try/catch block and just use
+      // imageData = context.getImageData( top_x, top_y, width, height );
+      try {
+        netscape.security.PrivilegeManager.enablePrivilege(
+          'UniversalBrowserRead'
+        )
+        imageData = context.getImageData(top_x, top_y, width, height)
+      } catch (e) {
+        alert('Cannot access local image')
+        throw new Error('unable to access local image data: ' + e)
+      }
     }
-	  }
   } catch (e) {
-	  alert('Cannot access image')
-	  throw new Error('unable to access image data: ' + e)
+    alert('Cannot access image')
+    throw new Error('unable to access image data: ' + e)
   }
 
   premultiplyAlpha(imageData)
 
   var pixels = imageData.data
 
-  var x, y, i, p, yp, yi, yw, r_sum, g_sum, b_sum, a_sum,
-    r_out_sum, g_out_sum, b_out_sum, a_out_sum,
-    r_in_sum, g_in_sum, b_in_sum, a_in_sum,
-    pr, pg, pb, pa, rbs
+  var x,
+    y,
+    i,
+    p,
+    yp,
+    yi,
+    yw,
+    r_sum,
+    g_sum,
+    b_sum,
+    a_sum,
+    r_out_sum,
+    g_out_sum,
+    b_out_sum,
+    a_out_sum,
+    r_in_sum,
+    g_in_sum,
+    b_in_sum,
+    a_in_sum,
+    pr,
+    pg,
+    pb,
+    pa,
+    rbs
 
   var div = radius + radius + 1
   var w4 = width << 2
@@ -174,7 +675,7 @@ function stackBlurCanvasRGBA (id, top_x, top_y, width, height, radius) {
 
   var stackStart = new BlurStack()
   var stack = stackStart
-  for (i = 1; i < div; i++)	{
+  for (i = 1; i < div; i++) {
     stack = stack.next = new BlurStack()
     if (i == radiusPlus1) var stackEnd = stack
   }
@@ -187,7 +688,7 @@ function stackBlurCanvasRGBA (id, top_x, top_y, width, height, radius) {
   var mul_sum = mul_table[radius]
   var shg_sum = shg_table[radius]
 
-  for (y = 0; y < height; y++)	{
+  for (y = 0; y < height; y++) {
     r_in_sum = g_in_sum = b_in_sum = a_in_sum = r_sum = g_sum = b_sum = a_sum = 0
 
     r_out_sum = radiusPlus1 * (pr = pixels[yi])
@@ -202,7 +703,7 @@ function stackBlurCanvasRGBA (id, top_x, top_y, width, height, radius) {
 
     stack = stackStart
 
-    for (i = 0; i < radiusPlus1; i++)		{
+    for (i = 0; i < radiusPlus1; i++) {
       stack.r = pr
       stack.g = pg
       stack.b = pb
@@ -210,12 +711,12 @@ function stackBlurCanvasRGBA (id, top_x, top_y, width, height, radius) {
       stack = stack.next
     }
 
-    for (i = 1; i < radiusPlus1; i++)		{
+    for (i = 1; i < radiusPlus1; i++) {
       p = yi + ((widthMinus1 < i ? widthMinus1 : i) << 2)
-      r_sum += (stack.r = (pr = pixels[p])) * (rbs = radiusPlus1 - i)
-      g_sum += (stack.g = (pg = pixels[p + 1])) * rbs
-      b_sum += (stack.b = (pb = pixels[p + 2])) * rbs
-      a_sum += (stack.a = (pa = pixels[p + 3])) * rbs
+      r_sum += (stack.r = pr = pixels[p]) * (rbs = radiusPlus1 - i)
+      g_sum += (stack.g = pg = pixels[p + 1]) * rbs
+      b_sum += (stack.b = pb = pixels[p + 2]) * rbs
+      a_sum += (stack.a = pa = pixels[p + 3]) * rbs
 
       r_in_sum += pr
       g_in_sum += pg
@@ -227,7 +728,7 @@ function stackBlurCanvasRGBA (id, top_x, top_y, width, height, radius) {
 
     stackIn = stackStart
     stackOut = stackEnd
-    for (x = 0; x < width; x++)		{
+    for (x = 0; x < width; x++) {
       pixels[yi] = (r_sum * mul_sum) >> shg_sum
       pixels[yi + 1] = (g_sum * mul_sum) >> shg_sum
       pixels[yi + 2] = (b_sum * mul_sum) >> shg_sum
@@ -245,10 +746,10 @@ function stackBlurCanvasRGBA (id, top_x, top_y, width, height, radius) {
 
       p = (yw + ((p = x + radius + 1) < widthMinus1 ? p : widthMinus1)) << 2
 
-      r_in_sum += (stackIn.r = pixels[p])
-      g_in_sum += (stackIn.g = pixels[p + 1])
-      b_in_sum += (stackIn.b = pixels[p + 2])
-      a_in_sum += (stackIn.a = pixels[p + 3])
+      r_in_sum += stackIn.r = pixels[p]
+      g_in_sum += stackIn.g = pixels[p + 1]
+      b_in_sum += stackIn.b = pixels[p + 2]
+      a_in_sum += stackIn.a = pixels[p + 3]
 
       r_sum += r_in_sum
       g_sum += g_in_sum
@@ -257,10 +758,10 @@ function stackBlurCanvasRGBA (id, top_x, top_y, width, height, radius) {
 
       stackIn = stackIn.next
 
-      r_out_sum += (pr = stackOut.r)
-      g_out_sum += (pg = stackOut.g)
-      b_out_sum += (pb = stackOut.b)
-      a_out_sum += (pa = stackOut.a)
+      r_out_sum += pr = stackOut.r
+      g_out_sum += pg = stackOut.g
+      b_out_sum += pb = stackOut.b
+      a_out_sum += pa = stackOut.a
 
       r_in_sum -= pr
       g_in_sum -= pg
@@ -274,7 +775,7 @@ function stackBlurCanvasRGBA (id, top_x, top_y, width, height, radius) {
     yw += width
   }
 
-  for (x = 0; x < width; x++)	{
+  for (x = 0; x < width; x++) {
     g_in_sum = b_in_sum = a_in_sum = r_in_sum = g_sum = b_sum = a_sum = r_sum = 0
 
     yi = x << 2
@@ -290,7 +791,7 @@ function stackBlurCanvasRGBA (id, top_x, top_y, width, height, radius) {
 
     stack = stackStart
 
-    for (i = 0; i < radiusPlus1; i++)		{
+    for (i = 0; i < radiusPlus1; i++) {
       stack.r = pr
       stack.g = pg
       stack.b = pb
@@ -300,13 +801,13 @@ function stackBlurCanvasRGBA (id, top_x, top_y, width, height, radius) {
 
     yp = width
 
-    for (i = 1; i <= radius; i++)		{
+    for (i = 1; i <= radius; i++) {
       yi = (yp + x) << 2
 
-      r_sum += (stack.r = (pr = pixels[yi])) * (rbs = radiusPlus1 - i)
-      g_sum += (stack.g = (pg = pixels[yi + 1])) * rbs
-      b_sum += (stack.b = (pb = pixels[yi + 2])) * rbs
-      a_sum += (stack.a = (pa = pixels[yi + 3])) * rbs
+      r_sum += (stack.r = pr = pixels[yi]) * (rbs = radiusPlus1 - i)
+      g_sum += (stack.g = pg = pixels[yi + 1]) * rbs
+      b_sum += (stack.b = pb = pixels[yi + 2]) * rbs
+      a_sum += (stack.a = pa = pixels[yi + 3]) * rbs
 
       r_in_sum += pr
       g_in_sum += pg
@@ -315,7 +816,7 @@ function stackBlurCanvasRGBA (id, top_x, top_y, width, height, radius) {
 
       stack = stack.next
 
-      if (i < heightMinus1)			{
+      if (i < heightMinus1) {
         yp += width
       }
     }
@@ -323,7 +824,7 @@ function stackBlurCanvasRGBA (id, top_x, top_y, width, height, radius) {
     yi = x
     stackIn = stackStart
     stackOut = stackEnd
-    for (y = 0; y < height; y++)		{
+    for (y = 0; y < height; y++) {
       p = yi << 2
       pixels[p] = (r_sum * mul_sum) >> shg_sum
       pixels[p + 1] = (g_sum * mul_sum) >> shg_sum
@@ -340,19 +841,22 @@ function stackBlurCanvasRGBA (id, top_x, top_y, width, height, radius) {
       b_out_sum -= stackIn.b
       a_out_sum -= stackIn.a
 
-      p = (x + (((p = y + radiusPlus1) < heightMinus1 ? p : heightMinus1) * width)) << 2
+      p =
+        (x +
+          ((p = y + radiusPlus1) < heightMinus1 ? p : heightMinus1) * width) <<
+        2
 
-      r_sum += (r_in_sum += (stackIn.r = pixels[p]))
-      g_sum += (g_in_sum += (stackIn.g = pixels[p + 1]))
-      b_sum += (b_in_sum += (stackIn.b = pixels[p + 2]))
-      a_sum += (a_in_sum += (stackIn.a = pixels[p + 3]))
+      r_sum += r_in_sum += stackIn.r = pixels[p]
+      g_sum += g_in_sum += stackIn.g = pixels[p + 1]
+      b_sum += b_in_sum += stackIn.b = pixels[p + 2]
+      a_sum += a_in_sum += stackIn.a = pixels[p + 3]
 
       stackIn = stackIn.next
 
-      r_out_sum += (pr = stackOut.r)
-      g_out_sum += (pg = stackOut.g)
-      b_out_sum += (pb = stackOut.b)
-      a_out_sum += (pa = stackOut.a)
+      r_out_sum += pr = stackOut.r
+      g_out_sum += pg = stackOut.g
+      b_out_sum += pb = stackOut.b
+      a_out_sum += pa = stackOut.a
 
       r_in_sum -= pr
       g_in_sum -= pg
@@ -379,32 +883,49 @@ function stackBlurCanvasRGB (id, top_x, top_y, width, height, radius) {
   var imageData
 
   try {
-	  try {
-    imageData = context.getImageData(top_x, top_y, width, height)
-	  } catch (e) {
-		// NOTE: this part is supposedly only needed if you want to work with local files
-		// so it might be okay to remove the whole try/catch block and just use
-		// imageData = context.getImageData( top_x, top_y, width, height );
     try {
-      netscape.security.PrivilegeManager.enablePrivilege('UniversalBrowserRead')
       imageData = context.getImageData(top_x, top_y, width, height)
     } catch (e) {
-      alert('Cannot access local image')
-      throw new Error('unable to access local image data: ' + e)
-      return
+      // NOTE: this part is supposedly only needed if you want to work with local files
+      // so it might be okay to remove the whole try/catch block and just use
+      // imageData = context.getImageData( top_x, top_y, width, height );
+      try {
+        netscape.security.PrivilegeManager.enablePrivilege(
+          'UniversalBrowserRead'
+        )
+        imageData = context.getImageData(top_x, top_y, width, height)
+      } catch (e) {
+        alert('Cannot access local image')
+        throw new Error('unable to access local image data: ' + e)
+      }
     }
-	  }
   } catch (e) {
-	  alert('Cannot access image')
-	  throw new Error('unable to access image data: ' + e)
+    alert('Cannot access image')
+    throw new Error('unable to access image data: ' + e)
   }
 
   var pixels = imageData.data
 
-  var x, y, i, p, yp, yi, yw, r_sum, g_sum, b_sum,
-    r_out_sum, g_out_sum, b_out_sum,
-    r_in_sum, g_in_sum, b_in_sum,
-    pr, pg, pb, rbs
+  var x,
+    y,
+    i,
+    p,
+    yp,
+    yi,
+    yw,
+    r_sum,
+    g_sum,
+    b_sum,
+    r_out_sum,
+    g_out_sum,
+    b_out_sum,
+    r_in_sum,
+    g_in_sum,
+    b_in_sum,
+    pr,
+    pg,
+    pb,
+    rbs
 
   var div = radius + radius + 1
   var w4 = width << 2
@@ -415,7 +936,7 @@ function stackBlurCanvasRGB (id, top_x, top_y, width, height, radius) {
 
   var stackStart = new BlurStack()
   var stack = stackStart
-  for (i = 1; i < div; i++)	{
+  for (i = 1; i < div; i++) {
     stack = stack.next = new BlurStack()
     if (i == radiusPlus1) var stackEnd = stack
   }
@@ -428,7 +949,7 @@ function stackBlurCanvasRGB (id, top_x, top_y, width, height, radius) {
   var mul_sum = mul_table[radius]
   var shg_sum = shg_table[radius]
 
-  for (y = 0; y < height; y++)	{
+  for (y = 0; y < height; y++) {
     r_in_sum = g_in_sum = b_in_sum = r_sum = g_sum = b_sum = 0
 
     r_out_sum = radiusPlus1 * (pr = pixels[yi])
@@ -441,18 +962,18 @@ function stackBlurCanvasRGB (id, top_x, top_y, width, height, radius) {
 
     stack = stackStart
 
-    for (i = 0; i < radiusPlus1; i++)		{
+    for (i = 0; i < radiusPlus1; i++) {
       stack.r = pr
       stack.g = pg
       stack.b = pb
       stack = stack.next
     }
 
-    for (i = 1; i < radiusPlus1; i++)		{
+    for (i = 1; i < radiusPlus1; i++) {
       p = yi + ((widthMinus1 < i ? widthMinus1 : i) << 2)
-      r_sum += (stack.r = (pr = pixels[p])) * (rbs = radiusPlus1 - i)
-      g_sum += (stack.g = (pg = pixels[p + 1])) * rbs
-      b_sum += (stack.b = (pb = pixels[p + 2])) * rbs
+      r_sum += (stack.r = pr = pixels[p]) * (rbs = radiusPlus1 - i)
+      g_sum += (stack.g = pg = pixels[p + 1]) * rbs
+      b_sum += (stack.b = pb = pixels[p + 2]) * rbs
 
       r_in_sum += pr
       g_in_sum += pg
@@ -463,7 +984,7 @@ function stackBlurCanvasRGB (id, top_x, top_y, width, height, radius) {
 
     stackIn = stackStart
     stackOut = stackEnd
-    for (x = 0; x < width; x++)		{
+    for (x = 0; x < width; x++) {
       pixels[yi] = (r_sum * mul_sum) >> shg_sum
       pixels[yi + 1] = (g_sum * mul_sum) >> shg_sum
       pixels[yi + 2] = (b_sum * mul_sum) >> shg_sum
@@ -478,9 +999,9 @@ function stackBlurCanvasRGB (id, top_x, top_y, width, height, radius) {
 
       p = (yw + ((p = x + radius + 1) < widthMinus1 ? p : widthMinus1)) << 2
 
-      r_in_sum += (stackIn.r = pixels[p])
-      g_in_sum += (stackIn.g = pixels[p + 1])
-      b_in_sum += (stackIn.b = pixels[p + 2])
+      r_in_sum += stackIn.r = pixels[p]
+      g_in_sum += stackIn.g = pixels[p + 1]
+      b_in_sum += stackIn.b = pixels[p + 2]
 
       r_sum += r_in_sum
       g_sum += g_in_sum
@@ -488,9 +1009,9 @@ function stackBlurCanvasRGB (id, top_x, top_y, width, height, radius) {
 
       stackIn = stackIn.next
 
-      r_out_sum += (pr = stackOut.r)
-      g_out_sum += (pg = stackOut.g)
-      b_out_sum += (pb = stackOut.b)
+      r_out_sum += pr = stackOut.r
+      g_out_sum += pg = stackOut.g
+      b_out_sum += pb = stackOut.b
 
       r_in_sum -= pr
       g_in_sum -= pg
@@ -503,7 +1024,7 @@ function stackBlurCanvasRGB (id, top_x, top_y, width, height, radius) {
     yw += width
   }
 
-  for (x = 0; x < width; x++)	{
+  for (x = 0; x < width; x++) {
     g_in_sum = b_in_sum = r_in_sum = g_sum = b_sum = r_sum = 0
 
     yi = x << 2
@@ -517,7 +1038,7 @@ function stackBlurCanvasRGB (id, top_x, top_y, width, height, radius) {
 
     stack = stackStart
 
-    for (i = 0; i < radiusPlus1; i++)		{
+    for (i = 0; i < radiusPlus1; i++) {
       stack.r = pr
       stack.g = pg
       stack.b = pb
@@ -526,12 +1047,12 @@ function stackBlurCanvasRGB (id, top_x, top_y, width, height, radius) {
 
     yp = width
 
-    for (i = 1; i <= radius; i++)		{
+    for (i = 1; i <= radius; i++) {
       yi = (yp + x) << 2
 
-      r_sum += (stack.r = (pr = pixels[yi])) * (rbs = radiusPlus1 - i)
-      g_sum += (stack.g = (pg = pixels[yi + 1])) * rbs
-      b_sum += (stack.b = (pb = pixels[yi + 2])) * rbs
+      r_sum += (stack.r = pr = pixels[yi]) * (rbs = radiusPlus1 - i)
+      g_sum += (stack.g = pg = pixels[yi + 1]) * rbs
+      b_sum += (stack.b = pb = pixels[yi + 2]) * rbs
 
       r_in_sum += pr
       g_in_sum += pg
@@ -539,7 +1060,7 @@ function stackBlurCanvasRGB (id, top_x, top_y, width, height, radius) {
 
       stack = stack.next
 
-      if (i < heightMinus1)			{
+      if (i < heightMinus1) {
         yp += width
       }
     }
@@ -547,7 +1068,7 @@ function stackBlurCanvasRGB (id, top_x, top_y, width, height, radius) {
     yi = x
     stackIn = stackStart
     stackOut = stackEnd
-    for (y = 0; y < height; y++)		{
+    for (y = 0; y < height; y++) {
       p = yi << 2
       pixels[p] = (r_sum * mul_sum) >> shg_sum
       pixels[p + 1] = (g_sum * mul_sum) >> shg_sum
@@ -561,17 +1082,20 @@ function stackBlurCanvasRGB (id, top_x, top_y, width, height, radius) {
       g_out_sum -= stackIn.g
       b_out_sum -= stackIn.b
 
-      p = (x + (((p = y + radiusPlus1) < heightMinus1 ? p : heightMinus1) * width)) << 2
+      p =
+        (x +
+          ((p = y + radiusPlus1) < heightMinus1 ? p : heightMinus1) * width) <<
+        2
 
-      r_sum += (r_in_sum += (stackIn.r = pixels[p]))
-      g_sum += (g_in_sum += (stackIn.g = pixels[p + 1]))
-      b_sum += (b_in_sum += (stackIn.b = pixels[p + 2]))
+      r_sum += r_in_sum += stackIn.r = pixels[p]
+      g_sum += g_in_sum += stackIn.g = pixels[p + 1]
+      b_sum += b_in_sum += stackIn.b = pixels[p + 2]
 
       stackIn = stackIn.next
 
-      r_out_sum += (pr = stackOut.r)
-      g_out_sum += (pg = stackOut.g)
-      b_out_sum += (pb = stackOut.b)
+      r_out_sum += pr = stackOut.r
+      g_out_sum += pg = stackOut.g
+      b_out_sum += pb = stackOut.b
 
       r_in_sum -= pr
       g_in_sum -= pg

--- a/src/browser/external/canvg/canvg.js
+++ b/src/browser/external/canvg/canvg.js
@@ -6,24 +6,24 @@
  *
  * Requires: rgbcolor.js - http://www.phpied.com/rgb-color-parser-in-javascript/
  */
-(function () {
-	// canvg(target, s)
-	// empty parameters: replace all 'svg' elements on page with 'canvas' elements
-	// target: canvas element or the id of a canvas element
-	// s: svg string, url to svg file, or xml document
-	// opts: optional hash of options
-	//		 ignoreMouse: true => ignore mouse events
-	//		 ignoreAnimation: true => ignore animations
-	//		 ignoreDimensions: true => does not try to resize canvas
-	//		 ignoreClear: true => does not clear canvas
-	//		 offsetX: int => draws at a x offset
-	//		 offsetY: int => draws at a y offset
-	//		 scaleWidth: int => scales horizontally to width
-	//		 scaleHeight: int => scales vertically to height
-	//		 renderCallback: function => will call the function after the first render is completed
-	//		 forceRedraw: function => will call the function on every frame, if it returns true, will redraw
+;(function () {
+  // canvg(target, s)
+  // empty parameters: replace all 'svg' elements on page with 'canvas' elements
+  // target: canvas element or the id of a canvas element
+  // s: svg string, url to svg file, or xml document
+  // opts: optional hash of options
+  //		 ignoreMouse: true => ignore mouse events
+  //		 ignoreAnimation: true => ignore animations
+  //		 ignoreDimensions: true => does not try to resize canvas
+  //		 ignoreClear: true => does not clear canvas
+  //		 offsetX: int => draws at a x offset
+  //		 offsetY: int => draws at a y offset
+  //		 scaleWidth: int => scales horizontally to width
+  //		 scaleHeight: int => scales vertically to height
+  //		 renderCallback: function => will call the function after the first render is completed
+  //		 forceRedraw: function => will call the function on every frame, if it returns true, will redraw
   this.canvg = function (target, s, opts) {
-		// no parameters
+    // no parameters
     if (target == null && s == null && opts == null) {
       var svgTags = document.querySelectorAll('svg')
       for (var i = 0; i < svgTags.length; i++) {
@@ -44,52 +44,59 @@
       target = document.getElementById(target)
     }
 
-		// store class on canvas
+    // store class on canvas
     if (target.svg != null) target.svg.stop()
     var svg = build(opts || {})
-		// on i.e. 8 for flash canvas, we can't assign the property so check for it
-    if (!(target.childNodes.length == 1 && target.childNodes[0].nodeName == 'OBJECT')) target.svg = svg
+    // on i.e. 8 for flash canvas, we can't assign the property so check for it
+    if (
+      !(
+        target.childNodes.length == 1 &&
+        target.childNodes[0].nodeName == 'OBJECT'
+      )
+    ) {
+      target.svg = svg
+    }
 
     var ctx = target.getContext('2d')
-    if (typeof (s.documentElement) !== 'undefined') {
-			// load from xml doc
+    if (typeof s.documentElement !== 'undefined') {
+      // load from xml doc
       svg.loadXmlDoc(ctx, s)
     } else if (s.substr(0, 1) == '<') {
-			// load from xml string
+      // load from xml string
       svg.loadXml(ctx, s)
     } else {
-			// load from url
+      // load from url
       svg.load(ctx, s)
     }
   }
 
-	// see https://developer.mozilla.org/en-US/docs/Web/API/Element.matches
+  // see https://developer.mozilla.org/en-US/docs/Web/API/Element.matches
   var matchesSelector
-  if (typeof (Element.prototype.matches) !== 'undefined') {
+  if (typeof Element.prototype.matches !== 'undefined') {
     matchesSelector = function (node, selector) {
       return node.matches(selector)
     }
-  } else if (typeof (Element.prototype.webkitMatchesSelector) !== 'undefined') {
+  } else if (typeof Element.prototype.webkitMatchesSelector !== 'undefined') {
     matchesSelector = function (node, selector) {
       return node.webkitMatchesSelector(selector)
     }
-  } else if (typeof (Element.prototype.mozMatchesSelector) !== 'undefined') {
+  } else if (typeof Element.prototype.mozMatchesSelector !== 'undefined') {
     matchesSelector = function (node, selector) {
       return node.mozMatchesSelector(selector)
     }
-  } else if (typeof (Element.prototype.msMatchesSelector) !== 'undefined') {
+  } else if (typeof Element.prototype.msMatchesSelector !== 'undefined') {
     matchesSelector = function (node, selector) {
       return node.msMatchesSelector(selector)
     }
-  } else if (typeof (Element.prototype.oMatchesSelector) !== 'undefined') {
+  } else if (typeof Element.prototype.oMatchesSelector !== 'undefined') {
     matchesSelector = function (node, selector) {
       return node.oMatchesSelector(selector)
     }
   } else {
-		// requires Sizzle: https://github.com/jquery/sizzle/wiki/Sizzle-Documentation
-		// or jQuery: http://jquery.com/download/
-		// or Zepto: http://zeptojs.com/#
-		// without it, this is a ReferenceError
+    // requires Sizzle: https://github.com/jquery/sizzle/wiki/Sizzle-Documentation
+    // or jQuery: http://jquery.com/download/
+    // or Zepto: http://zeptojs.com/#
+    // without it, this is a ReferenceError
 
     if (typeof jQuery === 'function' || typeof Zepto === 'function') {
       matchesSelector = function (node, selector) {
@@ -102,7 +109,7 @@
     }
   }
 
-	// slightly modified version of https://github.com/keeganstreet/specificity/blob/master/specificity.js
+  // slightly modified version of https://github.com/keeganstreet/specificity/blob/master/specificity.js
   var attributeRegex = /(\[[^\]]+\])/g
   var idRegex = /(#[^\s\+>~\.\[:]+)/g
   var classRegex = /(\.[^\s\+>~\.\[:]+)/g
@@ -142,14 +149,19 @@
     svg.MAX_VIRTUAL_PIXELS = 30000
 
     svg.log = function (msg) {}
-    if (svg.opts['log'] == true && typeof (console) !== 'undefined') {
-      svg.log = function (msg) { console.log(msg) }
-    };
+    if (svg.opts['log'] == true && typeof console !== 'undefined') {
+      svg.log = function (msg) {
+        console.log(msg)
+      }
+    }
 
-		// globals
+    // globals
     svg.init = function (ctx) {
       var uniqueId = 0
-      svg.UniqueId = function () { uniqueId++; return 'canvg' + uniqueId	}
+      svg.UniqueId = function () {
+        uniqueId++
+        return 'canvg' + uniqueId
+      }
       svg.Definitions = {}
       svg.Styles = {}
       svg.StylesSpecificity = {}
@@ -158,23 +170,38 @@
       svg.ctx = ctx
       svg.ViewPort = new function () {
         this.viewPorts = []
-        this.Clear = function () { this.viewPorts = [] }
-        this.SetCurrent = function (width, height) { this.viewPorts.push({ width: width, height: height }) }
-        this.RemoveCurrent = function () { this.viewPorts.pop() }
-        this.Current = function () { return this.viewPorts[this.viewPorts.length - 1] }
-        this.width = function () { return this.Current().width }
-        this.height = function () { return this.Current().height }
+        this.Clear = function () {
+          this.viewPorts = []
+        }
+        this.SetCurrent = function (width, height) {
+          this.viewPorts.push({ width: width, height: height })
+        }
+        this.RemoveCurrent = function () {
+          this.viewPorts.pop()
+        }
+        this.Current = function () {
+          return this.viewPorts[this.viewPorts.length - 1]
+        }
+        this.width = function () {
+          return this.Current().width
+        }
+        this.height = function () {
+          return this.Current().height
+        }
         this.ComputeSize = function (d) {
-          if (d != null && typeof (d) === 'number') return d
+          if (d != null && typeof d === 'number') return d
           if (d == 'x') return this.width()
           if (d == 'y') return this.height()
-          return Math.sqrt(Math.pow(this.width(), 2) + Math.pow(this.height(), 2)) / Math.sqrt(2)
+          return (
+            Math.sqrt(Math.pow(this.width(), 2) + Math.pow(this.height(), 2)) /
+            Math.sqrt(2)
+          )
         }
       }()
     }
     svg.init()
 
-		// images loaded
+    // images loaded
     svg.ImagesLoaded = function () {
       for (var i = 0; i < svg.Images.length; i++) {
         if (!svg.Images[i].loaded) return false
@@ -182,36 +209,48 @@
       return true
     }
 
-		// trim
-    svg.trim = function (s) { return s.replace(/^\s+|\s+$/g, '') }
+    // trim
+    svg.trim = function (s) {
+      return s.replace(/^\s+|\s+$/g, '')
+    }
 
-		// compress spaces
-    svg.compressSpaces = function (s) { return s.replace(/[\s\r\t\n]+/gm, ' ') }
+    // compress spaces
+    svg.compressSpaces = function (s) {
+      return s.replace(/[\s\r\t\n]+/gm, ' ')
+    }
 
-		// ajax
+    // ajax
     svg.ajax = function (url) {
       var AJAX
-      if (window.XMLHttpRequest) { AJAX = new XMLHttpRequest() } else { AJAX = new ActiveXObject('Microsoft.XMLHTTP') }
+      if (window.XMLHttpRequest) {
+        AJAX = new XMLHttpRequest()
+      } else {
+        AJAX = new ActiveXObject('Microsoft.XMLHTTP')
+      }
       if (AJAX) {
-			   AJAX.open('GET', url, false)
-			   AJAX.send(null)
-			   return AJAX.responseText
+        AJAX.open('GET', url, false)
+        AJAX.send(null)
+        return AJAX.responseText
       }
       return null
     }
 
-		// parse xml
+    // parse xml
     svg.parseXml = function (xml) {
-      if (typeof (Windows) !== 'undefined' && typeof (Windows.Data) !== 'undefined' && typeof (Windows.Data.Xml) !== 'undefined') {
+      if (
+        typeof Windows !== 'undefined' &&
+        typeof Windows.Data !== 'undefined' &&
+        typeof Windows.Data.Xml !== 'undefined'
+      ) {
         var xmlDoc = new Windows.Data.Xml.Dom.XmlDocument()
         var settings = new Windows.Data.Xml.Dom.XmlLoadSettings()
         settings.prohibitDtd = false
         xmlDoc.loadXml(xml, settings)
         return xmlDoc
-      } else if (window.DOMParser)			{
+      } else if (window.DOMParser) {
         var parser = new DOMParser()
         return parser.parseFromString(xml, 'text/xml')
-      } else			{
+      } else {
         xml = xml.replace(/<!DOCTYPE svg[^>]*>/, '')
         var xmlDoc = new ActiveXObject('Microsoft.XMLDOM')
         xmlDoc.async = 'false'
@@ -229,10 +268,10 @@
     }
 
     svg.Property.prototype.hasValue = function () {
-      return (this.value != null && this.value !== '')
+      return this.value != null && this.value !== ''
     }
 
-			// return the numerical value of the property
+    // return the numerical value of the property
     svg.Property.prototype.numValue = function () {
       if (!this.hasValue()) return 0
 
@@ -253,25 +292,43 @@
       return def
     }
 
-			// color extensions
-				// augment the current color value with the opacity
+    // color extensions
+    // augment the current color value with the opacity
     svg.Property.prototype.addOpacity = function (opacityProp) {
       var newValue = this.value
-      if (opacityProp.value != null && opacityProp.value != '' && typeof (this.value) === 'string') { // can only add opacity to colors, not patterns
+      if (
+        opacityProp.value != null &&
+        opacityProp.value != '' &&
+        typeof this.value === 'string'
+      ) {
+        // can only add opacity to colors, not patterns
         var color = new RGBColor(this.value)
         if (color.ok) {
-          newValue = 'rgba(' + color.r + ', ' + color.g + ', ' + color.b + ', ' + opacityProp.numValue() + ')'
+          newValue =
+            'rgba(' +
+            color.r +
+            ', ' +
+            color.g +
+            ', ' +
+            color.b +
+            ', ' +
+            opacityProp.numValue() +
+            ')'
         }
       }
       return new svg.Property(this.name, newValue)
     }
 
-			// definition extensions
-				// get the definition from the definitions table
+    // definition extensions
+    // get the definition from the definitions table
     svg.Property.prototype.getDefinition = function () {
       var name = this.value.match(/#([^\)'"]+)/)
-      if (name) { name = name[1] }
-      if (!name) { name = this.value }
+      if (name) {
+        name = name[1]
+      }
+      if (!name) {
+        name = this.value
+      }
       return svg.Definitions[name]
     }
 
@@ -282,17 +339,19 @@
     svg.Property.prototype.getFillStyleDefinition = function (e, opacityProp) {
       var def = this.getDefinition()
 
-					// gradient
+      // gradient
       if (def != null && def.createGradient) {
         return def.createGradient(svg.ctx, e, opacityProp)
       }
 
-					// pattern
+      // pattern
       if (def != null && def.createPattern) {
         if (def.getHrefAttribute().hasValue()) {
           var pt = def.attribute('patternTransform')
           def = def.getHrefAttribute().getDefinition()
-          if (pt.hasValue()) { def.attribute('patternTransform', true).value = pt.value }
+          if (pt.hasValue()) {
+            def.attribute('patternTransform', true).value = pt.value
+          }
         }
         return def.createPattern(svg.ctx, e)
       }
@@ -300,7 +359,7 @@
       return null
     }
 
-			// length extensions
+    // length extensions
     svg.Property.prototype.getDPI = function (viewPort) {
       return 96.0 // TODO: compute?
     }
@@ -308,7 +367,10 @@
     svg.Property.prototype.getEM = function (viewPort) {
       var em = 12
 
-      var fontSize = new svg.Property('fontSize', svg.Font.Parse(svg.ctx.font).fontSize)
+      var fontSize = new svg.Property(
+        'fontSize',
+        svg.Font.Parse(svg.ctx.font).fontSize
+      )
       if (fontSize.hasValue()) em = fontSize.toPixels(viewPort)
 
       return em
@@ -319,26 +381,32 @@
       return s.replace(/[0-9\.\-]/g, '')
     }
 
-				// get the length as pixels
+    // get the length as pixels
     svg.Property.prototype.toPixels = function (viewPort, processPercent) {
       if (!this.hasValue()) return 0
       var s = this.value + ''
       if (s.match(/em$/)) return this.numValue() * this.getEM(viewPort)
       if (s.match(/ex$/)) return this.numValue() * this.getEM(viewPort) / 2.0
       if (s.match(/px$/)) return this.numValue()
-      if (s.match(/pt$/)) return this.numValue() * this.getDPI(viewPort) * (1.0 / 72.0)
+      if (s.match(/pt$/)) {
+        return this.numValue() * this.getDPI(viewPort) * (1.0 / 72.0)
+      }
       if (s.match(/pc$/)) return this.numValue() * 15
       if (s.match(/cm$/)) return this.numValue() * this.getDPI(viewPort) / 2.54
       if (s.match(/mm$/)) return this.numValue() * this.getDPI(viewPort) / 25.4
       if (s.match(/in$/)) return this.numValue() * this.getDPI(viewPort)
-      if (s.match(/%$/)) return this.numValue() * svg.ViewPort.ComputeSize(viewPort)
+      if (s.match(/%$/)) {
+        return this.numValue() * svg.ViewPort.ComputeSize(viewPort)
+      }
       var n = this.numValue()
-      if (processPercent && n < 1.0) return n * svg.ViewPort.ComputeSize(viewPort)
+      if (processPercent && n < 1.0) {
+        return n * svg.ViewPort.ComputeSize(viewPort)
+      }
       return n
     }
 
-			// time extensions
-				// get the time as milliseconds
+    // time extensions
+    // get the time as milliseconds
     svg.Property.prototype.toMilliseconds = function () {
       if (!this.hasValue()) return 0
       var s = this.value + ''
@@ -347,8 +415,8 @@
       return this.numValue()
     }
 
-			// angle extensions
-				// get the angle as radians
+    // angle extensions
+    // get the angle as radians
     svg.Property.prototype.toRadians = function () {
       if (!this.hasValue()) return 0
       var s = this.value + ''
@@ -358,41 +426,60 @@
       return this.numValue() * (Math.PI / 180.0)
     }
 
-			// text extensions
-				// get the text baseline
+    // text extensions
+    // get the text baseline
     var textBaselineMapping = {
-      'baseline': 'alphabetic',
+      baseline: 'alphabetic',
       'before-edge': 'top',
       'text-before-edge': 'top',
-      'middle': 'middle',
-      'central': 'middle',
+      middle: 'middle',
+      central: 'middle',
       'after-edge': 'bottom',
       'text-after-edge': 'bottom',
-      'ideographic': 'ideographic',
-      'alphabetic': 'alphabetic',
-      'hanging': 'hanging',
-      'mathematical': 'alphabetic'
+      ideographic: 'ideographic',
+      alphabetic: 'alphabetic',
+      hanging: 'hanging',
+      mathematical: 'alphabetic'
     }
     svg.Property.prototype.toTextBaseline = function () {
       if (!this.hasValue()) return null
       return textBaselineMapping[this.value]
     }
 
-		// fonts
+    // fonts
     svg.Font = new function () {
       this.Styles = 'normal|italic|oblique|inherit'
       this.Variants = 'normal|small-caps|inherit'
-      this.Weights = 'normal|bold|bolder|lighter|100|200|300|400|500|600|700|800|900|inherit'
+      this.Weights =
+        'normal|bold|bolder|lighter|100|200|300|400|500|600|700|800|900|inherit'
 
-      this.CreateFont = function (fontStyle, fontVariant, fontWeight, fontSize, fontFamily, inherit) {
-        var f = inherit != null ? this.Parse(inherit) : this.CreateFont('', '', '', '', '', svg.ctx.font)
+      this.CreateFont = function (
+        fontStyle,
+        fontVariant,
+        fontWeight,
+        fontSize,
+        fontFamily,
+        inherit
+      ) {
+        var f =
+          inherit != null
+            ? this.Parse(inherit)
+            : this.CreateFont('', '', '', '', '', svg.ctx.font)
         return {
           fontFamily: fontFamily || f.fontFamily,
           fontSize: fontSize || f.fontSize,
           fontStyle: fontStyle || f.fontStyle,
           fontWeight: fontWeight || f.fontWeight,
           fontVariant: fontVariant || f.fontVariant,
-          toString: function () { return [this.fontStyle, this.fontVariant, this.fontWeight, this.fontSize, this.fontFamily].join(' ') }
+          toString: function () {
+            return [
+              this.fontStyle,
+              this.fontVariant,
+              this.fontWeight,
+              this.fontSize,
+              this.fontFamily
+            ].join(' ')
+          }
         }
       }
 
@@ -400,18 +487,40 @@
       this.Parse = function (s) {
         var f = {}
         var d = svg.trim(svg.compressSpaces(s || '')).split(' ')
-        var set = { fontSize: false, fontStyle: false, fontWeight: false, fontVariant: false }
+        var set = {
+          fontSize: false,
+          fontStyle: false,
+          fontWeight: false,
+          fontVariant: false
+        }
         var ff = ''
         for (var i = 0; i < d.length; i++) {
-          if (!set.fontStyle && that.Styles.indexOf(d[i]) != -1) { if (d[i] != 'inherit') f.fontStyle = d[i]; set.fontStyle = true } else if (!set.fontVariant && that.Variants.indexOf(d[i]) != -1) { if (d[i] != 'inherit') f.fontVariant = d[i]; set.fontStyle = set.fontVariant = true	} else if (!set.fontWeight && that.Weights.indexOf(d[i]) != -1) {	if (d[i] != 'inherit') f.fontWeight = d[i]; set.fontStyle = set.fontVariant = set.fontWeight = true } else if (!set.fontSize) { if (d[i] != 'inherit') f.fontSize = d[i].split('/')[0]; set.fontStyle = set.fontVariant = set.fontWeight = set.fontSize = true } else { if (d[i] != 'inherit') ff += d[i] }
-        } if (ff != '') f.fontFamily = ff
+          if (!set.fontStyle && that.Styles.indexOf(d[i]) != -1) {
+            if (d[i] != 'inherit') f.fontStyle = d[i]
+            set.fontStyle = true
+          } else if (!set.fontVariant && that.Variants.indexOf(d[i]) != -1) {
+            if (d[i] != 'inherit') f.fontVariant = d[i]
+            set.fontStyle = set.fontVariant = true
+          } else if (!set.fontWeight && that.Weights.indexOf(d[i]) != -1) {
+            if (d[i] != 'inherit') f.fontWeight = d[i]
+            set.fontStyle = set.fontVariant = set.fontWeight = true
+          } else if (!set.fontSize) {
+            if (d[i] != 'inherit') f.fontSize = d[i].split('/')[0]
+            set.fontStyle = set.fontVariant = set.fontWeight = set.fontSize = true
+          } else {
+            if (d[i] != 'inherit') ff += d[i]
+          }
+        }
+        if (ff != '') f.fontFamily = ff
         return f
       }
     }()
 
-		// points and paths
+    // points and paths
     svg.ToNumberArray = function (s) {
-      var a = svg.trim(svg.compressSpaces((s || '').replace(/,/g, ' '))).split(' ')
+      var a = svg
+        .trim(svg.compressSpaces((s || '').replace(/,/g, ' ')))
+        .split(' ')
       for (var i = 0; i < a.length; i++) {
         a[i] = parseFloat(a[i])
       }
@@ -445,17 +554,26 @@
       return path
     }
 
-		// bounding box
-    svg.BoundingBox = function (x1, y1, x2, y2) { // pass in initial points if you want
+    // bounding box
+    svg.BoundingBox = function (x1, y1, x2, y2) {
+      // pass in initial points if you want
       this.x1 = Number.NaN
       this.y1 = Number.NaN
       this.x2 = Number.NaN
       this.y2 = Number.NaN
 
-      this.x = function () { return this.x1 }
-      this.y = function () { return this.y1 }
-      this.width = function () { return this.x2 - this.x1 }
-      this.height = function () { return this.y2 - this.y1 }
+      this.x = function () {
+        return this.x1
+      }
+      this.y = function () {
+        return this.y1
+      }
+      this.width = function () {
+        return this.x2 - this.x1
+      }
+      this.height = function () {
+        return this.y2 - this.y1
+      }
 
       this.addPoint = function (x, y) {
         if (x != null) {
@@ -476,8 +594,12 @@
           if (y > this.y2) this.y2 = y
         }
       }
-      this.addX = function (x) { this.addPoint(x, null) }
-      this.addY = function (y) { this.addPoint(null, y) }
+      this.addX = function (x) {
+        this.addPoint(x, null)
+      }
+      this.addY = function (y) {
+        this.addPoint(null, y)
+      }
 
       this.addBoundingBox = function (bb) {
         this.addPoint(bb.x1, bb.y1)
@@ -489,21 +611,26 @@
         var cp1y = p0y + 2 / 3 * (p1y - p0y) // CP1 = QP0 + 2/3 *(QP1-QP0)
         var cp2x = cp1x + 1 / 3 * (p2x - p0x) // CP2 = CP1 + 1/3 *(QP2-QP0)
         var cp2y = cp1y + 1 / 3 * (p2y - p0y) // CP2 = CP1 + 1/3 *(QP2-QP0)
-        this.addBezierCurve(p0x, p0y, cp1x, cp2x, cp1y,	cp2y, p2x, p2y)
+        this.addBezierCurve(p0x, p0y, cp1x, cp2x, cp1y, cp2y, p2x, p2y)
       }
 
       this.addBezierCurve = function (p0x, p0y, p1x, p1y, p2x, p2y, p3x, p3y) {
-				// from http://blog.hackers-cafe.net/2009/06/how-to-calculate-bezier-curves-bounding.html
-        var p0 = [p0x, p0y], p1 = [p1x, p1y], p2 = [p2x, p2y], p3 = [p3x, p3y]
+        // from http://blog.hackers-cafe.net/2009/06/how-to-calculate-bezier-curves-bounding.html
+        var p0 = [p0x, p0y],
+          p1 = [p1x, p1y],
+          p2 = [p2x, p2y],
+          p3 = [p3x, p3y]
         this.addPoint(p0[0], p0[1])
         this.addPoint(p3[0], p3[1])
 
         for (i = 0; i <= 1; i++) {
           var f = function (t) {
-            return Math.pow(1 - t, 3) * p0[i]
-						+ 3 * Math.pow(1 - t, 2) * t * p1[i]
-						+ 3 * (1 - t) * Math.pow(t, 2) * p2[i]
-						+ Math.pow(t, 3) * p3[i]
+            return (
+              Math.pow(1 - t, 3) * p0[i] +
+              3 * Math.pow(1 - t, 2) * t * p1[i] +
+              3 * (1 - t) * Math.pow(t, 2) * p2[i] +
+              Math.pow(t, 3) * p3[i]
+            )
           }
 
           var b = 6 * p0[i] - 12 * p1[i] + 6 * p2[i]
@@ -536,19 +663,19 @@
       }
 
       this.isPointInBox = function (x, y) {
-        return (this.x1 <= x && x <= this.x2 && this.y1 <= y && y <= this.y2)
+        return this.x1 <= x && x <= this.x2 && this.y1 <= y && y <= this.y2
       }
 
       this.addPoint(x1, y1)
       this.addPoint(x2, y2)
     }
 
-		// transforms
+    // transforms
     svg.Transform = function (v) {
       var that = this
       this.Type = {}
 
-			// translate
+      // translate
       this.Type.translate = function (s) {
         this.p = svg.CreatePoint(s)
         this.apply = function (ctx) {
@@ -562,7 +689,7 @@
         }
       }
 
-			// rotate
+      // rotate
       this.Type.rotate = function (s) {
         var a = svg.ToNumberArray(s)
         this.angle = new svg.Property('angle', a[0])
@@ -581,7 +708,14 @@
         this.applyToPoint = function (p) {
           var a = this.angle.toRadians()
           p.applyTransform([1, 0, 0, 1, this.p.x || 0.0, this.p.y || 0.0])
-          p.applyTransform([Math.cos(a), Math.sin(a), -Math.sin(a), Math.cos(a), 0, 0])
+          p.applyTransform([
+            Math.cos(a),
+            Math.sin(a),
+            -Math.sin(a),
+            Math.cos(a),
+            0,
+            0
+          ])
           p.applyTransform([1, 0, 0, 1, -this.p.x || 0.0, -this.p.y || 0.0])
         }
       }
@@ -602,7 +736,14 @@
       this.Type.matrix = function (s) {
         this.m = svg.ToNumberArray(s)
         this.apply = function (ctx) {
-          ctx.transform(this.m[0], this.m[1], this.m[2], this.m[3], this.m[4], this.m[5])
+          ctx.transform(
+            this.m[0],
+            this.m[1],
+            this.m[2],
+            this.m[3],
+            this.m[4],
+            this.m[5]
+          )
         }
         this.unapply = function (ctx) {
           var a = this.m[0]
@@ -614,15 +755,17 @@
           var g = 0.0
           var h = 0.0
           var i = 1.0
-          var det = 1 / (a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g))
+          var det =
+            1 /
+            (a * (e * i - f * h) - b * (d * i - f * g) + c * (d * h - e * g))
           ctx.transform(
-						det * (e * i - f * h),
-						det * (f * g - d * i),
-						det * (c * h - b * i),
-						det * (a * i - c * g),
-						det * (b * f - c * e),
-						det * (c * d - a * f)
-					)
+            det * (e * i - f * h),
+            det * (f * g - d * i),
+            det * (c * h - b * i),
+            det * (a * i - c * g),
+            det * (b * f - c * e),
+            det * (c * d - a * f)
+          )
         }
         this.applyToPoint = function (p) {
           p.applyTransform(this.m)
@@ -670,7 +813,11 @@
         }
       }
 
-      var data = svg.trim(svg.compressSpaces(v)).replace(/\)([a-zA-Z])/g, ') $1').replace(/\)(\s?,\s?)/g, ') ').split(/\s(?=[a-z])/)
+      var data = svg
+        .trim(svg.compressSpaces(v))
+        .replace(/\)([a-zA-Z])/g, ') $1')
+        .replace(/\)(\s?,\s?)/g, ') ')
+        .split(/\s(?=[a-z])/)
       for (var i = 0; i < data.length; i++) {
         var type = svg.trim(data[i].split('(')[0])
         var s = data[i].split('(')[1].replace(')', '')
@@ -680,44 +827,88 @@
       }
     }
 
-		// aspect ratio
-    svg.AspectRatio = function (ctx, aspectRatio, width, desiredWidth, height, desiredHeight, minX, minY, refX, refY) {
-			// aspect ratio - http://www.w3.org/TR/SVG/coords.html#PreserveAspectRatioAttribute
+    // aspect ratio
+    svg.AspectRatio = function (
+      ctx,
+      aspectRatio,
+      width,
+      desiredWidth,
+      height,
+      desiredHeight,
+      minX,
+      minY,
+      refX,
+      refY
+    ) {
+      // aspect ratio - http://www.w3.org/TR/SVG/coords.html#PreserveAspectRatioAttribute
       aspectRatio = svg.compressSpaces(aspectRatio)
       aspectRatio = aspectRatio.replace(/^defer\s/, '') // ignore defer
       var align = aspectRatio.split(' ')[0] || 'xMidYMid'
       var meetOrSlice = aspectRatio.split(' ')[1] || 'meet'
 
-			// calculate scale
+      // calculate scale
       var scaleX = width / desiredWidth
       var scaleY = height / desiredHeight
       var scaleMin = Math.min(scaleX, scaleY)
       var scaleMax = Math.max(scaleX, scaleY)
-      if (meetOrSlice == 'meet') { desiredWidth *= scaleMin; desiredHeight *= scaleMin }
-      if (meetOrSlice == 'slice') { desiredWidth *= scaleMax; desiredHeight *= scaleMax }
+      if (meetOrSlice == 'meet') {
+        desiredWidth *= scaleMin
+        desiredHeight *= scaleMin
+      }
+      if (meetOrSlice == 'slice') {
+        desiredWidth *= scaleMax
+        desiredHeight *= scaleMax
+      }
 
       refX = new svg.Property('refX', refX)
       refY = new svg.Property('refY', refY)
       if (refX.hasValue() && refY.hasValue()) {
-        ctx.translate(-scaleMin * refX.toPixels('x'), -scaleMin * refY.toPixels('y'))
+        ctx.translate(
+          -scaleMin * refX.toPixels('x'),
+          -scaleMin * refY.toPixels('y')
+        )
       } else {
-				// align
-        if (align.match(/^xMid/) && ((meetOrSlice == 'meet' && scaleMin == scaleY) || (meetOrSlice == 'slice' && scaleMax == scaleY))) ctx.translate(width / 2.0 - desiredWidth / 2.0, 0)
-        if (align.match(/YMid$/) && ((meetOrSlice == 'meet' && scaleMin == scaleX) || (meetOrSlice == 'slice' && scaleMax == scaleX))) ctx.translate(0, height / 2.0 - desiredHeight / 2.0)
-        if (align.match(/^xMax/) && ((meetOrSlice == 'meet' && scaleMin == scaleY) || (meetOrSlice == 'slice' && scaleMax == scaleY))) ctx.translate(width - desiredWidth, 0)
-        if (align.match(/YMax$/) && ((meetOrSlice == 'meet' && scaleMin == scaleX) || (meetOrSlice == 'slice' && scaleMax == scaleX))) ctx.translate(0, height - desiredHeight)
+        // align
+        if (
+          align.match(/^xMid/) &&
+          ((meetOrSlice == 'meet' && scaleMin == scaleY) ||
+            (meetOrSlice == 'slice' && scaleMax == scaleY))
+        ) {
+          ctx.translate(width / 2.0 - desiredWidth / 2.0, 0)
+        }
+        if (
+          align.match(/YMid$/) &&
+          ((meetOrSlice == 'meet' && scaleMin == scaleX) ||
+            (meetOrSlice == 'slice' && scaleMax == scaleX))
+        ) {
+          ctx.translate(0, height / 2.0 - desiredHeight / 2.0)
+        }
+        if (
+          align.match(/^xMax/) &&
+          ((meetOrSlice == 'meet' && scaleMin == scaleY) ||
+            (meetOrSlice == 'slice' && scaleMax == scaleY))
+        ) {
+          ctx.translate(width - desiredWidth, 0)
+        }
+        if (
+          align.match(/YMax$/) &&
+          ((meetOrSlice == 'meet' && scaleMin == scaleX) ||
+            (meetOrSlice == 'slice' && scaleMax == scaleX))
+        ) {
+          ctx.translate(0, height - desiredHeight)
+        }
       }
 
-			// scale
+      // scale
       if (align == 'none') ctx.scale(scaleX, scaleY)
       else if (meetOrSlice == 'meet') ctx.scale(scaleMin, scaleMin)
       else if (meetOrSlice == 'slice') ctx.scale(scaleMax, scaleMax)
 
-			// translate
+      // translate
       ctx.translate(minX == null ? 0 : -minX, minY == null ? 0 : -minY)
     }
 
-		// elements
+    // elements
     svg.Element = {}
 
     svg.EmptyProperty = new svg.Property('EMPTY', '')
@@ -728,12 +919,15 @@
       this.stylesSpecificity = {}
       this.children = []
 
-			// get or create attribute
+      // get or create attribute
       this.attribute = function (name, createIfNotExists) {
         var a = this.attributes[name]
         if (a != null) return a
 
-        if (createIfNotExists == true) { a = new svg.Property(name, ''); this.attributes[name] = a }
+        if (createIfNotExists == true) {
+          a = new svg.Property(name, '')
+          this.attributes[name] = a
+        }
         return a || svg.EmptyProperty
       }
 
@@ -746,7 +940,7 @@
         return svg.EmptyProperty
       }
 
-			// get or create style, crawls up node tree
+      // get or create style, crawls up node tree
       this.style = function (name, createIfNotExists, skipAncestors) {
         var s = this.styles[name]
         if (s != null) return s
@@ -767,23 +961,28 @@
           }
         }
 
-        if (createIfNotExists == true) { s = new svg.Property(name, ''); this.styles[name] = s }
+        if (createIfNotExists == true) {
+          s = new svg.Property(name, '')
+          this.styles[name] = s
+        }
         return s || svg.EmptyProperty
       }
 
-			// base render
+      // base render
       this.render = function (ctx) {
-				// don't render display=none
+        // don't render display=none
         if (this.style('display').value == 'none') return
 
-				// don't render visibility=hidden
+        // don't render visibility=hidden
         if (this.style('visibility').value == 'hidden') return
 
         ctx.save()
-        if (this.attribute('mask').hasValue()) { // mask
+        if (this.attribute('mask').hasValue()) {
+          // mask
           var mask = this.attribute('mask').getDefinition()
           if (mask != null) mask.apply(ctx, this)
-        } else if (this.style('filter').hasValue()) { // filter
+        } else if (this.style('filter').hasValue()) {
+          // filter
           var filter = this.style('filter').getDefinition()
           if (filter != null) filter.apply(ctx, this)
         } else {
@@ -794,17 +993,17 @@
         ctx.restore()
       }
 
-			// base set context
+      // base set context
       this.setContext = function (ctx) {
-				// OVERRIDE ME!
+        // OVERRIDE ME!
       }
 
-			// base clear context
+      // base clear context
       this.clearContext = function (ctx) {
-				// OVERRIDE ME!
+        // OVERRIDE ME!
       }
 
-			// base render children
+      // base render children
       this.renderChildren = function (ctx) {
         for (var i = 0; i < this.children.length; i++) {
           this.children[i].render(ctx)
@@ -815,11 +1014,13 @@
         var child = childNode
         if (create) child = svg.CreateElement(childNode)
         child.parent = this
-        if (child.type != 'title') { this.children.push(child)	}
+        if (child.type != 'title') {
+          this.children.push(child)
+        }
       }
 
       this.addStylesFromStyleDefinition = function () {
-				// add styles
+        // add styles
         for (var selector in svg.Styles) {
           if (selector[0] != '@' && matchesSelector(node, selector)) {
             var styles = svg.Styles[selector]
@@ -827,7 +1028,7 @@
             if (styles != null) {
               for (var name in styles) {
                 var existingSpecificity = this.stylesSpecificity[name]
-                if (typeof (existingSpecificity) === 'undefined') {
+                if (typeof existingSpecificity === 'undefined') {
                   existingSpecificity = '000'
                 }
                 if (specificity > existingSpecificity) {
@@ -840,16 +1041,20 @@
         }
       }
 
-      if (node != null && node.nodeType == 1) { // ELEMENT_NODE
-				// add attributes
+      if (node != null && node.nodeType == 1) {
+        // ELEMENT_NODE
+        // add attributes
         for (var i = 0; i < node.attributes.length; i++) {
           var attribute = node.attributes[i]
-          this.attributes[attribute.nodeName] = new svg.Property(attribute.nodeName, attribute.value)
+          this.attributes[attribute.nodeName] = new svg.Property(
+            attribute.nodeName,
+            attribute.value
+          )
         }
 
         this.addStylesFromStyleDefinition()
 
-				// add inline styles
+        // add inline styles
         if (this.attribute('style').hasValue()) {
           var styles = this.attribute('style').value.split(';')
           for (var i = 0; i < styles.length; i++) {
@@ -862,19 +1067,23 @@
           }
         }
 
-				// add id
+        // add id
         if (this.attribute('id').hasValue()) {
           if (svg.Definitions[this.attribute('id').value] == null) {
             svg.Definitions[this.attribute('id').value] = this
           }
         }
 
-				// add children
+        // add children
         for (var i = 0; i < node.childNodes.length; i++) {
           var childNode = node.childNodes[i]
           if (childNode.nodeType == 1) this.addChild(childNode, true) // ELEMENT_NODE
-          if (this.captureTextNodes && (childNode.nodeType == 3 || childNode.nodeType == 4)) {
-            var text = childNode.value || childNode.text || childNode.textContent || ''
+          if (
+            this.captureTextNodes &&
+            (childNode.nodeType == 3 || childNode.nodeType == 4)
+          ) {
+            var text =
+              childNode.value || childNode.text || childNode.textContent || ''
             if (svg.compressSpaces(text) != '') {
               this.addChild(new svg.Element.tspan(childNode), false) // TEXT_NODE
             }
@@ -888,14 +1097,22 @@
       this.base(node)
 
       this.setContext = function (ctx) {
-				// fill
+        // fill
         if (this.style('fill').isUrlDefinition()) {
-          var fs = this.style('fill').getFillStyleDefinition(this, this.style('fill-opacity'))
+          var fs = this.style('fill').getFillStyleDefinition(
+            this,
+            this.style('fill-opacity')
+          )
           if (fs != null) ctx.fillStyle = fs
         } else if (this.style('fill').hasValue()) {
           var fillStyle = this.style('fill')
-          if (fillStyle.value == 'currentColor') fillStyle.value = this.style('color').value
-          if (fillStyle.value != 'inherit') ctx.fillStyle = (fillStyle.value == 'none' ? 'rgba(0,0,0,0)' : fillStyle.value)
+          if (fillStyle.value == 'currentColor') {
+            fillStyle.value = this.style('color').value
+          }
+          if (fillStyle.value != 'inherit') {
+            ctx.fillStyle =
+              fillStyle.value == 'none' ? 'rgba(0,0,0,0)' : fillStyle.value
+          }
         }
         if (this.style('fill-opacity').hasValue()) {
           var fillStyle = new svg.Property('fill', ctx.fillStyle)
@@ -903,14 +1120,22 @@
           ctx.fillStyle = fillStyle.value
         }
 
-				// stroke
+        // stroke
         if (this.style('stroke').isUrlDefinition()) {
-          var fs = this.style('stroke').getFillStyleDefinition(this, this.style('stroke-opacity'))
+          var fs = this.style('stroke').getFillStyleDefinition(
+            this,
+            this.style('stroke-opacity')
+          )
           if (fs != null) ctx.strokeStyle = fs
         } else if (this.style('stroke').hasValue()) {
           var strokeStyle = this.style('stroke')
-          if (strokeStyle.value == 'currentColor') strokeStyle.value = this.style('color').value
-          if (strokeStyle.value != 'inherit') ctx.strokeStyle = (strokeStyle.value == 'none' ? 'rgba(0,0,0,0)' : strokeStyle.value)
+          if (strokeStyle.value == 'currentColor') {
+            strokeStyle.value = this.style('color').value
+          }
+          if (strokeStyle.value != 'inherit') {
+            ctx.strokeStyle =
+              strokeStyle.value == 'none' ? 'rgba(0,0,0,0)' : strokeStyle.value
+          }
         }
         if (this.style('stroke-opacity').hasValue()) {
           var strokeStyle = new svg.Property('stroke', ctx.strokeStyle)
@@ -920,41 +1145,72 @@
         if (this.style('stroke-width').hasValue()) {
           var newLineWidth = this.style('stroke-width').toPixels()
           ctx.lineWidth = newLineWidth == 0 ? 0.001 : newLineWidth // browsers don't respect 0
-			    }
-        if (this.style('stroke-linecap').hasValue()) ctx.lineCap = this.style('stroke-linecap').value
-        if (this.style('stroke-linejoin').hasValue()) ctx.lineJoin = this.style('stroke-linejoin').value
-        if (this.style('stroke-miterlimit').hasValue()) ctx.miterLimit = this.style('stroke-miterlimit').value
-        if (this.style('stroke-dasharray').hasValue() && this.style('stroke-dasharray').value != 'none') {
+        }
+        if (this.style('stroke-linecap').hasValue()) {
+          ctx.lineCap = this.style('stroke-linecap').value
+        }
+        if (this.style('stroke-linejoin').hasValue()) {
+          ctx.lineJoin = this.style('stroke-linejoin').value
+        }
+        if (this.style('stroke-miterlimit').hasValue()) {
+          ctx.miterLimit = this.style('stroke-miterlimit').value
+        }
+        if (
+          this.style('stroke-dasharray').hasValue() &&
+          this.style('stroke-dasharray').value != 'none'
+        ) {
           var gaps = svg.ToNumberArray(this.style('stroke-dasharray').value)
-          if (typeof (ctx.setLineDash) !== 'undefined') { ctx.setLineDash(gaps) } else if (typeof (ctx.webkitLineDash) !== 'undefined') { ctx.webkitLineDash = gaps } else if (typeof (ctx.mozDash) !== 'undefined' && !(gaps.length == 1 && gaps[0] == 0)) { ctx.mozDash = gaps }
+          if (typeof ctx.setLineDash !== 'undefined') {
+            ctx.setLineDash(gaps)
+          } else if (typeof ctx.webkitLineDash !== 'undefined') {
+            ctx.webkitLineDash = gaps
+          } else if (
+            typeof ctx.mozDash !== 'undefined' &&
+            !(gaps.length == 1 && gaps[0] == 0)
+          ) {
+            ctx.mozDash = gaps
+          }
 
           var offset = this.style('stroke-dashoffset').numValueOrDefault(1)
-          if (typeof (ctx.lineDashOffset) !== 'undefined') { ctx.lineDashOffset = offset } else if (typeof (ctx.webkitLineDashOffset) !== 'undefined') { ctx.webkitLineDashOffset = offset } else if (typeof (ctx.mozDashOffset) !== 'undefined') { ctx.mozDashOffset = offset }
+          if (typeof ctx.lineDashOffset !== 'undefined') {
+            ctx.lineDashOffset = offset
+          } else if (typeof ctx.webkitLineDashOffset !== 'undefined') {
+            ctx.webkitLineDashOffset = offset
+          } else if (typeof ctx.mozDashOffset !== 'undefined') {
+            ctx.mozDashOffset = offset
+          }
         }
 
-				// font
-        if (typeof (ctx.font) !== 'undefined') {
-          ctx.font = svg.Font.CreateFont(
-						this.style('font-style').value,
-						this.style('font-variant').value,
-						this.style('font-weight').value,
-						this.style('font-size').hasValue() ? this.style('font-size').toPixels() + 'px' : '',
-						this.style('font-family').value).toString()
+        // font
+        if (typeof ctx.font !== 'undefined') {
+          ctx.font = svg.Font
+            .CreateFont(
+              this.style('font-style').value,
+              this.style('font-variant').value,
+              this.style('font-weight').value,
+              this.style('font-size').hasValue()
+                ? this.style('font-size').toPixels() + 'px'
+                : '',
+              this.style('font-family').value
+            )
+            .toString()
         }
 
-				// transform
+        // transform
         if (this.style('transform', false, true).hasValue()) {
-          var transform = new svg.Transform(this.style('transform', false, true).value)
+          var transform = new svg.Transform(
+            this.style('transform', false, true).value
+          )
           transform.apply(ctx)
         }
 
-				// clip
+        // clip
         if (this.attribute('clip-path', false, true).hasValue()) {
           var clip = this.attribute('clip-path', false, true).getDefinition()
           if (clip != null) clip.apply(ctx)
         }
 
-				// opacity
+        // opacity
         if (this.style('opacity').hasValue()) {
           ctx.globalAlpha = this.style('opacity').numValue()
         }
@@ -975,7 +1231,11 @@
         this.path(ctx)
         svg.Mouse.checkPath(this, ctx)
         if (ctx.fillStyle != '') {
-          if (this.style('fill-rule').valueOrDefault('inherit') != 'inherit') { ctx.fill(this.style('fill-rule').value) } else { ctx.fill() }
+          if (this.style('fill-rule').valueOrDefault('inherit') != 'inherit') {
+            ctx.fill(this.style('fill-rule').value)
+          } else {
+            ctx.fill()
+          }
         }
         if (ctx.strokeStyle != '') ctx.stroke()
 
@@ -993,7 +1253,11 @@
           }
           if (this.style('marker-end').isUrlDefinition()) {
             var marker = this.style('marker-end').getDefinition()
-            marker.render(ctx, markers[markers.length - 1][0], markers[markers.length - 1][1])
+            marker.render(
+              ctx,
+              markers[markers.length - 1][0],
+              markers[markers.length - 1][1]
+            )
           }
         }
       }
@@ -1006,9 +1270,10 @@
         return null
       }
     }
-    svg.Element.PathElementBase.prototype = new svg.Element.RenderedElementBase()
+    svg.Element.PathElementBase.prototype = new svg.Element
+      .RenderedElementBase()
 
-		// svg element
+    // svg element
     svg.Element.svg = function (node) {
       this.base = svg.Element.RenderedElementBase
       this.base(node)
@@ -1021,39 +1286,56 @@
 
       this.baseSetContext = this.setContext
       this.setContext = function (ctx) {
-				// initial values and defaults
+        // initial values and defaults
         ctx.strokeStyle = 'rgba(0,0,0,0)'
         ctx.lineCap = 'butt'
         ctx.lineJoin = 'miter'
         ctx.miterLimit = 4
-        if (typeof (ctx.font) !== 'undefined' && typeof (window.getComputedStyle) !== 'undefined') {
-          ctx.font = window.getComputedStyle(ctx.canvas).getPropertyValue('font')
+        if (
+          typeof ctx.font !== 'undefined' &&
+          typeof window.getComputedStyle !== 'undefined'
+        ) {
+          ctx.font = window
+            .getComputedStyle(ctx.canvas)
+            .getPropertyValue('font')
         }
 
         this.baseSetContext(ctx)
 
-				// create new view port
+        // create new view port
         if (!this.attribute('x').hasValue()) this.attribute('x', true).value = 0
         if (!this.attribute('y').hasValue()) this.attribute('y', true).value = 0
-        ctx.translate(this.attribute('x').toPixels('x'), this.attribute('y').toPixels('y'))
+        ctx.translate(
+          this.attribute('x').toPixels('x'),
+          this.attribute('y').toPixels('y')
+        )
 
         var width = svg.ViewPort.width()
         var height = svg.ViewPort.height()
 
-        if (!this.attribute('width').hasValue()) this.attribute('width', true).value = '100%'
-        if (!this.attribute('height').hasValue()) this.attribute('height', true).value = '100%'
-        if (typeof (this.root) === 'undefined') {
+        if (!this.attribute('width').hasValue()) {
+          this.attribute('width', true).value = '100%'
+        }
+        if (!this.attribute('height').hasValue()) {
+          this.attribute('height', true).value = '100%'
+        }
+        if (typeof this.root === 'undefined') {
           width = this.attribute('width').toPixels('x')
           height = this.attribute('height').toPixels('y')
 
           var x = 0
           var y = 0
-          if (this.attribute('refX').hasValue() && this.attribute('refY').hasValue()) {
+          if (
+            this.attribute('refX').hasValue() &&
+            this.attribute('refY').hasValue()
+          ) {
             x = -this.attribute('refX').toPixels('x')
             y = -this.attribute('refY').toPixels('y')
           }
 
-          if (this.attribute('overflow').valueOrDefault('hidden') != 'visible') {
+          if (
+            this.attribute('overflow').valueOrDefault('hidden') != 'visible'
+          ) {
             ctx.beginPath()
             ctx.moveTo(x, y)
             ctx.lineTo(width, y)
@@ -1065,7 +1347,7 @@
         }
         svg.ViewPort.SetCurrent(width, height)
 
-				// viewbox
+        // viewbox
         if (this.attribute('viewBox').hasValue()) {
           var viewBox = svg.ToNumberArray(this.attribute('viewBox').value)
           var minX = viewBox[0]
@@ -1073,16 +1355,18 @@
           width = viewBox[2]
           height = viewBox[3]
 
-          svg.AspectRatio(ctx,
-									this.attribute('preserveAspectRatio').value,
-									svg.ViewPort.width(),
-									width,
-									svg.ViewPort.height(),
-									height,
-									minX,
-									minY,
-									this.attribute('refX').value,
-									this.attribute('refY').value)
+          svg.AspectRatio(
+            ctx,
+            this.attribute('preserveAspectRatio').value,
+            svg.ViewPort.width(),
+            width,
+            svg.ViewPort.height(),
+            height,
+            minX,
+            minY,
+            this.attribute('refX').value,
+            this.attribute('refY').value
+          )
 
           svg.ViewPort.RemoveCurrent()
           svg.ViewPort.SetCurrent(viewBox[2], viewBox[3])
@@ -1091,7 +1375,7 @@
     }
     svg.Element.svg.prototype = new svg.Element.RenderedElementBase()
 
-		// rect element
+    // rect element
     svg.Element.rect = function (node) {
       this.base = svg.Element.PathElementBase
       this.base(node)
@@ -1103,8 +1387,18 @@
         var height = this.attribute('height').toPixels('y')
         var rx = this.attribute('rx').toPixels('x')
         var ry = this.attribute('ry').toPixels('y')
-        if (this.attribute('rx').hasValue() && !this.attribute('ry').hasValue()) ry = rx
-        if (this.attribute('ry').hasValue() && !this.attribute('rx').hasValue()) rx = ry
+        if (
+          this.attribute('rx').hasValue() &&
+          !this.attribute('ry').hasValue()
+        ) {
+          ry = rx
+        }
+        if (
+          this.attribute('ry').hasValue() &&
+          !this.attribute('rx').hasValue()
+        ) {
+          rx = ry
+        }
         rx = Math.min(rx, width / 2.0)
         ry = Math.min(ry, height / 2.0)
         if (ctx != null) {
@@ -1113,7 +1407,12 @@
           ctx.lineTo(x + width - rx, y)
           ctx.quadraticCurveTo(x + width, y, x + width, y + ry)
           ctx.lineTo(x + width, y + height - ry)
-          ctx.quadraticCurveTo(x + width, y + height, x + width - rx, y + height)
+          ctx.quadraticCurveTo(
+            x + width,
+            y + height,
+            x + width - rx,
+            y + height
+          )
           ctx.lineTo(x + rx, y + height)
           ctx.quadraticCurveTo(x, y + height, x, y + height - ry)
           ctx.lineTo(x, y + ry)
@@ -1126,7 +1425,7 @@
     }
     svg.Element.rect.prototype = new svg.Element.PathElementBase()
 
-		// circle element
+    // circle element
     svg.Element.circle = function (node) {
       this.base = svg.Element.PathElementBase
       this.base(node)
@@ -1147,7 +1446,7 @@
     }
     svg.Element.circle.prototype = new svg.Element.PathElementBase()
 
-		// ellipse element
+    // ellipse element
     svg.Element.ellipse = function (node) {
       this.base = svg.Element.PathElementBase
       this.base(node)
@@ -1162,10 +1461,38 @@
         if (ctx != null) {
           ctx.beginPath()
           ctx.moveTo(cx, cy - ry)
-          ctx.bezierCurveTo(cx + (KAPPA * rx), cy - ry, cx + rx, cy - (KAPPA * ry), cx + rx, cy)
-          ctx.bezierCurveTo(cx + rx, cy + (KAPPA * ry), cx + (KAPPA * rx), cy + ry, cx, cy + ry)
-          ctx.bezierCurveTo(cx - (KAPPA * rx), cy + ry, cx - rx, cy + (KAPPA * ry), cx - rx, cy)
-          ctx.bezierCurveTo(cx - rx, cy - (KAPPA * ry), cx - (KAPPA * rx), cy - ry, cx, cy - ry)
+          ctx.bezierCurveTo(
+            cx + KAPPA * rx,
+            cy - ry,
+            cx + rx,
+            cy - KAPPA * ry,
+            cx + rx,
+            cy
+          )
+          ctx.bezierCurveTo(
+            cx + rx,
+            cy + KAPPA * ry,
+            cx + KAPPA * rx,
+            cy + ry,
+            cx,
+            cy + ry
+          )
+          ctx.bezierCurveTo(
+            cx - KAPPA * rx,
+            cy + ry,
+            cx - rx,
+            cy + KAPPA * ry,
+            cx - rx,
+            cy
+          )
+          ctx.bezierCurveTo(
+            cx - rx,
+            cy - KAPPA * ry,
+            cx - KAPPA * rx,
+            cy - ry,
+            cx,
+            cy - ry
+          )
           ctx.closePath()
         }
 
@@ -1174,15 +1501,22 @@
     }
     svg.Element.ellipse.prototype = new svg.Element.PathElementBase()
 
-		// line element
+    // line element
     svg.Element.line = function (node) {
       this.base = svg.Element.PathElementBase
       this.base(node)
 
       this.getPoints = function () {
         return [
-          new svg.Point(this.attribute('x1').toPixels('x'), this.attribute('y1').toPixels('y')),
-          new svg.Point(this.attribute('x2').toPixels('x'), this.attribute('y2').toPixels('y'))]
+          new svg.Point(
+            this.attribute('x1').toPixels('x'),
+            this.attribute('y1').toPixels('y')
+          ),
+          new svg.Point(
+            this.attribute('x2').toPixels('x'),
+            this.attribute('y2').toPixels('y')
+          )
+        ]
       }
 
       this.path = function (ctx) {
@@ -1194,7 +1528,12 @@
           ctx.lineTo(points[1].x, points[1].y)
         }
 
-        return new svg.BoundingBox(points[0].x, points[0].y, points[1].x, points[1].y)
+        return new svg.BoundingBox(
+          points[0].x,
+          points[0].y,
+          points[1].x,
+          points[1].y
+        )
       }
 
       this.getMarkers = function () {
@@ -1205,7 +1544,7 @@
     }
     svg.Element.line.prototype = new svg.Element.PathElementBase()
 
-		// polyline element
+    // polyline element
     svg.Element.polyline = function (node) {
       this.base = svg.Element.PathElementBase
       this.base(node)
@@ -1227,15 +1566,21 @@
       this.getMarkers = function () {
         var markers = []
         for (var i = 0; i < this.points.length - 1; i++) {
-          markers.push([this.points[i], this.points[i].angleTo(this.points[i + 1])])
+          markers.push([
+            this.points[i],
+            this.points[i].angleTo(this.points[i + 1])
+          ])
         }
-        markers.push([this.points[this.points.length - 1], markers[markers.length - 1][1]])
+        markers.push([
+          this.points[this.points.length - 1],
+          markers[markers.length - 1][1]
+        ])
         return markers
       }
     }
     svg.Element.polyline.prototype = new svg.Element.PathElementBase()
 
-		// polygon element
+    // polygon element
     svg.Element.polygon = function (node) {
       this.base = svg.Element.polyline
       this.base(node)
@@ -1252,21 +1597,21 @@
     }
     svg.Element.polygon.prototype = new svg.Element.polyline()
 
-		// path element
+    // path element
     svg.Element.path = function (node) {
       this.base = svg.Element.PathElementBase
       this.base(node)
 
       var d = this.attribute('d').value
-			// TODO: convert to real lexer based on http://www.w3.org/TR/SVG11/paths.html#PathDataBNF
+      // TODO: convert to real lexer based on http://www.w3.org/TR/SVG11/paths.html#PathDataBNF
       d = d.replace(/,/gm, ' ') // get rid of all commas
-			// As the end of a match can also be the start of the next match, we need to run this replace twice.
+      // As the end of a match can also be the start of the next match, we need to run this replace twice.
       for (var i = 0; i < 2; i++) {
         d = d.replace(/([MmZzLlHhVvCcSsQqTtAa])([^\s])/gm, '$1 $2')
       } // suffix commands with spaces
       d = d.replace(/([^\s])([MmZzLlHhVvCcSsQqTtAa])/gm, '$1 $2') // prefix commands with spaces
       d = d.replace(/([0-9])([+\-])/gm, '$1 $2') // separate digits on +- signs
-			// Again, we need to run this twice to find all occurances
+      // Again, we need to run this twice to find all occurances
       for (var i = 0; i < 2; i++) {
         d = d.replace(/(\.[0-9]*)(\.)/gm, '$1 $2')
       } // separate digits when they start with a comma
@@ -1297,7 +1642,7 @@
         }
 
         this.isRelativeCommand = function () {
-          switch (this.command)					{
+          switch (this.command) {
             case 'm':
             case 'l':
             case 'h':
@@ -1346,15 +1691,20 @@
         }
 
         this.getReflectedControlPoint = function () {
-          if (this.previousCommand.toLowerCase() != 'c' &&
-					    this.previousCommand.toLowerCase() != 's' &&
-						this.previousCommand.toLowerCase() != 'q' &&
-						this.previousCommand.toLowerCase() != 't') {
+          if (
+            this.previousCommand.toLowerCase() != 'c' &&
+            this.previousCommand.toLowerCase() != 's' &&
+            this.previousCommand.toLowerCase() != 'q' &&
+            this.previousCommand.toLowerCase() != 't'
+          ) {
             return this.current
           }
 
-					// reflect point
-          var p = new svg.Point(2 * this.current.x - this.control.x, 2 * this.current.y - this.control.y)
+          // reflect point
+          var p = new svg.Point(
+            2 * this.current.x - this.control.x,
+            2 * this.current.y - this.control.y
+          )
           return p
         }
 
@@ -1367,9 +1717,15 @@
         }
 
         this.addMarker = function (p, from, priorTo) {
-					// if the last angle isn't filled in because we didn't have this point yet ...
-          if (priorTo != null && this.angles.length > 0 && this.angles[this.angles.length - 1] == null) {
-            this.angles[this.angles.length - 1] = this.points[this.points.length - 1].angleTo(priorTo)
+          // if the last angle isn't filled in because we didn't have this point yet ...
+          if (
+            priorTo != null &&
+            this.angles.length > 0 &&
+            this.angles[this.angles.length - 1] == null
+          ) {
+            this.angles[this.angles.length - 1] = this.points[
+              this.points.length - 1
+            ].angleTo(priorTo)
           }
           this.addMarkerAngle(p, from == null ? null : from.angleTo(p))
         }
@@ -1379,7 +1735,9 @@
           this.angles.push(a)
         }
 
-        this.getMarkerPoints = function () { return this.points }
+        this.getMarkerPoints = function () {
+          return this.points
+        }
         this.getMarkerAngles = function () {
           for (var i = 0; i < this.angles.length; i++) {
             if (this.angles[i] == null) {
@@ -1431,7 +1789,10 @@
             case 'H':
             case 'h':
               while (!pp.isCommandOrEnd()) {
-                var newP = new svg.Point((pp.isRelativeCommand() ? pp.current.x : 0) + pp.getScalar(), pp.current.y)
+                var newP = new svg.Point(
+                  (pp.isRelativeCommand() ? pp.current.x : 0) + pp.getScalar(),
+                  pp.current.y
+                )
                 pp.addMarker(newP, pp.current)
                 pp.current = newP
                 bb.addPoint(pp.current.x, pp.current.y)
@@ -1441,7 +1802,10 @@
             case 'V':
             case 'v':
               while (!pp.isCommandOrEnd()) {
-                var newP = new svg.Point(pp.current.x, (pp.isRelativeCommand() ? pp.current.y : 0) + pp.getScalar())
+                var newP = new svg.Point(
+                  pp.current.x,
+                  (pp.isRelativeCommand() ? pp.current.y : 0) + pp.getScalar()
+                )
                 pp.addMarker(newP, pp.current)
                 pp.current = newP
                 bb.addPoint(pp.current.x, pp.current.y)
@@ -1456,8 +1820,19 @@
                 var cntrl = pp.getAsControlPoint()
                 var cp = pp.getAsCurrentPoint()
                 pp.addMarker(cp, cntrl, p1)
-                bb.addBezierCurve(curr.x, curr.y, p1.x, p1.y, cntrl.x, cntrl.y, cp.x, cp.y)
-                if (ctx != null) ctx.bezierCurveTo(p1.x, p1.y, cntrl.x, cntrl.y, cp.x, cp.y)
+                bb.addBezierCurve(
+                  curr.x,
+                  curr.y,
+                  p1.x,
+                  p1.y,
+                  cntrl.x,
+                  cntrl.y,
+                  cp.x,
+                  cp.y
+                )
+                if (ctx != null) {
+                  ctx.bezierCurveTo(p1.x, p1.y, cntrl.x, cntrl.y, cp.x, cp.y)
+                }
               }
               break
             case 'S':
@@ -1468,8 +1843,19 @@
                 var cntrl = pp.getAsControlPoint()
                 var cp = pp.getAsCurrentPoint()
                 pp.addMarker(cp, cntrl, p1)
-                bb.addBezierCurve(curr.x, curr.y, p1.x, p1.y, cntrl.x, cntrl.y, cp.x, cp.y)
-                if (ctx != null) ctx.bezierCurveTo(p1.x, p1.y, cntrl.x, cntrl.y, cp.x, cp.y)
+                bb.addBezierCurve(
+                  curr.x,
+                  curr.y,
+                  p1.x,
+                  p1.y,
+                  cntrl.x,
+                  cntrl.y,
+                  cp.x,
+                  cp.y
+                )
+                if (ctx != null) {
+                  ctx.bezierCurveTo(p1.x, p1.y, cntrl.x, cntrl.y, cp.x, cp.y)
+                }
               }
               break
             case 'Q':
@@ -1479,8 +1865,17 @@
                 var cntrl = pp.getAsControlPoint()
                 var cp = pp.getAsCurrentPoint()
                 pp.addMarker(cp, cntrl, cntrl)
-                bb.addQuadraticCurve(curr.x, curr.y, cntrl.x, cntrl.y, cp.x, cp.y)
-                if (ctx != null) ctx.quadraticCurveTo(cntrl.x, cntrl.y, cp.x, cp.y)
+                bb.addQuadraticCurve(
+                  curr.x,
+                  curr.y,
+                  cntrl.x,
+                  cntrl.y,
+                  cp.x,
+                  cp.y
+                )
+                if (ctx != null) {
+                  ctx.quadraticCurveTo(cntrl.x, cntrl.y, cp.x, cp.y)
+                }
               }
               break
             case 'T':
@@ -1491,14 +1886,23 @@
                 pp.control = cntrl
                 var cp = pp.getAsCurrentPoint()
                 pp.addMarker(cp, cntrl, cntrl)
-                bb.addQuadraticCurve(curr.x, curr.y, cntrl.x, cntrl.y, cp.x, cp.y)
-                if (ctx != null) ctx.quadraticCurveTo(cntrl.x, cntrl.y, cp.x, cp.y)
+                bb.addQuadraticCurve(
+                  curr.x,
+                  curr.y,
+                  cntrl.x,
+                  cntrl.y,
+                  cp.x,
+                  cp.y
+                )
+                if (ctx != null) {
+                  ctx.quadraticCurveTo(cntrl.x, cntrl.y, cp.x, cp.y)
+                }
               }
               break
             case 'A':
             case 'a':
               while (!pp.isCommandOrEnd()) {
-						    var curr = pp.current
+                var curr = pp.current
                 var rx = pp.getScalar()
                 var ry = pp.getScalar()
                 var xAxisRotation = pp.getScalar() * (Math.PI / 180.0)
@@ -1506,53 +1910,80 @@
                 var sweepFlag = pp.getScalar()
                 var cp = pp.getAsCurrentPoint()
 
-							// Conversion from endpoint to center parameterization
-							// http://www.w3.org/TR/SVG11/implnote.html#ArcImplementationNotes
-							// x1', y1'
+                // Conversion from endpoint to center parameterization
+                // http://www.w3.org/TR/SVG11/implnote.html#ArcImplementationNotes
+                // x1', y1'
                 var currp = new svg.Point(
-								Math.cos(xAxisRotation) * (curr.x - cp.x) / 2.0 + Math.sin(xAxisRotation) * (curr.y - cp.y) / 2.0,
-								-Math.sin(xAxisRotation) * (curr.x - cp.x) / 2.0 + Math.cos(xAxisRotation) * (curr.y - cp.y) / 2.0
-							)
-							// adjust radii
-                var l = Math.pow(currp.x, 2) / Math.pow(rx, 2) + Math.pow(currp.y, 2) / Math.pow(ry, 2)
+                  Math.cos(xAxisRotation) * (curr.x - cp.x) / 2.0 +
+                    Math.sin(xAxisRotation) * (curr.y - cp.y) / 2.0,
+                  -Math.sin(xAxisRotation) * (curr.x - cp.x) / 2.0 +
+                    Math.cos(xAxisRotation) * (curr.y - cp.y) / 2.0
+                )
+                // adjust radii
+                var l =
+                  Math.pow(currp.x, 2) / Math.pow(rx, 2) +
+                  Math.pow(currp.y, 2) / Math.pow(ry, 2)
                 if (l > 1) {
                   rx *= Math.sqrt(l)
                   ry *= Math.sqrt(l)
                 }
-							// cx', cy'
-                var s = (largeArcFlag == sweepFlag ? -1 : 1) * Math.sqrt(
-								((Math.pow(rx, 2) * Math.pow(ry, 2)) - (Math.pow(rx, 2) * Math.pow(currp.y, 2)) - (Math.pow(ry, 2) * Math.pow(currp.x, 2))) /
-								(Math.pow(rx, 2) * Math.pow(currp.y, 2) + Math.pow(ry, 2) * Math.pow(currp.x, 2))
-							)
+                // cx', cy'
+                var s =
+                  (largeArcFlag == sweepFlag ? -1 : 1) *
+                  Math.sqrt(
+                    (Math.pow(rx, 2) * Math.pow(ry, 2) -
+                      Math.pow(rx, 2) * Math.pow(currp.y, 2) -
+                      Math.pow(ry, 2) * Math.pow(currp.x, 2)) /
+                      (Math.pow(rx, 2) * Math.pow(currp.y, 2) +
+                        Math.pow(ry, 2) * Math.pow(currp.x, 2))
+                  )
                 if (isNaN(s)) s = 0
-                var cpp = new svg.Point(s * rx * currp.y / ry, s * -ry * currp.x / rx)
-							// cx, cy
+                var cpp = new svg.Point(
+                  s * rx * currp.y / ry,
+                  s * -ry * currp.x / rx
+                )
+                // cx, cy
                 var centp = new svg.Point(
-								(curr.x + cp.x) / 2.0 + Math.cos(xAxisRotation) * cpp.x - Math.sin(xAxisRotation) * cpp.y,
-								(curr.y + cp.y) / 2.0 + Math.sin(xAxisRotation) * cpp.x + Math.cos(xAxisRotation) * cpp.y
-							)
-							// vector magnitude
-                var m = function (v) { return Math.sqrt(Math.pow(v[0], 2) + Math.pow(v[1], 2)) }
-							// ratio between two vectors
-                var r = function (u, v) { return (u[0] * v[0] + u[1] * v[1]) / (m(u) * m(v)) }
-							// angle between two vectors
-                var a = function (u, v) { return (u[0] * v[1] < u[1] * v[0] ? -1 : 1) * Math.acos(r(u, v)) }
-							// initial angle
-                var a1 = a([1, 0], [(currp.x - cpp.x) / rx, (currp.y - cpp.y) / ry])
-							// angle delta
+                  (curr.x + cp.x) / 2.0 +
+                    Math.cos(xAxisRotation) * cpp.x -
+                    Math.sin(xAxisRotation) * cpp.y,
+                  (curr.y + cp.y) / 2.0 +
+                    Math.sin(xAxisRotation) * cpp.x +
+                    Math.cos(xAxisRotation) * cpp.y
+                )
+                // vector magnitude
+                var m = function (v) {
+                  return Math.sqrt(Math.pow(v[0], 2) + Math.pow(v[1], 2))
+                }
+                // ratio between two vectors
+                var r = function (u, v) {
+                  return (u[0] * v[0] + u[1] * v[1]) / (m(u) * m(v))
+                }
+                // angle between two vectors
+                var a = function (u, v) {
+                  return (
+                    (u[0] * v[1] < u[1] * v[0] ? -1 : 1) * Math.acos(r(u, v))
+                  )
+                }
+                // initial angle
+                var a1 = a(
+                  [1, 0],
+                  [(currp.x - cpp.x) / rx, (currp.y - cpp.y) / ry]
+                )
+                // angle delta
                 var u = [(currp.x - cpp.x) / rx, (currp.y - cpp.y) / ry]
                 var v = [(-currp.x - cpp.x) / rx, (-currp.y - cpp.y) / ry]
                 var ad = a(u, v)
                 if (r(u, v) <= -1) ad = Math.PI
                 if (r(u, v) >= 1) ad = 0
 
-							// for markers
+                // for markers
                 var dir = 1 - sweepFlag ? 1.0 : -1.0
                 var ah = a1 + dir * (ad / 2.0)
                 var halfWay = new svg.Point(
-								centp.x + rx * Math.cos(ah),
-								centp.y + ry * Math.sin(ah)
-							)
+                  centp.x + rx * Math.cos(ah),
+                  centp.y + ry * Math.sin(ah)
+                )
                 pp.addMarkerAngle(halfWay, ah - dir * Math.PI / 2)
                 pp.addMarkerAngle(cp, ah - dir * Math.PI)
 
@@ -1595,7 +2026,7 @@
     }
     svg.Element.path.prototype = new svg.Element.PathElementBase()
 
-		// pattern element
+    // pattern element
     svg.Element.pattern = function (node) {
       this.base = svg.Element.ElementBase
       this.base(node)
@@ -1604,12 +2035,18 @@
         var width = this.attribute('width').toPixels('x', true)
         var height = this.attribute('height').toPixels('y', true)
 
-				// render me using a temporary svg element
+        // render me using a temporary svg element
         var tempSvg = new svg.Element.svg()
-        tempSvg.attributes['viewBox'] = new svg.Property('viewBox', this.attribute('viewBox').value)
+        tempSvg.attributes['viewBox'] = new svg.Property(
+          'viewBox',
+          this.attribute('viewBox').value
+        )
         tempSvg.attributes['width'] = new svg.Property('width', width + 'px')
         tempSvg.attributes['height'] = new svg.Property('height', height + 'px')
-        tempSvg.attributes['transform'] = new svg.Property('transform', this.attribute('patternTransform').value)
+        tempSvg.attributes['transform'] = new svg.Property(
+          'transform',
+          this.attribute('patternTransform').value
+        )
         tempSvg.children = this.children
 
         var c = document.createElement('canvas')
@@ -1617,9 +2054,12 @@
         c.height = height
         var cctx = c.getContext('2d')
         if (this.attribute('x').hasValue() && this.attribute('y').hasValue()) {
-          cctx.translate(this.attribute('x').toPixels('x', true), this.attribute('y').toPixels('y', true))
+          cctx.translate(
+            this.attribute('x').toPixels('x', true),
+            this.attribute('y').toPixels('y', true)
+          )
         }
-				// render 3x3 grid so when we transform there's no white space on edges
+        // render 3x3 grid so when we transform there's no white space on edges
         for (var x = -1; x <= 1; x++) {
           for (var y = -1; y <= 1; y++) {
             cctx.save()
@@ -1635,7 +2075,7 @@
     }
     svg.Element.pattern.prototype = new svg.Element.ElementBase()
 
-		// marker element
+    // marker element
     svg.Element.marker = function (node) {
       this.base = svg.Element.ElementBase
       this.base(node)
@@ -1643,42 +2083,77 @@
       this.baseRender = this.render
       this.render = function (ctx, point, angle) {
         ctx.translate(point.x, point.y)
-        if (this.attribute('orient').valueOrDefault('auto') == 'auto') ctx.rotate(angle)
-        if (this.attribute('markerUnits').valueOrDefault('strokeWidth') == 'strokeWidth') ctx.scale(ctx.lineWidth, ctx.lineWidth)
+        if (this.attribute('orient').valueOrDefault('auto') == 'auto') {
+          ctx.rotate(angle)
+        }
+        if (
+          this.attribute('markerUnits').valueOrDefault('strokeWidth') ==
+          'strokeWidth'
+        ) {
+          ctx.scale(ctx.lineWidth, ctx.lineWidth)
+        }
         ctx.save()
 
-				// render me using a temporary svg element
+        // render me using a temporary svg element
         var tempSvg = new svg.Element.svg()
-        tempSvg.attributes['viewBox'] = new svg.Property('viewBox', this.attribute('viewBox').value)
-        tempSvg.attributes['refX'] = new svg.Property('refX', this.attribute('refX').value)
-        tempSvg.attributes['refY'] = new svg.Property('refY', this.attribute('refY').value)
-        tempSvg.attributes['width'] = new svg.Property('width', this.attribute('markerWidth').value)
-        tempSvg.attributes['height'] = new svg.Property('height', this.attribute('markerHeight').value)
-        tempSvg.attributes['fill'] = new svg.Property('fill', this.attribute('fill').valueOrDefault('black'))
-        tempSvg.attributes['stroke'] = new svg.Property('stroke', this.attribute('stroke').valueOrDefault('none'))
+        tempSvg.attributes['viewBox'] = new svg.Property(
+          'viewBox',
+          this.attribute('viewBox').value
+        )
+        tempSvg.attributes['refX'] = new svg.Property(
+          'refX',
+          this.attribute('refX').value
+        )
+        tempSvg.attributes['refY'] = new svg.Property(
+          'refY',
+          this.attribute('refY').value
+        )
+        tempSvg.attributes['width'] = new svg.Property(
+          'width',
+          this.attribute('markerWidth').value
+        )
+        tempSvg.attributes['height'] = new svg.Property(
+          'height',
+          this.attribute('markerHeight').value
+        )
+        tempSvg.attributes['fill'] = new svg.Property(
+          'fill',
+          this.attribute('fill').valueOrDefault('black')
+        )
+        tempSvg.attributes['stroke'] = new svg.Property(
+          'stroke',
+          this.attribute('stroke').valueOrDefault('none')
+        )
         tempSvg.children = this.children
         tempSvg.render(ctx)
 
         ctx.restore()
-        if (this.attribute('markerUnits').valueOrDefault('strokeWidth') == 'strokeWidth') ctx.scale(1 / ctx.lineWidth, 1 / ctx.lineWidth)
-        if (this.attribute('orient').valueOrDefault('auto') == 'auto') ctx.rotate(-angle)
+        if (
+          this.attribute('markerUnits').valueOrDefault('strokeWidth') ==
+          'strokeWidth'
+        ) {
+          ctx.scale(1 / ctx.lineWidth, 1 / ctx.lineWidth)
+        }
+        if (this.attribute('orient').valueOrDefault('auto') == 'auto') {
+          ctx.rotate(-angle)
+        }
         ctx.translate(-point.x, -point.y)
       }
     }
     svg.Element.marker.prototype = new svg.Element.ElementBase()
 
-		// definitions element
+    // definitions element
     svg.Element.defs = function (node) {
       this.base = svg.Element.ElementBase
       this.base(node)
 
       this.render = function (ctx) {
-				// NOOP
+        // NOOP
       }
     }
     svg.Element.defs.prototype = new svg.Element.ElementBase()
 
-		// base for gradients
+    // base for gradients
     svg.Element.GradientBase = function (node) {
       this.base = svg.Element.ElementBase
       this.base(node)
@@ -1690,11 +2165,13 @@
       }
 
       this.getGradient = function () {
-				// OVERRIDE ME!
+        // OVERRIDE ME!
       }
 
       this.gradientUnits = function () {
-        return this.attribute('gradientUnits').valueOrDefault('objectBoundingBox')
+        return this.attribute('gradientUnits').valueOrDefault(
+          'objectBoundingBox'
+        )
       }
 
       this.attributesToInherit = ['gradientUnits']
@@ -1702,8 +2179,14 @@
       this.inheritStopContainer = function (stopsContainer) {
         for (var i = 0; i < this.attributesToInherit.length; i++) {
           var attributeToInherit = this.attributesToInherit[i]
-          if (!this.attribute(attributeToInherit).hasValue() && stopsContainer.attribute(attributeToInherit).hasValue()) {
-            this.attribute(attributeToInherit, true).value = stopsContainer.attribute(attributeToInherit).value
+          if (
+            !this.attribute(attributeToInherit).hasValue() &&
+            stopsContainer.attribute(attributeToInherit).hasValue()
+          ) {
+            this.attribute(
+              attributeToInherit,
+              true
+            ).value = stopsContainer.attribute(attributeToInherit).value
           }
         }
       }
@@ -1724,31 +2207,59 @@
         }
 
         var g = this.getGradient(ctx, element)
-        if (g == null) return addParentOpacity(stopsContainer.stops[stopsContainer.stops.length - 1].color)
+        if (g == null) {
+          return addParentOpacity(
+            stopsContainer.stops[stopsContainer.stops.length - 1].color
+          )
+        }
         for (var i = 0; i < stopsContainer.stops.length; i++) {
-          g.addColorStop(stopsContainer.stops[i].offset, addParentOpacity(stopsContainer.stops[i].color))
+          g.addColorStop(
+            stopsContainer.stops[i].offset,
+            addParentOpacity(stopsContainer.stops[i].color)
+          )
         }
 
         if (this.attribute('gradientTransform').hasValue()) {
-					// render as transformed pattern on temporary canvas
+          // render as transformed pattern on temporary canvas
           var rootView = svg.ViewPort.viewPorts[0]
 
           var rect = new svg.Element.rect()
-          rect.attributes['x'] = new svg.Property('x', -svg.MAX_VIRTUAL_PIXELS / 3.0)
-          rect.attributes['y'] = new svg.Property('y', -svg.MAX_VIRTUAL_PIXELS / 3.0)
-          rect.attributes['width'] = new svg.Property('width', svg.MAX_VIRTUAL_PIXELS)
-          rect.attributes['height'] = new svg.Property('height', svg.MAX_VIRTUAL_PIXELS)
+          rect.attributes['x'] = new svg.Property(
+            'x',
+            -svg.MAX_VIRTUAL_PIXELS / 3.0
+          )
+          rect.attributes['y'] = new svg.Property(
+            'y',
+            -svg.MAX_VIRTUAL_PIXELS / 3.0
+          )
+          rect.attributes['width'] = new svg.Property(
+            'width',
+            svg.MAX_VIRTUAL_PIXELS
+          )
+          rect.attributes['height'] = new svg.Property(
+            'height',
+            svg.MAX_VIRTUAL_PIXELS
+          )
 
           var group = new svg.Element.g()
-          group.attributes['transform'] = new svg.Property('transform', this.attribute('gradientTransform').value)
-          group.children = [ rect ]
+          group.attributes['transform'] = new svg.Property(
+            'transform',
+            this.attribute('gradientTransform').value
+          )
+          group.children = [rect]
 
           var tempSvg = new svg.Element.svg()
           tempSvg.attributes['x'] = new svg.Property('x', 0)
           tempSvg.attributes['y'] = new svg.Property('y', 0)
-          tempSvg.attributes['width'] = new svg.Property('width', rootView.width)
-          tempSvg.attributes['height'] = new svg.Property('height', rootView.height)
-          tempSvg.children = [ group ]
+          tempSvg.attributes['width'] = new svg.Property(
+            'width',
+            rootView.width
+          )
+          tempSvg.attributes['height'] = new svg.Property(
+            'height',
+            rootView.height
+          )
+          tempSvg.children = [group]
 
           var c = document.createElement('canvas')
           c.width = rootView.width
@@ -1764,7 +2275,7 @@
     }
     svg.Element.GradientBase.prototype = new svg.Element.ElementBase()
 
-		// linear gradient element
+    // linear gradient element
     svg.Element.linearGradient = function (node) {
       this.base = svg.Element.GradientBase
       this.base(node)
@@ -1775,30 +2286,39 @@
       this.attributesToInherit.push('y2')
 
       this.getGradient = function (ctx, element) {
-        var bb = this.gradientUnits() == 'objectBoundingBox' ? element.getBoundingBox() : null
+        var bb =
+          this.gradientUnits() == 'objectBoundingBox'
+            ? element.getBoundingBox()
+            : null
 
-        if (!this.attribute('x1').hasValue()
-				 && !this.attribute('y1').hasValue()
-				 && !this.attribute('x2').hasValue()
-				 && !this.attribute('y2').hasValue()) {
+        if (
+          !this.attribute('x1').hasValue() &&
+          !this.attribute('y1').hasValue() &&
+          !this.attribute('x2').hasValue() &&
+          !this.attribute('y2').hasValue()
+        ) {
           this.attribute('x1', true).value = 0
           this.attribute('y1', true).value = 0
           this.attribute('x2', true).value = 1
           this.attribute('y2', true).value = 0
-				 }
+        }
 
-        var x1 = (this.gradientUnits() == 'objectBoundingBox'
-					? bb.x() + bb.width() * this.attribute('x1').numValue()
-					: this.attribute('x1').toPixels('x'))
-        var y1 = (this.gradientUnits() == 'objectBoundingBox'
-					? bb.y() + bb.height() * this.attribute('y1').numValue()
-					: this.attribute('y1').toPixels('y'))
-        var x2 = (this.gradientUnits() == 'objectBoundingBox'
-					? bb.x() + bb.width() * this.attribute('x2').numValue()
-					: this.attribute('x2').toPixels('x'))
-        var y2 = (this.gradientUnits() == 'objectBoundingBox'
-					? bb.y() + bb.height() * this.attribute('y2').numValue()
-					: this.attribute('y2').toPixels('y'))
+        var x1 =
+          this.gradientUnits() == 'objectBoundingBox'
+            ? bb.x() + bb.width() * this.attribute('x1').numValue()
+            : this.attribute('x1').toPixels('x')
+        var y1 =
+          this.gradientUnits() == 'objectBoundingBox'
+            ? bb.y() + bb.height() * this.attribute('y1').numValue()
+            : this.attribute('y1').toPixels('y')
+        var x2 =
+          this.gradientUnits() == 'objectBoundingBox'
+            ? bb.x() + bb.width() * this.attribute('x2').numValue()
+            : this.attribute('x2').toPixels('x')
+        var y2 =
+          this.gradientUnits() == 'objectBoundingBox'
+            ? bb.y() + bb.height() * this.attribute('y2').numValue()
+            : this.attribute('y2').toPixels('y')
 
         if (x1 == x2 && y1 == y2) return null
         return ctx.createLinearGradient(x1, y1, x2, y2)
@@ -1806,7 +2326,7 @@
     }
     svg.Element.linearGradient.prototype = new svg.Element.GradientBase()
 
-		// radial gradient element
+    // radial gradient element
     svg.Element.radialGradient = function (node) {
       this.base = svg.Element.GradientBase
       this.base(node)
@@ -1820,40 +2340,51 @@
       this.getGradient = function (ctx, element) {
         var bb = element.getBoundingBox()
 
-        if (!this.attribute('cx').hasValue()) this.attribute('cx', true).value = '50%'
-        if (!this.attribute('cy').hasValue()) this.attribute('cy', true).value = '50%'
-        if (!this.attribute('r').hasValue()) this.attribute('r', true).value = '50%'
+        if (!this.attribute('cx').hasValue()) {
+          this.attribute('cx', true).value = '50%'
+        }
+        if (!this.attribute('cy').hasValue()) {
+          this.attribute('cy', true).value = '50%'
+        }
+        if (!this.attribute('r').hasValue()) {
+          this.attribute('r', true).value = '50%'
+        }
 
-        var cx = (this.gradientUnits() == 'objectBoundingBox'
-					? bb.x() + bb.width() * this.attribute('cx').numValue()
-					: this.attribute('cx').toPixels('x'))
-        var cy = (this.gradientUnits() == 'objectBoundingBox'
-					? bb.y() + bb.height() * this.attribute('cy').numValue()
-					: this.attribute('cy').toPixels('y'))
+        var cx =
+          this.gradientUnits() == 'objectBoundingBox'
+            ? bb.x() + bb.width() * this.attribute('cx').numValue()
+            : this.attribute('cx').toPixels('x')
+        var cy =
+          this.gradientUnits() == 'objectBoundingBox'
+            ? bb.y() + bb.height() * this.attribute('cy').numValue()
+            : this.attribute('cy').toPixels('y')
 
         var fx = cx
         var fy = cy
         if (this.attribute('fx').hasValue()) {
-          fx = (this.gradientUnits() == 'objectBoundingBox'
-					? bb.x() + bb.width() * this.attribute('fx').numValue()
-					: this.attribute('fx').toPixels('x'))
+          fx =
+            this.gradientUnits() == 'objectBoundingBox'
+              ? bb.x() + bb.width() * this.attribute('fx').numValue()
+              : this.attribute('fx').toPixels('x')
         }
         if (this.attribute('fy').hasValue()) {
-          fy = (this.gradientUnits() == 'objectBoundingBox'
-					? bb.y() + bb.height() * this.attribute('fy').numValue()
-					: this.attribute('fy').toPixels('y'))
+          fy =
+            this.gradientUnits() == 'objectBoundingBox'
+              ? bb.y() + bb.height() * this.attribute('fy').numValue()
+              : this.attribute('fy').toPixels('y')
         }
 
-        var r = (this.gradientUnits() == 'objectBoundingBox'
-					? (bb.width() + bb.height()) / 2.0 * this.attribute('r').numValue()
-					: this.attribute('r').toPixels())
+        var r =
+          this.gradientUnits() == 'objectBoundingBox'
+            ? (bb.width() + bb.height()) / 2.0 * this.attribute('r').numValue()
+            : this.attribute('r').toPixels()
 
         return ctx.createRadialGradient(fx, fy, 0, cx, cy, r)
       }
     }
     svg.Element.radialGradient.prototype = new svg.Element.GradientBase()
 
-		// gradient stop element
+    // gradient stop element
     svg.Element.stop = function (node) {
       this.base = svg.Element.ElementBase
       this.base(node)
@@ -1864,12 +2395,14 @@
 
       var stopColor = this.style('stop-color', true)
       if (stopColor.value === '') stopColor.value = '#000'
-      if (this.style('stop-opacity').hasValue()) stopColor = stopColor.addOpacity(this.style('stop-opacity'))
+      if (this.style('stop-opacity').hasValue()) {
+        stopColor = stopColor.addOpacity(this.style('stop-opacity'))
+      }
       this.color = stopColor.value
     }
     svg.Element.stop.prototype = new svg.Element.ElementBase()
 
-		// animation base element
+    // animation base element
     svg.Element.AnimateBase = function (node) {
       this.base = svg.Element.ElementBase
       this.base(node)
@@ -1895,43 +2428,53 @@
       this.removed = false
 
       this.calcValue = function () {
-				// OVERRIDE ME!
+        // OVERRIDE ME!
         return ''
       }
 
       this.update = function (delta) {
-				// set initial value
+        // set initial value
         if (this.initialValue == null) {
           this.initialValue = this.getProperty().value
           this.initialUnits = this.getProperty().getUnits()
         }
 
-				// if we're past the end time
+        // if we're past the end time
         if (this.duration > this.maxDuration) {
-					// loop for indefinitely repeating animations
-          if (this.attribute('repeatCount').value == 'indefinite'
-					 || this.attribute('repeatDur').value == 'indefinite') {
+          // loop for indefinitely repeating animations
+          if (
+            this.attribute('repeatCount').value == 'indefinite' ||
+            this.attribute('repeatDur').value == 'indefinite'
+          ) {
             this.duration = 0.0
-          } else if (this.attribute('fill').valueOrDefault('remove') == 'freeze' && !this.frozen) {
+          } else if (
+            this.attribute('fill').valueOrDefault('remove') == 'freeze' &&
+            !this.frozen
+          ) {
             this.frozen = true
             this.parent.animationFrozen = true
             this.parent.animationFrozenValue = this.getProperty().value
-          } else if (this.attribute('fill').valueOrDefault('remove') == 'remove' && !this.removed) {
+          } else if (
+            this.attribute('fill').valueOrDefault('remove') == 'remove' &&
+            !this.removed
+          ) {
             this.removed = true
-            this.getProperty().value = this.parent.animationFrozen ? this.parent.animationFrozenValue : this.initialValue
+            this.getProperty().value = this.parent.animationFrozen
+              ? this.parent.animationFrozenValue
+              : this.initialValue
             return true
           }
           return false
         }
         this.duration = this.duration + delta
 
-				// if we're past the begin time
+        // if we're past the begin time
         var updated = false
         if (this.begin < this.duration) {
           var newValue = this.calcValue() // tween
 
           if (this.attribute('type').hasValue()) {
-						// for transform, etc.
+            // for transform, etc.
             var type = this.attribute('type').value
             newValue = type + '(' + newValue + ')'
           }
@@ -1946,14 +2489,20 @@
       this.from = this.attribute('from')
       this.to = this.attribute('to')
       this.values = this.attribute('values')
-      if (this.values.hasValue()) this.values.value = this.values.value.split(';')
+      if (this.values.hasValue()) {
+        this.values.value = this.values.value.split(';')
+      }
 
-			// fraction of duration we've covered
+      // fraction of duration we've covered
       this.progress = function () {
-        var ret = { progress: (this.duration - this.begin) / (this.maxDuration - this.begin) }
+        var ret = {
+          progress:
+            (this.duration - this.begin) / (this.maxDuration - this.begin)
+        }
         if (this.values.hasValue()) {
           var p = ret.progress * (this.values.value.length - 1)
-          var lb = Math.floor(p), ub = Math.ceil(p)
+          var lb = Math.floor(p),
+            ub = Math.ceil(p)
           ret.from = new svg.Property('from', parseFloat(this.values.value[lb]))
           ret.to = new svg.Property('to', parseFloat(this.values.value[ub]))
           ret.progress = (p - lb) / (ub - lb)
@@ -1966,7 +2515,7 @@
     }
     svg.Element.AnimateBase.prototype = new svg.Element.ElementBase()
 
-		// animate element
+    // animate element
     svg.Element.animate = function (node) {
       this.base = svg.Element.AnimateBase
       this.base(node)
@@ -1974,14 +2523,15 @@
       this.calcValue = function () {
         var p = this.progress()
 
-				// tween value linearly
-        var newValue = p.from.numValue() + (p.to.numValue() - p.from.numValue()) * p.progress
+        // tween value linearly
+        var newValue =
+          p.from.numValue() + (p.to.numValue() - p.from.numValue()) * p.progress
         return newValue + this.initialUnits
       }
     }
     svg.Element.animate.prototype = new svg.Element.AnimateBase()
 
-		// animate color element
+    // animate color element
     svg.Element.animateColor = function (node) {
       this.base = svg.Element.AnimateBase
       this.base(node)
@@ -1992,18 +2542,26 @@
         var to = new RGBColor(p.to.value)
 
         if (from.ok && to.ok) {
-					// tween color linearly
+          // tween color linearly
           var r = from.r + (to.r - from.r) * p.progress
           var g = from.g + (to.g - from.g) * p.progress
           var b = from.b + (to.b - from.b) * p.progress
-          return 'rgb(' + parseInt(r, 10) + ',' + parseInt(g, 10) + ',' + parseInt(b, 10) + ')'
+          return (
+            'rgb(' +
+            parseInt(r, 10) +
+            ',' +
+            parseInt(g, 10) +
+            ',' +
+            parseInt(b, 10) +
+            ')'
+          )
         }
         return this.attribute('from').value
       }
     }
     svg.Element.animateColor.prototype = new svg.Element.AnimateBase()
 
-		// animate transform element
+    // animate transform element
     svg.Element.animateTransform = function (node) {
       this.base = svg.Element.AnimateBase
       this.base(node)
@@ -2011,7 +2569,7 @@
       this.calcValue = function () {
         var p = this.progress()
 
-				// tween value linearly
+        // tween value linearly
         var from = svg.ToNumberArray(p.from.value)
         var to = svg.ToNumberArray(p.to.value)
         var newValue = ''
@@ -2023,7 +2581,7 @@
     }
     svg.Element.animateTransform.prototype = new svg.Element.animate()
 
-		// font element
+    // font element
     svg.Element.font = function (node) {
       this.base = svg.Element.ElementBase
       this.base(node)
@@ -2047,7 +2605,9 @@
           if (child.arabicForm != '') {
             this.isRTL = true
             this.isArabic = true
-            if (typeof (this.glyphs[child.unicode]) === 'undefined') this.glyphs[child.unicode] = []
+            if (typeof this.glyphs[child.unicode] === 'undefined') {
+              this.glyphs[child.unicode] = []
+            }
             this.glyphs[child.unicode][child.arabicForm] = child
           } else {
             this.glyphs[child.unicode] = child
@@ -2057,7 +2617,7 @@
     }
     svg.Element.font.prototype = new svg.Element.ElementBase()
 
-		// font-face element
+    // font-face element
     svg.Element.fontface = function (node) {
       this.base = svg.Element.ElementBase
       this.base(node)
@@ -2068,7 +2628,7 @@
     }
     svg.Element.fontface.prototype = new svg.Element.ElementBase()
 
-		// missing-glyph element
+    // missing-glyph element
     svg.Element.missingglyph = function (node) {
       this.base = svg.Element.path
       this.base(node)
@@ -2077,7 +2637,7 @@
     }
     svg.Element.missingglyph.prototype = new svg.Element.path()
 
-		// glyph element
+    // glyph element
     svg.Element.glyph = function (node) {
       this.base = svg.Element.path
       this.base(node)
@@ -2088,7 +2648,7 @@
     }
     svg.Element.glyph.prototype = new svg.Element.path()
 
-		// text element
+    // text element
     svg.Element.text = function (node) {
       this.captureTextNodes = true
       this.base = svg.Element.RenderedElementBase
@@ -2099,22 +2659,37 @@
         this.baseSetContext(ctx)
 
         var textBaseline = this.style('dominant-baseline').toTextBaseline()
-        if (textBaseline == null) textBaseline = this.style('alignment-baseline').toTextBaseline()
+        if (textBaseline == null) {
+          textBaseline = this.style('alignment-baseline').toTextBaseline()
+        }
         if (textBaseline != null) ctx.textBaseline = textBaseline
       }
 
       this.getBoundingBox = function () {
         var x = this.attribute('x').toPixels('x')
         var y = this.attribute('y').toPixels('y')
-        var fontSize = this.parent.style('font-size').numValueOrDefault(svg.Font.Parse(svg.ctx.font).fontSize)
-        return new svg.BoundingBox(x, y - fontSize, x + Math.floor(fontSize * 2.0 / 3.0) * this.children[0].getText().length, y)
+        var fontSize = this.parent
+          .style('font-size')
+          .numValueOrDefault(svg.Font.Parse(svg.ctx.font).fontSize)
+        return new svg.BoundingBox(
+          x,
+          y - fontSize,
+          x +
+            Math.floor(fontSize * 2.0 / 3.0) *
+              this.children[0].getText().length,
+          y
+        )
       }
 
       this.renderChildren = function (ctx) {
         this.x = this.attribute('x').toPixels('x')
         this.y = this.attribute('y').toPixels('y')
-        if (this.attribute('dx').hasValue()) this.x += this.attribute('dx').toPixels('x')
-        if (this.attribute('dy').hasValue()) this.y += this.attribute('dy').toPixels('y')
+        if (this.attribute('dx').hasValue()) {
+          this.x += this.attribute('dx').toPixels('x')
+        }
+        if (this.attribute('dy').hasValue()) {
+          this.y += this.attribute('dy').toPixels('y')
+        }
         this.x += this.getAnchorDelta(ctx, this, 0)
         for (var i = 0; i < this.children.length; i++) {
           this.renderChild(ctx, this, i)
@@ -2138,19 +2713,29 @@
       this.renderChild = function (ctx, parent, i) {
         var child = parent.children[i]
         if (child.attribute('x').hasValue()) {
-          child.x = child.attribute('x').toPixels('x') + parent.getAnchorDelta(ctx, parent, i)
-          if (child.attribute('dx').hasValue()) child.x += child.attribute('dx').toPixels('x')
+          child.x =
+            child.attribute('x').toPixels('x') +
+            parent.getAnchorDelta(ctx, parent, i)
+          if (child.attribute('dx').hasValue()) {
+            child.x += child.attribute('dx').toPixels('x')
+          }
         } else {
-          if (child.attribute('dx').hasValue()) parent.x += child.attribute('dx').toPixels('x')
+          if (child.attribute('dx').hasValue()) {
+            parent.x += child.attribute('dx').toPixels('x')
+          }
           child.x = parent.x
         }
         parent.x = child.x + child.measureText(ctx)
 
         if (child.attribute('y').hasValue()) {
           child.y = child.attribute('y').toPixels('y')
-          if (child.attribute('dy').hasValue()) child.y += child.attribute('dy').toPixels('y')
+          if (child.attribute('dy').hasValue()) {
+            child.y += child.attribute('dy').toPixels('y')
+          }
         } else {
-          if (child.attribute('dy').hasValue()) parent.y += child.attribute('dy').toPixels('y')
+          if (child.attribute('dy').hasValue()) {
+            parent.y += child.attribute('dy').toPixels('y')
+          }
           child.y = parent.y
         }
         parent.y = child.y
@@ -2164,7 +2749,7 @@
     }
     svg.Element.text.prototype = new svg.Element.RenderedElementBase()
 
-		// text base
+    // text base
     svg.Element.TextElementBase = function (node) {
       this.base = svg.Element.RenderedElementBase
       this.base(node)
@@ -2174,12 +2759,33 @@
         var glyph = null
         if (font.isArabic) {
           var arabicForm = 'isolated'
-          if ((i == 0 || text[i - 1] == ' ') && i < text.length - 2 && text[i + 1] != ' ') arabicForm = 'terminal'
-          if (i > 0 && text[i - 1] != ' ' && i < text.length - 2 && text[i + 1] != ' ') arabicForm = 'medial'
-          if (i > 0 && text[i - 1] != ' ' && (i == text.length - 1 || text[i + 1] == ' ')) arabicForm = 'initial'
-          if (typeof (font.glyphs[c]) !== 'undefined') {
+          if (
+            (i == 0 || text[i - 1] == ' ') &&
+            i < text.length - 2 &&
+            text[i + 1] != ' '
+          ) {
+            arabicForm = 'terminal'
+          }
+          if (
+            i > 0 &&
+            text[i - 1] != ' ' &&
+            i < text.length - 2 &&
+            text[i + 1] != ' '
+          ) {
+            arabicForm = 'medial'
+          }
+          if (
+            i > 0 &&
+            text[i - 1] != ' ' &&
+            (i == text.length - 1 || text[i + 1] == ' ')
+          ) {
+            arabicForm = 'initial'
+          }
+          if (typeof font.glyphs[c] !== 'undefined') {
             glyph = font.glyphs[c][arabicForm]
-            if (glyph == null && font.glyphs[c].type == 'glyph') glyph = font.glyphs[c]
+            if (glyph == null && font.glyphs[c].type == 'glyph') {
+              glyph = font.glyphs[c]
+            }
           }
         } else {
           glyph = font.glyphs[c]
@@ -2191,8 +2797,12 @@
       this.renderChildren = function (ctx) {
         var customFont = this.parent.style('font-family').getDefinition()
         if (customFont != null) {
-          var fontSize = this.parent.style('font-size').numValueOrDefault(svg.Font.Parse(svg.ctx.font).fontSize)
-          var fontStyle = this.parent.style('font-style').valueOrDefault(svg.Font.Parse(svg.ctx.font).fontStyle)
+          var fontSize = this.parent
+            .style('font-size')
+            .numValueOrDefault(svg.Font.Parse(svg.ctx.font).fontSize)
+          var fontStyle = this.parent
+            .style('font-style')
+            .valueOrDefault(svg.Font.Parse(svg.ctx.font).fontStyle)
           var text = this.getText()
           if (customFont.isRTL) text = text.split('').reverse().join('')
 
@@ -2203,7 +2813,8 @@
             ctx.translate(this.x, this.y)
             ctx.scale(scale, -scale)
             var lw = ctx.lineWidth
-            ctx.lineWidth = ctx.lineWidth * customFont.fontFace.unitsPerEm / fontSize
+            ctx.lineWidth =
+              ctx.lineWidth * customFont.fontFace.unitsPerEm / fontSize
             if (fontStyle == 'italic') ctx.transform(1, 0, 0.4, 1, 0, 0)
             glyph.render(ctx)
             if (fontStyle == 'italic') ctx.transform(1, 0, -0.4, 1, 0, 0)
@@ -2211,20 +2822,27 @@
             ctx.scale(1 / scale, -1 / scale)
             ctx.translate(-this.x, -this.y)
 
-            this.x += fontSize * (glyph.horizAdvX || customFont.horizAdvX) / customFont.fontFace.unitsPerEm
-            if (typeof (dx[i]) !== 'undefined' && !isNaN(dx[i])) {
+            this.x +=
+              fontSize *
+              (glyph.horizAdvX || customFont.horizAdvX) /
+              customFont.fontFace.unitsPerEm
+            if (typeof dx[i] !== 'undefined' && !isNaN(dx[i])) {
               this.x += dx[i]
             }
           }
           return
         }
 
-        if (ctx.fillStyle != '') ctx.fillText(svg.compressSpaces(this.getText()), this.x, this.y)
-        if (ctx.strokeStyle != '') ctx.strokeText(svg.compressSpaces(this.getText()), this.x, this.y)
+        if (ctx.fillStyle != '') {
+          ctx.fillText(svg.compressSpaces(this.getText()), this.x, this.y)
+        }
+        if (ctx.strokeStyle != '') {
+          ctx.strokeText(svg.compressSpaces(this.getText()), this.x, this.y)
+        }
       }
 
       this.getText = function () {
-				// OVERRIDE ME
+        // OVERRIDE ME
       }
 
       this.measureTextRecursive = function (ctx) {
@@ -2238,15 +2856,20 @@
       this.measureText = function (ctx) {
         var customFont = this.parent.style('font-family').getDefinition()
         if (customFont != null) {
-          var fontSize = this.parent.style('font-size').numValueOrDefault(svg.Font.Parse(svg.ctx.font).fontSize)
+          var fontSize = this.parent
+            .style('font-size')
+            .numValueOrDefault(svg.Font.Parse(svg.ctx.font).fontSize)
           var measure = 0
           var text = this.getText()
           if (customFont.isRTL) text = text.split('').reverse().join('')
           var dx = svg.ToNumberArray(this.parent.attribute('dx').value)
           for (var i = 0; i < text.length; i++) {
             var glyph = this.getGlyph(customFont, text, i)
-            measure += (glyph.horizAdvX || customFont.horizAdvX) * fontSize / customFont.fontFace.unitsPerEm
-            if (typeof (dx[i]) !== 'undefined' && !isNaN(dx[i])) {
+            measure +=
+              (glyph.horizAdvX || customFont.horizAdvX) *
+              fontSize /
+              customFont.fontFace.unitsPerEm
+            if (typeof dx[i] !== 'undefined' && !isNaN(dx[i])) {
               measure += dx[i]
             }
           }
@@ -2263,24 +2886,29 @@
         return width
       }
     }
-    svg.Element.TextElementBase.prototype = new svg.Element.RenderedElementBase()
+    svg.Element.TextElementBase.prototype = new svg.Element
+      .RenderedElementBase()
 
-		// tspan
+    // tspan
     svg.Element.tspan = function (node) {
       this.captureTextNodes = true
       this.base = svg.Element.TextElementBase
       this.base(node)
 
-      this.text = svg.compressSpaces(node.value || node.text || node.textContent || '')
+      this.text = svg.compressSpaces(
+        node.value || node.text || node.textContent || ''
+      )
       this.getText = function () {
-				// if this node has children, then they own the text
-        if (this.children.length > 0) { return '' }
+        // if this node has children, then they own the text
+        if (this.children.length > 0) {
+          return ''
+        }
         return this.text
       }
     }
     svg.Element.tspan.prototype = new svg.Element.TextElementBase()
 
-		// tref
+    // tref
     svg.Element.tref = function (node) {
       this.base = svg.Element.TextElementBase
       this.base(node)
@@ -2292,7 +2920,7 @@
     }
     svg.Element.tref.prototype = new svg.Element.TextElementBase()
 
-		// a element
+    // a element
     svg.Element.a = function (node) {
       this.base = svg.Element.TextElementBase
       this.base(node)
@@ -2302,7 +2930,7 @@
         if (node.childNodes[i].nodeType != 3) this.hasText = false
       }
 
-			// this might contain text
+      // this might contain text
       this.text = this.hasText ? node.childNodes[0].value : ''
       this.getText = function () {
         return this.text
@@ -2311,12 +2939,23 @@
       this.baseRenderChildren = this.renderChildren
       this.renderChildren = function (ctx) {
         if (this.hasText) {
-					// render as text element
+          // render as text element
           this.baseRenderChildren(ctx)
-          var fontSize = new svg.Property('fontSize', svg.Font.Parse(svg.ctx.font).fontSize)
-          svg.Mouse.checkBoundingBox(this, new svg.BoundingBox(this.x, this.y - fontSize.toPixels('y'), this.x + this.measureText(ctx), this.y))
+          var fontSize = new svg.Property(
+            'fontSize',
+            svg.Font.Parse(svg.ctx.font).fontSize
+          )
+          svg.Mouse.checkBoundingBox(
+            this,
+            new svg.BoundingBox(
+              this.x,
+              this.y - fontSize.toPixels('y'),
+              this.x + this.measureText(ctx),
+              this.y
+            )
+          )
         } else if (this.children.length > 0) {
-					// render as temporary group
+          // render as temporary group
           var g = new svg.Element.g()
           g.children = this.children
           g.parent = this
@@ -2334,23 +2973,32 @@
     }
     svg.Element.a.prototype = new svg.Element.TextElementBase()
 
-		// image element
+    // image element
     svg.Element.image = function (node) {
       this.base = svg.Element.RenderedElementBase
       this.base(node)
 
       var href = this.getHrefAttribute().value
-      if (href == '') { return }
+      if (href == '') {
+        return
+      }
       var isSvg = href.match(/\.svg$/)
 
       svg.Images.push(this)
       this.loaded = false
       if (!isSvg) {
         this.img = document.createElement('img')
-        if (svg.opts['useCORS'] == true) { this.img.crossOrigin = 'Anonymous' }
+        if (svg.opts['useCORS'] == true) {
+          this.img.crossOrigin = 'Anonymous'
+        }
         var self = this
-        this.img.onload = function () { self.loaded = true }
-        this.img.onerror = function () { svg.log('ERROR: image "' + href + '" not found'); self.loaded = true }
+        this.img.onload = function () {
+          self.loaded = true
+        }
+        this.img.onerror = function () {
+          svg.log('ERROR: image "' + href + '" not found')
+          self.loaded = true
+        }
         this.img.src = href
       } else {
         this.img = svg.ajax(href)
@@ -2370,14 +3018,16 @@
           ctx.drawSvg(this.img, x, y, width, height)
         } else {
           ctx.translate(x, y)
-          svg.AspectRatio(ctx,
-									this.attribute('preserveAspectRatio').value,
-									width,
-									this.img.width,
-									height,
-									this.img.height,
-									0,
-									0)
+          svg.AspectRatio(
+            ctx,
+            this.attribute('preserveAspectRatio').value,
+            width,
+            this.img.width,
+            height,
+            this.img.height,
+            0,
+            0
+          )
           ctx.drawImage(this.img, 0, 0)
         }
         ctx.restore()
@@ -2393,7 +3043,7 @@
     }
     svg.Element.image.prototype = new svg.Element.RenderedElementBase()
 
-		// group element
+    // group element
     svg.Element.g = function (node) {
       this.base = svg.Element.RenderedElementBase
       this.base(node)
@@ -2408,28 +3058,31 @@
     }
     svg.Element.g.prototype = new svg.Element.RenderedElementBase()
 
-		// symbol element
+    // symbol element
     svg.Element.symbol = function (node) {
       this.base = svg.Element.RenderedElementBase
       this.base(node)
 
       this.render = function (ctx) {
-				// NO RENDER
+        // NO RENDER
       }
     }
     svg.Element.symbol.prototype = new svg.Element.RenderedElementBase()
 
-		// style element
+    // style element
     svg.Element.style = function (node) {
       this.base = svg.Element.ElementBase
       this.base(node)
 
-			// text, or spaces then CDATA
+      // text, or spaces then CDATA
       var css = ''
       for (var i = 0; i < node.childNodes.length; i++) {
-			  css += node.childNodes[i].data
+        css += node.childNodes[i].data
       }
-      css = css.replace(/(\/\*([^*]|[\r\n]|(\*+([^*\/]|[\r\n])))*\*+\/)|(^[\s]*\/\/.*)/gm, '') // remove comments
+      css = css.replace(
+        /(\/\*([^*]|[\r\n]|(\*+([^*\/]|[\r\n])))*\*+\/)|(^[\s]*\/\/.*)/gm,
+        ''
+      ) // remove comments
       css = svg.compressSpaces(css) // replace whitespace
       var cssDefs = css.split('}')
       for (var i = 0; i < cssDefs.length; i++) {
@@ -2444,9 +3097,15 @@
               for (var k = 0; k < cssProps.length; k++) {
                 var prop = cssProps[k].indexOf(':')
                 var name = cssProps[k].substr(0, prop)
-                var value = cssProps[k].substr(prop + 1, cssProps[k].length - prop)
+                var value = cssProps[k].substr(
+                  prop + 1,
+                  cssProps[k].length - prop
+                )
                 if (name != null && value != null) {
-                  props[svg.trim(name)] = new svg.Property(svg.trim(name), svg.trim(value))
+                  props[svg.trim(name)] = new svg.Property(
+                    svg.trim(name),
+                    svg.trim(value)
+                  )
                 }
               }
               svg.Styles[cssClass] = props
@@ -2458,7 +3117,10 @@
                   if (srcs[s].indexOf('format("svg")') > 0) {
                     var urlStart = srcs[s].indexOf('url')
                     var urlEnd = srcs[s].indexOf(')', urlStart)
-                    var url = srcs[s].substr(urlStart + 5, urlEnd - urlStart - 6)
+                    var url = srcs[s].substr(
+                      urlStart + 5,
+                      urlEnd - urlStart - 6
+                    )
                     var doc = svg.parseXml(svg.ajax(url))
                     var fonts = doc.getElementsByTagName('font')
                     for (var f = 0; f < fonts.length; f++) {
@@ -2475,7 +3137,7 @@
     }
     svg.Element.style.prototype = new svg.Element.ElementBase()
 
-		// use element
+    // use element
     svg.Element.use = function (node) {
       this.base = svg.Element.RenderedElementBase
       this.base(node)
@@ -2483,8 +3145,12 @@
       this.baseSetContext = this.setContext
       this.setContext = function (ctx) {
         this.baseSetContext(ctx)
-        if (this.attribute('x').hasValue()) ctx.translate(this.attribute('x').toPixels('x'), 0)
-        if (this.attribute('y').hasValue()) ctx.translate(0, this.attribute('y').toPixels('y'))
+        if (this.attribute('x').hasValue()) {
+          ctx.translate(this.attribute('x').toPixels('x'), 0)
+        }
+        if (this.attribute('y').hasValue()) {
+          ctx.translate(0, this.attribute('y').toPixels('y'))
+        }
       }
 
       var element = this.getHrefAttribute().getDefinition()
@@ -2501,18 +3167,37 @@
         if (element != null) {
           var tempSvg = element
           if (element.type == 'symbol') {
-						// render me using a temporary svg element in symbol cases (http://www.w3.org/TR/SVG/struct.html#UseElement)
+            // render me using a temporary svg element in symbol cases (http://www.w3.org/TR/SVG/struct.html#UseElement)
             tempSvg = new svg.Element.svg()
             tempSvg.type = 'svg'
-            tempSvg.attributes['viewBox'] = new svg.Property('viewBox', element.attribute('viewBox').value)
-            tempSvg.attributes['preserveAspectRatio'] = new svg.Property('preserveAspectRatio', element.attribute('preserveAspectRatio').value)
-            tempSvg.attributes['overflow'] = new svg.Property('overflow', element.attribute('overflow').value)
+            tempSvg.attributes['viewBox'] = new svg.Property(
+              'viewBox',
+              element.attribute('viewBox').value
+            )
+            tempSvg.attributes['preserveAspectRatio'] = new svg.Property(
+              'preserveAspectRatio',
+              element.attribute('preserveAspectRatio').value
+            )
+            tempSvg.attributes['overflow'] = new svg.Property(
+              'overflow',
+              element.attribute('overflow').value
+            )
             tempSvg.children = element.children
           }
           if (tempSvg.type == 'svg') {
-						// if symbol or svg, inherit width/height from me
-            if (this.attribute('width').hasValue()) tempSvg.attributes['width'] = new svg.Property('width', this.attribute('width').value)
-            if (this.attribute('height').hasValue()) tempSvg.attributes['height'] = new svg.Property('height', this.attribute('height').value)
+            // if symbol or svg, inherit width/height from me
+            if (this.attribute('width').hasValue()) {
+              tempSvg.attributes['width'] = new svg.Property(
+                'width',
+                this.attribute('width').value
+              )
+            }
+            if (this.attribute('height').hasValue()) {
+              tempSvg.attributes['height'] = new svg.Property(
+                'height',
+                this.attribute('height').value
+              )
+            }
           }
           var oldParent = tempSvg.parent
           tempSvg.parent = null
@@ -2523,13 +3208,13 @@
     }
     svg.Element.use.prototype = new svg.Element.RenderedElementBase()
 
-		// mask element
+    // mask element
     svg.Element.mask = function (node) {
       this.base = svg.Element.ElementBase
       this.base(node)
 
       this.apply = function (ctx, element) {
-				// render as temp svg
+        // render as temp svg
         var x = this.attribute('x').toPixels('x')
         var y = this.attribute('y').toPixels('y')
         var width = this.attribute('width').toPixels('x')
@@ -2543,10 +3228,10 @@
           var x = Math.floor(bb.x1)
           var y = Math.floor(bb.y1)
           var width = Math.floor(bb.width())
-          var	height = Math.floor(bb.height())
+          var height = Math.floor(bb.height())
         }
 
-				// temporarily remove mask to avoid recursion
+        // temporarily remove mask to avoid recursion
         var mask = element.attribute('mask').value
         element.attribute('mask').value = ''
 
@@ -2568,40 +3253,44 @@
         ctx.fillStyle = tempCtx.createPattern(c, 'no-repeat')
         ctx.fillRect(0, 0, x + width, y + height)
 
-				// reassign mask
+        // reassign mask
         element.attribute('mask').value = mask
       }
 
       this.render = function (ctx) {
-				// NO RENDER
+        // NO RENDER
       }
     }
     svg.Element.mask.prototype = new svg.Element.ElementBase()
 
-		// clip element
+    // clip element
     svg.Element.clipPath = function (node) {
       this.base = svg.Element.ElementBase
       this.base(node)
 
       this.apply = function (ctx) {
         var oldBeginPath = CanvasRenderingContext2D.prototype.beginPath
-        CanvasRenderingContext2D.prototype.beginPath = function () { }
+        CanvasRenderingContext2D.prototype.beginPath = function () {}
 
         var oldClosePath = CanvasRenderingContext2D.prototype.closePath
-        CanvasRenderingContext2D.prototype.closePath = function () { }
+        CanvasRenderingContext2D.prototype.closePath = function () {}
 
         oldBeginPath.call(ctx)
         for (var i = 0; i < this.children.length; i++) {
           var child = this.children[i]
-          if (typeof (child.path) !== 'undefined') {
+          if (typeof child.path !== 'undefined') {
             var transform = null
             if (child.style('transform', false, true).hasValue()) {
-              transform = new svg.Transform(child.style('transform', false, true).value)
+              transform = new svg.Transform(
+                child.style('transform', false, true).value
+              )
               transform.apply(ctx)
             }
             child.path(ctx)
             CanvasRenderingContext2D.prototype.closePath = oldClosePath
-            if (transform) { transform.unapply(ctx) }
+            if (transform) {
+              transform.unapply(ctx)
+            }
           }
         }
         oldClosePath.call(ctx)
@@ -2612,29 +3301,30 @@
       }
 
       this.render = function (ctx) {
-				// NO RENDER
+        // NO RENDER
       }
     }
     svg.Element.clipPath.prototype = new svg.Element.ElementBase()
 
-		// filters
+    // filters
     svg.Element.filter = function (node) {
       this.base = svg.Element.ElementBase
       this.base(node)
 
       this.apply = function (ctx, element) {
-				// render as temp svg
+        // render as temp svg
         var bb = element.getBoundingBox()
         var x = Math.floor(bb.x1)
         var y = Math.floor(bb.y1)
         var width = Math.floor(bb.width())
-        var	height = Math.floor(bb.height())
+        var height = Math.floor(bb.height())
 
-				// temporarily remove filter to avoid recursion
+        // temporarily remove filter to avoid recursion
         var filter = element.style('filter').value
         element.style('filter').value = ''
 
-        var px = 0, py = 0
+        var px = 0,
+          py = 0
         for (var i = 0; i < this.children.length; i++) {
           var efd = this.children[i].extraFilterDistance || 0
           px = Math.max(px, efd)
@@ -2648,22 +3338,38 @@
         tempCtx.translate(-x + px, -y + py)
         element.render(tempCtx)
 
-				// apply filters
+        // apply filters
         for (var i = 0; i < this.children.length; i++) {
-          if (typeof (this.children[i].apply) === 'function') {
-            this.children[i].apply(tempCtx, 0, 0, width + 2 * px, height + 2 * py)
+          if (typeof this.children[i].apply === 'function') {
+            this.children[i].apply(
+              tempCtx,
+              0,
+              0,
+              width + 2 * px,
+              height + 2 * py
+            )
           }
         }
 
-				// render on me
-        ctx.drawImage(c, 0, 0, width + 2 * px, height + 2 * py, x - px, y - py, width + 2 * px, height + 2 * py)
+        // render on me
+        ctx.drawImage(
+          c,
+          0,
+          0,
+          width + 2 * px,
+          height + 2 * py,
+          x - px,
+          y - py,
+          width + 2 * px,
+          height + 2 * py
+        )
 
-				// reassign filter
+        // reassign filter
         element.style('filter', true).value = filter
       }
 
       this.render = function (ctx) {
-				// NO RENDER
+        // NO RENDER
       }
     }
     svg.Element.filter.prototype = new svg.Element.ElementBase()
@@ -2673,7 +3379,7 @@
       this.base(node)
 
       this.apply = function (ctx, x, y, width, height) {
-				// TODO: implement
+        // TODO: implement
       }
     }
     svg.Element.feMorphology.prototype = new svg.Element.ElementBase()
@@ -2683,7 +3389,7 @@
       this.base(node)
 
       this.apply = function (ctx, x, y, width, height) {
-				// TODO: implement
+        // TODO: implement
       }
     }
     svg.Element.feComposite.prototype = new svg.Element.ElementBase()
@@ -2696,27 +3402,95 @@
       switch (this.attribute('type').valueOrDefault('matrix')) { // http://www.w3.org/TR/SVG/filters.html#feColorMatrixElement
         case 'saturate':
           var s = matrix[0]
-          matrix = [0.213 + 0.787 * s, 0.715 - 0.715 * s, 0.072 - 0.072 * s, 0, 0,
-							  0.213 - 0.213 * s, 0.715 + 0.285 * s, 0.072 - 0.072 * s, 0, 0,
-							  0.213 - 0.213 * s, 0.715 - 0.715 * s, 0.072 + 0.928 * s, 0, 0,
-							  0, 0, 0, 1, 0,
-							  0, 0, 0, 0, 1]
+          matrix = [
+            0.213 + 0.787 * s,
+            0.715 - 0.715 * s,
+            0.072 - 0.072 * s,
+            0,
+            0,
+            0.213 - 0.213 * s,
+            0.715 + 0.285 * s,
+            0.072 - 0.072 * s,
+            0,
+            0,
+            0.213 - 0.213 * s,
+            0.715 - 0.715 * s,
+            0.072 + 0.928 * s,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1
+          ]
           break
         case 'hueRotate':
           var a = matrix[0] * Math.PI / 180.0
-          var c = function (m1, m2, m3) { return m1 + Math.cos(a) * m2 + Math.sin(a) * m3 }
-          matrix = [c(0.213, 0.787, -0.213), c(0.715, -0.715, -0.715), c(0.072, -0.072, 0.928), 0, 0,
-							  c(0.213, -0.213, 0.143), c(0.715, 0.285, 0.140), c(0.072, -0.072, -0.283), 0, 0,
-							  c(0.213, -0.213, -0.787), c(0.715, -0.715, 0.715), c(0.072, 0.928, 0.072), 0, 0,
-							  0, 0, 0, 1, 0,
-							  0, 0, 0, 0, 1]
+          var c = function (m1, m2, m3) {
+            return m1 + Math.cos(a) * m2 + Math.sin(a) * m3
+          }
+          matrix = [
+            c(0.213, 0.787, -0.213),
+            c(0.715, -0.715, -0.715),
+            c(0.072, -0.072, 0.928),
+            0,
+            0,
+            c(0.213, -0.213, 0.143),
+            c(0.715, 0.285, 0.14),
+            c(0.072, -0.072, -0.283),
+            0,
+            0,
+            c(0.213, -0.213, -0.787),
+            c(0.715, -0.715, 0.715),
+            c(0.072, 0.928, 0.072),
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1
+          ]
           break
         case 'luminanceToAlpha':
-          matrix = [0, 0, 0, 0, 0,
-							  0, 0, 0, 0, 0,
-							  0, 0, 0, 0, 0,
-							  0.2125, 0.7154, 0.0721, 0, 0,
-							  0, 0, 0, 0, 1]
+          matrix = [
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0.2125,
+            0.7154,
+            0.0721,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1
+          ]
           break
       }
 
@@ -2734,7 +3508,7 @@
       }
 
       this.apply = function (ctx, x, y, width, height) {
-				// assuming x==0 && y==0 for now
+        // assuming x==0 && y==0 for now
         var srcData = ctx.getImageData(0, 0, width, height)
         for (var y = 0; y < height; y++) {
           for (var x = 0; x < width; x++) {
@@ -2742,10 +3516,42 @@
             var g = imGet(srcData.data, x, y, width, height, 1)
             var b = imGet(srcData.data, x, y, width, height, 2)
             var a = imGet(srcData.data, x, y, width, height, 3)
-            imSet(srcData.data, x, y, width, height, 0, m(0, r) + m(1, g) + m(2, b) + m(3, a) + m(4, 1))
-            imSet(srcData.data, x, y, width, height, 1, m(5, r) + m(6, g) + m(7, b) + m(8, a) + m(9, 1))
-            imSet(srcData.data, x, y, width, height, 2, m(10, r) + m(11, g) + m(12, b) + m(13, a) + m(14, 1))
-            imSet(srcData.data, x, y, width, height, 3, m(15, r) + m(16, g) + m(17, b) + m(18, a) + m(19, 1))
+            imSet(
+              srcData.data,
+              x,
+              y,
+              width,
+              height,
+              0,
+              m(0, r) + m(1, g) + m(2, b) + m(3, a) + m(4, 1)
+            )
+            imSet(
+              srcData.data,
+              x,
+              y,
+              width,
+              height,
+              1,
+              m(5, r) + m(6, g) + m(7, b) + m(8, a) + m(9, 1)
+            )
+            imSet(
+              srcData.data,
+              x,
+              y,
+              width,
+              height,
+              2,
+              m(10, r) + m(11, g) + m(12, b) + m(13, a) + m(14, 1)
+            )
+            imSet(
+              srcData.data,
+              x,
+              y,
+              width,
+              height,
+              3,
+              m(15, r) + m(16, g) + m(17, b) + m(18, a) + m(19, 1)
+            )
           }
         }
         ctx.clearRect(0, 0, width, height)
@@ -2762,12 +3568,12 @@
       this.extraFilterDistance = this.blurRadius
 
       this.apply = function (ctx, x, y, width, height) {
-        if (typeof (stackBlurCanvasRGBA) === 'undefined') {
+        if (typeof stackBlurCanvasRGBA === 'undefined') {
           svg.log('ERROR: StackBlur.js must be included for blur to work')
           return
         }
 
-				// StackBlur requires canvas be on document
+        // StackBlur requires canvas be on document
         ctx.canvas.id = svg.UniqueId()
         ctx.canvas.style.display = 'none'
         document.body.appendChild(ctx.canvas)
@@ -2777,27 +3583,25 @@
     }
     svg.Element.feGaussianBlur.prototype = new svg.Element.ElementBase()
 
-		// title element, do nothing
-    svg.Element.title = function (node) {
-    }
+    // title element, do nothing
+    svg.Element.title = function (node) {}
     svg.Element.title.prototype = new svg.Element.ElementBase()
 
-		// desc element, do nothing
-    svg.Element.desc = function (node) {
-    }
+    // desc element, do nothing
+    svg.Element.desc = function (node) {}
     svg.Element.desc.prototype = new svg.Element.ElementBase()
 
     svg.Element.MISSING = function (node) {
-      svg.log('ERROR: Element \'' + node.nodeName + '\' not yet implemented.')
+      svg.log("ERROR: Element '" + node.nodeName + "' not yet implemented.")
     }
     svg.Element.MISSING.prototype = new svg.Element.ElementBase()
 
-		// element factory
+    // element factory
     svg.CreateElement = function (node) {
       var className = node.nodeName.replace(/^[^:]+:/, '') // remove namespace
       className = className.replace(/\-/g, '') // remove dashes
       var e = null
-      if (typeof (svg.Element[className]) !== 'undefined') {
+      if (typeof svg.Element[className] !== 'undefined') {
         e = new svg.Element[className](node)
       } else {
         e = new svg.Element.MISSING(node)
@@ -2807,12 +3611,12 @@
       return e
     }
 
-		// load from url
+    // load from url
     svg.load = function (ctx, url) {
       svg.loadXml(ctx, svg.ajax(url))
     }
 
-		// load from xml
+    // load from xml
     svg.loadXml = function (ctx, xml) {
       svg.loadXmlDoc(ctx, svg.parseXml(xml))
     }
@@ -2832,14 +3636,24 @@
         return p
       }
 
-			// bind mouse
+      // bind mouse
       if (svg.opts['ignoreMouse'] != true) {
         ctx.canvas.onclick = function (e) {
-          var p = mapXY(new svg.Point(e != null ? e.clientX : event.clientX, e != null ? e.clientY : event.clientY))
+          var p = mapXY(
+            new svg.Point(
+              e != null ? e.clientX : event.clientX,
+              e != null ? e.clientY : event.clientY
+            )
+          )
           svg.Mouse.onclick(p.x, p.y)
         }
         ctx.canvas.onmousemove = function (e) {
-          var p = mapXY(new svg.Point(e != null ? e.clientX : event.clientX, e != null ? e.clientY : event.clientY))
+          var p = mapXY(
+            new svg.Point(
+              e != null ? e.clientX : event.clientX,
+              e != null ? e.clientY : event.clientY
+            )
+          )
           svg.Mouse.onmousemove(p.x, p.y)
         }
       }
@@ -2848,14 +3662,19 @@
       e.root = true
       e.addStylesFromStyleDefinition()
 
-			// render loop
+      // render loop
       var isFirstRender = true
       var draw = function () {
         svg.ViewPort.Clear()
-        if (ctx.canvas.parentNode) svg.ViewPort.SetCurrent(ctx.canvas.parentNode.clientWidth, ctx.canvas.parentNode.clientHeight)
+        if (ctx.canvas.parentNode) {
+          svg.ViewPort.SetCurrent(
+            ctx.canvas.parentNode.clientWidth,
+            ctx.canvas.parentNode.clientHeight
+          )
+        }
 
         if (svg.opts['ignoreDimensions'] != true) {
-					// set canvas size
+          // set canvas size
           if (e.style('width').hasValue()) {
             ctx.canvas.width = e.style('width').toPixels('x')
             ctx.canvas.style.width = ctx.canvas.width + 'px'
@@ -2867,43 +3686,68 @@
         }
         var cWidth = ctx.canvas.clientWidth || ctx.canvas.width
         var cHeight = ctx.canvas.clientHeight || ctx.canvas.height
-        if (svg.opts['ignoreDimensions'] == true && e.style('width').hasValue() && e.style('height').hasValue()) {
+        if (
+          svg.opts['ignoreDimensions'] == true &&
+          e.style('width').hasValue() &&
+          e.style('height').hasValue()
+        ) {
           cWidth = e.style('width').toPixels('x')
           cHeight = e.style('height').toPixels('y')
         }
         svg.ViewPort.SetCurrent(cWidth, cHeight)
 
-        if (svg.opts['offsetX'] != null) e.attribute('x', true).value = svg.opts['offsetX']
-        if (svg.opts['offsetY'] != null) e.attribute('y', true).value = svg.opts['offsetY']
+        if (svg.opts['offsetX'] != null) {
+          e.attribute('x', true).value = svg.opts['offsetX']
+        }
+        if (svg.opts['offsetY'] != null) {
+          e.attribute('y', true).value = svg.opts['offsetY']
+        }
         if (svg.opts['scaleWidth'] != null || svg.opts['scaleHeight'] != null) {
-          var xRatio = null, yRatio = null, viewBox = svg.ToNumberArray(e.attribute('viewBox').value)
+          var xRatio = null,
+            yRatio = null,
+            viewBox = svg.ToNumberArray(e.attribute('viewBox').value)
 
           if (svg.opts['scaleWidth'] != null) {
-            if (e.attribute('width').hasValue()) xRatio = e.attribute('width').toPixels('x') / svg.opts['scaleWidth']
-            else if (!isNaN(viewBox[2])) xRatio = viewBox[2] / svg.opts['scaleWidth']
+            if (e.attribute('width').hasValue()) {
+              xRatio =
+                e.attribute('width').toPixels('x') / svg.opts['scaleWidth']
+            } else if (!isNaN(viewBox[2])) {
+              xRatio = viewBox[2] / svg.opts['scaleWidth']
+            }
           }
 
           if (svg.opts['scaleHeight'] != null) {
-            if (e.attribute('height').hasValue()) yRatio = e.attribute('height').toPixels('y') / svg.opts['scaleHeight']
-            else if (!isNaN(viewBox[3])) yRatio = viewBox[3] / svg.opts['scaleHeight']
+            if (e.attribute('height').hasValue()) {
+              yRatio =
+                e.attribute('height').toPixels('y') / svg.opts['scaleHeight']
+            } else if (!isNaN(viewBox[3])) {
+              yRatio = viewBox[3] / svg.opts['scaleHeight']
+            }
           }
 
-          if (xRatio == null) { xRatio = yRatio }
-          if (yRatio == null) { yRatio = xRatio }
+          if (xRatio == null) {
+            xRatio = yRatio
+          }
+          if (yRatio == null) {
+            yRatio = xRatio
+          }
 
           e.attribute('width', true).value = svg.opts['scaleWidth']
           e.attribute('height', true).value = svg.opts['scaleHeight']
-          e.style('transform', true, true).value += ' scale(' + (1.0 / xRatio) + ',' + (1.0 / yRatio) + ')'
+          e.style('transform', true, true).value +=
+            ' scale(' + 1.0 / xRatio + ',' + 1.0 / yRatio + ')'
         }
 
-				// clear and render
+        // clear and render
         if (svg.opts['ignoreClear'] != true) {
           ctx.clearRect(0, 0, cWidth, cHeight)
         }
         e.render(ctx)
         if (isFirstRender) {
           isFirstRender = false
-          if (typeof (svg.opts['renderCallback']) === 'function') svg.opts['renderCallback'](dom)
+          if (typeof svg.opts['renderCallback'] === 'function') {
+            svg.opts['renderCallback'](dom)
+          }
         }
       }
 
@@ -2920,24 +3764,25 @@
           needUpdate = true
         }
 
-				// need update from mouse events?
+        // need update from mouse events?
         if (svg.opts['ignoreMouse'] != true) {
           needUpdate = needUpdate | svg.Mouse.hasEvents()
         }
 
-				// need update from animations?
+        // need update from animations?
         if (svg.opts['ignoreAnimation'] != true) {
           for (var i = 0; i < svg.Animations.length; i++) {
-            needUpdate = needUpdate | svg.Animations[i].update(1000 / svg.FRAMERATE)
+            needUpdate =
+              needUpdate | svg.Animations[i].update(1000 / svg.FRAMERATE)
           }
         }
 
-				// need update from redraw?
-        if (typeof (svg.opts['forceRedraw']) === 'function') {
+        // need update from redraw?
+        if (typeof svg.opts['forceRedraw'] === 'function') {
           if (svg.opts['forceRedraw']() == true) needUpdate = true
         }
 
-				// render if needed
+        // render if needed
         if (needUpdate) {
           draw()
           svg.Mouse.runEvents() // run and clear our events
@@ -2953,17 +3798,29 @@
 
     svg.Mouse = new function () {
       this.events = []
-      this.hasEvents = function () { return this.events.length != 0 }
+      this.hasEvents = function () {
+        return this.events.length != 0
+      }
 
       this.onclick = function (x, y) {
-        this.events.push({ type: 'onclick', x: x, y: y,
-          run: function (e) { if (e.onclick) e.onclick() }
+        this.events.push({
+          type: 'onclick',
+          x: x,
+          y: y,
+          run: function (e) {
+            if (e.onclick) e.onclick()
+          }
         })
       }
 
       this.onmousemove = function (x, y) {
-        this.events.push({ type: 'onmousemove', x: x, y: y,
-          run: function (e) { if (e.onmousemove) e.onmousemove() }
+        this.events.push({
+          type: 'onmousemove',
+          x: x,
+          y: y,
+          run: function (e) {
+            if (e.onmousemove) e.onmousemove()
+          }
         })
       }
 
@@ -2972,7 +3829,9 @@
       this.checkPath = function (element, ctx) {
         for (var i = 0; i < this.events.length; i++) {
           var e = this.events[i]
-          if (ctx.isPointInPath && ctx.isPointInPath(e.x, e.y)) this.eventElements[i] = element
+          if (ctx.isPointInPath && ctx.isPointInPath(e.x, e.y)) {
+            this.eventElements[i] = element
+          }
         }
       }
 
@@ -2995,7 +3854,7 @@
           }
         }
 
-				// done running, clear
+        // done running, clear
         this.events = []
         this.eventElements = []
       }
@@ -3005,7 +3864,7 @@
   }
 })()
 
-if (typeof (CanvasRenderingContext2D) !== 'undefined') {
+if (typeof CanvasRenderingContext2D !== 'undefined') {
   CanvasRenderingContext2D.prototype.drawSvg = function (s, dx, dy, dw, dh) {
     canvg(this.canvas, s, {
       ignoreMouse: true,

--- a/src/browser/external/canvg/rgbcolor.js
+++ b/src/browser/external/canvg/rgbcolor.js
@@ -7,16 +7,17 @@
 function RGBColor (color_string) {
   this.ok = false
 
-    // strip any leading #
-  if (color_string.charAt(0) == '#') { // remove # if any
+  // strip any leading #
+  if (color_string.charAt(0) == '#') {
+    // remove # if any
     color_string = color_string.substr(1, 6)
   }
 
   color_string = color_string.replace(/ /g, '')
   color_string = color_string.toLowerCase()
 
-    // before getting into regexps, try simple matches
-    // and overwrite the input
+  // before getting into regexps, try simple matches
+  // and overwrite the input
   var simple_colors = {
     aliceblue: 'f0f8ff',
     antiquewhite: 'faebd7',
@@ -167,19 +168,15 @@ function RGBColor (color_string) {
       color_string = simple_colors[key]
     }
   }
-    // emd of simple type-in colors
+  // emd of simple type-in colors
 
-    // array of color definition objects
+  // array of color definition objects
   var color_defs = [
     {
       re: /^rgb\((\d{1,3}),\s*(\d{1,3}),\s*(\d{1,3})\)$/,
       example: ['rgb(123, 234, 45)', 'rgb(255,234,245)'],
       process: function (bits) {
-        return [
-          parseInt(bits[1]),
-          parseInt(bits[2]),
-          parseInt(bits[3])
-        ]
+        return [parseInt(bits[1]), parseInt(bits[2]), parseInt(bits[3])]
       }
     },
     {
@@ -206,7 +203,7 @@ function RGBColor (color_string) {
     }
   ]
 
-    // search through the definitions to find a match
+  // search through the definitions to find a match
   for (var i = 0; i < color_defs.length; i++) {
     var re = color_defs[i].re
     var processor = color_defs[i].process
@@ -220,12 +217,12 @@ function RGBColor (color_string) {
     }
   }
 
-    // validate/cleanup values
-  this.r = (this.r < 0 || isNaN(this.r)) ? 0 : ((this.r > 255) ? 255 : this.r)
-  this.g = (this.g < 0 || isNaN(this.g)) ? 0 : ((this.g > 255) ? 255 : this.g)
-  this.b = (this.b < 0 || isNaN(this.b)) ? 0 : ((this.b > 255) ? 255 : this.b)
+  // validate/cleanup values
+  this.r = this.r < 0 || isNaN(this.r) ? 0 : this.r > 255 ? 255 : this.r
+  this.g = this.g < 0 || isNaN(this.g) ? 0 : this.g > 255 ? 255 : this.g
+  this.b = this.b < 0 || isNaN(this.b) ? 0 : this.b > 255 ? 255 : this.b
 
-    // some getters
+  // some getters
   this.toRGB = function () {
     return 'rgb(' + this.r + ', ' + this.g + ', ' + this.b + ')'
   }
@@ -239,17 +236,17 @@ function RGBColor (color_string) {
     return '#' + r + g + b
   }
 
-    // help
+  // help
   this.getHelpXML = function () {
     var examples = new Array()
-        // add regexps
+    // add regexps
     for (var i = 0; i < color_defs.length; i++) {
       var example = color_defs[i].example
       for (var j = 0; j < example.length; j++) {
         examples[examples.length] = example[j]
       }
     }
-        // add type-in colors
+    // add type-in colors
     for (var sc in simple_colors) {
       examples[examples.length] = sc
     }
@@ -262,15 +259,23 @@ function RGBColor (color_string) {
         var list_color = new RGBColor(examples[i])
         var example_div = document.createElement('div')
         example_div.style.cssText =
-                        'margin: 3px; '
-                        + 'border: 1px solid black; '
-                        + 'background:' + list_color.toHex() + '; '
-                        + 'color:' + list_color.toHex()
+          'margin: 3px; ' +
+          'border: 1px solid black; ' +
+          'background:' +
+          list_color.toHex() +
+          '; ' +
+          'color:' +
+          list_color.toHex()
 
         example_div.appendChild(document.createTextNode('test'))
         var list_item_value = document.createTextNode(
-                    ' ' + examples[i] + ' -> ' + list_color.toRGB() + ' -> ' + list_color.toHex()
-                )
+          ' ' +
+            examples[i] +
+            ' -> ' +
+            list_color.toRGB() +
+            ' -> ' +
+            list_color.toHex()
+        )
         list_item.appendChild(example_div)
         list_item.appendChild(list_item_value)
         xml.appendChild(list_item)
@@ -279,4 +284,3 @@ function RGBColor (color_string) {
     return xml
   }
 }
-

--- a/src/browser/external/neoPlanner.js
+++ b/src/browser/external/neoPlanner.js
@@ -21,7 +21,7 @@
 /* eslint-disable */
 window.neo = window.neo || {}
 
-neo.queryPlan = function (element) {
+neo.queryPlan = function(element) {
   let maxChildOperators = 2 // Fact we know about the cypher compiler
   let maxComparableRows = 1000000 // link widths are comparable between plans if all operators are below this row count
   let maxComparableDbHits = 1000000 // db hits are comparable between plans if all operators are below this db hit count
@@ -42,7 +42,15 @@ neo.queryPlan = function (element) {
   let linkColor = '#DFE1E3'
   let costColor = '#F25A29'
   let dividerColor = '#DFE1E3'
-  let operatorColors = ['#c6dbef', '#9ecae1', '#6baed6', '#4292c6', '#2171b5', '#08519c', '#08306b']
+  let operatorColors = [
+    '#c6dbef',
+    '#9ecae1',
+    '#6baed6',
+    '#4292c6',
+    '#2171b5',
+    '#08519c',
+    '#08306b'
+  ]
 
   let operatorCategories = {
     result: ['result'],
@@ -54,19 +62,18 @@ neo.queryPlan = function (element) {
     eager: ['eager']
   }
 
-  let augment = color =>
-    ({
-      color,
-      'border-color': d3.rgb(color).darker(),
-      'text-color-internal': d3.hsl(color).l < 0.7 ? '#FFFFFF' : '#000000'
-    })
+  let augment = color => ({
+    color,
+    'border-color': d3.rgb(color).darker(),
+    'text-color-internal': d3.hsl(color).l < 0.7 ? '#FFFFFF' : '#000000'
+  })
 
-  let colors =
-    d3.scale.ordinal()
+  let colors = d3.scale
+    .ordinal()
     .domain(d3.keys(operatorCategories))
     .range(operatorColors)
 
-  let color = function (d) {
+  let color = function(d) {
     for (let name in operatorCategories) {
       let keywords = operatorCategories[name]
       for (let keyword of Array.from(keywords)) {
@@ -78,24 +85,33 @@ neo.queryPlan = function (element) {
     return augment(colors('other'))
   }
 
-  let rows = function (operator) {
+  let rows = function(operator) {
     let left
-    return (left = operator.Rows != null ? operator.Rows : operator.EstimatedRows) != null ? left : 0
+    return (left =
+      operator.Rows != null ? operator.Rows : operator.EstimatedRows) != null
+      ? left
+      : 0
   }
 
-  let plural = function (noun, count) {
-    if (count === 1) { return noun } else { return noun + 's' }
+  let plural = function(noun, count) {
+    if (count === 1) {
+      return noun
+    } else {
+      return noun + 's'
+    }
   }
 
   let formatNumber = d3.format(',.0f')
 
-  let operatorDetails = function (operator) {
+  let operatorDetails = function(operator) {
     let expression, identifiers, index, left, left1
-    if (!operator.expanded) { return [] }
+    if (!operator.expanded) {
+      return []
+    }
 
     let details = []
 
-    let wordWrap = function (string, className) {
+    let wordWrap = function(string, className) {
       let measure = text => neo.utils.measureText(text, fixedWidthFont, 10)
 
       let words = string.split(/([^a-zA-Z\d])/)
@@ -105,56 +121,92 @@ neo.queryPlan = function (element) {
       return (() => {
         let result = []
         while (firstWord < words.length) {
-          while ((lastWord < words.length) && (measure(words.slice(firstWord, lastWord + 1).join('')) < (operatorWidth - (operatorPadding * 2)))) {
+          while (
+            lastWord < words.length &&
+            measure(words.slice(firstWord, lastWord + 1).join('')) <
+              operatorWidth - operatorPadding * 2
+          ) {
             lastWord++
           }
-          details.push({ className, value: words.slice(firstWord, lastWord).join('') })
+          details.push({
+            className,
+            value: words.slice(firstWord, lastWord).join('')
+          })
           firstWord = lastWord
-          result.push(lastWord = firstWord + 1)
+          result.push((lastWord = firstWord + 1))
         }
         return result
       })()
     }
 
-    if (identifiers = operator.identifiers != null ? operator.identifiers : (operator.KeyNames != null ? operator.KeyNames.split(', ') : undefined)) {
-      wordWrap(identifiers.filter(d => !(/^ {2}/.test(d))).join(', '), 'identifiers')
+    if (
+      (identifiers =
+        operator.identifiers != null
+          ? operator.identifiers
+          : operator.KeyNames != null
+            ? operator.KeyNames.split(', ')
+            : undefined)
+    ) {
+      wordWrap(
+        identifiers.filter(d => !/^ {2}/.test(d)).join(', '),
+        'identifiers'
+      )
       details.push({ className: 'padding' })
     }
 
-    if (index = operator.Index) {
+    if ((index = operator.Index)) {
       wordWrap(index, 'index')
       details.push({ className: 'padding' })
     }
 
-    if (expression = (left = (left1 = operator.LegacyExpression != null ? operator.LegacyExpression : operator.ExpandExpression) != null ? left1 : operator.LabelName) != null ? left : operator.Signature) {
+    if (
+      (expression =
+        (left =
+          (left1 =
+            operator.LegacyExpression != null
+              ? operator.LegacyExpression
+              : operator.ExpandExpression) != null
+            ? left1
+            : operator.LabelName) != null
+          ? left
+          : operator.Signature)
+    ) {
       wordWrap(expression, 'expression')
       details.push({ className: 'padding' })
     }
 
-    if ((operator.Rows != null) && (operator.EstimatedRows != null)) {
-      details.push({ className: 'estimated-rows', key: 'estimated rows', value: formatNumber(operator.EstimatedRows)})
+    if (operator.Rows != null && operator.EstimatedRows != null) {
+      details.push({
+        className: 'estimated-rows',
+        key: 'estimated rows',
+        value: formatNumber(operator.EstimatedRows)
+      })
     }
-    if ((operator.DbHits != null) && !operator.alwaysShowCost) {
-      details.push({ className: 'db-hits', key: plural('db hit', operator.DbHits || 0), value: formatNumber(operator.DbHits || 0)})
+    if (operator.DbHits != null && !operator.alwaysShowCost) {
+      details.push({
+        className: 'db-hits',
+        key: plural('db hit', operator.DbHits || 0),
+        value: formatNumber(operator.DbHits || 0)
+      })
     }
 
-    if (details.length && (details[details.length - 1].className === 'padding')) {
+    if (details.length && details[details.length - 1].className === 'padding') {
       details.pop()
     }
 
     let y = operatorDetailHeight
     for (let detail of Array.from(details)) {
       detail.y = y
-      y += detail.className === 'padding' ?
-        operatorPadding * 2
-      :
-        operatorDetailHeight
+      y +=
+        detail.className === 'padding'
+          ? operatorPadding * 2
+          : operatorDetailHeight
     }
 
     return details
   }
 
-  let transform = function (queryPlan) {
+  let transform = function(queryPlan) {
     let operators = []
     let links = []
 
@@ -163,16 +215,19 @@ neo.queryPlan = function (element) {
       children: [queryPlan.root]
     }
 
-    var collectLinks = function (operator, rank) {
+    var collectLinks = function(operator, rank) {
       operators.push(operator)
       operator.rank = rank
-      return Array.from(operator.children).map((child) =>
-        ((child.parent = operator),
-        collectLinks(child, rank + 1),
-        links.push({
-          source: child,
-          target: operator
-        })))
+      return Array.from(operator.children).map(
+        child => (
+          (child.parent = operator),
+          collectLinks(child, rank + 1),
+          links.push({
+            source: child,
+            target: operator
+          })
+        )
+      )
     }
 
     collectLinks(result, 0)
@@ -180,34 +235,52 @@ neo.queryPlan = function (element) {
     return [operators, links]
   }
 
-  let layout = function (operators, links) {
-    let costHeight = (function () {
-      let scale = d3.scale.log()
-      .domain([1, Math.max(d3.max(operators, operator => operator.DbHits || 0), maxComparableDbHits)])
-      .range([0, maxCostHeight])
-      return operator => scale((operator.DbHits != null ? operator.DbHits : 0) + 1)
+  let layout = function(operators, links) {
+    let costHeight = (function() {
+      let scale = d3.scale
+        .log()
+        .domain([
+          1,
+          Math.max(
+            d3.max(operators, operator => operator.DbHits || 0),
+            maxComparableDbHits
+          )
+        ])
+        .range([0, maxCostHeight])
+      return operator =>
+        scale((operator.DbHits != null ? operator.DbHits : 0) + 1)
     })()
 
-    let operatorHeight = function (operator) {
+    let operatorHeight = function(operator) {
       let height = operatorHeaderHeight
       if (operator.expanded) {
-        height += operatorDetails(operator).slice(-1)[0].y + (operatorPadding * 2)
+        height += operatorDetails(operator).slice(-1)[0].y + operatorPadding * 2
       }
       height += costHeight(operator)
       return height
     }
 
-    let linkWidth = (function () {
-      let scale = d3.scale.log()
-      .domain([1, Math.max(d3.max(operators, operator => rows(operator) + 1), maxComparableRows)])
-      .range([2, (operatorWidth - (operatorCornerRadius * 2)) / maxChildOperators])
+    let linkWidth = (function() {
+      let scale = d3.scale
+        .log()
+        .domain([
+          1,
+          Math.max(
+            d3.max(operators, operator => rows(operator) + 1),
+            maxComparableRows
+          )
+        ])
+        .range([
+          2,
+          (operatorWidth - operatorCornerRadius * 2) / maxChildOperators
+        ])
       return operator => scale(rows(operator) + 1)
     })()
 
     for (var operator of Array.from(operators)) {
       operator.height = operatorHeight(operator)
       operator.costHeight = costHeight(operator)
-      if (operator.costHeight > (operatorDetailHeight + operatorPadding)) {
+      if (operator.costHeight > operatorDetailHeight + operatorPadding) {
         operator.alwaysShowCost = true
       }
       let childrenWidth = d3.sum(operator.children, linkWidth)
@@ -222,21 +295,21 @@ neo.queryPlan = function (element) {
       link.width = linkWidth(link.source)
     }
 
-    let ranks = d3.nest()
-    .key(operator => operator.rank)
-    .entries(operators)
+    let ranks = d3.nest().key(operator => operator.rank).entries(operators)
 
     let currentY = 0
 
     for (var rank of Array.from(ranks)) {
-      currentY -= (d3.max(rank.values, operatorHeight) + rankMargin)
+      currentY -= d3.max(rank.values, operatorHeight) + rankMargin
       for (operator of Array.from(rank.values)) {
         operator.x = 0
         operator.y = currentY
       }
     }
 
-    let width = d3.max(ranks.map(rank => rank.values.length * (operatorWidth + operatorMargin)))
+    let width = d3.max(
+      ranks.map(rank => rank.values.length * (operatorWidth + operatorMargin))
+    )
     let height = -currentY
 
     let collide = () =>
@@ -257,13 +330,13 @@ neo.queryPlan = function (element) {
           dx = x0 - operatorMargin - width
           if (dx > 0) {
             let lastOperator = rank.values[rank.values.length - 1]
-            x0 = (lastOperator.x -= dx)
+            x0 = lastOperator.x -= dx
             item = (() => {
               let result1 = []
               for (let i = rank.values.length - 2; i >= 0; i--) {
                 let item1
                 operator = rank.values[i]
-                dx = (operator.x + operatorWidth + operatorMargin) - x0
+                dx = operator.x + operatorWidth + operatorMargin - x0
                 if (dx > 0) {
                   operator.x -= operatorWidth
                   item1 = x0 = operator.x
@@ -278,24 +351,30 @@ neo.queryPlan = function (element) {
         return result
       })()
 
-    let center = operator => operator.x + (operatorWidth / 2)
+    let center = operator => operator.x + operatorWidth / 2
 
     let relaxUpwards = alpha =>
       (() => {
         let result = []
         for (rank of Array.from(ranks)) {
-          result.push((() => {
-            let result1 = []
-            for (operator of Array.from(rank.values)) {
-              let item
-              if (operator.children.length) {
-                let x = d3.sum(operator.children, child => linkWidth(child) * center(child)) / d3.sum(operator.children, linkWidth)
-                item = operator.x += (x - center(operator)) * alpha
+          result.push(
+            (() => {
+              let result1 = []
+              for (operator of Array.from(rank.values)) {
+                let item
+                if (operator.children.length) {
+                  let x =
+                    d3.sum(
+                      operator.children,
+                      child => linkWidth(child) * center(child)
+                    ) / d3.sum(operator.children, linkWidth)
+                  item = operator.x += (x - center(operator)) * alpha
+                }
+                result1.push(item)
               }
-              result1.push(item)
-            }
-            return result1
-          })())
+              return result1
+            })()
+          )
         }
         return result
       })()
@@ -304,17 +383,20 @@ neo.queryPlan = function (element) {
       (() => {
         let result = []
         for (rank of Array.from(ranks.slice().reverse())) {
-          result.push((() => {
-            let result1 = []
-            for (operator of Array.from(rank.values)) {
-              let item
-              if (operator.parent) {
-                item = operator.x += (center(operator.parent) - center(operator)) * alpha
+          result.push(
+            (() => {
+              let result1 = []
+              for (operator of Array.from(rank.values)) {
+                let item
+                if (operator.parent) {
+                  item = operator.x +=
+                    (center(operator.parent) - center(operator)) * alpha
+                }
+                result1.push(item)
               }
-              result1.push(item)
-            }
-            return result1
-          })())
+              return result1
+            })()
+          )
         }
         return result
       })()
@@ -330,18 +412,28 @@ neo.queryPlan = function (element) {
       alpha *= 0.98
     }
 
-    width = (d3.max(operators, o => o.x) - d3.min(operators, o => o.x)) + operatorWidth
+    width =
+      d3.max(operators, o => o.x) - d3.min(operators, o => o.x) + operatorWidth
 
     return [width, height]
   }
 
-  let render = function (operators, links, width, height, redisplay) {
+  let render = function(operators, links, width, height, redisplay) {
     let svg = d3.select(element)
 
-    svg.transition()
-    .attr('width', width + (margin * 2))
-    .attr('height', height + (margin * 2))
-    .attr('viewBox', [d3.min(operators, o => o.x) - margin, -margin - height, width + (margin * 2), height + (margin * 2)].join(' '))
+    svg
+      .transition()
+      .attr('width', width + margin * 2)
+      .attr('height', height + margin * 2)
+      .attr(
+        'viewBox',
+        [
+          d3.min(operators, o => o.x) - margin,
+          -margin - height,
+          width + margin * 2,
+          height + margin * 2
+        ].join(' ')
+      )
 
     var join = (parent, children) =>
       (() => {
@@ -361,32 +453,28 @@ neo.queryPlan = function (element) {
     return join(svg, {
       'g.layer.links': {
         data: [links],
-        selections (enter) {
-          return enter.append('g')
-          .attr('class', 'layer links')
+        selections(enter) {
+          return enter.append('g').attr('class', 'layer links')
         },
         children: {
-
           '.link': {
-            data (d) { return d },
-            selections (enter) {
-              return enter.append('g')
-              .attr('class', 'link')
+            data(d) {
+              return d
+            },
+            selections(enter) {
+              return enter.append('g').attr('class', 'link')
             },
             children: {
+              path: {
+                data(d) {
+                  return [d]
+                },
+                selections(enter, update) {
+                  enter.append('path').attr('fill', linkColor)
 
-              'path': {
-                data (d) { return [d] },
-                selections (enter, update) {
-                  enter
-                  .append('path')
-                  .attr('fill', linkColor)
-
-                  return update
-                  .transition()
-                  .attr('d', function (d) {
+                  return update.transition().attr('d', function(d) {
                     width = Math.max(1, d.width)
-                    let sourceX = d.source.x + (operatorWidth / 2)
+                    let sourceX = d.source.x + operatorWidth / 2
                     let targetX = d.target.x + d.source.tx
 
                     let sourceY = d.source.y + d.source.height
@@ -396,56 +484,82 @@ neo.queryPlan = function (element) {
                     let curvature = 0.5
                     let control1 = yi(curvature)
                     let control2 = yi(1 - curvature)
-                    let controlWidth = Math.min(width / Math.PI, (targetY - sourceY) / Math.PI)
-                    if (sourceX > (targetX + (width / 2))) {
+                    let controlWidth = Math.min(
+                      width / Math.PI,
+                      (targetY - sourceY) / Math.PI
+                    )
+                    if (sourceX > targetX + width / 2) {
                       controlWidth *= -1
                     }
 
                     return [
-                      'M', (sourceX + (width / 2)), sourceY,
-                      'C', (sourceX + (width / 2)), control1 - controlWidth,
-                      (targetX + width), control2 - controlWidth,
-                      (targetX + width), targetY,
-                      'L', targetX, targetY,
-                      'C', targetX, control2 + controlWidth,
-                      (sourceX - (width / 2)), control1 + controlWidth,
-                      (sourceX - (width / 2)), sourceY,
+                      'M',
+                      sourceX + width / 2,
+                      sourceY,
+                      'C',
+                      sourceX + width / 2,
+                      control1 - controlWidth,
+                      targetX + width,
+                      control2 - controlWidth,
+                      targetX + width,
+                      targetY,
+                      'L',
+                      targetX,
+                      targetY,
+                      'C',
+                      targetX,
+                      control2 + controlWidth,
+                      sourceX - width / 2,
+                      control1 + controlWidth,
+                      sourceX - width / 2,
+                      sourceY,
                       'Z'
                     ].join(' ')
                   })
                 }
               },
 
-              'text': {
-                data (d) {
-                  let x = d.source.x + (operatorWidth / 2)
+              text: {
+                data(d) {
+                  let x = d.source.x + operatorWidth / 2
                   let y = d.source.y + d.source.height + operatorDetailHeight
                   let { source } = d
-                  if ((source.Rows != null) || (source.EstimatedRows != null)) {
-                    let [key, caption] = Array.from((source.Rows != null) ?
-                      ['Rows', 'row']
-                    :
-                      ['EstimatedRows', 'estimated row'])
+                  if (source.Rows != null || source.EstimatedRows != null) {
+                    let [key, caption] = Array.from(
+                      source.Rows != null
+                        ? ['Rows', 'row']
+                        : ['EstimatedRows', 'estimated row']
+                    )
                     return [
-                      { x, y, text: formatNumber(source[key]) + '\u00A0', anchor: 'end' },
-                      { x, y, text: plural(caption, source[key]), anchor: 'start' }
+                      {
+                        x,
+                        y,
+                        text: formatNumber(source[key]) + '\u00A0',
+                        anchor: 'end'
+                      },
+                      {
+                        x,
+                        y,
+                        text: plural(caption, source[key]),
+                        anchor: 'start'
+                      }
                     ]
                   } else {
                     return []
                   }
                 },
-                selections (enter, update) {
+                selections(enter, update) {
                   enter
-                  .append('text')
-                  .attr('font-size', detailFontSize)
-                  .attr('font-family', standardFont)
+                    .append('text')
+                    .attr('font-size', detailFontSize)
+                    .attr('font-family', standardFont)
 
                   return update
-                  .transition()
-                  .attr('x', d => d.x)
-                  .attr('y', d => d.y)
-                  .attr('text-anchor', d => d.anchor)
-                  .text(d => d.text)
+                    .transition()
+                    .attr('x', d => d.x)
+                    .attr('y', d => d.y)
+                    .attr('text-anchor', d => d.anchor)
+                    .text(d => d.text)
                 }
               }
             }
@@ -455,124 +569,186 @@ neo.queryPlan = function (element) {
 
       'g.layer.operators': {
         data: [operators],
-        selections (enter) {
-          return enter.append('g')
-          .attr('class', 'layer operators')
+        selections(enter) {
+          return enter.append('g').attr('class', 'layer operators')
         },
         children: {
-
           '.operator': {
-            data (d) { return d },
-            selections (enter, update) {
-              enter
-              .append('g')
-              .attr('class', 'operator')
+            data(d) {
+              return d
+            },
+            selections(enter, update) {
+              enter.append('g').attr('class', 'operator')
 
               return update
-              .transition()
-              .attr('transform', d => `translate(${d.x},${d.y})`)
+                .transition()
+                .attr('transform', d => `translate(${d.x},${d.y})`)
             },
             children: {
-
               'rect.background': {
-                data (d) { return [d] },
-                selections (enter, update) {
-                  enter
-                  .append('rect')
-                  .attr('class', 'background')
+                data(d) {
+                  return [d]
+                },
+                selections(enter, update) {
+                  enter.append('rect').attr('class', 'background')
 
                   return update
-                  .transition()
-                  .attr('width', operatorWidth)
-                  .attr('height', d => d.height)
-                  .attr('rx', operatorCornerRadius)
-                  .attr('ry', operatorCornerRadius)
-                  .attr('fill', 'white')
-                  .style('stroke', 'none')
+                    .transition()
+                    .attr('width', operatorWidth)
+                    .attr('height', d => d.height)
+                    .attr('rx', operatorCornerRadius)
+                    .attr('ry', operatorCornerRadius)
+                    .attr('fill', 'white')
+                    .style('stroke', 'none')
                 }
               },
 
               'g.header': {
-                data (d) { return [d] },
-                selections (enter) {
+                data(d) {
+                  return [d]
+                },
+                selections(enter) {
                   return enter
-                  .append('g')
-                  .attr('class', 'header')
-                  .attr('pointer-events', 'all')
-                  .on('click', function (d) {
-                    d.expanded = !d.expanded
-                    return redisplay()
-                  })
+                    .append('g')
+                    .attr('class', 'header')
+                    .attr('pointer-events', 'all')
+                    .on('click', function(d) {
+                      d.expanded = !d.expanded
+                      return redisplay()
+                    })
                 },
                 children: {
-
                   'path.banner': {
-                    data (d) { return [d] },
-                    selections (enter, update) {
-                      enter
-                      .append('path')
-                      .attr('class', 'banner')
+                    data(d) {
+                      return [d]
+                    },
+                    selections(enter, update) {
+                      enter.append('path').attr('class', 'banner')
 
                       return update
-                      .attr('d', function (d) {
-                        let shaving =
-                          d.height <= operatorHeaderHeight ?
-                            operatorCornerRadius
-                          : d.height < (operatorHeaderHeight + operatorCornerRadius) ?
-                            operatorCornerRadius - Math.sqrt(Math.pow(operatorCornerRadius, 2) -
-                                Math.pow((operatorCornerRadius - d.height) + operatorHeaderHeight, 2))
-                          : 0
-                        return [
-                          'M', operatorWidth - operatorCornerRadius, 0,
-                          'A', operatorCornerRadius, operatorCornerRadius, 0, 0, 1, operatorWidth, operatorCornerRadius,
-                          'L', operatorWidth, operatorHeaderHeight - operatorCornerRadius,
-                          'A', operatorCornerRadius, operatorCornerRadius, 0, 0, 1, operatorWidth - shaving, operatorHeaderHeight,
-                          'L', shaving, operatorHeaderHeight,
-                          'A', operatorCornerRadius, operatorCornerRadius, 0, 0, 1, 0, operatorHeaderHeight - operatorCornerRadius,
-                          'L', 0, operatorCornerRadius,
-                          'A', operatorCornerRadius, operatorCornerRadius, 0, 0, 1, operatorCornerRadius, 0,
-                          'Z'
-                        ].join(' ')
-                      })
-                      .style('fill', d => color(d.operatorType).color)
+                        .attr('d', function(d) {
+                          let shaving =
+                            d.height <= operatorHeaderHeight
+                              ? operatorCornerRadius
+                              : d.height <
+                                operatorHeaderHeight + operatorCornerRadius
+                                ? operatorCornerRadius -
+                                  Math.sqrt(
+                                    Math.pow(operatorCornerRadius, 2) -
+                                      Math.pow(
+                                        operatorCornerRadius -
+                                          d.height +
+                                          operatorHeaderHeight,
+                                        2
+                                      )
+                                  )
+                                : 0
+                          return [
+                            'M',
+                            operatorWidth - operatorCornerRadius,
+                            0,
+                            'A',
+                            operatorCornerRadius,
+                            operatorCornerRadius,
+                            0,
+                            0,
+                            1,
+                            operatorWidth,
+                            operatorCornerRadius,
+                            'L',
+                            operatorWidth,
+                            operatorHeaderHeight - operatorCornerRadius,
+                            'A',
+                            operatorCornerRadius,
+                            operatorCornerRadius,
+                            0,
+                            0,
+                            1,
+                            operatorWidth - shaving,
+                            operatorHeaderHeight,
+                            'L',
+                            shaving,
+                            operatorHeaderHeight,
+                            'A',
+                            operatorCornerRadius,
+                            operatorCornerRadius,
+                            0,
+                            0,
+                            1,
+                            0,
+                            operatorHeaderHeight - operatorCornerRadius,
+                            'L',
+                            0,
+                            operatorCornerRadius,
+                            'A',
+                            operatorCornerRadius,
+                            operatorCornerRadius,
+                            0,
+                            0,
+                            1,
+                            operatorCornerRadius,
+                            0,
+                            'Z'
+                          ].join(' ')
+                        })
+                        .style('fill', d => color(d.operatorType).color)
                     }
                   },
 
                   'path.expand': {
-                    data (d) { if (d.operatorType === 'Result') { return [] } else { return [d] } },
-                    selections (enter, update) {
-                      let rotateForExpand = function (d) {
+                    data(d) {
+                      if (d.operatorType === 'Result') {
+                        return []
+                      } else {
+                        return [d]
+                      }
+                    },
+                    selections(enter, update) {
+                      let rotateForExpand = function(d) {
                         d3.transform()
-                        return `translate(${operatorHeaderHeight / 2}, ${operatorHeaderHeight / 2}) ` +
-                        `rotate(${d.expanded ? 90 : 0}) ` +
-                        'scale(0.5)'
+                        return (
+                          `translate(${operatorHeaderHeight /
+                            2}, ${operatorHeaderHeight / 2}) ` +
+                          `rotate(${d.expanded ? 90 : 0}) ` +
+                          'scale(0.5)'
+                        )
                       }
 
                       enter
-                      .append('path')
-                      .attr('class', 'expand')
-                      .attr('fill', d => color(d.operatorType)['text-color-internal'])
-                      .attr('d', 'M -5 -10 L 8.66 0 L -5 10 Z')
-                      .attr('transform', rotateForExpand)
+                        .append('path')
+                        .attr('class', 'expand')
+                        .attr(
+                          'fill',
+                          d => color(d.operatorType)['text-color-internal']
+                        )
+                        .attr('d', 'M -5 -10 L 8.66 0 L -5 10 Z')
+                        .attr('transform', rotateForExpand)
 
                       return update
-                      .transition()
-                      .attrTween('transform', (d, i, a) => d3.interpolateString(a, rotateForExpand(d)))
+                        .transition()
+                        .attrTween('transform', (d, i, a) =>
+                          d3.interpolateString(a, rotateForExpand(d))
+                        )
                     }
                   },
 
                   'text.title': {
-                    data (d) { return [d] },
-                    selections (enter) {
+                    data(d) {
+                      return [d]
+                    },
+                    selections(enter) {
                       return enter
-                      .append('text')
-                      .attr('class', 'title')
-                      .attr('font-size', operatorHeaderFontSize)
-                      .attr('font-family', standardFont)
-                      .attr('x', operatorHeaderHeight)
-                      .attr('y', 13)
-                      .attr('fill', d => color(d.operatorType)['text-color-internal'])
-                      .text(d => d.operatorType)
+                        .append('text')
+                        .attr('class', 'title')
+                        .attr('font-size', operatorHeaderFontSize)
+                        .attr('font-family', standardFont)
+                        .attr('x', operatorHeaderHeight)
+                        .attr('y', 13)
+                        .attr(
+                          'fill',
+                          d => color(d.operatorType)['text-color-internal']
+                        )
+                        .text(d => d.operatorType)
                     }
                   }
                 }
@@ -580,30 +756,38 @@ neo.queryPlan = function (element) {
 
               'g.detail': {
                 data: operatorDetails,
-                selections (enter, update, exit) {
-                  enter
-                  .append('g')
+                selections(enter, update, exit) {
+                  enter.append('g')
 
                   update
-                  .attr('class', d => `detail ${d.className}`)
-                  .attr('transform', d => `translate(0, ${operatorHeaderHeight + d.y})`)
-                  .attr('font-family', function (d) {
-                    if ((d.className === 'expression') || (d.className === 'identifiers')) {
-                      return fixedWidthFont
-                    } else {
-                      return standardFont
-                    }
-                  })
+                    .attr('class', d => `detail ${d.className}`)
+                    .attr(
+                      'transform',
+                      d => `translate(0, ${operatorHeaderHeight + d.y})`
+                    )
+                    .attr('font-family', function(d) {
+                      if (
+                        d.className === 'expression' ||
+                        d.className === 'identifiers'
+                      ) {
+                        return fixedWidthFont
+                      } else {
+                        return standardFont
+                      }
+                    })
 
                   return exit.remove()
                 },
                 children: {
-
-                  'text': {
-                    data (d) {
+                  text: {
+                    data(d) {
                       if (d.key) {
                         return [
-                          { text: d.value + '\u00A0', anchor: 'end', x: operatorWidth / 2 },
+                          {
+                            text: d.value + '\u00A0',
+                            anchor: 'end',
+                            x: operatorWidth / 2
+                          },
                           { text: d.key, anchor: 'start', x: operatorWidth / 2 }
                         ]
                       } else {
@@ -612,84 +796,127 @@ neo.queryPlan = function (element) {
                         ]
                       }
                     },
-                    selections (enter, update, exit) {
-                      enter
-                      .append('text')
-                      .attr('font-size', detailFontSize)
+                    selections(enter, update, exit) {
+                      enter.append('text').attr('font-size', detailFontSize)
 
                       update
-                      .attr('x', d => d.x)
-                      .attr('text-anchor', d => d.anchor)
-                      .attr('fill', 'black')
-                      .transition()
-                      .each('end', () =>
-                        update
-                        .text(d => d.text)
-                      )
+                        .attr('x', d => d.x)
+                        .attr('text-anchor', d => d.anchor)
+                        .attr('fill', 'black')
+                        .transition()
+                        .each('end', () => update.text(d => d.text))
 
                       return exit.remove()
                     }
                   },
 
                   'path.divider': {
-                    data (d) {
+                    data(d) {
                       if (d.className === 'padding') {
                         return [d]
                       } else {
                         return []
                       }
                     },
-                    selections (enter, update) {
+                    selections(enter, update) {
                       enter
-                      .append('path')
-                      .attr('class', 'divider')
-                      .attr('visibility', 'hidden')
+                        .append('path')
+                        .attr('class', 'divider')
+                        .attr('visibility', 'hidden')
 
                       return update
-                      .attr('d', [
-                        'M', 0, -operatorPadding * 2,
-                        'L', operatorWidth, -operatorPadding * 2
-                      ].join(' '))
-                      .attr('stroke', dividerColor)
-                      .transition()
-                      .each('end', () =>
-                        update
-                        .attr('visibility', 'visible')
-                      )
+                        .attr(
+                          'd',
+                          [
+                            'M',
+                            0,
+                            -operatorPadding * 2,
+                            'L',
+                            operatorWidth,
+                            -operatorPadding * 2
+                          ].join(' ')
+                        )
+                        .attr('stroke', dividerColor)
+                        .transition()
+                        .each('end', () => update.attr('visibility', 'visible'))
                     }
                   }
                 }
               },
 
               'path.cost': {
-                data (d) { return [d] },
-                selections (enter, update) {
+                data(d) {
+                  return [d]
+                },
+                selections(enter, update) {
                   enter
-                  .append('path')
-                  .attr('class', 'cost')
-                  .attr('fill', costColor)
+                    .append('path')
+                    .attr('class', 'cost')
+                    .attr('fill', costColor)
 
-                  return update
-                  .transition()
-                  .attr('d', function (d) {
+                  return update.transition().attr('d', function(d) {
                     if (d.costHeight < operatorCornerRadius) {
-                      let shaving = operatorCornerRadius -
-                          Math.sqrt(Math.pow(operatorCornerRadius, 2) - Math.pow(operatorCornerRadius - d.costHeight, 2))
+                      let shaving =
+                        operatorCornerRadius -
+                        Math.sqrt(
+                          Math.pow(operatorCornerRadius, 2) -
+                            Math.pow(operatorCornerRadius - d.costHeight, 2)
+                        )
                       return [
-                        'M', operatorWidth - shaving, d.height - d.costHeight,
-                        'A', operatorCornerRadius, operatorCornerRadius, 0, 0, 1, operatorWidth - operatorCornerRadius, d.height,
-                        'L', operatorCornerRadius, d.height,
-                        'A', operatorCornerRadius, operatorCornerRadius, 0, 0, 1, shaving, d.height - d.costHeight,
+                        'M',
+                        operatorWidth - shaving,
+                        d.height - d.costHeight,
+                        'A',
+                        operatorCornerRadius,
+                        operatorCornerRadius,
+                        0,
+                        0,
+                        1,
+                        operatorWidth - operatorCornerRadius,
+                        d.height,
+                        'L',
+                        operatorCornerRadius,
+                        d.height,
+                        'A',
+                        operatorCornerRadius,
+                        operatorCornerRadius,
+                        0,
+                        0,
+                        1,
+                        shaving,
+                        d.height - d.costHeight,
                         'Z'
                       ].join(' ')
                     } else {
                       return [
-                        'M', 0, d.height - d.costHeight,
-                        'L', operatorWidth, d.height - d.costHeight,
-                        'L', operatorWidth, d.height - operatorCornerRadius,
-                        'A', operatorCornerRadius, operatorCornerRadius, 0, 0, 1, operatorWidth - operatorCornerRadius, d.height,
-                        'L', operatorCornerRadius, d.height,
-                        'A', operatorCornerRadius, operatorCornerRadius, 0, 0, 1, 0, d.height - operatorCornerRadius,
+                        'M',
+                        0,
+                        d.height - d.costHeight,
+                        'L',
+                        operatorWidth,
+                        d.height - d.costHeight,
+                        'L',
+                        operatorWidth,
+                        d.height - operatorCornerRadius,
+                        'A',
+                        operatorCornerRadius,
+                        operatorCornerRadius,
+                        0,
+                        0,
+                        1,
+                        operatorWidth - operatorCornerRadius,
+                        d.height,
+                        'L',
+                        operatorCornerRadius,
+                        d.height,
+                        'A',
+                        operatorCornerRadius,
+                        operatorCornerRadius,
+                        0,
+                        0,
+                        1,
+                        0,
+                        d.height - operatorCornerRadius,
                         'Z'
                       ].join(' ')
                     }
@@ -698,53 +925,54 @@ neo.queryPlan = function (element) {
               },
 
               'text.cost': {
-                data (d) {
+                data(d) {
                   if (d.alwaysShowCost) {
-                    let y = (d.height - d.costHeight) + operatorDetailHeight
+                    let y = d.height - d.costHeight + operatorDetailHeight
                     return [
-                      { text: formatNumber(d.DbHits) + '\u00A0', anchor: 'end', y },
+                      {
+                        text: formatNumber(d.DbHits) + '\u00A0',
+                        anchor: 'end',
+                        y
+                      },
                       { text: 'db hits', anchor: 'start', y }
                     ]
                   } else {
                     return []
                   }
                 },
-                selections (enter, update) {
+                selections(enter, update) {
                   enter
-                  .append('text')
-                  .attr('class', 'cost')
-                  .attr('font-size', detailFontSize)
-                  .attr('font-family', standardFont)
-                  .attr('fill', 'white')
+                    .append('text')
+                    .attr('class', 'cost')
+                    .attr('font-size', detailFontSize)
+                    .attr('font-family', standardFont)
+                    .attr('fill', 'white')
 
                   return update
-                  .attr('x', operatorWidth / 2)
-                  .attr('text-anchor', d => d.anchor)
-                  .transition()
-                  .attr('y', d => d.y)
-                  .each('end', () =>
-                    update
-                    .text(d => d.text)
-                  )
+                    .attr('x', operatorWidth / 2)
+                    .attr('text-anchor', d => d.anchor)
+                    .transition()
+                    .attr('y', d => d.y)
+                    .each('end', () => update.text(d => d.text))
                 }
               },
 
               'rect.outline': {
-                data (d) { return [d] },
-                selections (enter, update) {
-                  enter
-                  .append('rect')
-                  .attr('class', 'outline')
+                data(d) {
+                  return [d]
+                },
+                selections(enter, update) {
+                  enter.append('rect').attr('class', 'outline')
 
                   return update
-                  .transition()
-                  .attr('width', operatorWidth)
-                  .attr('height', d => d.height)
-                  .attr('rx', operatorCornerRadius)
-                  .attr('ry', operatorCornerRadius)
-                  .attr('fill', 'none')
-                  .attr('stroke-width', 1)
-                  .style('stroke', d => color(d.operatorType)['border-color'])
+                    .transition()
+                    .attr('width', operatorWidth)
+                    .attr('height', d => d.height)
+                    .attr('rx', operatorCornerRadius)
+                    .attr('ry', operatorCornerRadius)
+                    .attr('fill', 'none')
+                    .attr('stroke-width', 1)
+                    .style('stroke', d => color(d.operatorType)['border-color'])
                 }
               }
             }
@@ -754,7 +982,7 @@ neo.queryPlan = function (element) {
     })
   }
 
-  var display = function (queryPlan) {
+  var display = function(queryPlan) {
     let [operators, links] = Array.from(transform(queryPlan))
     let [width, height] = Array.from(layout(operators, links))
     return render(operators, links, width, height, () => display(queryPlan))

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -23,7 +23,10 @@ import { createEpicMiddleware } from 'redux-observable'
 import { render } from 'preact'
 import { createStore, combineReducers, applyMiddleware, compose } from 'redux'
 import { Provider } from 'preact-redux'
-import { createBus, createReduxMiddleware as createSuberReduxMiddleware } from 'suber'
+import {
+  createBus,
+  createReduxMiddleware as createSuberReduxMiddleware
+} from 'suber'
 import { BusProvider } from 'preact-suber'
 
 import reducers from 'shared/rootReducer'
@@ -56,7 +59,7 @@ const reducer = combineReducers({ ...reducers })
 
 const enhancer = compose(
   applyMiddleware(suberMiddleware, epicMiddleware, localStorageMiddleware),
-  window.devToolsExtension ? window.devToolsExtension() : (f) => f
+  window.devToolsExtension ? window.devToolsExtension() : f => f
 )
 
 const store = createStore(
@@ -70,7 +73,7 @@ bus.applyMiddleware((_, origin) => (channel, message, source) => {
   // No loop-backs
   if (source === 'redux') return
   // Send to Redux with the channel as the action type
-  store.dispatch({...message, type: channel, ...origin})
+  store.dispatch({ ...message, type: channel, ...origin })
 })
 
 // Signal app upstart (for epics)
@@ -85,9 +88,9 @@ const renderApp = () => {
       <BusProvider bus={bus}>
         <App />
       </BusProvider>
-    </Provider>
-    , mountElement
-    , elem
+    </Provider>,
+    mountElement,
+    elem
   )
 }
 renderApp()

--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -25,12 +25,24 @@ import { ThemeProvider } from 'styled-components'
 import * as themes from 'browser/styles/themes'
 import { getTheme, getCmdChar } from 'shared/modules/settings/settingsDuck'
 import { FOCUS, EXPAND } from 'shared/modules/editor/editorDuck'
-import { wasUnknownCommand, getErrorMessage } from 'shared/modules/commands/commandsDuck'
+import {
+  wasUnknownCommand,
+  getErrorMessage
+} from 'shared/modules/commands/commandsDuck'
 import { allowOutgoingConnections } from 'shared/modules/dbMeta/dbMetaDuck'
-import { getActiveConnection, getConnectionState, getActiveConnectionData } from 'shared/modules/connections/connectionsDuck'
+import {
+  getActiveConnection,
+  getConnectionState,
+  getActiveConnectionData
+} from 'shared/modules/connections/connectionsDuck'
 import { toggle } from 'shared/modules/sidebar/sidebarDuck'
 
-import { StyledWrapper, StyledApp, StyledBody, StyledMainWrapper } from './styled'
+import {
+  StyledWrapper,
+  StyledApp,
+  StyledBody,
+  StyledMainWrapper
+} from './styled'
 import Main from '../Main/Main'
 import Sidebar from '../Sidebar/Sidebar'
 import UserInteraction from '../UserInteraction'
@@ -58,7 +70,17 @@ class App extends Component {
     this.props.bus && this.props.bus.send(EXPAND)
   }
   render () {
-    const {drawer, cmdchar, handleNavClick, activeConnection, connectionState, theme, showUnknownCommandBanner, errorMessage, loadUdc} = this.props
+    const {
+      drawer,
+      cmdchar,
+      handleNavClick,
+      activeConnection,
+      connectionState,
+      theme,
+      showUnknownCommandBanner,
+      errorMessage,
+      loadUdc
+    } = this.props
     const themeData = themes[theme] || themes['normal']
     return (
       <ThemeProvider theme={themeData}>
@@ -88,7 +110,7 @@ class App extends Component {
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   const connectionData = getActiveConnectionData(state)
   return {
     drawer: state.drawer,
@@ -103,9 +125,9 @@ const mapStateToProps = (state) => {
   }
 }
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
-    handleNavClick: (id) => {
+    handleNavClick: id => {
       dispatch(toggle(id))
     }
   }

--- a/src/browser/modules/ClickToCode/index.jsx
+++ b/src/browser/modules/ClickToCode/index.jsx
@@ -21,10 +21,19 @@ import { withBus } from 'preact-suber'
 import { SET_CONTENT, setContent } from 'shared/modules/editor/editorDuck'
 import { StyledCodeBlock } from './styled'
 
-export const ClickToCode = ({CodeComponent = StyledCodeBlock, bus, code, children}) => {
+export const ClickToCode = ({
+  CodeComponent = StyledCodeBlock,
+  bus,
+  code,
+  children
+}) => {
   if (!children || children.length === 0) return null
   code = code || children.join('')
-  return <CodeComponent onClick={() => bus.send(SET_CONTENT, setContent(code))}>{children}</CodeComponent>
+  return (
+    <CodeComponent onClick={() => bus.send(SET_CONTENT, setContent(code))}>
+      {children}
+    </CodeComponent>
+  )
 }
 
 export default withBus(ClickToCode)

--- a/src/browser/modules/ClickToCode/index.test.js
+++ b/src/browser/modules/ClickToCode/index.test.js
@@ -29,9 +29,13 @@ describe('ClickToCode', () => {
   let MyComp
   let bus
   beforeEach(() => {
-    MyComp = ({onClick, children}) => {
+    MyComp = ({ onClick, children }) => {
       onClick()
-      return <code>{children}</code>
+      return (
+        <code>
+          {children}
+        </code>
+      )
     }
     bus = createBus()
   })
@@ -65,12 +69,16 @@ describe('ClickToCode', () => {
 
     // When
     bus.take(SET_CONTENT, myFn)
-    const component = render(<ClickToCode CodeComponent={MyComp} code={code} bus={bus}>yo</ClickToCode>)
+    const component = render(
+      <ClickToCode CodeComponent={MyComp} code={code} bus={bus}>
+        yo
+      </ClickToCode>
+    )
 
     // Then
     expect(component).toMatchSnapshot()
     expect(myFn).toHaveBeenCalledTimes(1)
-    expect(myFn).toHaveBeenCalledWith({message: code, type: SET_CONTENT})
+    expect(myFn).toHaveBeenCalledWith({ message: code, type: SET_CONTENT })
   })
   test('renders children as code if no code is provided', () => {
     // Given
@@ -80,26 +88,41 @@ describe('ClickToCode', () => {
 
     // When
     bus.take(SET_CONTENT, myFn)
-    const component = render(<ClickToCode CodeComponent={MyComp} bus={bus}>{hello}hi!</ClickToCode>)
+    const component = render(
+      <ClickToCode CodeComponent={MyComp} bus={bus}>
+        {hello}hi!
+      </ClickToCode>
+    )
 
     // Then
     expect(component).toMatchSnapshot()
     expect(myFn).toHaveBeenCalledTimes(1)
-    expect(myFn).toHaveBeenCalledWith({message: childrenString, type: SET_CONTENT})
+    expect(myFn).toHaveBeenCalledWith({
+      message: childrenString,
+      type: SET_CONTENT
+    })
   })
   test('renders all children', () => {
     // Given
     const myFn = jest.fn()
     const code = 'my code'
-    const children = <div><span>hello</span>hi!</div>
+    const children = (
+      <div>
+        <span>hello</span>hi!
+      </div>
+    )
 
     // When
     bus.take(SET_CONTENT, myFn)
-    const component = render(<ClickToCode CodeComponent={MyComp} code={code} bus={bus}>{children}</ClickToCode>)
+    const component = render(
+      <ClickToCode CodeComponent={MyComp} code={code} bus={bus}>
+        {children}
+      </ClickToCode>
+    )
 
     // Then
     expect(component).toMatchSnapshot()
     expect(myFn).toHaveBeenCalledTimes(1)
-    expect(myFn).toHaveBeenCalledWith({message: code, type: SET_CONTENT})
+    expect(myFn).toHaveBeenCalledWith({ message: code, type: SET_CONTENT })
   })
 })

--- a/src/browser/modules/ConnectionsDropdown/ConnectionsDropdown.jsx
+++ b/src/browser/modules/ConnectionsDropdown/ConnectionsDropdown.jsx
@@ -26,36 +26,42 @@ import { getBookmarks, getActiveBookmark } from '../reducer'
 export class Dropdown extends Component {
   constructor (props) {
     super(props)
-    this.state = {selected: this.props.activeBookmark}
+    this.state = { selected: this.props.activeBookmark }
   }
   change (event) {
-    this.setState({selected: event.target.value}, () => {
+    this.setState({ selected: event.target.value }, () => {
       this.props.onBookmarkChange(this.state.selected)
     })
   }
   componentWillReceiveProps (newProps) {
-    this.setState({selected: newProps.activeBookmark})
+    this.setState({ selected: newProps.activeBookmark })
   }
   render () {
-    let bms = this.props.bookmarks.map((bm) => {
-      return <option value={bm.id} key={bm.id}>{bm.name}</option>
+    let bms = this.props.bookmarks.map(bm => {
+      return (
+        <option value={bm.id} key={bm.id}>
+          {bm.name}
+        </option>
+      )
     })
     return (
-      <select onChange={this.change.bind(this)} value={this.state.selected}>{bms}</select>
+      <select onChange={this.change.bind(this)} value={this.state.selected}>
+        {bms}
+      </select>
     )
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     bookmarks: getBookmarks(state),
     activeBookmark: getActiveBookmark(state)
   }
 }
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
-    onBookmarkChange: (id) => {
+    onBookmarkChange: id => {
       dispatch(selectBookmark(id))
     }
   }

--- a/src/browser/modules/D3Visualization/GraphEventHandler.js
+++ b/src/browser/modules/D3Visualization/GraphEventHandler.js
@@ -18,10 +18,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {mapNodes, mapRelationships, getGraphStats} from './mapper'
+import { mapNodes, mapRelationships, getGraphStats } from './mapper'
 
 export class GraphEventHandler {
-  constructor (graph, graphView, getNodeNeighbours, onItemMouseOver, onItemSelected, onGraphModelChange) {
+  constructor (
+    graph,
+    graphView,
+    getNodeNeighbours,
+    onItemMouseOver,
+    onItemSelected,
+    onGraphModelChange
+  ) {
     this.graph = graph
     this.graphView = graphView
     this.getNodeNeighbours = getNodeNeighbours
@@ -49,7 +56,13 @@ export class GraphEventHandler {
       this.selectedItem.selected = false
       this.selectedItem = null
     }
-    this.onItemSelected({type: 'canvas', item: {nodeCount: this.graph.nodes().length, relationshipCount: this.graph.relationships().length}})
+    this.onItemSelected({
+      type: 'canvas',
+      item: {
+        nodeCount: this.graph.nodes().length,
+        relationshipCount: this.graph.relationships().length
+      }
+    })
     this.graphView.update()
   }
 
@@ -65,7 +78,10 @@ export class GraphEventHandler {
     d.fixed = true
     if (!d.selected) {
       this.selectItem(d)
-      this.onItemSelected({type: 'node', item: {id: d.id, labels: d.labels, properties: d.propertyList}})
+      this.onItemSelected({
+        type: 'node',
+        item: { id: d.id, labels: d.labels, properties: d.propertyList }
+      })
     } else {
       this.deselectItem()
     }
@@ -80,7 +96,10 @@ export class GraphEventHandler {
     const graph = this.graph
     const graphView = this.graphView
     const graphModelChanged = this.graphModelChanged.bind(this)
-    this.getNodeNeighbours(d, this.graph.findNodeNeighbourIds(d.id), function (err, {nodes, relationships}) {
+    this.getNodeNeighbours(d, this.graph.findNodeNeighbourIds(d.id), function (
+      err,
+      { nodes, relationships }
+    ) {
       if (err) return
       graph.addNodes(mapNodes(nodes))
       graph.addRelationships(mapRelationships(relationships, graph))
@@ -91,20 +110,48 @@ export class GraphEventHandler {
 
   onNodeMouseOver (node) {
     if (!node.contextMenu) {
-      this.onItemMouseOver({type: 'node', item: {id: node.id, labels: node.labels, properties: node.propertyList}})
+      this.onItemMouseOver({
+        type: 'node',
+        item: {
+          id: node.id,
+          labels: node.labels,
+          properties: node.propertyList
+        }
+      })
     }
   }
   onMenuMouseOver (itemWithMenu) {
-    this.onItemMouseOver({type: 'context-menu-item', item: {label: itemWithMenu.contextMenu.label, content: itemWithMenu.contextMenu.menuContent, selection: itemWithMenu.contextMenu.menuSelection}})
+    this.onItemMouseOver({
+      type: 'context-menu-item',
+      item: {
+        label: itemWithMenu.contextMenu.label,
+        content: itemWithMenu.contextMenu.menuContent,
+        selection: itemWithMenu.contextMenu.menuSelection
+      }
+    })
   }
   onRelationshipMouseOver (relationship) {
-    this.onItemMouseOver({type: 'relationship', item: {id: relationship.id, type: relationship.type, properties: relationship.propertyList}})
+    this.onItemMouseOver({
+      type: 'relationship',
+      item: {
+        id: relationship.id,
+        type: relationship.type,
+        properties: relationship.propertyList
+      }
+    })
   }
 
   onRelationshipClicked (relationship) {
     if (!relationship.selected) {
       this.selectItem(relationship)
-      this.onItemSelected({type: 'relationship', item: {id: relationship.id, type: relationship.type, properties: relationship.propertyList}})
+      this.onItemSelected({
+        type: 'relationship',
+        item: {
+          id: relationship.id,
+          type: relationship.type,
+          properties: relationship.propertyList
+        }
+      })
     } else {
       this.deselectItem()
     }
@@ -115,23 +162,29 @@ export class GraphEventHandler {
   }
 
   onItemMouseOut (item) {
-    this.onItemMouseOver({type: 'canvas', item: {nodeCount: this.graph.nodes().length, relationshipCount: this.graph.relationships().length}})
+    this.onItemMouseOver({
+      type: 'canvas',
+      item: {
+        nodeCount: this.graph.nodes().length,
+        relationshipCount: this.graph.relationships().length
+      }
+    })
   }
 
   bindEventHandlers () {
     this.graphView
-     .on('nodeMouseOver', this.onNodeMouseOver.bind(this))
-     .on('nodeMouseOut', this.onItemMouseOut.bind(this))
-     .on('menuMouseOver', this.onMenuMouseOver.bind(this))
-     .on('menuMouseOut', this.onItemMouseOut.bind(this))
-     .on('relMouseOver', this.onRelationshipMouseOver.bind(this))
-     .on('relMouseOut', this.onItemMouseOut.bind(this))
-     .on('relationshipClicked', this.onRelationshipClicked.bind(this))
-     .on('canvasClicked', this.onCanvasClicked.bind(this))
-     .on('nodeClose', this.nodeClose.bind(this))
-     .on('nodeClicked', this.nodeClicked.bind(this))
-     .on('nodeDblClicked', this.nodeDblClicked.bind(this))
-     .on('nodeUnlock', this.nodeUnlock.bind(this))
+      .on('nodeMouseOver', this.onNodeMouseOver.bind(this))
+      .on('nodeMouseOut', this.onItemMouseOut.bind(this))
+      .on('menuMouseOver', this.onMenuMouseOver.bind(this))
+      .on('menuMouseOut', this.onItemMouseOut.bind(this))
+      .on('relMouseOver', this.onRelationshipMouseOver.bind(this))
+      .on('relMouseOut', this.onItemMouseOut.bind(this))
+      .on('relationshipClicked', this.onRelationshipClicked.bind(this))
+      .on('canvasClicked', this.onCanvasClicked.bind(this))
+      .on('nodeClose', this.nodeClose.bind(this))
+      .on('nodeClicked', this.nodeClicked.bind(this))
+      .on('nodeDblClicked', this.nodeDblClicked.bind(this))
+      .on('nodeUnlock', this.nodeUnlock.bind(this))
     this.onItemMouseOut()
   }
 }

--- a/src/browser/modules/D3Visualization/components/Explorer.jsx
+++ b/src/browser/modules/D3Visualization/components/Explorer.jsx
@@ -20,22 +20,25 @@
 
 import { Component } from 'preact'
 import { deepEquals } from 'services/utils'
-import {GraphComponent} from './Graph'
+import { GraphComponent } from './Graph'
 import neoGraphStyle from '../graphStyle'
-import {InspectorComponent} from './Inspector'
-import {LegendComponent} from './Legend'
-import {StyledFullSizeContainer} from './styled'
+import { InspectorComponent } from './Inspector'
+import { LegendComponent } from './Legend'
+import { StyledFullSizeContainer } from './styled'
 
-const deduplicateNodes = (nodes) => {
-  return nodes.reduce((all, curr) => {
-    if (all.taken.indexOf(curr.id) > -1) {
-      return all
-    } else {
-      all.nodes.push(curr)
-      all.taken.push(curr.id)
-      return all
-    }
-  }, {nodes: [], taken: []}).nodes
+const deduplicateNodes = nodes => {
+  return nodes.reduce(
+    (all, curr) => {
+      if (all.taken.indexOf(curr.id) > -1) {
+        return all
+      } else {
+        all.nodes.push(curr)
+        all.taken.push(curr.id)
+        return all
+      }
+    },
+    { nodes: [], taken: [] }
+  ).nodes
 }
 
 export class ExplorerComponent extends Component {
@@ -47,14 +50,23 @@ export class ExplorerComponent extends Component {
     let selectedItem = ''
     if (nodes.length > parseInt(this.props.initialNodeDisplay)) {
       nodes = nodes.slice(0, this.props.initialNodeDisplay)
-      relationships = this.props.relationships.filter((item) => nodes.filter((node) => node.id === item.startNodeId).length > 0 && this.state.nodes.filter((node) => node.id === item.endNodeId).length > 0)
-      selectedItem = {type: 'status-item', item: `Not all return nodes are being displayed due to Initial Node Display setting. Only ${this.props.initialNodeDisplay} of ${nodes.length} nodes are being displayed`}
+      relationships = this.props.relationships.filter(
+        item =>
+          nodes.filter(node => node.id === item.startNodeId).length > 0 &&
+          this.state.nodes.filter(node => node.id === item.endNodeId).length > 0
+      )
+      selectedItem = {
+        type: 'status-item',
+        item: `Not all return nodes are being displayed due to Initial Node Display setting. Only ${this
+          .props
+          .initialNodeDisplay} of ${nodes.length} nodes are being displayed`
+      }
     }
     if (this.props.graphStyleData) {
       graphStyle.loadRules(this.props.graphStyleData)
     }
     this.state = {
-      stats: {labels: {}, relTypes: {}},
+      stats: { labels: {}, relTypes: {} },
       graphStyle,
       nodes,
       relationships,
@@ -64,51 +76,80 @@ export class ExplorerComponent extends Component {
 
   getNodeNeighbours (node, currentNeighbours, callback) {
     if (currentNeighbours.length > this.props.maxNeighbours) {
-      callback(null, {nodes: [], relationships: []})
+      callback(null, { nodes: [], relationships: [] })
     }
-    this.props.getNeighbours(node.id, currentNeighbours).then((result) => {
-      let nodes = result.nodes
-      if (result.count > (this.props.maxNeighbours - currentNeighbours.length)) {
-        this.setState({selectedItem: {type: 'status-item', item: `Rendering was limited to ${this.props.maxNeighbours} of the node's total ${result.count + currentNeighbours.length} neighbours due to browser config maxNeighbours.`}})
+    this.props.getNeighbours(node.id, currentNeighbours).then(
+      result => {
+        let nodes = result.nodes
+        if (
+          result.count >
+          this.props.maxNeighbours - currentNeighbours.length
+        ) {
+          this.setState({
+            selectedItem: {
+              type: 'status-item',
+              item: `Rendering was limited to ${this.props
+                .maxNeighbours} of the node's total ${result.count +
+                currentNeighbours.length} neighbours due to browser config maxNeighbours.`
+            }
+          })
+        }
+        callback(null, { nodes: nodes, relationships: result.relationships })
+      },
+      () => {
+        callback(null, { nodes: [], relationships: [] })
       }
-      callback(null, {nodes: nodes, relationships: result.relationships})
-    }, () => {
-      callback(null, {nodes: [], relationships: []})
-    })
+    )
   }
 
   onItemMouseOver (item) {
-    this.setState({hoveredItem: item})
+    this.setState({ hoveredItem: item })
   }
 
   onItemSelect (item) {
-    this.setState({selectedItem: item})
+    this.setState({ selectedItem: item })
   }
 
   onGraphModelChange (stats) {
-    this.setState({stats: stats})
+    this.setState({ stats: stats })
     this.props.updateStyle(this.state.graphStyle.toSheet())
   }
 
   onSelectedLabel (label, propertyKeys) {
-    this.setState({selectedItem: {type: 'legend-item', item: {selectedLabel: {label: label, propertyKeys: propertyKeys}, selectedRelType: null}}})
+    this.setState({
+      selectedItem: {
+        type: 'legend-item',
+        item: {
+          selectedLabel: { label: label, propertyKeys: propertyKeys },
+          selectedRelType: null
+        }
+      }
+    })
   }
 
   onSelectedRelType (relType, propertyKeys) {
-    this.setState({selectedItem: {type: 'legend-item', item: {selectedLabel: null, selectedRelType: {relType: relType, propertyKeys: propertyKeys}}}})
+    this.setState({
+      selectedItem: {
+        type: 'legend-item',
+        item: {
+          selectedLabel: null,
+          selectedRelType: { relType: relType, propertyKeys: propertyKeys }
+        }
+      }
+    })
   }
 
   componentWillReceiveProps (props) {
     if (!deepEquals(props.graphStyleData, this.props.graphStyleData)) {
       if (props.graphStyleData) {
         this.state.graphStyle.loadRules(props.graphStyleData)
-        this.setState({graphStyle: this.state.graphStyle})
+        this.setState({ graphStyle: this.state.graphStyle })
       } else {
         this.state.graphStyle.resetToDefault()
         this.setState(
-          {graphStyle: this.state.graphStyle, freezeLegend: true},
+          { graphStyle: this.state.graphStyle, freezeLegend: true },
           () => {
-            this.setState({freezeLegend: false})
+            this.setState({ freezeLegend: false })
             this.props.updateStyle(this.state.graphStyle.toSheet())
           }
         )
@@ -116,16 +157,19 @@ export class ExplorerComponent extends Component {
     }
 
     if (!deepEquals(props.nodes, this.props.nodes)) {
-      this.setState({nodes: props.nodes})
+      this.setState({ nodes: props.nodes })
     }
 
     if (!deepEquals(props.relationships, this.props.relationships)) {
-      this.setState({relationships: props.relationships})
+      this.setState({ relationships: props.relationships })
     }
   }
 
   onInspectorExpandToggled (contracted, inspectorHeight) {
-    this.setState({ inspectorContracted: contracted, forcePaddingBottom: inspectorHeight })
+    this.setState({
+      inspectorContracted: contracted,
+      forcePaddingBottom: inspectorHeight
+    })
   }
 
   render () {
@@ -134,14 +178,39 @@ export class ExplorerComponent extends Component {
     // and also doing this in a different order from the graph. This leads to different default colors being asigned to different labels.
     var legend
     if (this.state.freezeLegend) {
-      legend = <LegendComponent stats={this.state.stats} graphStyle={neoGraphStyle()} onSelectedLabel={this.onSelectedLabel.bind(this)} onSelectedRelType={this.onSelectedRelType.bind(this)} />
+      legend = (
+        <LegendComponent
+          stats={this.state.stats}
+          graphStyle={neoGraphStyle()}
+          onSelectedLabel={this.onSelectedLabel.bind(this)}
+          onSelectedRelType={this.onSelectedRelType.bind(this)}
+        />
+      )
     } else {
-      legend = <LegendComponent stats={this.state.stats} graphStyle={this.state.graphStyle} onSelectedLabel={this.onSelectedLabel.bind(this)} onSelectedRelType={this.onSelectedRelType.bind(this)} />
+      legend = (
+        <LegendComponent
+          stats={this.state.stats}
+          graphStyle={this.state.graphStyle}
+          onSelectedLabel={this.onSelectedLabel.bind(this)}
+          onSelectedRelType={this.onSelectedRelType.bind(this)}
+        />
+      )
     }
-    const inspectingItemType = !this.state.inspectorContracted && ((this.state.hoveredItem && this.state.hoveredItem.type !== 'canvas') || (this.state.selectedItem && this.state.selectedItem.type !== 'canvas'))
+    const inspectingItemType =
+      !this.state.inspectorContracted &&
+      ((this.state.hoveredItem && this.state.hoveredItem.type !== 'canvas') ||
+        (this.state.selectedItem && this.state.selectedItem.type !== 'canvas'))
 
     return (
-      <StyledFullSizeContainer id='svg-vis' className={Object.keys(this.state.stats.relTypes).length ? '' : 'one-legend-row'} forcePaddingBottom={inspectingItemType ? this.state.forcePaddingBottom : null}>
+      <StyledFullSizeContainer
+        id='svg-vis'
+        className={
+          Object.keys(this.state.stats.relTypes).length ? '' : 'one-legend-row'
+        }
+        forcePaddingBottom={
+          inspectingItemType ? this.state.forcePaddingBottom : null
+        }
+      >
         {legend}
         <GraphComponent
           fullscreen={this.props.fullscreen}
@@ -155,8 +224,15 @@ export class ExplorerComponent extends Component {
           onGraphModelChange={this.onGraphModelChange.bind(this)}
           assignVisElement={this.props.assignVisElement}
           getAutoCompleteCallback={this.props.getAutoCompleteCallback}
-          setGraph={this.props.setGraph} />
-        <InspectorComponent fullscreen={this.props.fullscreen} hoveredItem={this.state.hoveredItem} selectedItem={this.state.selectedItem} graphStyle={this.state.graphStyle} onExpandToggled={this.onInspectorExpandToggled.bind(this)} />
+          setGraph={this.props.setGraph}
+        />
+        <InspectorComponent
+          fullscreen={this.props.fullscreen}
+          hoveredItem={this.state.hoveredItem}
+          selectedItem={this.state.selectedItem}
+          graphStyle={this.state.graphStyle}
+          onExpandToggled={this.onInspectorExpandToggled.bind(this)}
+        />
       </StyledFullSizeContainer>
     )
   }

--- a/src/browser/modules/D3Visualization/components/Graph.jsx
+++ b/src/browser/modules/D3Visualization/components/Graph.jsx
@@ -20,11 +20,16 @@
 
 import { Component } from 'preact'
 import { deepEquals } from 'services/utils'
-import {createGraph, mapNodes, mapRelationships, getGraphStats} from '../mapper'
-import {GraphEventHandler} from '../GraphEventHandler'
+import {
+  createGraph,
+  mapNodes,
+  mapRelationships,
+  getGraphStats
+} from '../mapper'
+import { GraphEventHandler } from '../GraphEventHandler'
 import '../lib/visualization/index'
 import { dim } from 'browser-styles/constants'
-import {StyledZoomHolder, StyledSvgWrapper, StyledZoomButton} from './styled'
+import { StyledZoomHolder, StyledSvgWrapper, StyledZoomButton } from './styled'
 import { ZoomInIcon, ZoomOutIcon } from 'browser-components/icons/Icons'
 
 export class GraphComponent extends Component {
@@ -42,19 +47,32 @@ export class GraphComponent extends Component {
 
   zoomInClicked (el) {
     let limits = this.graphView.zoomIn(el)
-    this.setState({zoomInLimitReached: limits.zoomInLimit, zoomOutLimitReached: limits.zoomOutLimit})
+    this.setState({
+      zoomInLimitReached: limits.zoomInLimit,
+      zoomOutLimitReached: limits.zoomOutLimit
+    })
   }
 
   zoomOutlicked (el) {
     let limits = this.graphView.zoomOut(el)
-    this.setState({zoomInLimitReached: limits.zoomInLimit, zoomOutLimitReached: limits.zoomOutLimit})
+    this.setState({
+      zoomInLimitReached: limits.zoomInLimit,
+      zoomOutLimitReached: limits.zoomOutLimit
+    })
   }
 
   getVisualAreaHeight () {
     if (this.props.frameHeight && this.props.fullscreen) {
-      return this.props.frameHeight - (dim.frameStatusbarHeight + dim.frameTitlebarHeight * 2)
+      return (
+        this.props.frameHeight -
+        (dim.frameStatusbarHeight + dim.frameTitlebarHeight * 2)
+      )
     } else {
-      return this.props.frameHeight - (dim.frameStatusbarHeight + dim.frameTitlebarHeight * 2) || this.svgElement.parentNode.offsetHeight
+      return (
+        this.props.frameHeight -
+          (dim.frameStatusbarHeight + dim.frameTitlebarHeight * 2) ||
+        this.svgElement.parentNode.offsetHeight
+      )
     }
   }
 
@@ -62,8 +80,12 @@ export class GraphComponent extends Component {
     if (this.svgElement != null) {
       this.initGraphView()
       this.graph && this.props.setGraph && this.props.setGraph(this.graph)
-      this.props.getAutoCompleteCallback && this.props.getAutoCompleteCallback(this.addInternalRelationships.bind(this))
-      this.props.assignVisElement && this.props.assignVisElement(this.svgElement, this.graphView)
+      this.props.getAutoCompleteCallback &&
+        this.props.getAutoCompleteCallback(
+          this.addInternalRelationships.bind(this)
+        )
+      this.props.assignVisElement &&
+        this.props.assignVisElement(this.svgElement, this.graphView)
     }
   }
 
@@ -71,11 +93,20 @@ export class GraphComponent extends Component {
     if (!this.graphView) {
       let NeoConstructor = neo.graphView
       let measureSize = () => {
-        return {width: this.svgElement.offsetWidth, height: this.getVisualAreaHeight()}
+        return {
+          width: this.svgElement.offsetWidth,
+          height: this.getVisualAreaHeight()
+        }
       }
       this.graph = createGraph(this.props.nodes, this.props.relationships)
-      this.graphView = new NeoConstructor(this.svgElement, measureSize, this.graph, this.props.graphStyle)
-      this.graphEH = new GraphEventHandler(this.graph,
+      this.graphView = new NeoConstructor(
+        this.svgElement,
+        measureSize,
+        this.graph,
+        this.props.graphStyle
+      )
+      this.graphEH = new GraphEventHandler(
+        this.graph,
         this.graphView,
         this.props.getNodeNeighbours,
         this.props.onItemMouseOver,
@@ -92,27 +123,40 @@ export class GraphComponent extends Component {
 
   addInternalRelationships (internalRelationships) {
     if (this.graph) {
-      this.graph.addInternalRelationships(mapRelationships(internalRelationships, this.graph))
+      this.graph.addInternalRelationships(
+        mapRelationships(internalRelationships, this.graph)
+      )
       this.graphView.update()
       this.graphEH.onItemMouseOut()
     }
   }
 
   componentWillReceiveProps (props) {
-    if ((!deepEquals(props.relationships, this.props.relationships) || !deepEquals(props.nodes, this.props.nodes)) && this.graphView) {
+    if (
+      (!deepEquals(props.relationships, this.props.relationships) ||
+        !deepEquals(props.nodes, this.props.nodes)) &&
+      this.graphView
+    ) {
       this.graph.resetGraph()
       this.graph.addNodes(mapNodes(props.nodes))
-      this.graph.addRelationships(mapRelationships(props.relationships, this.graph))
+      this.graph.addRelationships(
+        mapRelationships(props.relationships, this.graph)
+      )
       this.props.onGraphModelChange(getGraphStats(this.graph))
-    } else if (!deepEquals(this.state.currentStyleRules, props.graphStyle.toString())) {
+    } else if (
+      !deepEquals(this.state.currentStyleRules, props.graphStyle.toString())
+    ) {
       this.state.currentStyleRules = props.graphStyle.toString()
       this.graphView.update()
     }
 
-    if (this.props.fullscreen !== props.fullscreen || this.props.frameHeight !== props.frameHeight) {
-      this.setState({shouldResize: true})
+    if (
+      this.props.fullscreen !== props.fullscreen ||
+      this.props.frameHeight !== props.frameHeight
+    ) {
+      this.setState({ shouldResize: true })
     } else {
-      this.setState({shouldResize: false})
+      this.setState({ shouldResize: false })
     }
   }
 
@@ -126,10 +170,20 @@ export class GraphComponent extends Component {
     if (this.props.fullscreen) {
       return (
         <StyledZoomHolder>
-          <StyledZoomButton className={this.state.zoomInLimitReached ? 'faded zoom-in' : 'zoom-in'} onClick={this.zoomInClicked.bind(this)}>
+          <StyledZoomButton
+            className={
+              this.state.zoomInLimitReached ? 'faded zoom-in' : 'zoom-in'
+            }
+            onClick={this.zoomInClicked.bind(this)}
+          >
             <ZoomInIcon />
           </StyledZoomButton>
-          <StyledZoomButton className={this.state.zoomOutLimitReached ? 'faded zoom-out' : 'zoom-out'} onClick={this.zoomOutlicked.bind(this)}>
+          <StyledZoomButton
+            className={
+              this.state.zoomOutLimitReached ? 'faded zoom-out' : 'zoom-out'
+            }
+            onClick={this.zoomOutlicked.bind(this)}
+          >
             <ZoomOutIcon />
           </StyledZoomButton>
         </StyledZoomHolder>

--- a/src/browser/modules/D3Visualization/components/GrassEditor.jsx
+++ b/src/browser/modules/D3Visualization/components/GrassEditor.jsx
@@ -21,7 +21,16 @@
 import { Component } from 'preact'
 import { connect } from 'preact-redux'
 import neoGraphStyle from '../graphStyle'
-import {StyledPickerSelector, StyledTokenRelationshipType, StyledInlineList, StyledInlineListItem, StyledLabelToken, StyledPickerListItem, StyledCircleSelector, StyledCaptionSelector} from './styled'
+import {
+  StyledPickerSelector,
+  StyledTokenRelationshipType,
+  StyledInlineList,
+  StyledInlineListItem,
+  StyledLabelToken,
+  StyledPickerListItem,
+  StyledCircleSelector,
+  StyledCaptionSelector
+} from './styled'
 import * as actions from 'shared/modules/grass/grassDuck'
 
 export class GrassEditorComponent extends Component {
@@ -50,7 +59,16 @@ export class GrassEditorComponent extends Component {
     this.props.update(this.graphStyle.toSheet())
   }
 
-  circleSelector (styleProps, styleProvider, activeProvider, className, selector, textProvider = () => { return '' }) {
+  circleSelector (
+    styleProps,
+    styleProvider,
+    activeProvider,
+    className,
+    selector,
+    textProvider = () => {
+      return ''
+    }
+  ) {
     return styleProps.map((styleProp, i) => {
       const onClick = () => {
         this.updateStyle(selector, styleProp)
@@ -60,7 +78,13 @@ export class GrassEditorComponent extends Component {
       const active = activeProvider(styleProp)
       return (
         <StyledPickerListItem className={className} key={i}>
-          <StyledCircleSelector className={active ? 'active' : ''} style={style} onClick={onClick}>{text}</StyledCircleSelector>
+          <StyledCircleSelector
+            className={active ? 'active' : ''}
+            style={style}
+            onClick={onClick}
+          >
+            {text}
+          </StyledCircleSelector>
         </StyledPickerListItem>
       )
     })
@@ -71,7 +95,17 @@ export class GrassEditorComponent extends Component {
       <StyledInlineListItem key='color-picker'>
         <StyledInlineList className='color-picker picker'>
           <StyledInlineListItem>Color:</StyledInlineListItem>
-          {this.circleSelector(this.graphStyle.defaultColors(), (color) => { return {'backgroundColor': color.color} }, (color) => { return color.color === styleForLabel.get('color') }, 'color-picker-item', selector)}
+          {this.circleSelector(
+            this.graphStyle.defaultColors(),
+            color => {
+              return { backgroundColor: color.color }
+            },
+            color => {
+              return color.color === styleForLabel.get('color')
+            },
+            'color-picker-item',
+            selector
+          )}
         </StyledInlineList>
       </StyledInlineListItem>
     )
@@ -82,24 +116,47 @@ export class GrassEditorComponent extends Component {
       <StyledInlineListItem key='size-picker'>
         <StyledInlineList className='size-picker picker'>
           <StyledInlineListItem>Size:</StyledInlineListItem>
-          {this.circleSelector(this.graphStyle.defaultSizes(), (size, index) => { return { width: this.nodeDisplaySizes[index], height: this.nodeDisplaySizes[index] } }, (size) => { return this.sizeLessThan(size.diameter, styleForLabel.get('diameter')) }, 'size-picker-item', selector)}
+          {this.circleSelector(
+            this.graphStyle.defaultSizes(),
+            (size, index) => {
+              return {
+                width: this.nodeDisplaySizes[index],
+                height: this.nodeDisplaySizes[index]
+              }
+            },
+            size => {
+              return this.sizeLessThan(
+                size.diameter,
+                styleForLabel.get('diameter')
+              )
+            },
+            'size-picker-item',
+            selector
+          )}
         </StyledInlineList>
       </StyledInlineListItem>
     )
   }
   widthPicker (selector, styleForItem) {
-    let widthSelectors = this.graphStyle.defaultArrayWidths().map((widthValue, i) => {
-      const onClick = () => {
-        this.updateStyle(selector, widthValue)
-      }
-      const style = { width: this.widths[i] }
-      const active = styleForItem.get('shaft-width') === widthValue['shaft-width']
-      return (
-        <StyledPickerListItem className='width-picker-item' key={i}>
-          <StyledPickerSelector className={active ? 'active' : ''} style={style} onClick={onClick} />
-        </StyledPickerListItem>
-      )
-    })
+    let widthSelectors = this.graphStyle
+      .defaultArrayWidths()
+      .map((widthValue, i) => {
+        const onClick = () => {
+          this.updateStyle(selector, widthValue)
+        }
+        const style = { width: this.widths[i] }
+        const active =
+          styleForItem.get('shaft-width') === widthValue['shaft-width']
+        return (
+          <StyledPickerListItem className='width-picker-item' key={i}>
+            <StyledPickerSelector
+              className={active ? 'active' : ''}
+              style={style}
+              onClick={onClick}
+            />
+          </StyledPickerListItem>
+        )
+      })
     return (
       <StyledInlineListItem key='width-picker'>
         <StyledInlineList className='width-picker picker'>
@@ -115,13 +172,28 @@ export class GrassEditorComponent extends Component {
       <li key='icon-picker'>
         Icon:
         <ul className='icon-picker picker'>
-          {this.picker(this.graphStyle.defaultIconCodes(), (iconCode) => { return { 'fontFamily': 'streamline' } }, 'icon-picker-item', selector, (iconCode) => { return iconCode['icon-code'] })}
+          {this.picker(
+            this.graphStyle.defaultIconCodes(),
+            iconCode => {
+              return { fontFamily: 'streamline' }
+            },
+            'icon-picker-item',
+            selector,
+            iconCode => {
+              return iconCode['icon-code']
+            }
+          )}
         </ul>
       </li>
     )
   }
 
-  captionPicker (selector, styleForItem, propertyKeys, showTypeSelector = false) {
+  captionPicker (
+    selector,
+    styleForItem,
+    propertyKeys,
+    showTypeSelector = false
+  ) {
     let captionSelector = (displayCaption, captionToSave, key) => {
       const onClick = () => {
         this.updateStyle(selector, { caption: captionToSave })
@@ -129,7 +201,12 @@ export class GrassEditorComponent extends Component {
       let active = styleForItem.props.caption === captionToSave
       return (
         <StyledPickerListItem key={key}>
-          <StyledCaptionSelector className={active ? 'active' : ''} onClick={onClick}>{displayCaption}</StyledCaptionSelector>
+          <StyledCaptionSelector
+            className={active ? 'active' : ''}
+            onClick={onClick}
+          >
+            {displayCaption}
+          </StyledCaptionSelector>
         </StyledPickerListItem>
       )
     }
@@ -156,17 +233,57 @@ export class GrassEditorComponent extends Component {
     let pickers
     let title
     if (this.props.selectedLabel) {
-      const labelList = this.props.selectedLabel.label !== '*' ? [this.props.selectedLabel.label] : []
+      const labelList =
+        this.props.selectedLabel.label !== '*'
+          ? [this.props.selectedLabel.label]
+          : []
       const styleForLabel = this.graphStyle.forNode({ labels: labelList })
-      const inlineStyle = {'backgroundColor': styleForLabel.get('color'), 'color': styleForLabel.get('text-color-internal')}
-      pickers = [this.colorPicker(styleForLabel.selector, styleForLabel), this.sizePicker(styleForLabel.selector, styleForLabel), this.captionPicker(styleForLabel.selector, styleForLabel, this.props.selectedLabel.propertyKeys)]
-      title = (<StyledLabelToken className='token token-label' style={inlineStyle}>{this.props.selectedLabel.label || '*'}</StyledLabelToken>)
+      const inlineStyle = {
+        backgroundColor: styleForLabel.get('color'),
+        color: styleForLabel.get('text-color-internal')
+      }
+      pickers = [
+        this.colorPicker(styleForLabel.selector, styleForLabel),
+        this.sizePicker(styleForLabel.selector, styleForLabel),
+        this.captionPicker(
+          styleForLabel.selector,
+          styleForLabel,
+          this.props.selectedLabel.propertyKeys
+        )
+      ]
+      title = (
+        <StyledLabelToken className='token token-label' style={inlineStyle}>
+          {this.props.selectedLabel.label || '*'}
+        </StyledLabelToken>
+      )
     } else if (this.props.selectedRelType) {
-      const relTypeSelector = this.props.selectedRelType.relType !== '*' ? {type: this.props.selectedRelType.relType} : {}
+      const relTypeSelector =
+        this.props.selectedRelType.relType !== '*'
+          ? { type: this.props.selectedRelType.relType }
+          : {}
       const styleForRelType = this.graphStyle.forRelationship(relTypeSelector)
-      const inlineStyle = {'backgroundColor': styleForRelType.get('color'), 'color': styleForRelType.get('text-color-internal')}
-      pickers = [this.colorPicker(styleForRelType.selector, styleForRelType), this.widthPicker(styleForRelType.selector, styleForRelType), this.captionPicker(styleForRelType.selector, styleForRelType, this.props.selectedRelType.propertyKeys, true)]
-      title = (<StyledTokenRelationshipType className='token token-relationship' style={inlineStyle}>{this.props.selectedRelType.relType || '*'}</StyledTokenRelationshipType>)
+      const inlineStyle = {
+        backgroundColor: styleForRelType.get('color'),
+        color: styleForRelType.get('text-color-internal')
+      }
+      pickers = [
+        this.colorPicker(styleForRelType.selector, styleForRelType),
+        this.widthPicker(styleForRelType.selector, styleForRelType),
+        this.captionPicker(
+          styleForRelType.selector,
+          styleForRelType,
+          this.props.selectedRelType.propertyKeys,
+          true
+        )
+      ]
+      title = (
+        <StyledTokenRelationshipType
+          className='token token-relationship'
+          style={inlineStyle}
+        >
+          {this.props.selectedRelType.relType || '*'}
+        </StyledTokenRelationshipType>
+      )
     } else {
       return null
     }
@@ -179,7 +296,10 @@ export class GrassEditorComponent extends Component {
   }
 
   componentWillReceiveProps (nextProps) {
-    if (nextProps.graphStyleData && nextProps.graphStyleData !== this.props.graphStyleData) {
+    if (
+      nextProps.graphStyleData &&
+      nextProps.graphStyleData !== this.props.graphStyleData
+    ) {
       this.graphStyle.loadRules(nextProps.graphStyleData)
     }
   }
@@ -188,19 +308,21 @@ export class GrassEditorComponent extends Component {
     return this.stylePicker()
   }
 }
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     graphStyleData: actions.getGraphStyleData(state),
     meta: state.meta
   }
 }
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
-    update: (data) => {
+    update: data => {
       dispatch(actions.updateGraphStyleData(data))
     }
   }
 }
 
-export const GrassEditor = connect(mapStateToProps, mapDispatchToProps)(GrassEditorComponent)
+export const GrassEditor = connect(mapStateToProps, mapDispatchToProps)(
+  GrassEditorComponent
+)

--- a/src/browser/modules/D3Visualization/components/Inspector.jsx
+++ b/src/browser/modules/D3Visualization/components/Inspector.jsx
@@ -20,16 +20,34 @@
 
 import { Component } from 'preact'
 import { deepEquals } from 'services/utils'
-import {inspectorFooterContractedHeight, StyledInspectorFooterStatusMessage, StyledTokenContextMenuKey, StyledTokenRelationshipType, StyledLabelToken, StyledStatusBar, StyledStatus, StyledInspectorFooter, StyledInspectorFooterRow, StyledInspectorFooterRowListPair, StyledInspectorFooterRowListKey, StyledInspectorFooterRowListValue, StyledInlineList} from './styled'
-import {GrassEditor} from './GrassEditor'
-import {RowExpandToggleComponent} from './RowExpandToggle'
+import {
+  inspectorFooterContractedHeight,
+  StyledInspectorFooterStatusMessage,
+  StyledTokenContextMenuKey,
+  StyledTokenRelationshipType,
+  StyledLabelToken,
+  StyledStatusBar,
+  StyledStatus,
+  StyledInspectorFooter,
+  StyledInspectorFooterRow,
+  StyledInspectorFooterRowListPair,
+  StyledInspectorFooterRowListKey,
+  StyledInspectorFooterRowListValue,
+  StyledInlineList
+} from './styled'
+import { GrassEditor } from './GrassEditor'
+import { RowExpandToggleComponent } from './RowExpandToggle'
 
-const mapItemProperties = (itemProperties) => {
+const mapItemProperties = itemProperties => {
   return itemProperties.map((prop, i) => {
     return (
       <StyledInspectorFooterRowListPair className='pair' key={'prop' + i}>
-        <StyledInspectorFooterRowListKey className='key'>{prop.key + ': '}</StyledInspectorFooterRowListKey>
-        <StyledInspectorFooterRowListValue className='value'>{prop.value.toString()}</StyledInspectorFooterRowListValue>
+        <StyledInspectorFooterRowListKey className='key'>
+          {prop.key + ': '}
+        </StyledInspectorFooterRowListKey>
+        <StyledInspectorFooterRowListValue className='value'>
+          {prop.value.toString()}
+        </StyledInspectorFooterRowListValue>
       </StyledInspectorFooterRowListPair>
     )
   })
@@ -37,10 +55,19 @@ const mapItemProperties = (itemProperties) => {
 
 const mapLabels = (graphStyle, itemLabels) => {
   return itemLabels.map((label, i) => {
-    const graphStyleForLabel = graphStyle.forNode({labels: [label]})
-    const style = {'backgroundColor': graphStyleForLabel.get('color'), 'color': graphStyleForLabel.get('text-color-internal')}
+    const graphStyleForLabel = graphStyle.forNode({ labels: [label] })
+    const style = {
+      backgroundColor: graphStyleForLabel.get('color'),
+      color: graphStyleForLabel.get('text-color-internal')
+    }
     return (
-      <StyledLabelToken key={'label' + i} style={style} className={'token' + ' ' + 'token-label'}>{label}</StyledLabelToken>
+      <StyledLabelToken
+        key={'label' + i}
+        style={style}
+        className={'token' + ' ' + 'token-label'}
+      >
+        {label}
+      </StyledLabelToken>
     )
   })
 }
@@ -71,27 +98,42 @@ export class InspectorComponent extends Component {
     } else if (this.props.selectedItem) {
       item = this.props.selectedItem.item
       type = this.props.selectedItem.type
-    } else if (this.props.hoveredItem) { // Canvas
+    } else if (this.props.hoveredItem) {
+      // Canvas
       item = this.props.hoveredItem.item
       type = this.props.hoveredItem.type
     }
     if (item && type) {
       if (type === 'legend-item') {
         inspectorContent = (
-          <GrassEditor selectedLabel={item.selectedLabel} selectedRelType={item.selectedRelType} />
+          <GrassEditor
+            selectedLabel={item.selectedLabel}
+            selectedRelType={item.selectedRelType}
+          />
         )
       }
       if (type === 'status-item') {
         inspectorContent = (
-          <StyledInspectorFooterStatusMessage className='value'>{item}</StyledInspectorFooterStatusMessage>
+          <StyledInspectorFooterStatusMessage className='value'>
+            {item}
+          </StyledInspectorFooterStatusMessage>
         )
       }
       if (type === 'context-menu-item') {
         inspectorContent = (
           <StyledInlineList className='list-inline'>
-            <StyledTokenContextMenuKey key='token' className={'token' + ' ' + 'token-context-menu-key' + ' ' + 'token-label'}>{item.label}</StyledTokenContextMenuKey>
+            <StyledTokenContextMenuKey
+              key='token'
+              className={
+                'token' + ' ' + 'token-context-menu-key' + ' ' + 'token-label'
+              }
+            >
+              {item.label}
+            </StyledTokenContextMenuKey>
             <StyledInspectorFooterRowListPair key='pair' className='pair'>
-              <StyledInspectorFooterRowListValue className='value'>{item.content}</StyledInspectorFooterRowListValue>
+              <StyledInspectorFooterRowListValue className='value'>
+                {item.content}
+              </StyledInspectorFooterRowListValue>
             </StyledInspectorFooterRowListPair>
           </StyledInlineList>
         )
@@ -100,7 +142,9 @@ export class InspectorComponent extends Component {
         inspectorContent = (
           <StyledInlineList className='list-inline'>
             <StyledInspectorFooterRowListPair className='pair' key='pair'>
-              <StyledInspectorFooterRowListValue className='value'>{description}</StyledInspectorFooterRowListValue>
+              <StyledInspectorFooterRowListValue className='value'>
+                {description}
+              </StyledInspectorFooterRowListValue>
             </StyledInspectorFooterRowListPair>
           </StyledInlineList>
         )
@@ -109,20 +153,41 @@ export class InspectorComponent extends Component {
           <StyledInlineList className='list-inline'>
             {mapLabels(this.state.graphStyle, item.labels)}
             <StyledInspectorFooterRowListPair key='pair' className='pair'>
-              <StyledInspectorFooterRowListKey className='key'>{'<id>:'}</StyledInspectorFooterRowListKey>
-              <StyledInspectorFooterRowListValue className='value'>{item.id}</StyledInspectorFooterRowListValue>
+              <StyledInspectorFooterRowListKey className='key'>
+                {'<id>:'}
+              </StyledInspectorFooterRowListKey>
+              <StyledInspectorFooterRowListValue className='value'>
+                {item.id}
+              </StyledInspectorFooterRowListValue>
             </StyledInspectorFooterRowListPair>
             {mapItemProperties(item.properties)}
           </StyledInlineList>
         )
       } else if (type === 'relationship') {
-        const style = {'backgroundColor': this.state.graphStyle.forRelationship(item).get('color'), 'color': this.state.graphStyle.forRelationship(item).get('text-color-internal')}
+        const style = {
+          backgroundColor: this.state.graphStyle
+            .forRelationship(item)
+            .get('color'),
+          color: this.state.graphStyle
+            .forRelationship(item)
+            .get('text-color-internal')
+        }
         inspectorContent = (
           <StyledInlineList className='list-inline'>
-            <StyledTokenRelationshipType key='token' style={style} className={'token' + ' ' + 'token-relationship-type'}>{item.type}</StyledTokenRelationshipType>
+            <StyledTokenRelationshipType
+              key='token'
+              style={style}
+              className={'token' + ' ' + 'token-relationship-type'}
+            >
+              {item.type}
+            </StyledTokenRelationshipType>
             <StyledInspectorFooterRowListPair key='pair' className='pair'>
-              <StyledInspectorFooterRowListKey className='key'>{'<id>:'}</StyledInspectorFooterRowListKey>
-              <StyledInspectorFooterRowListValue className='value'>{item.id}</StyledInspectorFooterRowListValue>
+              <StyledInspectorFooterRowListKey className='key'>
+                {'<id>:'}
+              </StyledInspectorFooterRowListKey>
+              <StyledInspectorFooterRowListValue className='value'>
+                {item.id}
+              </StyledInspectorFooterRowListValue>
             </StyledInspectorFooterRowListPair>
             {mapItemProperties(item.properties)}
           </StyledInlineList>
@@ -131,11 +196,30 @@ export class InspectorComponent extends Component {
     }
 
     return (
-      <StyledStatusBar fullscreen={this.props.fullscreen} className='status-bar'>
+      <StyledStatusBar
+        fullscreen={this.props.fullscreen}
+        className='status-bar'
+      >
         <StyledStatus className='status'>
-          <StyledInspectorFooter className={this.state.contracted ? 'contracted inspector-footer' : 'inspector-footer'}>
-            <StyledInspectorFooterRow className='inspector-footer-row' ref={this.setFooterRowELem.bind(this)}>
-              { type === 'canvas' ? null : <RowExpandToggleComponent contracted={this.state.contracted} rowElem={this.footerRowElem} containerHeight={inspectorFooterContractedHeight} onClick={this.toggleExpand.bind(this)} /> }
+          <StyledInspectorFooter
+            className={
+              this.state.contracted
+                ? 'contracted inspector-footer'
+                : 'inspector-footer'
+            }
+          >
+            <StyledInspectorFooterRow
+              className='inspector-footer-row'
+              ref={this.setFooterRowELem.bind(this)}
+            >
+              {type === 'canvas'
+                ? null
+                : <RowExpandToggleComponent
+                  contracted={this.state.contracted}
+                  rowElem={this.footerRowElem}
+                  containerHeight={inspectorFooterContractedHeight}
+                  onClick={this.toggleExpand.bind(this)}
+                />}
               {inspectorContent}
             </StyledInspectorFooterRow>
           </StyledInspectorFooter>
@@ -147,7 +231,11 @@ export class InspectorComponent extends Component {
   toggleExpand () {
     this.setState({ contracted: !this.state.contracted }, () => {
       const inspectorHeight = this.footerRowElem.base.clientHeight
-      this.props.onExpandToggled && this.props.onExpandToggled(this.state.contracted, this.state.contracted ? 0 : inspectorHeight)
+      this.props.onExpandToggled &&
+        this.props.onExpandToggled(
+          this.state.contracted,
+          this.state.contracted ? 0 : inspectorHeight
+        )
     })
   }
   componentWillReceiveProps (nextProps) {

--- a/src/browser/modules/D3Visualization/components/Legend.jsx
+++ b/src/browser/modules/D3Visualization/components/Legend.jsx
@@ -18,9 +18,19 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {Component} from 'preact'
-import {legendRowHeight, StyledLegendRow, StyledTokenRelationshipType, StyledLegendInlineListItem, StyledLegend, StyledLegendContents, StyledLabelToken, StyledTokenCount, StyledLegendInlineList} from './styled'
-import {RowExpandToggleComponent} from './RowExpandToggle'
+import { Component } from 'preact'
+import {
+  legendRowHeight,
+  StyledLegendRow,
+  StyledTokenRelationshipType,
+  StyledLegendInlineListItem,
+  StyledLegend,
+  StyledLegendContents,
+  StyledLabelToken,
+  StyledTokenCount,
+  StyledLegendInlineList
+} from './styled'
+import { RowExpandToggleComponent } from './RowExpandToggle'
 
 export class LegendComponent extends Component {
   constructor (props) {
@@ -41,54 +51,113 @@ export class LegendComponent extends Component {
     }
   }
   render () {
-    const mapLabels = (labels) => {
+    const mapLabels = labels => {
       const labelList = Object.keys(labels).map((legendItemKey, i) => {
-        const styleForItem = this.props.graphStyle.forNode({labels: [legendItemKey]})
-        const onClick = () => { this.props.onSelectedLabel(legendItemKey, Object.keys(labels[legendItemKey].properties)) }
-        const style = {'backgroundColor': styleForItem.get('color'), 'color': styleForItem.get('text-color-internal')}
+        const styleForItem = this.props.graphStyle.forNode({
+          labels: [legendItemKey]
+        })
+        const onClick = () => {
+          this.props.onSelectedLabel(
+            legendItemKey,
+            Object.keys(labels[legendItemKey].properties)
+          )
+        }
+        const style = {
+          backgroundColor: styleForItem.get('color'),
+          color: styleForItem.get('text-color-internal')
+        }
         return (
           <StyledLegendInlineListItem key={i}>
             <StyledLegendContents className='contents'>
-              <StyledLabelToken onClick={onClick} style={style} className='token token-label'>
+              <StyledLabelToken
+                onClick={onClick}
+                style={style}
+                className='token token-label'
+              >
                 {legendItemKey}
-                <StyledTokenCount className='count'>{`(${labels[legendItemKey].count})`}</StyledTokenCount>
+                <StyledTokenCount className='count'>{`(${labels[legendItemKey]
+                  .count})`}</StyledTokenCount>
               </StyledLabelToken>
             </StyledLegendContents>
           </StyledLegendInlineListItem>
         )
       })
       return (
-        <StyledLegendRow className={this.state.labelRowContracted ? 'contracted' : ''}>
-          <StyledLegendInlineList className='list-inline' ref={this.setLabelRowELem.bind(this)}>
-            <RowExpandToggleComponent contracted={this.state.labelRowContracted} rowElem={this.state.labelRowELem} containerHeight={legendRowHeight} onClick={() => { this.setState({ labelRowContracted: !this.state.labelRowContracted }) }} />
+        <StyledLegendRow
+          className={this.state.labelRowContracted ? 'contracted' : ''}
+        >
+          <StyledLegendInlineList
+            className='list-inline'
+            ref={this.setLabelRowELem.bind(this)}
+          >
+            <RowExpandToggleComponent
+              contracted={this.state.labelRowContracted}
+              rowElem={this.state.labelRowELem}
+              containerHeight={legendRowHeight}
+              onClick={() => {
+                this.setState({
+                  labelRowContracted: !this.state.labelRowContracted
+                })
+              }}
+            />
             {labelList}
           </StyledLegendInlineList>
         </StyledLegendRow>
       )
     }
-    const mapRelTypes = (legendItems) => {
+    const mapRelTypes = legendItems => {
       if (!legendItems || !Object.keys(legendItems).length) {
         return null
       }
       const relTypeList = Object.keys(legendItems).map((legendItemKey, i) => {
-        const styleForItem = this.props.graphStyle.forRelationship({type: legendItemKey})
-        const onClick = () => { this.props.onSelectedRelType(legendItemKey, Object.keys(legendItems[legendItemKey].properties)) }
-        const style = {'backgroundColor': styleForItem.get('color'), 'color': styleForItem.get('text-color-internal')}
+        const styleForItem = this.props.graphStyle.forRelationship({
+          type: legendItemKey
+        })
+        const onClick = () => {
+          this.props.onSelectedRelType(
+            legendItemKey,
+            Object.keys(legendItems[legendItemKey].properties)
+          )
+        }
+        const style = {
+          backgroundColor: styleForItem.get('color'),
+          color: styleForItem.get('text-color-internal')
+        }
         return (
           <StyledLegendInlineListItem key={i}>
             <StyledLegendContents className='contents'>
-              <StyledTokenRelationshipType onClick={onClick} style={style} className='token token-relationship-type'>
+              <StyledTokenRelationshipType
+                onClick={onClick}
+                style={style}
+                className='token token-relationship-type'
+              >
                 {legendItemKey}
-                <StyledTokenCount className='count'>{`(${legendItems[legendItemKey].count})`}</StyledTokenCount>
+                <StyledTokenCount className='count'>
+                  {`(${legendItems[legendItemKey].count})`}
+                </StyledTokenCount>
               </StyledTokenRelationshipType>
             </StyledLegendContents>
           </StyledLegendInlineListItem>
         )
       })
       return (
-        <StyledLegendRow className={this.state.typeRowContracted ? 'contracted' : ''}>
-          <StyledLegendInlineList className='list-inline' ref={this.setTypeRowELem.bind(this)}>
-            <RowExpandToggleComponent contracted={this.state.typeRowContracted} rowElem={this.state.typeRowElem} containerHeight={legendRowHeight} onClick={() => { this.setState({ typeRowContracted: !this.state.typeRowContracted }) }} />
+        <StyledLegendRow
+          className={this.state.typeRowContracted ? 'contracted' : ''}
+        >
+          <StyledLegendInlineList
+            className='list-inline'
+            ref={this.setTypeRowELem.bind(this)}
+          >
+            <RowExpandToggleComponent
+              contracted={this.state.typeRowContracted}
+              rowElem={this.state.typeRowElem}
+              containerHeight={legendRowHeight}
+              onClick={() => {
+                this.setState({
+                  typeRowContracted: !this.state.typeRowContracted
+                })
+              }}
+            />
             {relTypeList}
           </StyledLegendInlineList>
         </StyledLegendRow>
@@ -100,7 +169,6 @@ export class LegendComponent extends Component {
         {mapLabels(this.props.stats.labels)}
         {relTypes}
       </StyledLegend>
-
     )
   }
 }

--- a/src/browser/modules/D3Visualization/components/RowExpandToggle.jsx
+++ b/src/browser/modules/D3Visualization/components/RowExpandToggle.jsx
@@ -21,11 +21,12 @@
 import { Component } from 'preact'
 import { StyledRowToggle, StyledCaret } from './styled'
 
-const getHeightFromElem = (rowElem) => (rowElem && rowElem.base) ? rowElem.base.clientHeight : 0
+const getHeightFromElem = rowElem =>
+  rowElem && rowElem.base ? rowElem.base.clientHeight : 0
 
 export class RowExpandToggleComponent extends Component {
   updateDimensions () {
-    this.setState({rowHeight: getHeightFromElem(this.props.rowElem)})
+    this.setState({ rowHeight: getHeightFromElem(this.props.rowElem) })
   }
 
   componentDidMount () {
@@ -47,7 +48,11 @@ export class RowExpandToggleComponent extends Component {
     if (this.props.containerHeight * 1.1 < this.state.rowHeight) {
       return (
         <StyledRowToggle onClick={this.props.onClick}>
-          <StyledCaret className={this.props.contracted ? 'fa fa-caret-left' : 'fa fa-caret-down'} />
+          <StyledCaret
+            className={
+              this.props.contracted ? 'fa fa-caret-left' : 'fa fa-caret-down'
+            }
+          />
         </StyledRowToggle>
       )
     } else {

--- a/src/browser/modules/D3Visualization/components/styled.jsx
+++ b/src/browser/modules/D3Visualization/components/styled.jsx
@@ -194,7 +194,7 @@ export const StyledStatusBarWrapper = styled.div`
 `
 export const StyledStatusBar = styled.div`
   min-height: 39px;
-  line-height:  39px;
+  line-height: 39px;
   color: ${props => props.theme.secondaryText};
   font-size: 13px;
   position: relative;
@@ -202,7 +202,8 @@ export const StyledStatusBar = styled.div`
   white-space: nowrap;
   overflow: hidden;
   border-top: 1px solid #e6e9ef;
-  ${props => props.fullscreen ? 'margin-top: -39px;' : 'margin-bottom: -39px;'};
+  ${props =>
+    props.fullscreen ? 'margin-top: -39px;' : 'margin-bottom: -39px;'};
 `
 
 export const StyledStatus = styled.div`
@@ -251,9 +252,7 @@ export const StyledTokenContextMenuKey = styled(StyledLabelToken)`
   padding: 4px 9px;
 `
 
-export const StyledTokenCount = styled.span`
-  font-weight: normal;
-`
+export const StyledTokenCount = styled.span`font-weight: normal;`
 export const StyledLegendContents = styled.div`
   float: left;
   line-height: 1em;
@@ -271,7 +270,7 @@ export const StyledLegendRow = styled.div`
 `
 export const StyledLegend = styled.div`
   background-color: ${props => props.theme.secondaryBackground};
-  margin-top: -${(legendRowHeight * 2) + 1}px;
+  margin-top: -${legendRowHeight * 2 + 1}px;
   &.one-row {
     margin-top: -${legendRowHeight}px;
   }
@@ -300,7 +299,7 @@ export const StyledPickerSelector = styled.a`
   cursor: pointer;
   opacity: 0.4;
   &:hover {
-   opacity: 1;
+    opacity: 1;
   }
   &.active {
     opacity: 1;
@@ -316,8 +315,8 @@ export const StyledCaptionSelector = styled.a`
   padding: 1px 6px;
   font-size: 12px;
   line-height: 1em;
-  color: #9195A0;
-  border: 1px solid #9195A0;
+  color: #9195a0;
+  border: 1px solid #9195a0;
   overflow: hidden;
   border-radius: .25em;
   margin-right: 0;
@@ -329,22 +328,23 @@ export const StyledCaptionSelector = styled.a`
   }
   &.active {
     color: white;
-    background-color: #9195A0;
+    background-color: #9195a0;
   }
 `
 
 export const StyledFullSizeContainer = styled.div`
   height: 100%;
-  padding-top: ${(legendRowHeight * 2) + 1}px;
-  padding-bottom: ${props => props.forcePaddingBottom ? (props.forcePaddingBottom + 2 * pMarginTop) + 'px' : '39px'};
+  padding-top: ${legendRowHeight * 2 + 1}px;
+  padding-bottom: ${props =>
+    props.forcePaddingBottom
+      ? props.forcePaddingBottom + 2 * pMarginTop + 'px'
+      : '39px'};
   &.one-legend-row {
     padding-top: ${legendRowHeight}px;
   }
 `
 
-export const StyledInspectorFooterStatusMessage = styled.div`
-  font-weight: bold;
-`
+export const StyledInspectorFooterStatusMessage = styled.div`font-weight: bold;`
 
 export const StyledZoomHolder = styled.div`
   position: absolute;
@@ -367,16 +367,16 @@ export const StyledZoomButton = styled.button`
   border-color: black;
   padding: 2px 6px 3px;
   &:hover {
-   color:black;
+    color: black;
   }
   &:focus {
     outline: none;
   }
   &.faded {
-   opacity: .3;
-   cursor: auto;
-   &:hover {
-     color: #9b9da2;
-   }
+    opacity: .3;
+    cursor: auto;
+    &:hover {
+      color: #9b9da2;
+    }
   }
 `

--- a/src/browser/modules/D3Visualization/graphStyle.js
+++ b/src/browser/modules/D3Visualization/graphStyle.js
@@ -20,70 +20,87 @@
 
 export default function neoGraphStyle () {
   const defaultStyle = {
-    'node': {
-      'diameter': '50px',
-      'color': '#A5ABB6',
+    node: {
+      diameter: '50px',
+      color: '#A5ABB6',
       'border-color': '#9AA1AC',
       'border-width': '2px',
       'text-color-internal': '#FFFFFF',
       'font-size': '10px'
     },
-    'relationship': {
-      'color': '#A5ABB6',
+    relationship: {
+      color: '#A5ABB6',
       'shaft-width': '1px',
       'font-size': '8px',
-      'padding': '3px',
+      padding: '3px',
       'text-color-external': '#000000',
       'text-color-internal': '#FFFFFF',
-      'caption': '<type>'
+      caption: '<type>'
     }
   }
   const defaultSizes = [
     {
       diameter: '10px'
-    }, {
+    },
+    {
       diameter: '20px'
-    }, {
+    },
+    {
       diameter: '50px'
-    }, {
+    },
+    {
       diameter: '65px'
-    }, {
+    },
+    {
       diameter: '80px'
     }
   ]
   const defaultIconCodes = [
     {
       'icon-code': 'a'
-    }, {
+    },
+    {
       'icon-code': '"'
-    }, {
+    },
+    {
       'icon-code': 'z'
-    }, {
+    },
+    {
       'icon-code': '_'
-    }, {
+    },
+    {
       'icon-code': '/'
-    }, {
+    },
+    {
       'icon-code': '>'
-    }, {
+    },
+    {
       'icon-code': 'k'
     }
   ]
   const defaultArrayWidths = [
     {
       'shaft-width': '1px'
-    }, {
+    },
+    {
       'shaft-width': '2px'
-    }, {
+    },
+    {
       'shaft-width': '3px'
-    }, {
+    },
+    {
       'shaft-width': '5px'
-    }, {
+    },
+    {
       'shaft-width': '8px'
-    }, {
+    },
+    {
       'shaft-width': '13px'
-    }, {
+    },
+    {
       'shaft-width': '25px'
-    }, {
+    },
+    {
       'shaft-width': '38px'
     }
   ]
@@ -92,27 +109,33 @@ export default function neoGraphStyle () {
       color: '#A5ABB6',
       'border-color': '#9AA1AC',
       'text-color-internal': '#FFFFFF'
-    }, {
+    },
+    {
       color: '#68BDF6',
       'border-color': '#5CA8DB',
       'text-color-internal': '#FFFFFF'
-    }, {
+    },
+    {
       color: '#6DCE9E',
       'border-color': '#60B58B',
       'text-color-internal': '#FFFFFF'
-    }, {
+    },
+    {
       color: '#FF756E',
       'border-color': '#E06760',
       'text-color-internal': '#FFFFFF'
-    }, {
+    },
+    {
       color: '#DE9BF9',
       'border-color': '#BF85D6',
       'text-color-internal': '#FFFFFF'
-    }, {
+    },
+    {
       color: '#FB95AF',
       'border-color': '#E0849B',
       'text-color-internal': '#FFFFFF'
-    }, {
+    },
+    {
       color: '#FFD86E',
       'border-color': '#EDBA39',
       'text-color-internal': '#604A0E'
@@ -150,7 +173,7 @@ export default function neoGraphStyle () {
       }
       for (let i = 0; i < this.selector.classes.length; i++) {
         const classs = this.selector.classes[i]
-        if ((classs != null) && selector.classes.indexOf(classs) === -1) {
+        if (classs != null && selector.classes.indexOf(classs) === -1) {
           return false
         }
       }
@@ -158,7 +181,10 @@ export default function neoGraphStyle () {
     }
 
     StyleRule.prototype.matchesExact = function (selector) {
-      return this.matches(selector) && this.selector.classes.length === selector.classes.length
+      return (
+        this.matches(selector) &&
+        this.selector.classes.length === selector.classes.length
+      )
     }
 
     return StyleRule
@@ -174,7 +200,7 @@ export default function neoGraphStyle () {
       for (let i = 0; i < rules.length; i++) {
         const rule = rules[i]
         if (rule.matches(this.selector)) {
-          this.props = {...this.props, ...rule.props}
+          this.props = { ...this.props, ...rule.props }
           this.props.caption = this.props.caption || this.props.defaultCaption
         }
       }
@@ -233,21 +259,39 @@ export default function neoGraphStyle () {
     }
 
     const findAvailableDefaultColor = function (rules) {
-      const usedColors = rules.filter((rule) => { return rule.props.color != null }).map((rule) => {
-        return rule.props.color
-      })
-      let index = usedColors.length - 1 > defaultColors ? 0 : usedColors.length - 1
+      const usedColors = rules
+        .filter(rule => {
+          return rule.props.color != null
+        })
+        .map(rule => {
+          return rule.props.color
+        })
+      let index =
+        usedColors.length - 1 > defaultColors ? 0 : usedColors.length - 1
       return defaultColors[index]
     }
 
     const getDefaultNodeCaption = function (item) {
-      if (!item || !(item.propertyList != null ? item.propertyList.length : 0) > 0) {
+      if (
+        !item ||
+        !(item.propertyList != null ? item.propertyList.length : 0) > 0
+      ) {
         return {
           defaultCaption: '<id>'
         }
       }
-      const captionPrioOrder = [/^name$/i, /^title$/i, /^label$/i, /name$/i, /description$/i, /^.+/]
-      let defaultCaption = captionPrioOrder.reduceRight(function (leading, current) {
+      const captionPrioOrder = [
+        /^name$/i,
+        /^title$/i,
+        /^label$/i,
+        /name$/i,
+        /description$/i,
+        /^.+/
+      ]
+      let defaultCaption = captionPrioOrder.reduceRight(function (
+        leading,
+        current
+      ) {
         let hits = item.propertyList.filter(function (prop) {
           return current.test(prop.key)
         })
@@ -285,12 +329,21 @@ export default function neoGraphStyle () {
           }
         }
       }
-      const minimalSelector = new Selector(selector.tag, selector.classes.sort().slice(0, 1))
+      const minimalSelector = new Selector(
+        selector.tag,
+        selector.classes.sort().slice(0, 1)
+      )
       if (defaultColor) {
-        this.changeForSelector(minimalSelector, findAvailableDefaultColor(this.rules))
+        this.changeForSelector(
+          minimalSelector,
+          findAvailableDefaultColor(this.rules)
+        )
       }
       if (defaultCaption) {
-        return this.changeForSelector(minimalSelector, getDefaultNodeCaption(item))
+        return this.changeForSelector(
+          minimalSelector,
+          getDefaultNodeCaption(item)
+        )
       }
     }
 
@@ -300,7 +353,7 @@ export default function neoGraphStyle () {
         rule = new StyleRule(selector, props)
         this.rules.push(rule)
       }
-      rule.props = {...rule.props, ...props}
+      rule.props = { ...rule.props, ...props }
       return rule
     }
 
@@ -349,7 +402,6 @@ export default function neoGraphStyle () {
             }
             break
           case "'":
-          case '\'':
             insideString ^= true
             break
           default:
@@ -369,7 +421,7 @@ export default function neoGraphStyle () {
       for (let k in rules) {
         const v = rules[k]
         rules[k] = {}
-        v.split(';').forEach((prop) => {
+        v.split(';').forEach(prop => {
           const [key, val] = prop.split(':')
           if (key && val) {
             rules[k][key.trim()] = val.trim()
@@ -386,7 +438,7 @@ export default function neoGraphStyle () {
 
     GraphStyle.prototype.toSheet = function () {
       let sheet = {}
-      this.rules.forEach((rule) => {
+      this.rules.forEach(rule => {
         sheet[rule.selector.toString()] = rule.props
       })
       return sheet
@@ -394,7 +446,7 @@ export default function neoGraphStyle () {
 
     GraphStyle.prototype.toString = function () {
       let str = ''
-      this.rules.forEach((r) => {
+      this.rules.forEach(r => {
         str += r.selector.toString() + ' {\n'
         for (let k in r.props) {
           let v = r.props[k]

--- a/src/browser/modules/D3Visualization/mapper.js
+++ b/src/browser/modules/D3Visualization/mapper.js
@@ -27,22 +27,30 @@ export function createGraph (nodes, relationships) {
 }
 
 export function mapNodes (nodes) {
-  return nodes.map((node) => new neo.models.Node(node.id, node.labels, node.properties))
+  return nodes.map(
+    node => new neo.models.Node(node.id, node.labels, node.properties)
+  )
 }
 
 export function mapRelationships (relationships, graph) {
-  return relationships.map((rel) => {
+  return relationships.map(rel => {
     const source = graph.findNode(rel.startNodeId)
     const target = graph.findNode(rel.endNodeId)
-    return new neo.models.Relationship(rel.id, source, target, rel.type, rel.properties)
+    return new neo.models.Relationship(
+      rel.id,
+      source,
+      target,
+      rel.type,
+      rel.properties
+    )
   })
 }
 
 export function getGraphStats (graph) {
   let labelStats = {}
   let relTypeStats = {}
-  graph.nodes().forEach((node) => {
-    node.labels.forEach((label) => {
+  graph.nodes().forEach(node => {
+    node.labels.forEach(label => {
       if (labelStats['*']) {
         labelStats['*'].count = labelStats['*'].count + 1
       } else {
@@ -53,7 +61,11 @@ export function getGraphStats (graph) {
       }
       if (labelStats[label]) {
         labelStats[label].count = labelStats[label].count + 1
-        labelStats[label].properties = Object.assign({}, labelStats[label].properties, node.propertyMap)
+        labelStats[label].properties = Object.assign(
+          {},
+          labelStats[label].properties,
+          node.propertyMap
+        )
       } else {
         labelStats[label] = {
           count: 1,
@@ -62,7 +74,7 @@ export function getGraphStats (graph) {
       }
     })
   })
-  graph.relationships().forEach((rel) => {
+  graph.relationships().forEach(rel => {
     if (relTypeStats['*']) {
       relTypeStats['*'].count = relTypeStats['*'].count + 1
     } else {
@@ -73,7 +85,11 @@ export function getGraphStats (graph) {
     }
     if (relTypeStats[rel.type]) {
       relTypeStats[rel.type].count = relTypeStats[rel.type].count + 1
-      relTypeStats[rel.type].properties = Object.assign({}, relTypeStats[rel.type].properties, rel.propertyMap)
+      relTypeStats[rel.type].properties = Object.assign(
+        {},
+        relTypeStats[rel.type].properties,
+        rel.propertyMap
+      )
     } else {
       relTypeStats[rel.type] = {
         count: 1,
@@ -81,5 +97,5 @@ export function getGraphStats (graph) {
       }
     }
   })
-  return {labels: labelStats, relTypes: relTypeStats}
+  return { labels: labelStats, relTypes: relTypeStats }
 }

--- a/src/browser/modules/DatabaseInfo/DatabaseInfo.jsx
+++ b/src/browser/modules/DatabaseInfo/DatabaseInfo.jsx
@@ -25,7 +25,7 @@ import { executeCommand } from 'shared/modules/commands/commandsDuck'
 import { LabelItems, RelationshipItems, PropertyItems } from './MetaItems'
 import UserDetails from './UserDetails'
 import DatabaseKernelInfo from './DatabaseKernelInfo'
-import {Drawer, DrawerBody, DrawerHeader} from 'browser-components/drawer'
+import { Drawer, DrawerBody, DrawerHeader } from 'browser-components/drawer'
 
 export class DatabaseInfo extends Component {
   constructor (props) {
@@ -38,7 +38,7 @@ export class DatabaseInfo extends Component {
     }
   }
   onMoreClick (type) {
-    return (num) => {
+    return num => {
       this.setState({ [type + 'Max']: this.state[type + 'Max'] + num })
     }
   }
@@ -57,44 +57,53 @@ export class DatabaseInfo extends Component {
         <DrawerHeader>Database Information</DrawerHeader>
         <DrawerBody>
           <LabelItems
-            labels={labels.slice(0, this.state.labelsMax).map((l) => l.val)}
+            labels={labels.slice(0, this.state.labelsMax).map(l => l.val)}
             totalNumItems={labels.length}
             onItemClick={onItemClick}
             onMoreClick={this.onMoreClick.bind(this)('labels')}
             moreStep={this.state.moreStep}
           />
           <RelationshipItems
-            relationshipTypes={relationshipTypes.slice(0, this.state.relationshipsMax).map((l) => l.val)}
+            relationshipTypes={relationshipTypes
+              .slice(0, this.state.relationshipsMax)
+              .map(l => l.val)}
             onItemClick={onItemClick}
             totalNumItems={relationshipTypes.length}
             onMoreClick={this.onMoreClick.bind(this)('relationships')}
             moreStep={this.state.moreStep}
           />
           <PropertyItems
-            properties={properties.slice(0, this.state.propertiesMax).map((l) => l.val)}
+            properties={properties
+              .slice(0, this.state.propertiesMax)
+              .map(l => l.val)}
             onItemClick={onItemClick}
             totalNumItems={properties.length}
             onMoreClick={this.onMoreClick.bind(this)('properties')}
             moreStep={this.state.moreStep}
           />
           <UserDetails userDetails={userDetails} onItemClick={onItemClick} />
-          <DatabaseKernelInfo databaseKernelInfo={databaseKernelInfo} onItemClick={onItemClick} />
+          <DatabaseKernelInfo
+            databaseKernelInfo={databaseKernelInfo}
+            onItemClick={onItemClick}
+          />
         </DrawerBody>
       </Drawer>
     )
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return state.meta || {}
 }
 const mapDispatchToProps = (_, ownProps) => {
   return {
-    onItemClick: (cmd) => {
+    onItemClick: cmd => {
       const action = executeCommand(cmd)
       ownProps.bus.send(action.type, action)
     }
   }
 }
 
-export default withBus(connect(mapStateToProps, mapDispatchToProps)(DatabaseInfo))
+export default withBus(
+  connect(mapStateToProps, mapDispatchToProps)(DatabaseInfo)
+)

--- a/src/browser/modules/DatabaseInfo/DatabaseInfo.test.jsx
+++ b/src/browser/modules/DatabaseInfo/DatabaseInfo.test.jsx
@@ -45,48 +45,72 @@ describe('DatabaseInfo', () => {
       expect(wrapper.find('.token-label').length).toBe(0)
     })
     test('should show labels when there are labels', () => {
-      const labels = [{val: 'Person'}, {val: 'Movie'}]
+      const labels = [{ val: 'Person' }, { val: 'Movie' }]
       const wrapper = mount(<DatabaseInfoComponent labels={labels} />)
       expect(wrapper.find('.token-label').length).toBe(3)
       expect(wrapper.find('.token-label').first().text()).toEqual('*')
     })
     test('should call on click callback with correct cypher * label is clicked', () => {
-      const labels = [{val: 'Person'}]
-      const wrapper = mount(<DatabaseInfoComponent labels={labels} onItemClick={onItemClick} />)
+      const labels = [{ val: 'Person' }]
+      const wrapper = mount(
+        <DatabaseInfoComponent labels={labels} onItemClick={onItemClick} />
+      )
       simulateEvent(wrapper.find('.token-label').first(), 'click')
       expect(onItemClick).toHaveBeenCalledWith('MATCH (n) RETURN n LIMIT 25')
     })
     test('should call on click callback with correct cypher when a non * label is clicked', () => {
-      const labels = [{val: 'Person'}]
-      const wrapper = mount(<DatabaseInfoComponent labels={labels} onItemClick={onItemClick} />)
+      const labels = [{ val: 'Person' }]
+      const wrapper = mount(
+        <DatabaseInfoComponent labels={labels} onItemClick={onItemClick} />
+      )
       simulateEvent(wrapper.find('.token-label').last(), 'click')
-      expect(onItemClick).toHaveBeenCalledWith('MATCH (n:Person) RETURN n LIMIT 25')
+      expect(onItemClick).toHaveBeenCalledWith(
+        'MATCH (n:Person) RETURN n LIMIT 25'
+      )
     })
   })
 
   describe('relationshipTypes', () => {
     test('should not show relationshipTypes when there are no relationshipTypes', () => {
       const relationshipTypes = []
-      const wrapper = mount(<DatabaseInfoComponent relationshipTypes={relationshipTypes} />)
+      const wrapper = mount(
+        <DatabaseInfoComponent relationshipTypes={relationshipTypes} />
+      )
       expect(wrapper.find('.token-relationship').length).toBe(0)
     })
     test('should show relationshipTypes when there are relationshipTypes', () => {
-      const relationshipTypes = [{val: 'lives'}, {val: 'knows'}]
-      const wrapper = mount(<DatabaseInfoComponent relationshipTypes={relationshipTypes} />)
+      const relationshipTypes = [{ val: 'lives' }, { val: 'knows' }]
+      const wrapper = mount(
+        <DatabaseInfoComponent relationshipTypes={relationshipTypes} />
+      )
       expect(wrapper.find('.token-relationship').length).toBe(3)
       expect(wrapper.find('.token-relationship').first().text()).toEqual('*')
     })
     test('should call on click callback with correct cypher when * relationship is clicked', () => {
-      const relationshipTypes = [{val: 'DIRECTED'}]
-      const wrapper = mount(<DatabaseInfoComponent relationshipTypes={relationshipTypes} onItemClick={onItemClick} />)
+      const relationshipTypes = [{ val: 'DIRECTED' }]
+      const wrapper = mount(
+        <DatabaseInfoComponent
+          relationshipTypes={relationshipTypes}
+          onItemClick={onItemClick}
+        />
+      )
       simulateEvent(wrapper.find('.token-relationship').first(), 'click')
-      expect(onItemClick).toHaveBeenCalledWith('MATCH p=()-->() RETURN p LIMIT 25')
+      expect(onItemClick).toHaveBeenCalledWith(
+        'MATCH p=()-->() RETURN p LIMIT 25'
+      )
     })
     test('should call on click callback with correct cypher when a non * relationship is clicked', () => {
-      const relationshipTypes = [{val: 'DIRECTED'}]
-      const wrapper = mount(<DatabaseInfoComponent relationshipTypes={relationshipTypes} onItemClick={onItemClick} />)
+      const relationshipTypes = [{ val: 'DIRECTED' }]
+      const wrapper = mount(
+        <DatabaseInfoComponent
+          relationshipTypes={relationshipTypes}
+          onItemClick={onItemClick}
+        />
+      )
       simulateEvent(wrapper.find('.token-relationship').last(), 'click')
-      expect(onItemClick).toHaveBeenCalledWith('MATCH p=()-[r:DIRECTED]->() RETURN p LIMIT 25')
+      expect(onItemClick).toHaveBeenCalledWith(
+        'MATCH p=()-[r:DIRECTED]->() RETURN p LIMIT 25'
+      )
     })
   })
 
@@ -97,16 +121,23 @@ describe('DatabaseInfo', () => {
       expect(wrapper.find('.token-property').length).toBe(0)
     })
     test('should show properties when there are properties', () => {
-      const properties = [{val: 'born'}, {val: 'name'}]
+      const properties = [{ val: 'born' }, { val: 'name' }]
       const wrapper = mount(<DatabaseInfoComponent properties={properties} />)
       expect(wrapper.find('.token-property').length).toBe(2)
       expect(wrapper.find('.token-property').first().text()).toEqual('born')
     })
     test('should call on click callback with correct cypher when property is clicked', () => {
-      const properties = [{val: 'born'}]
-      const wrapper = mount(<DatabaseInfoComponent properties={properties} onItemClick={onItemClick} />)
+      const properties = [{ val: 'born' }]
+      const wrapper = mount(
+        <DatabaseInfoComponent
+          properties={properties}
+          onItemClick={onItemClick}
+        />
+      )
       simulateEvent(wrapper.find('.token-property').first(), 'click')
-      expect(onItemClick).toHaveBeenCalledWith('MATCH (n) WHERE EXISTS(n.born) RETURN DISTINCT "node" as element, n.born AS born LIMIT 25 UNION ALL MATCH ()-[r]-() WHERE EXISTS(r.born) RETURN DISTINCT "relationship" AS element, r.born AS born LIMIT 25')
+      expect(onItemClick).toHaveBeenCalledWith(
+        'MATCH (n) WHERE EXISTS(n.born) RETURN DISTINCT "node" as element, n.born AS born LIMIT 25 UNION ALL MATCH ()-[r]-() WHERE EXISTS(r.born) RETURN DISTINCT "relationship" AS element, r.born AS born LIMIT 25'
+      )
     })
   })
 })

--- a/src/browser/modules/DatabaseInfo/DatabaseKernelInfo.jsx
+++ b/src/browser/modules/DatabaseInfo/DatabaseKernelInfo.jsx
@@ -20,15 +20,38 @@
 
 import { connect } from 'preact-redux'
 import { withBus } from 'preact-suber'
-import { getVersion, getEdition, getDbName, getStoreSize, getClusterRole } from 'shared/modules/dbMeta/dbMetaDuck'
+import {
+  getVersion,
+  getEdition,
+  getDbName,
+  getStoreSize,
+  getClusterRole
+} from 'shared/modules/dbMeta/dbMetaDuck'
 import { executeCommand } from 'shared/modules/commands/commandsDuck'
 import { toHumanReadableBytes } from 'services/utils'
 
 import Render from 'browser-components/Render'
-import {DrawerSection, DrawerSectionBody, DrawerSubHeader} from 'browser-components/drawer'
-import {StyledTable, StyledKey, StyledValue, StyledValueUCFirst, Link} from './styled'
+import {
+  DrawerSection,
+  DrawerSectionBody,
+  DrawerSubHeader
+} from 'browser-components/drawer'
+import {
+  StyledTable,
+  StyledKey,
+  StyledValue,
+  StyledValueUCFirst,
+  Link
+} from './styled'
 
-export const DatabaseKernelInfo = ({role, version, edition, dbName, storeSize, onItemClick}) => {
+export const DatabaseKernelInfo = ({
+  role,
+  version,
+  edition,
+  dbName,
+  storeSize,
+  onItemClick
+}) => {
   return (
     <DrawerSection className='database-kernel-info'>
       <DrawerSubHeader>Database</DrawerSubHeader>
@@ -37,34 +60,55 @@ export const DatabaseKernelInfo = ({role, version, edition, dbName, storeSize, o
           <tbody>
             <Render if={role}>
               <tr>
-                <StyledKey>Cluster role: </StyledKey><StyledValue>{role}</StyledValue>
+                <StyledKey>Cluster role: </StyledKey>
+                <StyledValue>
+                  {role}
+                </StyledValue>
               </tr>
             </Render>
             <Render if={version}>
               <tr>
-                <StyledKey>Version: </StyledKey><StyledValue>{version}</StyledValue>
+                <StyledKey>Version: </StyledKey>
+                <StyledValue>
+                  {version}
+                </StyledValue>
               </tr>
             </Render>
             <Render if={edition}>
               <tr>
-                <StyledKey>Edition: </StyledKey><StyledValueUCFirst>{edition}</StyledValueUCFirst>
+                <StyledKey>Edition: </StyledKey>
+                <StyledValueUCFirst>
+                  {edition}
+                </StyledValueUCFirst>
               </tr>
             </Render>
             <Render if={dbName}>
               <tr>
-                <StyledKey>Name: </StyledKey><StyledValue>{dbName}</StyledValue>
+                <StyledKey>Name: </StyledKey>
+                <StyledValue>
+                  {dbName}
+                </StyledValue>
               </tr>
             </Render>
             <Render if={storeSize}>
               <tr>
-                <StyledKey>Size: </StyledKey><StyledValue>{toHumanReadableBytes(storeSize)}</StyledValue>
+                <StyledKey>Size: </StyledKey>
+                <StyledValue>
+                  {toHumanReadableBytes(storeSize)}
+                </StyledValue>
               </tr>
             </Render>
             <tr>
-              <StyledKey>Information: </StyledKey><StyledValue><Link onClick={() => onItemClick(':sysinfo')}>:sysinfo</Link></StyledValue>
+              <StyledKey>Information: </StyledKey>
+              <StyledValue>
+                <Link onClick={() => onItemClick(':sysinfo')}>:sysinfo</Link>
+              </StyledValue>
             </tr>
             <tr>
-              <StyledKey>Query List: </StyledKey><StyledValue><Link onClick={() => onItemClick(':queries')}>:queries</Link></StyledValue>
+              <StyledKey>Query List: </StyledKey>
+              <StyledValue>
+                <Link onClick={() => onItemClick(':queries')}>:queries</Link>
+              </StyledValue>
             </tr>
           </tbody>
         </StyledTable>
@@ -73,7 +117,7 @@ export const DatabaseKernelInfo = ({role, version, edition, dbName, storeSize, o
   )
 }
 
-const mapStateToProps = (store) => {
+const mapStateToProps = store => {
   return {
     version: getVersion(store),
     edition: getEdition(store),
@@ -84,11 +128,13 @@ const mapStateToProps = (store) => {
 }
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    onItemClick: (cmd) => {
+    onItemClick: cmd => {
       const action = executeCommand(cmd)
       ownProps.bus.send(action.type, action)
     }
   }
 }
 
-export default withBus(connect(mapStateToProps, mapDispatchToProps)(DatabaseKernelInfo))
+export default withBus(
+  connect(mapStateToProps, mapDispatchToProps)(DatabaseKernelInfo)
+)

--- a/src/browser/modules/DatabaseInfo/DatabaseKernelInfo.test.jsx
+++ b/src/browser/modules/DatabaseInfo/DatabaseKernelInfo.test.jsx
@@ -26,7 +26,9 @@ import { shallow } from 'enzyme'
 describe('connected as', () => {
   test('should not show database kernal info if not connected', () => {
     const databaseKernelInfo = null
-    const wrapper = shallow(<DatabaseKernelInfo databaseKernelInfo={databaseKernelInfo} />)
+    const wrapper = shallow(
+      <DatabaseKernelInfo databaseKernelInfo={databaseKernelInfo} />
+    )
     expect(wrapper.find('.database-kernel-info').length).toBe(0)
   })
   test('should show verion and edition when connected', () => {
@@ -34,7 +36,9 @@ describe('connected as', () => {
       version: 'test',
       edition: ['3.1.0']
     }
-    const wrapper = shallow(<DatabaseKernelInfo databaseKernelInfo={databaseKernelInfo} />)
+    const wrapper = shallow(
+      <DatabaseKernelInfo databaseKernelInfo={databaseKernelInfo} />
+    )
     expect(wrapper.find('.database-kernel-info').length).toBeGreaterThan(0)
     expect(wrapper.find('.version').text()).toEqual('test')
     expect(wrapper.find('.edition').text()).toEqual('3.1.0')

--- a/src/browser/modules/DatabaseInfo/MetaItems.jsx
+++ b/src/browser/modules/DatabaseInfo/MetaItems.jsx
@@ -21,8 +21,18 @@
 import { ecsapeCypherMetaItem } from 'services/utils'
 import classNames from 'classnames'
 import styles from './style_meta.css'
-import {DrawerSubHeader, DrawerSection, DrawerSectionBody} from 'browser-components/drawer'
-import { StyledLabel, StyledRelationship, StyledProperty, StyledShowMoreContainer, StyledShowMoreLink } from './styled'
+import {
+  DrawerSubHeader,
+  DrawerSection,
+  DrawerSectionBody
+} from 'browser-components/drawer'
+import {
+  StyledLabel,
+  StyledRelationship,
+  StyledProperty,
+  StyledShowMoreContainer,
+  StyledShowMoreLink
+} from './styled'
 import Render from 'browser-components/Render'
 
 const ShowMore = ({ total, shown, moreStep, onMore }) => {
@@ -30,15 +40,25 @@ const ShowMore = ({ total, shown, moreStep, onMore }) => {
   return (
     <Render if={shown < total}>
       <StyledShowMoreContainer>
-        <StyledShowMoreLink onClick={() => onMore(numMore)}>Show {numMore} more</StyledShowMoreLink>
+        <StyledShowMoreLink onClick={() => onMore(numMore)}>
+          Show {numMore} more
+        </StyledShowMoreLink>
         &nbsp;|&nbsp;
-        <StyledShowMoreLink onClick={() => onMore(total)}>Show all</StyledShowMoreLink>
+        <StyledShowMoreLink onClick={() => onMore(total)}>
+          Show all
+        </StyledShowMoreLink>
       </StyledShowMoreContainer>
     </Render>
   )
 }
 
-const createItems = (originalList, onItemClick, RenderType, editorCommandTemplate, showStar = true) => {
+const createItems = (
+  originalList,
+  onItemClick,
+  RenderType,
+  editorCommandTemplate,
+  showStar = true
+) => {
   let items = [...originalList]
   if (showStar) {
     items.unshift('*')
@@ -48,81 +68,145 @@ const createItems = (originalList, onItemClick, RenderType, editorCommandTemplat
     return (
       <RenderType.component
         key={index}
-        onClick={() => onItemClick(getNodesCypher)}>
+        onClick={() => onItemClick(getNodesCypher)}
+      >
         {text}
       </RenderType.component>
     )
   })
 }
-const LabelItems = ({labels, totalNumItems, onItemClick, moreStep, onMoreClick}) => {
+const LabelItems = ({
+  labels,
+  totalNumItems,
+  onItemClick,
+  moreStep,
+  onMoreClick
+}) => {
   let labelItems = <p>There are no labels in database</p>
   if (labels.length) {
-    const editorCommandTemplate = (text) => {
+    const editorCommandTemplate = text => {
       if (text === '*') {
         return 'MATCH (n) RETURN n LIMIT 25'
       }
       return `MATCH (n:${ecsapeCypherMetaItem(text)}) RETURN n LIMIT 25`
     }
-    labelItems = createItems(labels, onItemClick, {component: StyledLabel}, editorCommandTemplate)
+    labelItems = createItems(
+      labels,
+      onItemClick,
+      { component: StyledLabel },
+      editorCommandTemplate
+    )
   }
   return (
     <DrawerSection>
       <DrawerSubHeader>Node Labels</DrawerSubHeader>
-      <DrawerSectionBody className={classNames({
-        [styles['wrapper']]: true
-      })}>
+      <DrawerSectionBody
+        className={classNames({
+          [styles['wrapper']]: true
+        })}
+      >
         {labelItems}
       </DrawerSectionBody>
-      <ShowMore total={totalNumItems} shown={labels.length} moreStep={moreStep} onMore={onMoreClick} />
+      <ShowMore
+        total={totalNumItems}
+        shown={labels.length}
+        moreStep={moreStep}
+        onMore={onMoreClick}
+      />
     </DrawerSection>
   )
 }
-const RelationshipItems = ({relationshipTypes, totalNumItems, onItemClick, moreStep, onMoreClick}) => {
+const RelationshipItems = ({
+  relationshipTypes,
+  totalNumItems,
+  onItemClick,
+  moreStep,
+  onMoreClick
+}) => {
   let relationshipItems = <p>No relationships in database</p>
   if (relationshipTypes.length > 0) {
-    const editorCommandTemplate = (text) => {
+    const editorCommandTemplate = text => {
       if (text === '*') {
         return 'MATCH p=()-->() RETURN p LIMIT 25'
       }
-      return `MATCH p=()-[r:${ecsapeCypherMetaItem(text)}]->() RETURN p LIMIT 25`
+      return `MATCH p=()-[r:${ecsapeCypherMetaItem(
+        text
+      )}]->() RETURN p LIMIT 25`
     }
-    relationshipItems = createItems(relationshipTypes, onItemClick, {component: StyledRelationship}, editorCommandTemplate)
+    relationshipItems = createItems(
+      relationshipTypes,
+      onItemClick,
+      { component: StyledRelationship },
+      editorCommandTemplate
+    )
   }
   return (
     <DrawerSection>
       <DrawerSubHeader>Relationship Types</DrawerSubHeader>
-      <DrawerSectionBody className={classNames({
-        [styles['wrapper']]: true
-      })}>
+      <DrawerSectionBody
+        className={classNames({
+          [styles['wrapper']]: true
+        })}
+      >
         {relationshipItems}
       </DrawerSectionBody>
-      <ShowMore total={totalNumItems} shown={relationshipTypes.length} moreStep={moreStep} onMore={onMoreClick} />
+      <ShowMore
+        total={totalNumItems}
+        shown={relationshipTypes.length}
+        moreStep={moreStep}
+        onMore={onMoreClick}
+      />
     </DrawerSection>
   )
 }
-const PropertyItems = ({properties, totalNumItems, onItemClick, moreStep, onMoreClick}) => {
+const PropertyItems = ({
+  properties,
+  totalNumItems,
+  onItemClick,
+  moreStep,
+  onMoreClick
+}) => {
   let propertyItems = <p>There are no properties in database</p>
   if (properties.length > 0) {
-    const editorCommandTemplate = (text) => {
-      return `MATCH (n) WHERE EXISTS(n.${ecsapeCypherMetaItem(text)}) RETURN DISTINCT "node" as entity, n.${ecsapeCypherMetaItem(text)} AS ${ecsapeCypherMetaItem(text)} LIMIT 25 UNION ALL MATCH ()-[r]-() WHERE EXISTS(r.${ecsapeCypherMetaItem(text)}) RETURN DISTINCT "relationship" AS entity, r.${ecsapeCypherMetaItem(text)} AS ${ecsapeCypherMetaItem(text)} LIMIT 25`
+    const editorCommandTemplate = text => {
+      return `MATCH (n) WHERE EXISTS(n.${ecsapeCypherMetaItem(
+        text
+      )}) RETURN DISTINCT "node" as entity, n.${ecsapeCypherMetaItem(
+        text
+      )} AS ${ecsapeCypherMetaItem(
+        text
+      )} LIMIT 25 UNION ALL MATCH ()-[r]-() WHERE EXISTS(r.${ecsapeCypherMetaItem(
+        text
+      )}) RETURN DISTINCT "relationship" AS entity, r.${ecsapeCypherMetaItem(
+        text
+      )} AS ${ecsapeCypherMetaItem(text)} LIMIT 25`
     }
-    propertyItems = createItems(properties, onItemClick, {component: StyledProperty}, editorCommandTemplate, false)
+    propertyItems = createItems(
+      properties,
+      onItemClick,
+      { component: StyledProperty },
+      editorCommandTemplate,
+      false
+    )
   }
   return (
     <DrawerSection>
       <DrawerSubHeader>Property Keys</DrawerSubHeader>
-      <DrawerSectionBody className={classNames({
-        [styles['wrapper']]: true
-      })}>
+      <DrawerSectionBody
+        className={classNames({
+          [styles['wrapper']]: true
+        })}
+      >
         {propertyItems}
       </DrawerSectionBody>
-      <ShowMore total={totalNumItems} shown={properties.length} moreStep={moreStep} onMore={onMoreClick} />
+      <ShowMore
+        total={totalNumItems}
+        shown={properties.length}
+        moreStep={moreStep}
+        onMore={onMoreClick}
+      />
     </DrawerSection>
   )
 }
 
-export {
-  LabelItems,
-  RelationshipItems,
-  PropertyItems
-}
+export { LabelItems, RelationshipItems, PropertyItems }

--- a/src/browser/modules/DatabaseInfo/UserDetails.jsx
+++ b/src/browser/modules/DatabaseInfo/UserDetails.jsx
@@ -25,7 +25,11 @@ import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
 import { executeCommand } from 'shared/modules/commands/commandsDuck'
 
 import Render from 'browser-components/Render'
-import { DrawerSubHeader, DrawerSection, DrawerSectionBody } from 'browser-components/drawer'
+import {
+  DrawerSubHeader,
+  DrawerSection,
+  DrawerSectionBody
+} from 'browser-components/drawer'
 import { StyledTable, StyledKey, StyledValue, Link } from './styled'
 
 export class UserDetails extends Component {
@@ -39,14 +43,18 @@ export class UserDetails extends Component {
     this.props.bus.self(
       CYPHER_REQUEST,
       { query: 'CALL dbms.security.showCurrentUser()' },
-      (response) => {
+      response => {
         if (!response.success) return
         const result = response.result
         const keys = result.records[0].keys
         this.setState({
           userDetails: {
-            username: (keys.includes('username')) ? result.records[0].get('username') : '-',
-            roles: (keys.includes('roles')) ? result.records[0].get('roles') : ['admin']
+            username: keys.includes('username')
+              ? result.records[0].get('username')
+              : '-',
+            roles: keys.includes('roles')
+              ? result.records[0].get('roles')
+              : ['admin']
           }
         })
       }
@@ -61,8 +69,11 @@ export class UserDetails extends Component {
   render () {
     const userDetails = this.state.userDetails
     if (userDetails.username) {
-      const mappedRoles = (userDetails.roles.length > 0) ? userDetails.roles.join(', ') : '-'
-      const hasAdminRole = userDetails.roles.map((role) => role.toLowerCase()).includes('admin')
+      const mappedRoles =
+        userDetails.roles.length > 0 ? userDetails.roles.join(', ') : '-'
+      const hasAdminRole = userDetails.roles
+        .map(role => role.toLowerCase())
+        .includes('admin')
       return (
         <DrawerSection className='user-details'>
           <DrawerSubHeader>Connected as</DrawerSubHeader>
@@ -70,14 +81,25 @@ export class UserDetails extends Component {
             <StyledTable>
               <tbody>
                 <tr>
-                  <StyledKey>Username:</StyledKey><StyledValue>{userDetails.username}</StyledValue>
+                  <StyledKey>Username:</StyledKey>
+                  <StyledValue>
+                    {userDetails.username}
+                  </StyledValue>
                 </tr>
                 <tr>
-                  <StyledKey>Roles:</StyledKey><StyledValue>{mappedRoles}</StyledValue>
+                  <StyledKey>Roles:</StyledKey>
+                  <StyledValue>
+                    {mappedRoles}
+                  </StyledValue>
                 </tr>
                 <Render if={hasAdminRole}>
                   <tr>
-                    <StyledKey className='user-list-button'>Admin:</StyledKey><Link onClick={() => this.props.onItemClick(':server user add')}>:server user add</Link>
+                    <StyledKey className='user-list-button'>Admin:</StyledKey>
+                    <Link
+                      onClick={() => this.props.onItemClick(':server user add')}
+                    >
+                      :server user add
+                    </Link>
                   </tr>
                 </Render>
               </tbody>
@@ -93,7 +115,7 @@ export class UserDetails extends Component {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    onItemClick: (cmd) => {
+    onItemClick: cmd => {
       const action = executeCommand(cmd)
       ownProps.bus.send(action.type, action)
     }

--- a/src/browser/modules/DatabaseInfo/styled.jsx
+++ b/src/browser/modules/DatabaseInfo/styled.jsx
@@ -59,8 +59,7 @@ export const StyledProperty = styled(chip)`
     border-color: #fff;
   }
 `
-export const StyledTable = styled.table`
-`
+export const StyledTable = styled.table``
 export const StyledKey = styled.td`
   text-align: right;
   padding-right: 13px;
@@ -68,8 +67,7 @@ export const StyledKey = styled.td`
   color: #bcc0c9;
   font-family: ${props => props.theme.primaryFontFamily};
   outline-color: rgb(188, 192, 201);
-  text-shadow: rgba(0,0,0,.4)0 1px 0;
-
+  text-shadow: rgba(0, 0, 0, .4)0 1px 0;
 `
 export const StyledValue = styled.td`
   font-family: ${props => props.theme.primaryFontFamily};
@@ -89,14 +87,16 @@ export const StyledLink = styled.a`
     text-decoration: none;
   }
 `
-export const Link = (props) => {
-  const {children, ...rest} = props
-  return <StyledLink {...rest}><PlainPlayIcon />&nbsp;{children}</StyledLink>
+export const Link = props => {
+  const { children, ...rest } = props
+  return (
+    <StyledLink {...rest}>
+      <PlainPlayIcon />&nbsp;{children}
+    </StyledLink>
+  )
 }
 
-export const StyledShowMoreContainer = styled.div`
-  margin-top: 10px;
-`
+export const StyledShowMoreContainer = styled.div`margin-top: 10px;`
 
 export const StyledShowMoreLink = styled.span`
   cursor: pointer;

--- a/src/browser/modules/DocTitle/index.test.js
+++ b/src/browser/modules/DocTitle/index.test.js
@@ -18,18 +18,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
- /* global describe, beforeEach, afterEach, test, expect */
+/* global describe, beforeEach, afterEach, test, expect */
 import { mount } from 'services/testUtils'
 import DocTitle from './index'
 
 describe('DocTitle', () => {
   test('should set document title', () => {
-   // Given
+    // Given
     const titleString = 'foo'
     const result = mount(DocTitle)
       // When
-      .withProps({titleString})
-      .then((wrapper) => {
+      .withProps({ titleString })
+      .then(wrapper => {
         expect(document.title).toBe(titleString)
       })
     return result

--- a/src/browser/modules/DocTitle/titleStringBuilder.js
+++ b/src/browser/modules/DocTitle/titleStringBuilder.js
@@ -18,14 +18,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const asTitleString = (connectionData) => {
+const asTitleString = connectionData => {
   const buildTitleFromConnectionData = () => {
     if (!connectionData) return null
     if (connectionData.username && connectionData.host) {
       return `${connectionData.username}@${connectionData.host}`
     }
-    if (connectionData.username) { return connectionData.username }
-    if (connectionData.host) { return connectionData.host }
+    if (connectionData.username) {
+      return connectionData.username
+    }
+    if (connectionData.host) {
+      return connectionData.host
+    }
     return null
   }
   const builtTitle = buildTitleFromConnectionData()

--- a/src/browser/modules/DocTitle/titleStringBuilder.test.js
+++ b/src/browser/modules/DocTitle/titleStringBuilder.test.js
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
- /* global describe, beforeEach, afterEach, test, expect */
+/* global describe, beforeEach, afterEach, test, expect */
 import asTitleString from './titleStringBuilder'
 
 describe('asTitleString', () => {
@@ -36,7 +36,7 @@ describe('asTitleString', () => {
     // Given
     const username = undefined
     const host = null
-    const connectionData = {username, host}
+    const connectionData = { username, host }
 
     // When
     const title = asTitleString(connectionData)
@@ -48,7 +48,7 @@ describe('asTitleString', () => {
     // Given
     const username = undefined
     const host = 'foo'
-    const connectionData = {username, host}
+    const connectionData = { username, host }
 
     // When
     const title = asTitleString(connectionData)
@@ -60,7 +60,7 @@ describe('asTitleString', () => {
     // Given
     const username = 'foo'
     const host = undefined
-    const connectionData = {username, host}
+    const connectionData = { username, host }
 
     // When
     const title = asTitleString(connectionData)
@@ -72,7 +72,7 @@ describe('asTitleString', () => {
     // Given
     const username = 'foo'
     const host = 'bar'
-    const connectionData = {username, host}
+    const connectionData = { username, host }
 
     // When
     const title = asTitleString(connectionData)

--- a/src/browser/modules/Editor/Codemirror.jsx
+++ b/src/browser/modules/Editor/Codemirror.jsx
@@ -53,7 +53,10 @@ export default class CodeMirror extends Component {
 
   componentDidMount () {
     const textareaNode = this.editorReference
-    const { editor, editorSupport } = createCypherEditor(textareaNode, this.props.options)
+    const { editor, editorSupport } = createCypherEditor(
+      textareaNode,
+      this.props.options
+    )
     this.codeMirror = editor
     this.codeMirror.on('change', this.codemirrorValueChanged.bind(this))
     this.codeMirror.on('focus', this.focusChanged.bind(this, true))
@@ -79,13 +82,19 @@ export default class CodeMirror extends Component {
   }
 
   componentWillReceiveProps (nextProps) {
-    if (this.codeMirror &&
+    if (
+      this.codeMirror &&
       nextProps.value !== undefined &&
-      normalizeLineEndings(this.codeMirror.getValue()) !== normalizeLineEndings(nextProps.value)) {
+      normalizeLineEndings(this.codeMirror.getValue()) !==
+        normalizeLineEndings(nextProps.value)
+    ) {
       if (this.props.preserveScrollPosition) {
         const prevScrollPosition = this.codeMirror.getScrollInfo()
         this.codeMirror.setValue(nextProps.value)
-        this.codeMirror.scrollTo(prevScrollPosition.left, prevScrollPosition.top)
+        this.codeMirror.scrollTo(
+          prevScrollPosition.left,
+          prevScrollPosition.top
+        )
       } else {
         this.codeMirror.setValue(nextProps.value)
       }
@@ -136,11 +145,9 @@ export default class CodeMirror extends Component {
       this.props.classNames
     )
 
-    const setEditorReference = (ref) => {
+    const setEditorReference = ref => {
       this.editorReference = ref
     }
-    return (
-      <div className={editorClassNames} ref={setEditorReference} />
-    )
+    return <div className={editorClassNames} ref={setEditorReference} />
   }
 }

--- a/src/browser/modules/Editor/Editor.jsx
+++ b/src/browser/modules/Editor/Editor.jsx
@@ -22,11 +22,22 @@
 import { Component } from 'preact'
 import { connect } from 'preact-redux'
 import { withBus } from 'preact-suber'
-import { executeCommand, executeSystemCommand } from 'shared/modules/commands/commandsDuck'
+import {
+  executeCommand,
+  executeSystemCommand
+} from 'shared/modules/commands/commandsDuck'
 import * as favorites from 'shared/modules/favorites/favoritesDuck'
-import { SET_CONTENT, EDIT_CONTENT, FOCUS, EXPAND } from 'shared/modules/editor/editorDuck'
+import {
+  SET_CONTENT,
+  EDIT_CONTENT,
+  FOCUS,
+  EXPAND
+} from 'shared/modules/editor/editorDuck'
 import { getHistory } from 'shared/modules/history/historyDuck'
-import { getCmdChar, shouldEditorAutocomplete } from 'shared/modules/settings/settingsDuck'
+import {
+  getCmdChar,
+  shouldEditorAutocomplete
+} from 'shared/modules/settings/settingsDuck'
 import { Bar, ActionButtonSection, EditorWrapper } from './styled'
 import { EditorButton, EditModeEditorButton } from 'browser-components/buttons'
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
@@ -110,7 +121,8 @@ export class Editor extends Component {
   historyPrev (cm) {
     if (!this.props.history.length) return
     if (this.state.historyIndex + 1 === this.props.history.length) return
-    if (this.state.historyIndex === -1) { // Save what's currently in the editor
+    if (this.state.historyIndex === -1) {
+      // Save what's currently in the editor
       this.setState({ buffer: cm.getValue() })
     }
     this.setState({
@@ -123,7 +135,8 @@ export class Editor extends Component {
   historyNext (cm) {
     if (!this.props.history.length) return
     if (this.state.historyIndex <= -1) return
-    if (this.state.historyIndex === 0) { // Should read from buffer
+    if (this.state.historyIndex === 0) {
+      // Should read from buffer
       this.setState({ historyIndex: -1 })
       this.setEditorValue(this.state.buffer)
       return
@@ -141,7 +154,8 @@ export class Editor extends Component {
     }
 
     const text = changed.text[0]
-    const triggerAutocompletion = text === '.' ||
+    const triggerAutocompletion =
+      text === '.' ||
       text === ':' ||
       text === '[]' ||
       text === '()' ||
@@ -155,7 +169,10 @@ export class Editor extends Component {
   }
 
   componentWillReceiveProps (nextProps) {
-    if (nextProps.content !== null && nextProps.content !== this.getEditorValue()) {
+    if (
+      nextProps.content !== null &&
+      nextProps.content !== this.getEditorValue()
+    ) {
       this.setEditorValue(nextProps.content)
     }
   }
@@ -170,11 +187,11 @@ export class Editor extends Component {
     }
 
     if (this.props.bus) {
-      this.props.bus.take(SET_CONTENT, (msg) => {
+      this.props.bus.take(SET_CONTENT, msg => {
         this.setContentId(null)
         this.setEditorValue(msg.message)
       })
-      this.props.bus.take(EDIT_CONTENT, (msg) => {
+      this.props.bus.take(EDIT_CONTENT, msg => {
         this.setContentId(msg.id)
         this.setEditorValue(msg.message)
       })
@@ -195,16 +212,17 @@ export class Editor extends Component {
   }
 
   setContentId (id) {
-    this.setState({contentId: id})
+    this.setState({ contentId: id })
   }
 
-  updateCode (newCode, change, cb = () => {
-  }) {
-    const mode = this.props.cmdchar && newCode.trim().indexOf(this.props.cmdchar) === 0
-      ? 'text'
-      : 'cypher'
+  updateCode (newCode, change, cb = () => {}) {
+    const mode =
+      this.props.cmdchar && newCode.trim().indexOf(this.props.cmdchar) === 0
+        ? 'text'
+        : 'cypher'
     this.clearHints()
-    if (mode === 'cypher' &&
+    if (
+      mode === 'cypher' &&
       newCode.trim().length > 0 &&
       !newCode.trimLeft().toUpperCase().startsWith('EXPLAIN') &&
       !newCode.trimLeft().toUpperCase().startsWith('PROFILE')
@@ -214,20 +232,30 @@ export class Editor extends Component {
 
     const lastPosition = change && change.to
 
-    this.setState({
-      mode,
-      lastPosition: lastPosition ? { line: lastPosition.line, column: lastPosition.ch } : this.state.lastPosition,
-      editorHeight: this.editor && this.editor.base.clientHeight
-    }, cb)
+    this.setState(
+      {
+        mode,
+        lastPosition: lastPosition
+          ? { line: lastPosition.line, column: lastPosition.ch }
+          : this.state.lastPosition,
+        editorHeight: this.editor && this.editor.base.clientHeight
+      },
+      cb
+    )
   }
 
   checkForHints (code) {
     this.props.bus.self(
       CYPHER_REQUEST,
       { query: 'EXPLAIN ' + code },
-      (response) => {
-        if (response.success === true && response.result.summary.notifications.length > 0) {
-          this.setState({ notifications: response.result.summary.notifications })
+      response => {
+        if (
+          response.success === true &&
+          response.result.summary.notifications.length > 0
+        ) {
+          this.setState({
+            notifications: response.result.summary.notifications
+          })
         } else {
           this.clearHints()
         }
@@ -243,18 +271,25 @@ export class Editor extends Component {
     if (this.codeMirror) {
       this.codeMirror.clearGutter('cypher-hints')
       this.state.notifications.forEach(notification => {
-        this.codeMirror.setGutterMarker((notification.position.line || 1) - 1, 'cypher-hints', (() => {
-          let gutter = document.createElement('div')
-          gutter.style.color = '#822'
-          gutter.innerHTML = '<i class="fa fa-exclamation-triangle gutter-warning gutter-warning" aria-hidden="true"></i>'
-          gutter.title = `${notification.title}\n${notification.description}`
-          gutter.onclick = () => {
-            const action = executeSystemCommand(`EXPLAIN ${this.getEditorValue()}`)
-            action.forceView = viewTypes.WARNINGS
-            this.props.bus.send(action.type, action)
-          }
-          return gutter
-        })())
+        this.codeMirror.setGutterMarker(
+          (notification.position.line || 1) - 1,
+          'cypher-hints',
+          (() => {
+            let gutter = document.createElement('div')
+            gutter.style.color = '#822'
+            gutter.innerHTML =
+              '<i class="fa fa-exclamation-triangle gutter-warning gutter-warning" aria-hidden="true"></i>'
+            gutter.title = `${notification.title}\n${notification.description}`
+            gutter.onclick = () => {
+              const action = executeSystemCommand(
+                `EXPLAIN ${this.getEditorValue()}`
+              )
+              action.forceView = viewTypes.WARNINGS
+              this.props.bus.send(action.type, action)
+            }
+            return gutter
+          })()
+        )
       })
     }
   }
@@ -289,16 +324,16 @@ export class Editor extends Component {
       lint: true,
       extraKeys: {
         'Ctrl-Space': 'autocomplete',
-        'Enter': this.handleEnter.bind(this),
+        Enter: this.handleEnter.bind(this),
         'Shift-Enter': this.newlineAndIndent.bind(this),
         'Cmd-Enter': this.execCurrent.bind(this),
         'Ctrl-Enter': this.execCurrent.bind(this),
         'Cmd-Up': this.historyPrev.bind(this),
         'Ctrl-Up': this.historyPrev.bind(this),
-        'Up': this.handleUp.bind(this),
+        Up: this.handleUp.bind(this),
         'Cmd-Down': this.historyNext.bind(this),
         'Ctrl-Down': this.historyNext.bind(this),
-        'Down': this.handleDown.bind(this)
+        Down: this.handleDown.bind(this)
       },
       hintOptions: {
         completeSingle: false,
@@ -316,9 +351,12 @@ export class Editor extends Component {
 
     return (
       <Bar expanded={this.state.expanded} minHeight={this.state.editorHeight}>
-        <EditorWrapper expanded={this.state.expanded} minHeight={this.state.editorHeight}>
+        <EditorWrapper
+          expanded={this.state.expanded}
+          minHeight={this.state.editorHeight}
+        >
           <Codemirror
-            ref={(ref) => {
+            ref={ref => {
               this.editor = ref
             }}
             onChange={updateCode}
@@ -330,12 +368,16 @@ export class Editor extends Component {
         <ActionButtonSection>
           <Render if={this.state.contentId}>
             <EditModeEditorButton
-              onClick={() => this.props.onFavoriteUpdateClick(this.state.contentId, this.getEditorValue())}
+              onClick={() =>
+                this.props.onFavoriteUpdateClick(
+                  this.state.contentId,
+                  this.getEditorValue()
+                )}
               disabled={this.getEditorValue().length < 1}
               color='#ffaf00'
               title='Favorite'
-              hoverIcon='"\74"'
-              icon='"\25"'
+              hoverIcon='&quot;\74&quot;'
+              icon='&quot;\25&quot;'
             />
           </Render>
           <Render if={!this.state.contentId}>
@@ -343,8 +385,8 @@ export class Editor extends Component {
               onClick={() => this.props.onFavoriteClick(this.getEditorValue())}
               disabled={this.getEditorValue().length < 1}
               title='Update favorite'
-              hoverIcon='"\58"'
-              icon='"\73"'
+              hoverIcon='&quot;\58&quot;'
+              icon='&quot;\73&quot;'
             />
           </Render>
           <EditorButton
@@ -352,16 +394,16 @@ export class Editor extends Component {
             onClick={() => this.clearEditor()}
             disabled={this.getEditorValue().length < 1}
             title='Clear'
-            hoverIcon='"\e005"'
-            icon='"\5e"'
+            hoverIcon='&quot;\e005&quot;'
+            icon='&quot;\5e&quot;'
           />
           <EditorButton
             data-test-id='submitQuery'
             onClick={() => this.execCurrent()}
             disabled={this.getEditorValue().length < 1}
             title='Play'
-            hoverIcon='"\e002"'
-            icon='"\77"'
+            hoverIcon='&quot;\e002&quot;'
+            icon='&quot;\77&quot;'
           />
         </ActionButtonSection>
       </Bar>
@@ -371,7 +413,7 @@ export class Editor extends Component {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    onFavoriteClick: (cmd) => {
+    onFavoriteClick: cmd => {
       const action = favorites.addFavorite(cmd)
       ownProps.bus.send(action.type, action)
     },
@@ -379,14 +421,14 @@ const mapDispatchToProps = (dispatch, ownProps) => {
       const action = favorites.updateFavorite(id, cmd)
       ownProps.bus.send(action.type, action)
     },
-    onExecute: (cmd) => {
+    onExecute: cmd => {
       const action = executeCommand(cmd)
       ownProps.bus.send(action.type, action)
     }
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     enableEditorAutocomplete: shouldEditorAutocomplete(state),
     content: null,
@@ -395,7 +437,9 @@ const mapStateToProps = (state) => {
     schema: {
       consoleCommands: consoleCommands,
       labels: state.meta.labels.map(schemaConvert.toLabel),
-      relationshipTypes: state.meta.relationshipTypes.map(schemaConvert.toRelationshipType),
+      relationshipTypes: state.meta.relationshipTypes.map(
+        schemaConvert.toRelationshipType
+      ),
       propertyKeys: state.meta.properties.map(schemaConvert.toPropertyKey),
       functions: [
         ...cypherFunctions,

--- a/src/browser/modules/Editor/Editor.test.jsx
+++ b/src/browser/modules/Editor/Editor.test.jsx
@@ -32,24 +32,43 @@ describe('Editor', () => {
     onExecute = jest.fn()
   })
 
-  test.skip('should render Codemirror component with correct properties', () => {
-    const content = 'content-' + Math.random()
-    const wrapper = mount(
-      <EditorComponent bus={createBus()} onExecute={onExecute} content={content} history='' />
-    )
-    const codeMirror = wrapper.find(Codemirror)
-    expect(codeMirror.props().value).toEqual(content)
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Cmd-Enter'](codeMirror.get(0).getCodeMirror())
-    expect(onExecute).toHaveBeenCalled()
-  })
+  test.skip(
+    'should render Codemirror component with correct properties',
+    () => {
+      const content = 'content-' + Math.random()
+      const wrapper = mount(
+        <EditorComponent
+          bus={createBus()}
+          onExecute={onExecute}
+          content={content}
+          history=''
+        />
+      )
+      const codeMirror = wrapper.find(Codemirror)
+      expect(codeMirror.props().value).toEqual(content)
+      codeMirror
+        .get(0)
+        .getCodeMirrorInstance()
+        .keyMap['default']['Cmd-Enter'](codeMirror.get(0).getCodeMirror())
+      expect(onExecute).toHaveBeenCalled()
+    }
+  )
 
   test.skip('should execute current command on Cmd-Enter', () => {
     const content = 'content-' + Math.random()
     const wrapper = mount(
-      <EditorComponent bus={createBus()} onExecute={onExecute} content={content} history='' />
+      <EditorComponent
+        bus={createBus()}
+        onExecute={onExecute}
+        content={content}
+        history=''
+      />
     )
     const codeMirror = wrapper.find(Codemirror)
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Cmd-Enter'](codeMirror.get(0).getCodeMirror())
+    codeMirror
+      .get(0)
+      .getCodeMirrorInstance()
+      .keyMap['default']['Cmd-Enter'](codeMirror.get(0).getCodeMirror())
     expect(onExecute).toHaveBeenCalledWith(content)
     expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('')
   })
@@ -57,44 +76,92 @@ describe('Editor', () => {
   test.skip('should execute current command on Ctrl-Enter', () => {
     const content = 'content-' + Math.random()
     const wrapper = mount(
-      <EditorComponent bus={createBus()} onExecute={onExecute} content={content} history='' />
+      <EditorComponent
+        bus={createBus()}
+        onExecute={onExecute}
+        content={content}
+        history=''
+      />
     )
     const codeMirror = wrapper.find(Codemirror)
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Ctrl-Enter'](codeMirror.get(0).getCodeMirror())
+    codeMirror
+      .get(0)
+      .getCodeMirrorInstance()
+      .keyMap['default']['Ctrl-Enter'](codeMirror.get(0).getCodeMirror())
     expect(onExecute).toHaveBeenCalledWith(content)
     expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('')
   })
 
-  test.skip('should replace content as with history as user arrows up and down', () => {
-    const content = 'content-' + Math.random()
-    const history = [{cmd: 'latest'}, {cmd: 'middle'}, {cmd: 'oldest'}]
-    const wrapper = mount(
-      <EditorComponent bus={createBus()} onExecute={onExecute} content={content} history={history} />
-    )
-    const codeMirror = wrapper.find(Codemirror)
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Cmd-Up'](codeMirror.get(0).getCodeMirror())
-    expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('latest')
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Ctrl-Up'](codeMirror.get(0).getCodeMirror())
-    expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('middle')
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Ctrl-Up'](codeMirror.get(0).getCodeMirror())
-    expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('oldest')
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Cmd-Down'](codeMirror.get(0).getCodeMirror())
-    expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('middle')
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Ctrl-Down'](codeMirror.get(0).getCodeMirror())
-    expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('latest')
-  })
+  test.skip(
+    'should replace content as with history as user arrows up and down',
+    () => {
+      const content = 'content-' + Math.random()
+      const history = [{ cmd: 'latest' }, { cmd: 'middle' }, { cmd: 'oldest' }]
+      const wrapper = mount(
+        <EditorComponent
+          bus={createBus()}
+          onExecute={onExecute}
+          content={content}
+          history={history}
+        />
+      )
+      const codeMirror = wrapper.find(Codemirror)
+      codeMirror
+        .get(0)
+        .getCodeMirrorInstance()
+        .keyMap['default']['Cmd-Up'](codeMirror.get(0).getCodeMirror())
+      expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('latest')
+      codeMirror
+        .get(0)
+        .getCodeMirrorInstance()
+        .keyMap['default']['Ctrl-Up'](codeMirror.get(0).getCodeMirror())
+      expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('middle')
+      codeMirror
+        .get(0)
+        .getCodeMirrorInstance()
+        .keyMap['default']['Ctrl-Up'](codeMirror.get(0).getCodeMirror())
+      expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('oldest')
+      codeMirror
+        .get(0)
+        .getCodeMirrorInstance()
+        .keyMap['default']['Cmd-Down'](codeMirror.get(0).getCodeMirror())
+      expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('middle')
+      codeMirror
+        .get(0)
+        .getCodeMirrorInstance()
+        .keyMap['default']['Ctrl-Down'](codeMirror.get(0).getCodeMirror())
+      expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('latest')
+    }
+  )
 
   test.skip('should resest history after execution', () => {
-    const history = [{cmd: 'latest'}, {cmd: 'middle'}, {cmd: 'oldest'}]
+    const history = [{ cmd: 'latest' }, { cmd: 'middle' }, { cmd: 'oldest' }]
     const wrapper = mount(
-      <EditorComponent bus={createBus()} onExecute={onExecute} content='' history={history} />
+      <EditorComponent
+        bus={createBus()}
+        onExecute={onExecute}
+        content=''
+        history={history}
+      />
     )
     const codeMirror = wrapper.find(Codemirror)
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Cmd-Up'](codeMirror.get(0).getCodeMirror())
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Cmd-Up'](codeMirror.get(0).getCodeMirror())
+    codeMirror
+      .get(0)
+      .getCodeMirrorInstance()
+      .keyMap['default']['Cmd-Up'](codeMirror.get(0).getCodeMirror())
+    codeMirror
+      .get(0)
+      .getCodeMirrorInstance()
+      .keyMap['default']['Cmd-Up'](codeMirror.get(0).getCodeMirror())
     expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('middle')
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Cmd-Enter'](codeMirror.get(0).getCodeMirror())
-    codeMirror.get(0).getCodeMirrorInstance().keyMap['default']['Cmd-Up'](codeMirror.get(0).getCodeMirror())
+    codeMirror
+      .get(0)
+      .getCodeMirrorInstance()
+      .keyMap['default']['Cmd-Enter'](codeMirror.get(0).getCodeMirror())
+    codeMirror
+      .get(0)
+      .getCodeMirrorInstance()
+      .keyMap['default']['Cmd-Up'](codeMirror.get(0).getCodeMirror())
     expect(codeMirror.get(0).getCodeMirror().getValue()).toEqual('latest')
   })
 })

--- a/src/browser/modules/Editor/cypher/functions.js
+++ b/src/browser/modules/Editor/cypher/functions.js
@@ -67,8 +67,14 @@ export const aggregation = [
   func('count', '(expression :: ANY) :: (INTEGER)'),
   func('max', '(expression :: NUMBER) :: (NUMBER)'),
   func('min', '(expression :: NUMBER) :: (NUMBER)'),
-  func('percentileCont', '(expression :: NUMBER, percentile :: FLOAT) :: (FLOAT)'),
-  func('percentileDisc', '(expression :: NUMBER, percentile :: FLOAT) :: (NUMBER)'),
+  func(
+    'percentileCont',
+    '(expression :: NUMBER, percentile :: FLOAT) :: (FLOAT)'
+  ),
+  func(
+    'percentileDisc',
+    '(expression :: NUMBER, percentile :: FLOAT) :: (NUMBER)'
+  ),
   func('stDev', '(expression :: NUMBER) :: (FLOAT)'),
   func('stDevP', '(expression :: NUMBER) :: (FLOAT)'),
   func('sum', '(expression :: NUMBER) :: (NUMBER)')
@@ -81,8 +87,14 @@ export const list = [
   func('keys', '(relationship :: RELATIONSHIP) :: (LIST OF STRING)'),
   func('labels', '(node :: NODE) :: (LIST OF STRING)'),
   func('nodes', '(path :: PATH) :: (LIST OF NODE)'),
-  func('range', '(start :: INTEGER, end :: INTEGER, step = 1 :: INTEGER) :: (LIST OF INTEGER)'),
-  func('reduce', '(accumulator = initial :: ANY, variable IN list | expression :: ANY) :: (ANY)'),
+  func(
+    'range',
+    '(start :: INTEGER, end :: INTEGER, step = 1 :: INTEGER) :: (LIST OF INTEGER)'
+  ),
+  func(
+    'reduce',
+    '(accumulator = initial :: ANY, variable IN list | expression :: ANY) :: (ANY)'
+  ),
   func('relationships', '(path :: PATH) :: (LIST OF RELATIONSHIP)'),
   func('rels', '(path :: PATH) :: (LIST OF RELATIONSHIP)'),
   func('tail', '(expression :: LIST OF ANY) :: (LIST OF ANY)')
@@ -123,12 +135,21 @@ export const mathematicTrigonometric = [
 export const string = [
   func('left', '(original :: STRING, length :: INTEGER) :: (STRING)'),
   func('lTrim', '(original :: STRING) :: (STRING)'),
-  func('replace', '(original :: STRING, search :: STRING, replace :: STRING) :: (STRING)'),
+  func(
+    'replace',
+    '(original :: STRING, search :: STRING, replace :: STRING) :: (STRING)'
+  ),
   func('reverse', '(original :: STRING) :: (STRING)'),
   func('right', '(original :: STRING, length :: INTEGER) :: (STRING)'),
   func('rTrim', '(original :: STRING) :: (STRING)'),
-  func('split', '(original :: STRING, splitPattern :: STRING) :: (LIST OF STRING)'),
-  func('substring', '(original :: STRING, start :: INTEGER, length = length(original) :: INTEGER) :: (STRING)'),
+  func(
+    'split',
+    '(original :: STRING, splitPattern :: STRING) :: (LIST OF STRING)'
+  ),
+  func(
+    'substring',
+    '(original :: STRING, start :: INTEGER, length = length(original) :: INTEGER) :: (STRING)'
+  ),
   func('toLower', '(original :: STRING) :: (STRING)'),
   func('toString', '(expression :: ANY) :: (STRING)'),
   func('toUpper', '(original :: STRING) :: (STRING)'),

--- a/src/browser/modules/Editor/editorSchemaConverter.js
+++ b/src/browser/modules/Editor/editorSchemaConverter.js
@@ -44,15 +44,13 @@ export function toProcedure (procedure) {
   let returnItems = []
   const matches = signature.match(/\([^)]*\) :: \((.*)\)/i)
   if (matches) {
-    returnItems = matches[1]
-      .split(', ')
-      .map((returnItem) => {
-        const returnItemMatches = returnItem.match(/(.*) :: (.*)/)
-        return {
-          name: returnItemMatches[1],
-          signature: returnItemMatches[2]
-        }
-      })
+    returnItems = matches[1].split(', ').map(returnItem => {
+      const returnItemMatches = returnItem.match(/(.*) :: (.*)/)
+      return {
+        name: returnItemMatches[1],
+        signature: returnItemMatches[2]
+      }
+    })
   }
 
   return {

--- a/src/browser/modules/Editor/editorSchemaConverter.test.js
+++ b/src/browser/modules/Editor/editorSchemaConverter.test.js
@@ -35,20 +35,24 @@ describe('editor meta to schema conversion', () => {
   })
 
   test('convert meta function', () => {
-    expect(convert.toFunction({
-      val: 'ns.functionName',
-      signature: 'ns.functionName() :: (STRING?)'
-    })).toEqual({
+    expect(
+      convert.toFunction({
+        val: 'ns.functionName',
+        signature: 'ns.functionName() :: (STRING?)'
+      })
+    ).toEqual({
       name: 'ns.functionName',
       signature: '() :: (STRING?)'
     })
   })
 
   test('convert meta procedure with void return items', () => {
-    expect(convert.toProcedure({
-      val: 'db.createLabel',
-      signature: 'db.createLabel(newLabel :: STRING?) :: VOID'
-    })).toEqual({
+    expect(
+      convert.toProcedure({
+        val: 'db.createLabel',
+        signature: 'db.createLabel(newLabel :: STRING?) :: VOID'
+      })
+    ).toEqual({
       name: 'db.createLabel',
       signature: '(newLabel :: STRING?) :: VOID',
       returnItems: []
@@ -56,25 +60,29 @@ describe('editor meta to schema conversion', () => {
   })
 
   test('convert meta procedure with single return item', () => {
-    expect(convert.toProcedure({
-      val: 'db.constraints',
-      signature: 'db.constraints() :: (description :: STRING?)'
-    })).toEqual({
+    expect(
+      convert.toProcedure({
+        val: 'db.constraints',
+        signature: 'db.constraints() :: (description :: STRING?)'
+      })
+    ).toEqual({
       name: 'db.constraints',
       signature: '() :: (description :: STRING?)',
-      returnItems: [
-        { name: 'description', signature: 'STRING?' }
-      ]
+      returnItems: [{ name: 'description', signature: 'STRING?' }]
     })
   })
 
   test('convert meta procedure with multiple return items', () => {
-    expect(convert.toProcedure({
-      val: 'db.indexes',
-      signature: 'db.indexes() :: (description :: STRING?, state :: STRING?, type :: STRING?)'
-    })).toEqual({
+    expect(
+      convert.toProcedure({
+        val: 'db.indexes',
+        signature:
+          'db.indexes() :: (description :: STRING?, state :: STRING?, type :: STRING?)'
+      })
+    ).toEqual({
       name: 'db.indexes',
-      signature: '() :: (description :: STRING?, state :: STRING?, type :: STRING?)',
+      signature:
+        '() :: (description :: STRING?, state :: STRING?, type :: STRING?)',
       returnItems: [
         { name: 'description', signature: 'STRING?' },
         { name: 'state', signature: 'STRING?' },

--- a/src/browser/modules/Editor/language/consoleCommands.js
+++ b/src/browser/modules/Editor/language/consoleCommands.js
@@ -47,7 +47,8 @@ export default [
   },
   {
     name: ':play',
-    description: ' - loads a mini-deck with either guide material or sample data',
+    description:
+      ' - loads a mini-deck with either guide material or sample data',
     commands: [
       {
         name: 'start',
@@ -86,10 +87,7 @@ export default [
       {
         name: 'user',
         description: ' - user management for administrators',
-        commands: [
-          { name: 'add' },
-          { name: 'list' }
-        ]
+        commands: [{ name: 'add' }, { name: 'list' }]
       }
     ]
   },

--- a/src/browser/modules/Editor/styled.jsx
+++ b/src/browser/modules/Editor/styled.jsx
@@ -27,22 +27,25 @@ export const BaseBar = styled.div`
   display: flex;
   flex-direction: row;
   align-items: middle;
-  min-height: ${props => Math.max(dim.editorbarHeight, props.minHeight + editorPadding * 2)}px;
+  min-height: ${props =>
+    Math.max(dim.editorbarHeight, props.minHeight + editorPadding * 2)}px;
   overflow: hidden;
-  box-shadow: 0 1px 4px rgba(0,0,0,.1);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, .1);
   margin: 0 24px;
 `
 export const Bar = styled(BaseBar)`
-  ${(props => {
+  ${props => {
     if (props.expanded) {
-      return 'position: absolute;' +
-      'height: 100vh;' +
-      'z-index: 100;' +
-      'right: 0;' +
-      'left: 0;' +
-      'bottom: 0;'
+      return (
+        'position: absolute;' +
+        'height: 100vh;' +
+        'z-index: 100;' +
+        'right: 0;' +
+        'left: 0;' +
+        'bottom: 0;'
+      )
     }
-  })}
+  }}
 `
 export const ActionButtonSection = styled.div`
   flex: 0 0 130px;
@@ -58,8 +61,9 @@ const BaseEditorWrapper = styled.div`
   flex: auto;
   padding: ${editorPadding}px;
   background-color: ${props => props.theme.editorBarBackground};
-  font-family: Monaco,"Courier New",Terminal,monospace;
-  min-Height: ${props => Math.max(dim.editorbarHeight, props.minHeight + editorPadding * 2)}px;
+  font-family: Monaco, "Courier New", Terminal, monospace;
+  min-Height: ${props =>
+    Math.max(dim.editorbarHeight, props.minHeight + editorPadding * 2)}px;
   .CodeMirror {
     background-color: ${props => props.theme.editorBackground} !important;
     color: ${props => props.theme.editorCommandColor};
@@ -67,20 +71,22 @@ const BaseEditorWrapper = styled.div`
 `
 
 export const EditorWrapper = styled(BaseEditorWrapper)`
-  ${(props => {
+  ${props => {
     if (props.expanded) {
-      return 'height: 100%;' +
-      'z-index: 2;' +
-      '.CodeMirror {' +
-      '  position: absolute;' +
-      '  left: 12px;' +
-      '  right: 142px;' +
-      '  top: 12px;' +
-      '  bottom: 12px;' +
-      '}' +
-      '.CodeMirror-scroll {' +
-      '   max-height: initial !important;' +
-      '}'
+      return (
+        'height: 100%;' +
+        'z-index: 2;' +
+        '.CodeMirror {' +
+        '  position: absolute;' +
+        '  left: 12px;' +
+        '  right: 142px;' +
+        '  top: 12px;' +
+        '  bottom: 12px;' +
+        '}' +
+        '.CodeMirror-scroll {' +
+        '   max-height: initial !important;' +
+        '}'
+      )
     }
-  })}
+  }}
 `

--- a/src/browser/modules/Guides/Carousel.jsx
+++ b/src/browser/modules/Guides/Carousel.jsx
@@ -42,31 +42,51 @@ export default class Carousel extends Component {
     return this.state.firstRender
   }
   next () {
-    this.setState({visibleSlide: this.state.visibleSlide + 1})
+    this.setState({ visibleSlide: this.state.visibleSlide + 1 })
   }
   prev () {
-    this.setState({visibleSlide: this.state.visibleSlide - 1})
+    this.setState({ visibleSlide: this.state.visibleSlide - 1 })
   }
   getSlide (slideNumber) {
     return this.slides[slideNumber]
   }
   goToSlide (slideNumber) {
-    this.setState({visibleSlide: slideNumber})
+    this.setState({ visibleSlide: slideNumber })
   }
   render () {
     return (
       <StyledCarousel data-test-id='carousel'>
         <StyledCarouselButtonContainer>
           <Render if={this.state.visibleSlide !== 0}>
-            <StyledCarouselLeft><CarouselButton data-test-id='previousSlide' onClick={this.prev.bind(this)}>{'‹'}</CarouselButton></StyledCarouselLeft>
+            <StyledCarouselLeft>
+              <CarouselButton
+                data-test-id='previousSlide'
+                onClick={this.prev.bind(this)}
+              >
+                {'‹'}
+              </CarouselButton>
+            </StyledCarouselLeft>
           </Render>
-          <Render if={this.state.visibleSlide !== (this.slides.length - 1)}>
-            <StyledCarouselRight><CarouselButton data-test-id='nextSlide' onClick={this.next.bind(this)}>{'›'}</CarouselButton></StyledCarouselRight>
+          <Render if={this.state.visibleSlide !== this.slides.length - 1}>
+            <StyledCarouselRight>
+              <CarouselButton
+                data-test-id='nextSlide'
+                onClick={this.next.bind(this)}
+              >
+                {'›'}
+              </CarouselButton>
+            </StyledCarouselRight>
           </Render>
         </StyledCarouselButtonContainer>
-        <SlideContainer>{this.getSlide(this.state.visibleSlide)}</SlideContainer>
         <SlideContainer>
-          <CarouselSlidePicker slides={this.slides} visibleSlide={this.state.visibleSlide} onClickEvent={(slideNumber) => this.goToSlide(slideNumber)} />
+          {this.getSlide(this.state.visibleSlide)}
+        </SlideContainer>
+        <SlideContainer>
+          <CarouselSlidePicker
+            slides={this.slides}
+            visibleSlide={this.state.visibleSlide}
+            onClickEvent={slideNumber => this.goToSlide(slideNumber)}
+          />
         </SlideContainer>
       </StyledCarousel>
     )

--- a/src/browser/modules/Guides/CarouselSlidePicker.jsx
+++ b/src/browser/modules/Guides/CarouselSlidePicker.jsx
@@ -24,14 +24,19 @@ import {
   StyledUl
 } from './styled'
 
-const CarouselSlidePicker = ({slides, visibleSlide, onClickEvent}) => {
+const CarouselSlidePicker = ({ slides, visibleSlide, onClickEvent }) => {
   if (!slides || slides.length === 0) return null
-  const Indicators = slides.map((_, i) =>
-    (i !== visibleSlide)
-      ? <CarouselIndicatorInactive onClick={() => onClickEvent(i)} />
-      : <CarouselIndicatorActive onClick={() => onClickEvent(i)} />
-    )
-  return <StyledUl>{Indicators}</StyledUl>
+  const Indicators = slides.map(
+    (_, i) =>
+      i !== visibleSlide
+        ? <CarouselIndicatorInactive onClick={() => onClickEvent(i)} />
+        : <CarouselIndicatorActive onClick={() => onClickEvent(i)} />
+  )
+  return (
+    <StyledUl>
+      {Indicators}
+    </StyledUl>
+  )
 }
 
 export default CarouselSlidePicker

--- a/src/browser/modules/Guides/CarouselSlidePicker.test.js
+++ b/src/browser/modules/Guides/CarouselSlidePicker.test.js
@@ -28,7 +28,7 @@ describe('CarouselSlidePicker', () => {
     const result = mount(CarouselSlidePicker)
       // When
       .withProps({})
-      .then((wrapper) => {
+      .then(wrapper => {
         expect(wrapper.text()).toBe('')
       })
     return result
@@ -38,8 +38,8 @@ describe('CarouselSlidePicker', () => {
     const slides = ['foo', 'bar']
     const result = mount(CarouselSlidePicker)
       // When
-      .withProps({slides})
-      .then((wrapper) => {
+      .withProps({ slides })
+      .then(wrapper => {
         expect(wrapper.find('li').length).toBe(2)
       })
     return result
@@ -50,8 +50,8 @@ describe('CarouselSlidePicker', () => {
     const visibleSlide = 0
     const result = mount(CarouselSlidePicker)
       // When
-      .withProps({slides, visibleSlide})
-      .then((wrapper) => {
+      .withProps({ slides, visibleSlide })
+      .then(wrapper => {
         expect(wrapper.find('li').length).toBe(2)
         expect(wrapper.find('li').get(0)).not.toEqual(wrapper.find('li').get(1))
       })

--- a/src/browser/modules/Guides/Guides.jsx
+++ b/src/browser/modules/Guides/Guides.jsx
@@ -27,13 +27,13 @@ import Carousel from './Carousel'
 export default class Guides extends Component {
   constructor (props) {
     super(props)
-    this.state = {slides: null, firstRender: true}
+    this.state = { slides: null, firstRender: true }
   }
   componentDidMount () {
     const slides = this.base.getElementsByTagName('slide')
     let reactSlides = this
     if (slides.length > 0) {
-      reactSlides = Array.from(slides).map((slide) => {
+      reactSlides = Array.from(slides).map(slide => {
         return {
           html: slide
         }
@@ -43,8 +43,10 @@ export default class Guides extends Component {
   }
   render () {
     if (this.state.slides && Array.isArray(this.state.slides)) {
-      const ListOfSlides = this.state.slides.map((slide) => {
-        const slideComponent = <Slide key={uuid.v4()} html={slide.html.innerHTML} />
+      const ListOfSlides = this.state.slides.map(slide => {
+        const slideComponent = (
+          <Slide key={uuid.v4()} html={slide.html.innerHTML} />
+        )
         if (this.props.withDirectives) {
           return (
             <div key={uuid.v4()}>
@@ -59,16 +61,17 @@ export default class Guides extends Component {
           )
         }
       })
-      return (<Carousel slides={ListOfSlides} withDirectives={this.props.withDirectives} />)
+      return (
+        <Carousel
+          slides={ListOfSlides}
+          withDirectives={this.props.withDirectives}
+        />
+      )
     }
     if (this.props.withDirectives) {
-      return (
-        <Directives content={<Slide html={this.props.html} />} />
-      )
+      return <Directives content={<Slide html={this.props.html} />} />
     } else {
-      return (
-        <Slide html={this.props.html} />
-      )
+      return <Slide html={this.props.html} />
     }
   }
 }

--- a/src/browser/modules/Guides/Guides.test.jsx
+++ b/src/browser/modules/Guides/Guides.test.jsx
@@ -24,7 +24,7 @@ import React from 'react'
 import Guides from './Guides'
 import Slide from './Slide'
 
-import {mount} from 'enzyme'
+import { mount } from 'enzyme'
 
 describe('Guides', () => {
   test('should render Guides when html has `slide` tag', () => {

--- a/src/browser/modules/Guides/Slide.jsx
+++ b/src/browser/modules/Guides/Slide.jsx
@@ -21,8 +21,13 @@
 import styles from './style.css'
 import { StyledSlide } from './styled.jsx'
 
-const Slide = ({html}) => {
-  return (<StyledSlide className={styles.slide} dangerouslySetInnerHTML={{__html: html}} />)
+const Slide = ({ html }) => {
+  return (
+    <StyledSlide
+      className={styles.slide}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
 }
 
 export default Slide

--- a/src/browser/modules/Guides/Slide.test.jsx
+++ b/src/browser/modules/Guides/Slide.test.jsx
@@ -22,7 +22,7 @@
 import React from 'react'
 import Slide from './Slide'
 
-import {mount} from 'enzyme'
+import { mount } from 'enzyme'
 
 describe('Slide', () => {
   test('should render html', () => {

--- a/src/browser/modules/Guides/styled.jsx
+++ b/src/browser/modules/Guides/styled.jsx
@@ -20,22 +20,15 @@
 
 import styled from 'styled-components'
 
-export const StyledCarousel = styled.div`
-`
+export const StyledCarousel = styled.div``
 export const SlideContainer = styled.div`
   padding: 0 60px;
   width: 100%;
   display: inline-block;
 `
-export const StyledCarouselLeft = styled.div`
-  float: left;
-`
-export const StyledCarouselRight = styled.div`
-  float: right;
-`
-export const StyledCarouselButtonContainer = styled.div`
-  margin-top: -40px;
-`
+export const StyledCarouselLeft = styled.div`float: left;`
+export const StyledCarouselRight = styled.div`float: right;`
+export const StyledCarouselButtonContainer = styled.div`margin-top: -40px;`
 const CarouselIndicator = styled.li`
   display: inline-block;
   width: 10px;
@@ -47,7 +40,7 @@ const CarouselIndicator = styled.li`
   border: 1px solid #fff;
   border-radius: 10px;
   cursor: pointer;
-  background-color: rgba(188,195,207,.64);
+  background-color: rgba(188, 195, 207, .64);
 `
 export const CarouselIndicatorInactive = styled(CarouselIndicator)`
   &:hover {
@@ -59,18 +52,21 @@ export const CarouselIndicatorActive = styled(CarouselIndicator)`
   height: 12px;
   background-color: #428bca;
 `
-export const StyledUl = styled.ul`
-  margin: 15px;
-`
+export const StyledUl = styled.ul`margin: 15px;`
 
 export const StyledSlide = styled.div`
   color: ${props => props.theme.primaryText};
-  & p.lead, .title, .subtitle, .content > p, .table-help {
+  & p.lead,
+  .title,
+  .subtitle,
+  .content > p,
+  .table-help {
     color: ${props => props.theme.primaryText} !important;
   }
   & a {
     color: ${props => props.theme.link};
-    text-decoration: ${props => props.theme.name === 'dark' ? 'underline' : 'none'};
+    text-decoration: ${props =>
+    props.theme.name === 'dark' ? 'underline' : 'none'};
   }
   & kbd {
     color: ${props => props.theme.primaryBackground} !important; /* inverted */
@@ -88,11 +84,17 @@ export const StyledSlide = styled.div`
     background-color: ${props => props.theme.secondaryBackground};
     color: ${props => props.theme.preText};
   }
-  & a[help-topic], a[play-topic], a[server-topic], a[exec-topic] {
+  & a[help-topic],
+  a[play-topic],
+  a[server-topic],
+  a[exec-topic] {
     background-color: ${props => props.theme.topicBackground} !important;
     color: ${props => props.theme.topicText} !important;
   }
-  & button [help-topic], button [play-topic], button [server-topic], button [exec-topic] {
+  & button [help-topic],
+  button [play-topic],
+  button [server-topic],
+  button [exec-topic] {
     background-color: ${props => props.theme.primaryButtonBackground};
     color: ${props => props.theme.primaryButtonText};
   }

--- a/src/browser/modules/Intercom/index.jsx
+++ b/src/browser/modules/Intercom/index.jsx
@@ -36,7 +36,7 @@ export class Intercom extends Component {
       return
     }
     if (!window.Intercom) {
-      (function (w, d, id, s, x) {
+      ;(function (w, d, id, s, x) {
         function i () {
           i.c(arguments)
         }
@@ -81,9 +81,9 @@ export class Intercom extends Component {
   }
 }
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
-    updateData: (data) => dispatch(updateData(data))
+    updateData: data => dispatch(updateData(data))
   }
 }
 export default connect(null, mapDispatchToProps)(Intercom)

--- a/src/browser/modules/Main/Main.jsx
+++ b/src/browser/modules/Main/Main.jsx
@@ -18,15 +18,25 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { DISCONNECTED_STATE, PENDING_STATE } from 'shared/modules/connections/connectionsDuck'
+import {
+  DISCONNECTED_STATE,
+  PENDING_STATE
+} from 'shared/modules/connections/connectionsDuck'
 import Editor from '../Editor/Editor'
 import Stream from '../Stream/Stream'
 import Render from 'browser-components/Render'
 import ClickToCode from '../ClickToCode'
-import { StyledMain, WarningBanner, ErrorBanner, NotAuthedBanner, StyledCodeBlockAuthBar, StyledCodeBlockErrorBar } from './styled'
+import {
+  StyledMain,
+  WarningBanner,
+  ErrorBanner,
+  NotAuthedBanner,
+  StyledCodeBlockAuthBar,
+  StyledCodeBlockErrorBar
+} from './styled'
 import SyncReminderBanner from './SyncReminderBanner'
 
-const Main = (props) => {
+const Main = props => {
   return (
     <StyledMain>
       <Editor />
@@ -35,8 +45,7 @@ const Main = (props) => {
           Type&nbsp;
           <ClickToCode CodeComponent={StyledCodeBlockErrorBar}>
             {props.cmdchar}help commands
-          </ClickToCode>&nbsp;
-          for a list of available commands.
+          </ClickToCode>&nbsp; for a list of available commands.
         </ErrorBanner>
       </Render>
       <Render if={props.errorMessage}>
@@ -49,8 +58,8 @@ const Main = (props) => {
           Database access not available. Please use&nbsp;
           <ClickToCode CodeComponent={StyledCodeBlockAuthBar}>
             {props.cmdchar}server connect
-          </ClickToCode>&nbsp;
-          to establish connection. There's a graph waiting for you.
+          </ClickToCode>&nbsp; to establish connection. There's a graph waiting
+          for you.
         </NotAuthedBanner>
       </Render>
       <Render if={props.connectionState === PENDING_STATE}>

--- a/src/browser/modules/Main/SyncReminderBanner.jsx
+++ b/src/browser/modules/Main/SyncReminderBanner.jsx
@@ -20,8 +20,17 @@
 
 import { Component } from 'preact'
 import { connect } from 'preact-redux'
-import { SyncDisconnectedBanner, SyncSignInBarButton, StyledCancelLink, StyledSyncReminderSpan, StyledSyncReminderButtonContainer } from './styled'
-import { CONNECTED_STATE, getConnectionState } from 'shared/modules/connections/connectionsDuck'
+import {
+  SyncDisconnectedBanner,
+  SyncSignInBarButton,
+  StyledCancelLink,
+  StyledSyncReminderSpan,
+  StyledSyncReminderButtonContainer
+} from './styled'
+import {
+  CONNECTED_STATE,
+  getConnectionState
+} from 'shared/modules/connections/connectionsDuck'
 import Render from 'browser-components/Render'
 import BrowserSyncAuthWindow from '../Sync/BrowserSyncAuthWindow'
 import { getBrowserSyncConfig } from 'shared/modules/settings/settingsDuck'
@@ -37,25 +46,38 @@ class SyncReminderBanner extends Component {
     })
   }
   serviceReady (status) {
-    this.setState({status})
+    this.setState({ status })
   }
   logIn () {
-    BrowserSyncAuthWindow(this.props.browserSyncConfig.authWindowUrl, this.syncManager.authCallBack.bind(this.syncManager))
+    BrowserSyncAuthWindow(
+      this.props.browserSyncConfig.authWindowUrl,
+      this.syncManager.authCallBack.bind(this.syncManager)
+    )
   }
   render () {
     const { dbConnectionState, syncConsent, sync, optOutSync } = this.props
     const dbConnected = dbConnectionState === CONNECTED_STATE
     const syncDisconnected = !sync || !sync.authData
-    const syncConsentGiven = syncConsent && syncConsent.consented === true && !syncConsent.optedOut
+    const syncConsentGiven =
+      syncConsent && syncConsent.consented === true && !syncConsent.optedOut
 
-    const visible = dbConnected && syncDisconnected && syncConsentGiven && this.state.status === 'UP'
+    const visible =
+      dbConnected &&
+      syncDisconnected &&
+      syncConsentGiven &&
+      this.state.status === 'UP'
 
     return (
       <Render if={visible}>
         <SyncDisconnectedBanner height='100px'>
-          <StyledSyncReminderSpan>You are currently not signed into Neo4j Browser Sync. Connect through a simple social sign-in to get started.</StyledSyncReminderSpan>
+          <StyledSyncReminderSpan>
+            You are currently not signed into Neo4j Browser Sync. Connect
+            through a simple social sign-in to get started.
+          </StyledSyncReminderSpan>
           <StyledSyncReminderButtonContainer>
-            <SyncSignInBarButton onClick={this.logIn.bind(this)}>Sign In</SyncSignInBarButton>
+            <SyncSignInBarButton onClick={this.logIn.bind(this)}>
+              Sign In
+            </SyncSignInBarButton>
             <StyledCancelLink onClick={() => optOutSync()}>X</StyledCancelLink>
           </StyledSyncReminderButtonContainer>
         </SyncDisconnectedBanner>
@@ -64,7 +86,7 @@ class SyncReminderBanner extends Component {
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     syncConsent: state.syncConsent,
     sync: state.sync,
@@ -75,7 +97,7 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    onSync: (syncObject) => {
+    onSync: syncObject => {
       dispatch(setSync(syncObject))
     },
     optOutSync: () => {

--- a/src/browser/modules/Main/styled.jsx
+++ b/src/browser/modules/Main/styled.jsx
@@ -22,7 +22,7 @@ import styled, { keyframes } from 'styled-components'
 import { StyledCodeBlock } from '../ClickToCode/styled'
 import { SyncSignInButton } from 'browser-components/buttons'
 
-const grow = (height) => {
+const grow = height => {
   return keyframes`
     0% {
       max-height: 0px;
@@ -87,19 +87,17 @@ export const SyncSignInBarButton = styled(SyncSignInButton)`
 export const StyledCancelLink = styled.a`
   cursor: pointer;
   text-decoration: none;
-  color: #D0D0D0;
+  color: #d0d0d0;
   &:hover {
-    color: #FFFFFF;
+    color: #ffffff;
     text-decoration: none;
-  };
+  }
 `
 export const StyledSyncReminderSpan = styled.span`
-  text-overflow : ellipsis;
-  white-space : nowrap;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   overflow: hidden;
   float: left;
 `
 
-export const StyledSyncReminderButtonContainer = styled.div`
-  float: right;
-`
+export const StyledSyncReminderButtonContainer = styled.div`float: right;`

--- a/src/browser/modules/Sidebar/About.jsx
+++ b/src/browser/modules/Sidebar/About.jsx
@@ -19,7 +19,15 @@
  */
 
 import { version } from 'project-root/package.json'
-import {Drawer, DrawerBody, DrawerHeader, DrawerSubHeader, DrawerSection, DrawerSectionBody, DrawerFooter} from 'browser-components/drawer'
+import {
+  Drawer,
+  DrawerBody,
+  DrawerHeader,
+  DrawerSubHeader,
+  DrawerSection,
+  DrawerSectionBody,
+  DrawerFooter
+} from 'browser-components/drawer'
 
 const About = () => {
   return (
@@ -28,53 +36,86 @@ const About = () => {
       <DrawerBody>
         <DrawerSection>
           <DrawerSubHeader>
-            Made by <a target='_blank' href='http://neo4j.com/'>Neo Technology</a>
+            Made by{' '}
+            <a target='_blank' href='http://neo4j.com/'>
+              Neo Technology
+            </a>
           </DrawerSubHeader>
         </DrawerSection>
         <DrawerSection>
-          <DrawerSectionBody>
-            Copyright &#169; 2002-2017
-          </DrawerSectionBody>
+          <DrawerSectionBody>Copyright &#169; 2002-2017</DrawerSectionBody>
         </DrawerSection>
         <DrawerSection>
-          <DrawerSubHeader>
-            Neo4j Browser
-          </DrawerSubHeader>
+          <DrawerSubHeader>Neo4j Browser</DrawerSubHeader>
           <DrawerSectionBody>
             You are running version {version}
           </DrawerSectionBody>
         </DrawerSection>
         <DrawerSection>
-          <DrawerSubHeader>
-            License
-          </DrawerSubHeader>
+          <DrawerSubHeader>License</DrawerSubHeader>
           <DrawerSectionBody>
-            <a target='_blank' href='http://www.gnu.org/licenses/gpl.html'>GPLv3</a> or <a target='_blank' href='http://www.gnu.org/licenses/agpl-3.0.html'>AGPL</a> for Open Source, and <a target='_blank' href='https://neo4j.com/licensing/'>NTCL</a> Commercial.
+            <a target='_blank' href='http://www.gnu.org/licenses/gpl.html'>
+              GPLv3
+            </a>{' '}
+            or{' '}
+            <a target='_blank' href='http://www.gnu.org/licenses/agpl-3.0.html'>
+              AGPL
+            </a>{' '}
+            for Open Source, and{' '}
+            <a target='_blank' href='https://neo4j.com/licensing/'>
+              NTCL
+            </a>{' '}
+            Commercial.
           </DrawerSectionBody>
         </DrawerSection>
         <DrawerSection>
-          <DrawerSubHeader>
-            Participate
-          </DrawerSubHeader>
+          <DrawerSubHeader>Participate</DrawerSubHeader>
           <DrawerSectionBody>
-            Ask questions at <a target='_blank' href='http://stackoverflow.com/questions/tagged/neo4j'>Stack Overflow</a><br />
-            Discuss Neo4j on <a target='_blank' href='http://neo4j.com/slack'>Slack</a> or <a target='_blank' href='http://groups.google.com/group/neo4j'>Google Groups</a><br />
-            Visit a local <a target='_blank' href='http://neo4j.meetup.com/'>Meetup Group</a><br />
-            Contribute code to <a target='_blank' href='http://github.com/neo4j'>Neo4j</a> or <a target='_blank' href='http://github.com/neo4j/neo4j-browser'>Neo4j Browser</a><br />
-            Send us your Browser feedback via <a href='mailto:browser@neotechnology.com?subject=Neo4j Browser feedback'>email</a>
+            Ask questions at{' '}
+            <a
+              target='_blank'
+              href='http://stackoverflow.com/questions/tagged/neo4j'
+            >
+              Stack Overflow
+            </a>
+            <br />
+            Discuss Neo4j on{' '}
+            <a target='_blank' href='http://neo4j.com/slack'>
+              Slack
+            </a>{' '}
+            or{' '}
+            <a target='_blank' href='http://groups.google.com/group/neo4j'>
+              Google Groups
+            </a>
+            <br />
+            Visit a local{' '}
+            <a target='_blank' href='http://neo4j.meetup.com/'>
+              Meetup Group
+            </a>
+            <br />
+            Contribute code to{' '}
+            <a target='_blank' href='http://github.com/neo4j'>
+              Neo4j
+            </a>{' '}
+            or{' '}
+            <a target='_blank' href='http://github.com/neo4j/neo4j-browser'>
+              Neo4j Browser
+            </a>
+            <br />
+            Send us your Browser feedback via{' '}
+            <a href='mailto:browser@neotechnology.com?subject=Neo4j Browser feedback'>
+              email
+            </a>
           </DrawerSectionBody>
         </DrawerSection>
         <DrawerSection>
-          <DrawerSubHeader>
-            Thanks
-          </DrawerSubHeader>
+          <DrawerSubHeader>Thanks</DrawerSubHeader>
           <DrawerSectionBody>
-            Neo4j wouldn't be possible without a fantastic community. Thanks for all the feedback, discussions and contributions.
+            Neo4j wouldn't be possible without a fantastic community. Thanks for
+            all the feedback, discussions and contributions.
           </DrawerSectionBody>
           <DrawerFooter>
-            <DrawerSectionBody>
-             With &#9829; from Sweden.
-            </DrawerSectionBody>
+            <DrawerSectionBody>With &#9829; from Sweden.</DrawerSectionBody>
           </DrawerFooter>
         </DrawerSection>
       </DrawerBody>

--- a/src/browser/modules/Sidebar/DocumentItems.jsx
+++ b/src/browser/modules/Sidebar/DocumentItems.jsx
@@ -21,29 +21,45 @@
 import { connect } from 'preact-redux'
 import { withBus } from 'preact-suber'
 import { SET_CONTENT, setContent } from 'shared/modules/editor/editorDuck'
-import {DrawerSubHeader, DrawerSection, DrawerSectionBody} from 'browser-components/drawer'
-import { StyledHelpLink, StyledHelpItem, StyledDocumentActionLink } from './styled'
+import {
+  DrawerSubHeader,
+  DrawerSection,
+  DrawerSectionBody
+} from 'browser-components/drawer'
+import {
+  StyledHelpLink,
+  StyledHelpItem,
+  StyledDocumentActionLink
+} from './styled'
 
-export const DocumentItems = ({header, items, onItemClick = null}) => {
-  const listOfItems = items.map((item) => {
+export const DocumentItems = ({ header, items, onItemClick = null }) => {
+  const listOfItems = items.map(item => {
     switch (item.type) {
       case 'link':
         return (
           <StyledHelpItem>
-            <StyledHelpLink href={item.command} target='_blank'>{item.name}</StyledHelpLink>
+            <StyledHelpLink href={item.command} target='_blank'>
+              {item.name}
+            </StyledHelpLink>
           </StyledHelpItem>
         )
       default:
         return (
           <StyledHelpItem>
-            <StyledDocumentActionLink onClick={() => onItemClick(item.command)} name={item.name} type={item.type} />
+            <StyledDocumentActionLink
+              onClick={() => onItemClick(item.command)}
+              name={item.name}
+              type={item.type}
+            />
           </StyledHelpItem>
         )
     }
   })
   return (
     <DrawerSection>
-      <DrawerSubHeader>{header}</DrawerSubHeader>
+      <DrawerSubHeader>
+        {header}
+      </DrawerSubHeader>
       <DrawerSectionBody>
         <ul className='document'>
           {listOfItems}
@@ -55,7 +71,7 @@ export const DocumentItems = ({header, items, onItemClick = null}) => {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    onItemClick: (cmd) => {
+    onItemClick: cmd => {
       ownProps.bus.send(SET_CONTENT, setContent(cmd))
     }
   }

--- a/src/browser/modules/Sidebar/DocumentItems.test.jsx
+++ b/src/browser/modules/Sidebar/DocumentItems.test.jsx
@@ -24,8 +24,8 @@ import { shallow } from 'enzyme'
 import { DocumentItems as DocumentItemsComponent } from './DocumentItems'
 
 describe('DocumentItemsComponent', () => {
-  const link = {name: 'Link', command: 'url.com', type: 'link'}
-  const command = {name: 'Command', command: 'TEST'}
+  const link = { name: 'Link', command: 'url.com', type: 'link' }
+  const command = { name: 'Command', command: 'TEST' }
 
   test('should render href when link is provided', () => {
     const wrapper = shallow(<DocumentItemsComponent items={[link]} />)

--- a/src/browser/modules/Sidebar/Documents.jsx
+++ b/src/browser/modules/Sidebar/Documents.jsx
@@ -23,23 +23,47 @@ import { Drawer, DrawerBody, DrawerHeader } from 'browser-components/drawer'
 
 const staticItems = {
   intro: [
-    {name: 'Getting started', command: ':play intro', type: 'play'},
-    {name: 'Basic graph concepts', command: ':play graphs', type: 'play'},
-    {name: 'Writing Cypher queries', command: ':play cypher', type: 'play'}
+    { name: 'Getting started', command: ':play intro', type: 'play' },
+    { name: 'Basic graph concepts', command: ':play graphs', type: 'play' },
+    { name: 'Writing Cypher queries', command: ':play cypher', type: 'play' }
   ],
   help: [
-    {name: 'Help', command: ':help help', type: 'help'},
-    {name: 'Cypher syntax', command: ':help cypher', type: 'help'},
-    {name: 'Available commands', command: ':help commands', type: 'help'},
-    {name: 'Keyboard shortcuts', command: ':help keys', type: 'help'}
+    { name: 'Help', command: ':help help', type: 'help' },
+    { name: 'Cypher syntax', command: ':help cypher', type: 'help' },
+    { name: 'Available commands', command: ':help commands', type: 'help' },
+    { name: 'Keyboard shortcuts', command: ':help keys', type: 'help' }
   ],
   reference: [
-    {name: 'Developer Manual', command: 'https://neo4j.com/docs/developer-manual/3.2/', type: 'link'},
-    {name: 'Operations Manual', command: 'https://neo4j.com/docs/operations-manual/3.2/', type: 'link'},
-    {name: 'Cypher Refcard', command: 'https://neo4j.com/docs/cypher-refcard/3.2/', type: 'link'},
-    {name: 'GraphGists', command: 'https://neo4j.com/graphgists/', type: 'link'},
-    {name: 'Developer Site', command: 'https://www.neo4j.com/developer/', type: 'link'},
-    {name: 'Knowledge Base', command: 'https://neo4j.com/developer/kb/', type: 'link'}
+    {
+      name: 'Developer Manual',
+      command: 'https://neo4j.com/docs/developer-manual/3.2/',
+      type: 'link'
+    },
+    {
+      name: 'Operations Manual',
+      command: 'https://neo4j.com/docs/operations-manual/3.2/',
+      type: 'link'
+    },
+    {
+      name: 'Cypher Refcard',
+      command: 'https://neo4j.com/docs/cypher-refcard/3.2/',
+      type: 'link'
+    },
+    {
+      name: 'GraphGists',
+      command: 'https://neo4j.com/graphgists/',
+      type: 'link'
+    },
+    {
+      name: 'Developer Site',
+      command: 'https://www.neo4j.com/developer/',
+      type: 'link'
+    },
+    {
+      name: 'Knowledge Base',
+      command: 'https://neo4j.com/developer/kb/',
+      type: 'link'
+    }
   ]
 }
 

--- a/src/browser/modules/Sidebar/Documents.test.jsx
+++ b/src/browser/modules/Sidebar/Documents.test.jsx
@@ -26,7 +26,11 @@ import { shallow } from 'enzyme'
 
 describe('DocumentsComponent', () => {
   test('should show list of documents', () => {
-    const documents = {intro: [], help: [], reference: [{name: 'hello', command: 'test commands'}]}
+    const documents = {
+      intro: [],
+      help: [],
+      reference: [{ name: 'hello', command: 'test commands' }]
+    }
     const wrapper = shallow(<DocumentsComponent items={documents} />)
     expect(wrapper.find(DocumentItems).length).toBe(3)
   })

--- a/src/browser/modules/Sidebar/Favorite.jsx
+++ b/src/browser/modules/Sidebar/Favorite.jsx
@@ -18,12 +18,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {connect} from 'preact-redux'
+import { connect } from 'preact-redux'
 import * as favorite from 'shared/modules/favorites/favoritesDuck'
-import {StyledListItem, StyledFavoriteText, DeleteFavButton, ExecFavoriteButton} from './styled'
-import {withBus} from 'preact-suber'
-import {Component} from 'preact'
-import {DragSource, DropTarget} from 'react-dnd'
+import {
+  StyledListItem,
+  StyledFavoriteText,
+  DeleteFavButton,
+  ExecFavoriteButton
+} from './styled'
+import { withBus } from 'preact-suber'
+import { Component } from 'preact'
+import { DragSource, DropTarget } from 'react-dnd'
 import ItemTypes from './DragItemTypes'
 
 function extractNameFromCommand (input) {
@@ -72,7 +77,14 @@ const calculateNewPosition = (props, component, monitor) => {
     return null
   }
 
-  return { dragIndex, dragFolder: dragItem.folder, hoverIndex, hoverFolder: props.entry.folder, dragItem, hoveredItemProps: props }
+  return {
+    dragIndex,
+    dragFolder: dragItem.folder,
+    hoverIndex,
+    hoverFolder: props.entry.folder,
+    dragItem,
+    hoveredItemProps: props
+  }
 }
 
 const favoriteTarget = {
@@ -80,7 +92,7 @@ const favoriteTarget = {
     let newValues = calculateNewPosition(props, component, monitor)
 
     if (newValues) {
-      props.moveFavorite(Object.assign({...newValues}, {dropped: false}))
+      props.moveFavorite(Object.assign({ ...newValues }, { dropped: false }))
       monitor.getItem().index = newValues.hoverIndex
     }
   },
@@ -88,7 +100,15 @@ const favoriteTarget = {
     const dragItem = monitor.getItem()
     const dragIndex = dragItem.index
     const hoverIndex = props.index
-    props.moveFavorite({ dragIndex, dragFolder: dragItem.folder, hoverIndex, hoverFolder: props.entry.folder, dragItem, hoveredItemProps: props, dropped: true })
+    props.moveFavorite({
+      dragIndex,
+      dragFolder: dragItem.folder,
+      hoverIndex,
+      hoverFolder: props.entry.folder,
+      dragItem,
+      hoveredItemProps: props,
+      dropped: true
+    })
   }
 }
 
@@ -97,20 +117,32 @@ class FavoriteDp extends Component {
     const name = extractNameFromCommand(this.props.content)
     let favoriteContent = (
       <StyledListItem isChild={this.props.isChild}>
-        <ExecFavoriteButton onClick={() => this.props.onExecClick(this.props.content)} />
-        <StyledFavoriteText {...this.props}
-          onClick={() => this.props.onItemClick(this.props.id, this.props.content)}>
+        <ExecFavoriteButton
+          onClick={() => this.props.onExecClick(this.props.content)}
+        />
+        <StyledFavoriteText
+          {...this.props}
+          onClick={() =>
+            this.props.onItemClick(this.props.id, this.props.content)}
+        >
           {name}
         </StyledFavoriteText>
-        <DeleteFavButton id={this.props.id} removeClick={() => this.props.removeClick(this.props.id)}
-          isStatic={this.props.isStatic} />
+        <DeleteFavButton
+          id={this.props.id}
+          removeClick={() => this.props.removeClick(this.props.id)}
+          isStatic={this.props.isStatic}
+        />
       </StyledListItem>
     )
 
     if (this.props.isStatic) {
       return favoriteContent
     } else {
-      return this.props.connectDropTarget(<div>{favoriteContent}</div>)
+      return this.props.connectDropTarget(
+        <div>
+          {favoriteContent}
+        </div>
+      )
     }
   }
 }
@@ -131,19 +163,27 @@ class FavoriteDg extends Component {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    removeClick: (id) => {
+    removeClick: id => {
       dispatch(favorite.removeFavorite(id))
     }
   }
 }
 
-const FavoriteDrop = DropTarget(ItemTypes.FAVORITE, favoriteTarget, connect => ({
-  connectDropTarget: connect.dropTarget()
-}))(FavoriteDg)
+const FavoriteDrop = DropTarget(
+  ItemTypes.FAVORITE,
+  favoriteTarget,
+  connect => ({
+    connectDropTarget: connect.dropTarget()
+  })
+)(FavoriteDg)
 
-const FavoriteDrag = DragSource(ItemTypes.FAVORITE, favoriteSource, (connect, monitor) => ({
-  connectDragSource: connect.dragSource(),
-  isDragging: monitor.isDragging()
-}))(FavoriteDrop)
+const FavoriteDrag = DragSource(
+  ItemTypes.FAVORITE,
+  favoriteSource,
+  (connect, monitor) => ({
+    connectDragSource: connect.dragSource(),
+    isDragging: monitor.isDragging()
+  })
+)(FavoriteDrop)
 
 export default withBus(connect(null, mapDispatchToProps)(FavoriteDrag))

--- a/src/browser/modules/Sidebar/Favorite.test.jsx
+++ b/src/browser/modules/Sidebar/Favorite.test.jsx
@@ -49,7 +49,9 @@ describe('FavoriteComponent', () => {
     ]
     testCases.forEach((testCase, i) => {
       test(`should extract name of script from case ${i}`, () => {
-        const wrapper = shallow(<FavoriteComponent content={testCase.command} />)
+        const wrapper = shallow(
+          <FavoriteComponent content={testCase.command} />
+        )
         const item = wrapper.find('.favorite')
         expect(item.length).toBe(1)
         expect(item.props().primaryText).toEqual(testCase.expected)
@@ -59,7 +61,9 @@ describe('FavoriteComponent', () => {
 
   test('should show tigger event with content of script', () => {
     const onItemClick = jest.fn()
-    const wrapper = shallow(<FavoriteComponent content={'Cypher'} onItemClick={onItemClick} />)
+    const wrapper = shallow(
+      <FavoriteComponent content={'Cypher'} onItemClick={onItemClick} />
+    )
     const favoriteElement = wrapper.find('.favorite')
     expect(favoriteElement.length).toBe(1)
     favoriteElement.first().simulate('click')
@@ -69,7 +73,9 @@ describe('FavoriteComponent', () => {
   test('should remove favorite that has been clicked', () => {
     const id = 'SomeId'
     const onRemoveClick = jest.fn()
-    const wrapper = mount(<FavoriteComponent id={id} content='hej' removeClick={onRemoveClick} />)
+    const wrapper = mount(
+      <FavoriteComponent id={id} content='hej' removeClick={onRemoveClick} />
+    )
     const favoriteElement = wrapper.find('.favorite')
     expect(favoriteElement.length).toBe(1)
     wrapper.find('.remove').simulate('click')

--- a/src/browser/modules/Sidebar/Favorites.jsx
+++ b/src/browser/modules/Sidebar/Favorites.jsx
@@ -18,54 +18,83 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {Component} from 'preact'
-import {connect} from 'preact-redux'
-import {withBus} from 'preact-suber'
+import { Component } from 'preact'
+import { connect } from 'preact-redux'
+import { withBus } from 'preact-suber'
 import * as editor from 'shared/modules/editor/editorDuck'
 import * as favorite from 'shared/modules/favorites/favoritesDuck'
 import * as folder from 'shared/modules/favorites/foldersDuck'
-import {getSettings} from 'shared/modules/settings/settingsDuck'
-import {executeCommand} from 'shared/modules/commands/commandsDuck'
+import { getSettings } from 'shared/modules/settings/settingsDuck'
+import { executeCommand } from 'shared/modules/commands/commandsDuck'
 
 import Render from 'browser-components/Render'
 import Favorite from './Favorite'
 import Folder from './Folder'
 import FileDrop from './FileDrop'
-import {Drawer, DrawerBody, DrawerHeader, DrawerSection, DrawerSubHeader} from 'browser-components/drawer'
-import {DragDropContext} from 'react-dnd'
+import {
+  Drawer,
+  DrawerBody,
+  DrawerHeader,
+  DrawerSection,
+  DrawerSubHeader
+} from 'browser-components/drawer'
+import { DragDropContext } from 'react-dnd'
 import HTML5Backend from 'react-dnd-html5-backend'
-import {NewFolderButton} from './styled'
+import { NewFolderButton } from './styled'
 
 const mapFavorites = (favorites, props, isChild, moveAction) => {
   return favorites.map((entry, index) => {
-    return <Favorite entry={entry} key={entry.id} id={entry.id} name={entry.name} content={entry.content}
-      onItemClick={props.onItemClick} onExecClick={props.onExecClick} removeClick={props.removeClick} isChild={isChild}
-      isStatic={entry.isStatic} index={index} moveFavorite={moveAction} />
+    return (
+      <Favorite
+        entry={entry}
+        key={entry.id}
+        id={entry.id}
+        name={entry.name}
+        content={entry.content}
+        onItemClick={props.onItemClick}
+        onExecClick={props.onExecClick}
+        removeClick={props.removeClick}
+        isChild={isChild}
+        isStatic={entry.isStatic}
+        index={index}
+        moveFavorite={moveAction}
+      />
+    )
   })
 }
 
 class Favorites extends Component {
   constructor (props) {
     super(props)
-    this.state = {...this.props}
+    this.state = { ...this.props }
   }
 
   componentWillReceiveProps (nextProps) {
-    this.setState({favorites: nextProps.favorites, folders: nextProps.folders})
+    this.setState({
+      favorites: nextProps.favorites,
+      folders: nextProps.folders
+    })
   }
 
   moveFavorite (dragDropValues) {
-    const {dropped} = dragDropValues
+    const { dropped } = dragDropValues
     let newFavorites = this.arrangeFavoriteList(dragDropValues)
 
     if (dropped) {
       this.props.updateFavorites(newFavorites)
     } else {
-      this.setState({favorites: newFavorites})
+      this.setState({ favorites: newFavorites })
     }
   }
 
-  arrangeFavoriteList ({dragIndex, dragFolder, hoverIndex, hoverFolder, dragItem, hoveredItemProps}) {
+  arrangeFavoriteList ({
+    dragIndex,
+    dragFolder,
+    hoverIndex,
+    hoverFolder,
+    dragItem,
+    hoveredItemProps
+  }) {
     let newFavorites
 
     if (dragFolder === hoverFolder || (!dragFolder && !hoverFolder)) {
@@ -74,16 +103,24 @@ class Favorites extends Component {
       let draggedFavIndex = favorites.findIndex(fav => fav.id === dragItem.id)
       let newIndex = draggedFavIndex + (hoverIndex - dragIndex)
       favorites.splice(draggedFavIndex, 1)
-      newFavorites = favorites.slice(0, newIndex).concat([draggedFav]).concat(favorites.slice(newIndex))
+      newFavorites = favorites
+        .slice(0, newIndex)
+        .concat([draggedFav])
+        .concat(favorites.slice(newIndex))
     } else {
       let favorites = this.state.favorites
       let draggedFav = favorites.find(fav => fav.id === dragItem.id)
       let draggedFavIndex = favorites.findIndex(fav => fav.id === dragItem.id)
-      let hoveredFavIndex = favorites.findIndex(fav => fav.id === hoveredItemProps.id)
+      let hoveredFavIndex = favorites.findIndex(
+        fav => fav.id === hoveredItemProps.id
+      )
       let newIndex = hoveredFavIndex
       favorites.splice(draggedFavIndex, 1)
       draggedFav.folder = hoverFolder
-      newFavorites = favorites.slice(0, newIndex).concat([draggedFav]).concat(favorites.slice(newIndex))
+      newFavorites = favorites
+        .slice(0, newIndex)
+        .concat([draggedFav])
+        .concat(favorites.slice(newIndex))
     }
 
     return newFavorites
@@ -96,7 +133,7 @@ class Favorites extends Component {
     if (dropped) {
       this.props.updateFavorites(this.state.favorites)
     } else {
-      this.setState({favorites: this.state.favorites})
+      this.setState({ favorites: this.state.favorites })
     }
   }
 
@@ -107,19 +144,49 @@ class Favorites extends Component {
   }
 
   render () {
-    const {favorites, folders} = {...this.state}
+    const { favorites, folders } = { ...this.state }
 
-    const ListOfFavorites = mapFavorites(favorites.filter(fav => !fav.isStatic && !fav.folder), this.props, false, this.moveFavorite.bind(this))
-    const ListOfFolders = folders.filter(folder => !folder.isStatic).map((folder) => {
-      const Favorites = mapFavorites(favorites.filter(fav => !fav.isStatic && fav.folder === folder.id), this.props, true, this.moveFavorite.bind(this))
-      return <Folder folder={folder} removeClick={this.props.removeFolderClick}
-        moveToFolder={this.moveToFolder.bind(this)}
-        updateFolder={this.updateFolder.bind(this)}>{Favorites}</Folder>
-    })
-    const ListOfSampleFolders = folders.filter(folder => folder.isStatic).map((folder) => {
-      const Favorites = mapFavorites(favorites.filter(fav => fav.isStatic && fav.folder === folder.id), this.props, true, this.moveFavorite.bind(this))
-      return <Folder folder={folder}>{Favorites}</Folder>
-    })
+    const ListOfFavorites = mapFavorites(
+      favorites.filter(fav => !fav.isStatic && !fav.folder),
+      this.props,
+      false,
+      this.moveFavorite.bind(this)
+    )
+    const ListOfFolders = folders
+      .filter(folder => !folder.isStatic)
+      .map(folder => {
+        const Favorites = mapFavorites(
+          favorites.filter(fav => !fav.isStatic && fav.folder === folder.id),
+          this.props,
+          true,
+          this.moveFavorite.bind(this)
+        )
+        return (
+          <Folder
+            folder={folder}
+            removeClick={this.props.removeFolderClick}
+            moveToFolder={this.moveToFolder.bind(this)}
+            updateFolder={this.updateFolder.bind(this)}
+          >
+            {Favorites}
+          </Folder>
+        )
+      })
+    const ListOfSampleFolders = folders
+      .filter(folder => folder.isStatic)
+      .map(folder => {
+        const Favorites = mapFavorites(
+          favorites.filter(fav => fav.isStatic && fav.folder === folder.id),
+          this.props,
+          true,
+          this.moveFavorite.bind(this)
+        )
+        return (
+          <Folder folder={folder}>
+            {Favorites}
+          </Folder>
+        )
+      })
 
     return (
       <Drawer id='db-favorites'>
@@ -149,7 +216,7 @@ class Favorites extends Component {
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     favorites: state.documents || [],
     folders: state.folders || [],
@@ -161,11 +228,11 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     onItemClick: (id, cmd) => {
       ownProps.bus.send(editor.EDIT_CONTENT, editor.editContent(id, cmd))
     },
-    onExecClick: (cmd) => {
+    onExecClick: cmd => {
       const action = executeCommand(cmd)
       ownProps.bus.send(action.type, action)
     },
-    removeClick: (id) => {
+    removeClick: id => {
       const action = favorite.removeFavorite(id)
       dispatch(action)
     },
@@ -173,18 +240,20 @@ const mapDispatchToProps = (dispatch, ownProps) => {
       const action = folder.addFolder()
       dispatch(action)
     },
-    removeFolderClick: (id) => {
+    removeFolderClick: id => {
       const action = folder.removeFolder(id)
       dispatch(action)
     },
-    updateFavorites: (favorites) => {
+    updateFavorites: favorites => {
       const action = favorite.updateFavorites(favorites)
       dispatch(action)
     },
-    updateFolders: (folders) => {
+    updateFolders: folders => {
       const action = folder.updateFolders(folders)
       dispatch(action)
     }
   }
 }
-export default DragDropContext(HTML5Backend)(withBus(connect(mapStateToProps, mapDispatchToProps)(Favorites)))
+export default DragDropContext(HTML5Backend)(
+  withBus(connect(mapStateToProps, mapDispatchToProps)(Favorites))
+)

--- a/src/browser/modules/Sidebar/Favorites.test.jsx
+++ b/src/browser/modules/Sidebar/Favorites.test.jsx
@@ -27,8 +27,13 @@ import Favorite from './Favorite'
 
 describe('FavoritesComponent', () => {
   test('should show list of favorites', () => {
-    const favorites = [{id: '1', content: '//Test1 Hello'}, {id: '2', content: '//Test2 Again'}]
-    const wrapper = shallow(<FavoritesComponent scripts={favorites} dispatch={() => null} />)
+    const favorites = [
+      { id: '1', content: '//Test1 Hello' },
+      { id: '2', content: '//Test2 Again' }
+    ]
+    const wrapper = shallow(
+      <FavoritesComponent scripts={favorites} dispatch={() => null} />
+    )
     expect(wrapper.find(Favorite).length).toBe(2)
   })
 })

--- a/src/browser/modules/Sidebar/FileDrop.jsx
+++ b/src/browser/modules/Sidebar/FileDrop.jsx
@@ -42,7 +42,7 @@ export class FileDrop extends Component {
     this.fileReader = this.props.fileReader || new FileReader()
   }
   onDrop (files) {
-    this.setState({error: null, success: null})
+    this.setState({ error: null, success: null })
 
     const file = files[0]
     const fileExtension = file.name.split('.').pop()
@@ -53,31 +53,35 @@ export class FileDrop extends Component {
     } else if (this.grassExtenstions.includes(fileExtension)) {
       loader = this.props.onGrassFileDropped
     } else {
-      return this.setState({'error': `'.${fileExtension}' is not a valid file extension`})
+      return this.setState({
+        error: `'.${fileExtension}' is not a valid file extension`
+      })
     }
 
     this.fileReader.onload = () => {
       loader(this.fileReader.result)
-      this.setState({'success': `'${file.name}' has been added`})
+      this.setState({ success: `'${file.name}' has been added` })
     }
     this.fileReader.readAsText(file)
   }
   render () {
     return (
-      <Dropzone
-        disableClick
-        multiple={false}
-        onDrop={this.onDrop.bind(this)}>
-        <StyledDropzoneText>{this.state.error || this.state.success || 'Drop a file to import Cypher (*.cyp, *.cypher, *.cql, *.txt) or Grass (*.grass)'}</StyledDropzoneText>
-      </Dropzone>)
+      <Dropzone disableClick multiple={false} onDrop={this.onDrop.bind(this)}>
+        <StyledDropzoneText>
+          {this.state.error ||
+            this.state.success ||
+            'Drop a file to import Cypher (*.cyp, *.cypher, *.cql, *.txt) or Grass (*.grass)'}
+        </StyledDropzoneText>
+      </Dropzone>
+    )
   }
 }
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    onFavoriteFileDropped: (fileContent) => {
+    onFavoriteFileDropped: fileContent => {
       dispatch(addFavorite(fileContent))
     },
-    onGrassFileDropped: (fileContent) => {
+    onGrassFileDropped: fileContent => {
       const parsedGrass = parseGrass(fileContent)
       if (parsedGrass) {
         dispatch(updateGraphStyleData(parsedGrass))

--- a/src/browser/modules/Sidebar/FileDrop.test.jsx
+++ b/src/browser/modules/Sidebar/FileDrop.test.jsx
@@ -30,9 +30,11 @@ describe('FileDrop', () => {
   const readAsText = jest.fn()
   const stubFileReader = { readAsText, result: expectedFileContent }
 
-  test('should read file', (done) => {
+  test('should read file', done => {
     const onFileDropped = jest.fn()
-    const wrapper = shallow(<FileDrop fileReader={stubFileReader} onFileDropped={onFileDropped} />)
+    const wrapper = shallow(
+      <FileDrop fileReader={stubFileReader} onFileDropped={onFileDropped} />
+    )
     wrapper.instance().onDrop([file])
 
     try {
@@ -42,9 +44,11 @@ describe('FileDrop', () => {
       done.fail(error)
     }
   })
-  test('should not read file', (done) => {
+  test('should not read file', done => {
     const onFileDropped = jest.fn()
-    const wrapper = shallow(<FileDrop fileReader={stubFileReader} onFileDropped={onFileDropped} />)
+    const wrapper = shallow(
+      <FileDrop fileReader={stubFileReader} onFileDropped={onFileDropped} />
+    )
     wrapper.instance().onDrop([unknownFile])
 
     try {

--- a/src/browser/modules/Sidebar/Folder.jsx
+++ b/src/browser/modules/Sidebar/Folder.jsx
@@ -27,16 +27,19 @@ import {
   FolderButtonContainer,
   EditFolderInput
 } from './styled'
-import {Component} from 'preact'
-import {CollapseMenuIcon, ExpandMenuIcon} from 'browser-components/icons/Icons'
-import {DropTarget} from 'react-dnd'
+import { Component } from 'preact'
+import {
+  CollapseMenuIcon,
+  ExpandMenuIcon
+} from 'browser-components/icons/Icons'
+import { DropTarget } from 'react-dnd'
 import Render from 'browser-components/Render'
 import ItemTypes from './DragItemTypes'
 
 class Folder extends Component {
   constructor (props) {
     super(props)
-    this.state = {...props}
+    this.state = { ...props }
   }
 
   onFolderNameChanged (e) {
@@ -52,7 +55,7 @@ class Folder extends Component {
 
   handleKeyPress (e) {
     if (e.keyCode === 13) {
-      this.setState({editing: false})
+      this.setState({ editing: false })
     }
   }
 
@@ -67,24 +70,40 @@ class Folder extends Component {
         <StyledList>
           <StyledListHeaderItem>
             <Render if={!this.state.editing}>
-              <span onClick={() => this.setState({active: !this.state.active})}>{this.props.folder.name}</span>
+              <span
+                onClick={() => this.setState({ active: !this.state.active })}
+              >
+                {this.props.folder.name}
+              </span>
             </Render>
             <Render if={this.state.editing}>
-              <EditFolderInput type='text' onChange={this.onFolderNameChanged.bind(this)}
-                onBlur={() => this.setState({editing: false})}
-                value={this.props.folder.name} innerRef={this.folderNameInputSet.bind(this)} />
+              <EditFolderInput
+                type='text'
+                onChange={this.onFolderNameChanged.bind(this)}
+                onBlur={() => this.setState({ editing: false })}
+                value={this.props.folder.name}
+                innerRef={this.folderNameInputSet.bind(this)}
+              />
             </Render>
             <FolderButtonContainer>
-              <FoldersButton onClick={() => this.setState({active: !this.state.active})}>{icon}</FoldersButton>
+              <FoldersButton
+                onClick={() => this.setState({ active: !this.state.active })}
+              >
+                {icon}
+              </FoldersButton>
               <Render if={!this.props.folder.isStatic}>
-                <EditFolderButton editClick={() => {
-                  this.setState({editing: true})
-                  return false
-                }
-                } />
+                <EditFolderButton
+                  editClick={() => {
+                    this.setState({ editing: true })
+                    return false
+                  }}
+                />
               </Render>&nbsp;
-              <DeleteFavButton id={this.props.folder.id} removeClick={this.props.removeClick}
-                isStatic={this.props.folder.isStatic} />
+              <DeleteFavButton
+                id={this.props.folder.id}
+                removeClick={this.props.removeClick}
+                isStatic={this.props.folder.isStatic}
+              />
             </FolderButtonContainer>
           </StyledListHeaderItem>
           {this.state.active ? this.props.children : null}

--- a/src/browser/modules/Sidebar/Settings.jsx
+++ b/src/browser/modules/Sidebar/Settings.jsx
@@ -20,147 +20,192 @@
 
 import { connect } from 'preact-redux'
 import * as actions from 'shared/modules/settings/settingsDuck'
-import { Drawer, DrawerBody, DrawerHeader, DrawerSection, DrawerSectionBody, DrawerSubHeader } from 'browser-components/drawer'
+import {
+  Drawer,
+  DrawerBody,
+  DrawerHeader,
+  DrawerSection,
+  DrawerSectionBody,
+  DrawerSubHeader
+} from 'browser-components/drawer'
 import { RadioSelector, CheckboxSelector } from 'browser-components/Form'
-import { StyledSetting, StyledSettingLabel, StyledSettingTextInput } from './styled'
+import {
+  StyledSetting,
+  StyledSettingLabel,
+  StyledSettingTextInput
+} from './styled'
 
-const visualSettings =
-  [
-    {
-      title: 'User Interface',
-      settings: [
-        {
-          theme: {
-            displayName: 'Theme',
-            type: 'radio',
-            options: ['normal', 'outline', 'dark']
-          }
-        },
-        {
-          'editorAutocomplete': {
-            displayName: 'Trigger autocomplete when typing',
-            tooltip: 'Autocomplete written queries in editor (shortcut keys will still work)',
-            type: 'checkbox'
-          }
+const visualSettings = [
+  {
+    title: 'User Interface',
+    settings: [
+      {
+        theme: {
+          displayName: 'Theme',
+          type: 'radio',
+          options: ['normal', 'outline', 'dark']
         }
-      ]
-    },
-    {
-      title: 'Preferences',
-      settings: [
-        {
-          showSampleScripts: {
-            displayName: 'Show sample scripts',
-            tooltip: 'Show sample scripts in favorites drawer.',
-            type: 'checkbox'
-          }
+      },
+      {
+        editorAutocomplete: {
+          displayName: 'Trigger autocomplete when typing',
+          tooltip:
+            'Autocomplete written queries in editor (shortcut keys will still work)',
+          type: 'checkbox'
         }
-      ]
-    },
-    {
-      title: 'Network Connection',
-      settings: [
-        {
-          'useBoltRouting': {
-            displayName: 'Use bolt+routing',
-            tooltip: 'Use bolt+routing protocol when in a causal cluster.',
-            type: 'checkbox'
-          }
+      }
+    ]
+  },
+  {
+    title: 'Preferences',
+    settings: [
+      {
+        showSampleScripts: {
+          displayName: 'Show sample scripts',
+          tooltip: 'Show sample scripts in favorites drawer.',
+          type: 'checkbox'
         }
-      ]
-    },
-    {
-      title: 'Result Frames',
-      settings: [
-        {
-          maxFrames: {
-            displayName: 'Maximum number of result frames',
-            tooltip: 'Max number of result frames. When reached, old frames gets retired.'
-          }
-        },
-        {
-          maxHistory: {
-            displayName: 'Max History',
-            tooltip: 'Max number of history entries. When reached, old entries gets retired.'
-          }
-        },
-        {
-          scrollToTop: {
-            displayName: 'Scroll To Top',
-            tooltip: 'Automatically scroll stream to top on new frames.',
-            type: 'checkbox'
-          }
+      }
+    ]
+  },
+  {
+    title: 'Network Connection',
+    settings: [
+      {
+        useBoltRouting: {
+          displayName: 'Use bolt+routing',
+          tooltip: 'Use bolt+routing protocol when in a causal cluster.',
+          type: 'checkbox'
         }
-      ]
-    },
-    {
-      title: 'Graph Visualization',
-      settings: [
-        {
-          initialNodeDisplay: {
-            displayName: 'Initial Node Display',
-            tooltip: 'Limit number of nodes displayed on first load of the graph visualization.'
-          }
-        },
-        {
-          maxNeighbours: {
-            displayName: 'Max Neighbours',
-            tooltip: 'Limit exploratary queries to this limit.'
-          }
-        },
-        {
-          maxRows: {
-            displayName: 'Max Rows',
-            tooltip: "Max number of rows to render in 'Rows' result view"
-          }
-        },
-        {
-          autoComplete: {
-            displayName: 'Connect result nodes',
-            tooltip: 'If this is checked, after a cypher query result is retrieved, a second query is executed to fetch relationships between result nodes.',
-            type: 'checkbox'
-          }
+      }
+    ]
+  },
+  {
+    title: 'Result Frames',
+    settings: [
+      {
+        maxFrames: {
+          displayName: 'Maximum number of result frames',
+          tooltip:
+            'Max number of result frames. When reached, old frames gets retired.'
         }
-      ]
-    }
-  ]
+      },
+      {
+        maxHistory: {
+          displayName: 'Max History',
+          tooltip:
+            'Max number of history entries. When reached, old entries gets retired.'
+        }
+      },
+      {
+        scrollToTop: {
+          displayName: 'Scroll To Top',
+          tooltip: 'Automatically scroll stream to top on new frames.',
+          type: 'checkbox'
+        }
+      }
+    ]
+  },
+  {
+    title: 'Graph Visualization',
+    settings: [
+      {
+        initialNodeDisplay: {
+          displayName: 'Initial Node Display',
+          tooltip:
+            'Limit number of nodes displayed on first load of the graph visualization.'
+        }
+      },
+      {
+        maxNeighbours: {
+          displayName: 'Max Neighbours',
+          tooltip: 'Limit exploratary queries to this limit.'
+        }
+      },
+      {
+        maxRows: {
+          displayName: 'Max Rows',
+          tooltip: "Max number of rows to render in 'Rows' result view"
+        }
+      },
+      {
+        autoComplete: {
+          displayName: 'Connect result nodes',
+          tooltip:
+            'If this is checked, after a cypher query result is retrieved, a second query is executed to fetch relationships between result nodes.',
+          type: 'checkbox'
+        }
+      }
+    ]
+  }
+]
 
-export const Settings = ({settings, onSettingsSave = () => {}}) => {
+export const Settings = ({ settings, onSettingsSave = () => {} }) => {
   if (!settings) return null
   const mappedSettings = visualSettings.map((visualSetting, i) => {
-    const title = <DrawerSubHeader>{visualSetting.title}</DrawerSubHeader>
-    const mapSettings = visualSetting.settings.map((settingObj, i) => {
-      const setting = Object.keys(settingObj)[0]
-      if (typeof settings[setting] === 'undefined') return false
-      const visual = settingObj[setting].displayName
-      const tooltip = settingObj[setting].tooltip || ''
+    const title = (
+      <DrawerSubHeader>
+        {visualSetting.title}
+      </DrawerSubHeader>
+    )
+    const mapSettings = visualSetting.settings
+      .map((settingObj, i) => {
+        const setting = Object.keys(settingObj)[0]
+        if (typeof settings[setting] === 'undefined') return false
+        const visual = settingObj[setting].displayName
+        const tooltip = settingObj[setting].tooltip || ''
 
-      if (!settingObj[setting].type || settingObj[setting].type === 'input') {
-        return (<StyledSetting key={i}>
-          <StyledSettingLabel title={tooltip}>{visual}</StyledSettingLabel>
-          <StyledSettingTextInput onChange={(event) => {
-            settings[setting] = event.target.value
-            onSettingsSave(settings)
-          }} defaultValue={settings[setting]} title={[tooltip]} className={setting} />
-        </StyledSetting>)
-      } else if (settingObj[setting].type === 'radio') {
-        return (<StyledSetting key={i}>
-          <StyledSettingLabel title={tooltip}>{visual}</StyledSettingLabel>
-          <RadioSelector options={settingObj[setting].options} onChange={(event) => {
-            settings[setting] = event.target.value
-            onSettingsSave(settings)
-          }} selectedValue={settings[setting]} />
-        </StyledSetting>)
-      } else if (settingObj[setting].type === 'checkbox') {
-        return (<StyledSetting key={i}>
-          <CheckboxSelector onChange={(event) => {
-            settings[setting] = event.target.checked
-            onSettingsSave(settings)
-          }} checked={settings[setting]} />
-          <StyledSettingLabel title={tooltip}>{visual}</StyledSettingLabel>
-        </StyledSetting>)
-      }
-    }).filter((setting) => setting !== false)
+        if (!settingObj[setting].type || settingObj[setting].type === 'input') {
+          return (
+            <StyledSetting key={i}>
+              <StyledSettingLabel title={tooltip}>
+                {visual}
+              </StyledSettingLabel>
+              <StyledSettingTextInput
+                onChange={event => {
+                  settings[setting] = event.target.value
+                  onSettingsSave(settings)
+                }}
+                defaultValue={settings[setting]}
+                title={[tooltip]}
+                className={setting}
+              />
+            </StyledSetting>
+          )
+        } else if (settingObj[setting].type === 'radio') {
+          return (
+            <StyledSetting key={i}>
+              <StyledSettingLabel title={tooltip}>
+                {visual}
+              </StyledSettingLabel>
+              <RadioSelector
+                options={settingObj[setting].options}
+                onChange={event => {
+                  settings[setting] = event.target.value
+                  onSettingsSave(settings)
+                }}
+                selectedValue={settings[setting]}
+              />
+            </StyledSetting>
+          )
+        } else if (settingObj[setting].type === 'checkbox') {
+          return (
+            <StyledSetting key={i}>
+              <CheckboxSelector
+                onChange={event => {
+                  settings[setting] = event.target.checked
+                  onSettingsSave(settings)
+                }}
+                checked={settings[setting]}
+              />
+              <StyledSettingLabel title={tooltip}>
+                {visual}
+              </StyledSettingLabel>
+            </StyledSetting>
+          )
+        }
+      })
+      .filter(setting => setting !== false)
     return (
       <div>
         {title}
@@ -183,15 +228,15 @@ export const Settings = ({settings, onSettingsSave = () => {}}) => {
   )
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     settings: state.settings
   }
 }
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
-    onSettingsSave: (settings) => {
+    onSettingsSave: settings => {
       dispatch(actions.update(settings))
     }
   }

--- a/src/browser/modules/Sidebar/Settings.test.js
+++ b/src/browser/modules/Sidebar/Settings.test.js
@@ -27,9 +27,8 @@ describe('Settings', () => {
     // Given
     const result = mount(SettingsComponent)
       .withProps({ settings: { maxRows: 100 } })
-
       // Then
-      .then((wrapper) => {
+      .then(wrapper => {
         expect(wrapper.find('.maxRows').prop('value')).toBe(100)
       })
 

--- a/src/browser/modules/Sidebar/Sidebar.jsx
+++ b/src/browser/modules/Sidebar/Sidebar.jsx
@@ -27,7 +27,11 @@ import About from './About'
 import TabNavigation from 'browser-components/TabNavigation/Navigation'
 import Settings from './Settings'
 import BrowserSync from './../Sync/BrowserSync'
-import { PENDING_STATE, CONNECTED_STATE, DISCONNECTED_STATE } from 'shared/modules/connections/connectionsDuck'
+import {
+  PENDING_STATE,
+  CONNECTED_STATE,
+  DISCONNECTED_STATE
+} from 'shared/modules/connections/connectionsDuck'
 
 import {
   DatabaseIcon,
@@ -48,26 +52,66 @@ class Sidebar extends Component {
     const SettingsDrawer = Settings
     const AboutDrawer = About
     const topNavItemsList = [
-      {name: 'DB', title: 'Database', icon: (isOpen) => <DatabaseIcon isOpen={isOpen} connectionState={this.props.neo4jConnectionState} />, content: DatabaseDrawer},
-      {name: 'Favorites', title: 'Favorites', icon: (isOpen) => <FavoritesIcon isOpen={isOpen} />, content: FavoritesDrawer},
-      {name: 'Documents', title: 'Documentation', icon: (isOpen) => <DocumentsIcon isOpen={isOpen} />, content: DocumentsDrawer}
+      {
+        name: 'DB',
+        title: 'Database',
+        icon: isOpen =>
+          <DatabaseIcon
+            isOpen={isOpen}
+            connectionState={this.props.neo4jConnectionState}
+          />,
+        content: DatabaseDrawer
+      },
+      {
+        name: 'Favorites',
+        title: 'Favorites',
+        icon: isOpen => <FavoritesIcon isOpen={isOpen} />,
+        content: FavoritesDrawer
+      },
+      {
+        name: 'Documents',
+        title: 'Documentation',
+        icon: isOpen => <DocumentsIcon isOpen={isOpen} />,
+        content: DocumentsDrawer
+      }
     ]
     const bottomNavItemsList = [
-      {name: 'Sync', title: 'Cloud Services', icon: (isOpen) => <CloudSyncIcon isOpen={isOpen} connected={this.props.syncConnected} />, content: BrowserSync},
-      {name: 'Settings', title: 'Browser Settings', icon: (isOpen) => <SettingsIcon isOpen={isOpen} />, content: SettingsDrawer},
-      {name: 'About', title: 'About Neo4j', icon: (isOpen) => <AboutIcon isOpen={isOpen} />, content: AboutDrawer}
+      {
+        name: 'Sync',
+        title: 'Cloud Services',
+        icon: isOpen =>
+          <CloudSyncIcon
+            isOpen={isOpen}
+            connected={this.props.syncConnected}
+          />,
+        content: BrowserSync
+      },
+      {
+        name: 'Settings',
+        title: 'Browser Settings',
+        icon: isOpen => <SettingsIcon isOpen={isOpen} />,
+        content: SettingsDrawer
+      },
+      {
+        name: 'About',
+        title: 'About Neo4j',
+        icon: isOpen => <AboutIcon isOpen={isOpen} />,
+        content: AboutDrawer
+      }
     ]
 
-    return (<TabNavigation
-      openDrawer={openDrawer}
-      onNavClick={onNavClick}
-      topNavItems={topNavItemsList}
-      bottomNavItems={bottomNavItemsList}
-    />)
+    return (
+      <TabNavigation
+        openDrawer={openDrawer}
+        onNavClick={onNavClick}
+        topNavItems={topNavItemsList}
+        bottomNavItems={bottomNavItemsList}
+      />
+    )
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   let connectionState = 'disconnected'
   if (state.connections) {
     switch (state.connections.connectionState) {

--- a/src/browser/modules/Sidebar/Sidebar.test.jsx
+++ b/src/browser/modules/Sidebar/Sidebar.test.jsx
@@ -34,7 +34,7 @@ import settings from '../../../shared/modules/settings/settingsDuck'
 describe('Sidebar', () => {
   const reducer = combineReducers({
     favorites,
-    documents: (a) => a || null,
+    documents: a => a || null,
     settings
   })
   const store = createStore(reducer)

--- a/src/browser/modules/Sidebar/styled.jsx
+++ b/src/browser/modules/Sidebar/styled.jsx
@@ -19,11 +19,16 @@
  */
 
 import styled from 'styled-components'
-import {QuestionIcon, PlayIcon, PlainPlayIcon, PlusIcon, BinIcon, EditIcon} from 'browser-components/icons/Icons'
+import {
+  QuestionIcon,
+  PlayIcon,
+  PlainPlayIcon,
+  PlusIcon,
+  BinIcon,
+  EditIcon
+} from 'browser-components/icons/Icons'
 
-export const StyledSetting = styled.div`
-  padding-bottom: 15px;
-`
+export const StyledSetting = styled.div`padding-bottom: 15px;`
 
 export const StyledSettingLabel = styled.div`
   word-wrap: break-wrap;
@@ -41,8 +46,7 @@ export const StyledSettingTextInput = styled.input`
   width: 192px;
 `
 
-export const StyledHelpLink = styled.a`
-`
+export const StyledHelpLink = styled.a``
 export const StyledHelpItem = styled.li`
   list-style-type: none;
   margin: 8px 0 0 0;
@@ -57,12 +61,13 @@ const StyledDocumentText = styled.a`
   }
 `
 
-export const StyledDocumentActionLink = (props) => {
-  const {name, ...rest} = props
+export const StyledDocumentActionLink = props => {
+  const { name, ...rest } = props
   return (
     <StyledHelpItem onClick={props.onClick}>
-      <StyledDocumentText {...rest}>{props.type === 'play' ? <PlayIcon />
-        : <QuestionIcon />}&nbsp;{name}</StyledDocumentText>
+      <StyledDocumentText {...rest}>
+        {props.type === 'play' ? <PlayIcon /> : <QuestionIcon />}&nbsp;{name}
+      </StyledDocumentText>
     </StyledHelpItem>
   )
 }
@@ -73,7 +78,7 @@ export const StyledList = styled.ul`
 `
 export const StyledListItem = styled.li`
   list-style-type: none;
-  margin: 8px 0px 8px ${props => props.isChild ? '16px' : '8px'};
+  margin: 8px 0px 8px ${props => (props.isChild ? '16px' : '8px')};
   cursor: pointer;
 `
 export const StyledListHeaderItem = styled.li`
@@ -105,19 +110,15 @@ const NewFolderStyledButton = styled.button`
   outline: none;
 `
 
-const SytledFavFolderButtonSpan = styled.span`
-  float: right;
-`
+const SytledFavFolderButtonSpan = styled.span`float: right;`
 
-export const FolderButtonContainer = styled.span`
-  float: right;
-`
+export const FolderButtonContainer = styled.span`float: right;`
 
 export const EditFolderInput = styled.input`
   color: black;
   border: none;
   outline: none;
-  border-radius:5px;
+  border-radius: 5px;
   line-height: 200%;
   padding-left: 5px;
 `
@@ -136,7 +137,7 @@ const StyledExecFavoriteButton = styled.div`
     opacity: 1;
   }
 `
-export const ExecFavoriteButton = (props) => {
+export const ExecFavoriteButton = props => {
   return (
     <StyledExecFavoriteButton {...props}>
       <PlainPlayIcon />
@@ -144,7 +145,7 @@ export const ExecFavoriteButton = (props) => {
   )
 }
 
-export const NewFolderButton = (props) => {
+export const NewFolderButton = props => {
   return (
     <NewFolderStyledButton onClick={props.onClick}>
       <PlusIcon />New Folder
@@ -152,15 +153,22 @@ export const NewFolderButton = (props) => {
   )
 }
 
-export const DeleteFavButton = (props) => {
-  const rightIcon = (props.removeClick && !props.isStatic) ? (<BinIcon className={'remove'} />) : null
+export const DeleteFavButton = props => {
+  const rightIcon =
+    props.removeClick && !props.isStatic
+      ? <BinIcon className={'remove'} />
+      : null
   return (
-    <SytledFavFolderButtonSpan onClick={() => props.removeClick(props.id)}>{rightIcon}</SytledFavFolderButtonSpan>
+    <SytledFavFolderButtonSpan onClick={() => props.removeClick(props.id)}>
+      {rightIcon}
+    </SytledFavFolderButtonSpan>
   )
 }
 
-export const EditFolderButton = (props) => {
+export const EditFolderButton = props => {
   return (
-    <FoldersButton onClick={props.editClick}><EditIcon /></FoldersButton>
+    <FoldersButton onClick={props.editClick}>
+      <EditIcon />
+    </FoldersButton>
   )
 }

--- a/src/browser/modules/Stream/Auth/ChangePasswordForm.jsx
+++ b/src/browser/modules/Stream/Auth/ChangePasswordForm.jsx
@@ -20,7 +20,7 @@
 
 import { Component } from 'preact'
 
-import {FormButton} from 'browser-components/buttons'
+import { FormButton } from 'browser-components/buttons'
 import {
   StyledConnectionForm,
   StyledConnectionTextInput,
@@ -61,8 +61,17 @@ export default class ChangePasswordForm extends Component {
     this.props.onChange(this.state.newPassword, this.state.newPassword2)
   }
   validateSame () {
-    if (this.state.newPassword && this.state.newPassword !== '' && this.state.newPassword !== this.state.newPassword2) {
-      return this.props.onChangePasswordClick({error: {code: 'Mismatch', message: 'The two entered passwords must be the same.'}})
+    if (
+      this.state.newPassword &&
+      this.state.newPassword !== '' &&
+      this.state.newPassword !== this.state.newPassword2
+    ) {
+      return this.props.onChangePasswordClick({
+        error: {
+          code: 'Mismatch',
+          message: 'The two entered passwords must be the same.'
+        }
+      })
     }
     this.props.onChangePasswordClick({ newPassword: this.state.newPassword })
   }
@@ -74,13 +83,31 @@ export default class ChangePasswordForm extends Component {
         {this.props.children}
         <StyledConnectionFormEntry>
           <StyledConnectionLabel>New password</StyledConnectionLabel>
-          <StyledConnectionTextInput data-test-id='newPassword' innerRef={(el) => this.formKeyHandler.registerInput(el, 1 + inputTabOffset)} type='password' onChange={this.onNewPasswordChange.bind(this)} value={this.state.newPassword} />
+          <StyledConnectionTextInput
+            data-test-id='newPassword'
+            innerRef={el =>
+              this.formKeyHandler.registerInput(el, 1 + inputTabOffset)}
+            type='password'
+            onChange={this.onNewPasswordChange.bind(this)}
+            value={this.state.newPassword}
+          />
         </StyledConnectionFormEntry>
         <StyledConnectionFormEntry>
           <StyledConnectionLabel>Repeat new password</StyledConnectionLabel>
-          <StyledConnectionTextInput data-test-id='newPasswordConfirmation' innerRef={(el) => this.formKeyHandler.registerInput(el, 2 + inputTabOffset)} type='password' onChange={this.onNewPasswordChange2.bind(this)} value={this.state.newPassword2} />
+          <StyledConnectionTextInput
+            data-test-id='newPasswordConfirmation'
+            innerRef={el =>
+              this.formKeyHandler.registerInput(el, 2 + inputTabOffset)}
+            type='password'
+            onChange={this.onNewPasswordChange2.bind(this)}
+            value={this.state.newPassword2}
+          />
         </StyledConnectionFormEntry>
-        <FormButton data-test-id='changePassword' onClick={this.validateSame.bind(this)} label='Change password' />
+        <FormButton
+          data-test-id='changePassword'
+          onClick={this.validateSame.bind(this)}
+          label='Change password'
+        />
       </StyledConnectionForm>
     )
   }

--- a/src/browser/modules/Stream/Auth/ChangePasswordForm.test.js
+++ b/src/browser/modules/Stream/Auth/ChangePasswordForm.test.js
@@ -28,7 +28,7 @@ describe('ChangePasswordForm', () => {
     const result = mount(ChangePasswordForm)
       // When
       .withProps({})
-      .then((wrapper) => {
+      .then(wrapper => {
         expect(wrapper.length).toBe(1)
       })
     return result
@@ -38,8 +38,8 @@ describe('ChangePasswordForm', () => {
     const children = <span className='child'>foo</span>
     const result = mount(ChangePasswordForm)
       // When
-      .withProps({children})
-      .then((wrapper) => {
+      .withProps({ children })
+      .then(wrapper => {
         expect(wrapper.html()).toContain('<span class="child">foo</span>')
       })
     return result

--- a/src/browser/modules/Stream/Auth/ChangePasswordFrame.jsx
+++ b/src/browser/modules/Stream/Auth/ChangePasswordFrame.jsx
@@ -57,16 +57,16 @@ export class ChangePasswordFrame extends Component {
     if (e.code === 'N/A') {
       e.message = 'Existing password is incorrect'
     }
-    this.setState({error: e})
+    this.setState({ error: e })
   }
   onPasswordChange (event) {
     const password = event.target.value
-    this.setState({password})
+    this.setState({ password })
     this.error({})
   }
   onSuccess () {
-    this.setState({password: ''})
-    this.setState({success: true})
+    this.setState({ password: '' })
+    this.setState({ success: true })
   }
   render () {
     const content = (
@@ -74,18 +74,33 @@ export class ChangePasswordFrame extends Component {
         <StyledConnectionAside>
           <H3>Password change</H3>
           <Render if={!this.state.success}>
-            <Lead>Enter your current password and the new twice to change your password.</Lead>
+            <Lead>
+              Enter your current password and the new twice to change your
+              password.
+            </Lead>
           </Render>
           <Render if={this.state.success}>
             <Lead>Password change successful</Lead>
           </Render>
         </StyledConnectionAside>
 
-        <ConnectionForm {...this.props} formKeyHandler={this.formKeyHandler} error={this.error.bind(this)} oldPassword={this.state.password} onSuccess={this.onSuccess.bind(this)} forcePasswordChange>
+        <ConnectionForm
+          {...this.props}
+          formKeyHandler={this.formKeyHandler}
+          error={this.error.bind(this)}
+          oldPassword={this.state.password}
+          onSuccess={this.onSuccess.bind(this)}
+          forcePasswordChange
+        >
           <Render if={!this.state.success}>
             <StyledConnectionFormEntry>
               <StyledConnectionLabel>Existing password</StyledConnectionLabel>
-              <StyledConnectionTextInput innerRef={(el) => this.formKeyHandler.registerInput(el, 1)} type='password' value={this.state.password} onChange={this.onPasswordChange.bind(this)} />
+              <StyledConnectionTextInput
+                innerRef={el => this.formKeyHandler.registerInput(el, 1)}
+                type='password'
+                value={this.state.password}
+                onChange={this.onPasswordChange.bind(this)}
+              />
             </StyledConnectionFormEntry>
           </Render>
         </ConnectionForm>
@@ -94,7 +109,12 @@ export class ChangePasswordFrame extends Component {
     return (
       <FrameTemplate
         header={this.props.frame}
-        statusbar={<FrameError code={this.state.error.code} message={this.state.error.message} />}
+        statusbar={
+          <FrameError
+            code={this.state.error.code}
+            message={this.state.error.message}
+          />
+        }
         contents={content}
       />
     )

--- a/src/browser/modules/Stream/Auth/ConnectForm.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectForm.jsx
@@ -20,7 +20,7 @@
 
 import { Component } from 'preact'
 import Render from 'browser-components/Render'
-import {FormButton} from 'browser-components/buttons'
+import { FormButton } from 'browser-components/buttons'
 import {
   StyledConnectionForm,
   StyledConnectionTextInput,
@@ -43,8 +43,8 @@ export default class ConnectForm extends Component {
     this.formKeyHandler.initialize(this.props.used === false)
   }
   onConnectClick () {
-    this.setState({connecting: true}, () => {
-      this.props.onConnectClick(() => this.setState({connecting: false}))
+    this.setState({ connecting: true }, () => {
+      this.props.onConnectClick(() => this.setState({ connecting: false }))
     })
   }
   render () {
@@ -52,22 +52,41 @@ export default class ConnectForm extends Component {
       <StyledConnectionForm>
         <StyledConnectionFormEntry>
           <StyledConnectionLabel>Host</StyledConnectionLabel>
-          <StyledConnectionTextInput data-test-id='boltaddress' innerRef={(el) => this.formKeyHandler.registerInput(el, 1)} onChange={this.props.onHostChange} value={this.props.host} />
+          <StyledConnectionTextInput
+            data-test-id='boltaddress'
+            innerRef={el => this.formKeyHandler.registerInput(el, 1)}
+            onChange={this.props.onHostChange}
+            value={this.props.host}
+          />
         </StyledConnectionFormEntry>
         <StyledConnectionFormEntry>
           <StyledConnectionLabel>Username</StyledConnectionLabel>
-          <StyledConnectionTextInput data-test-id='username' innerRef={(el) => this.formKeyHandler.registerInput(el, 2)} onChange={this.props.onUsernameChange} value={this.props.username} />
+          <StyledConnectionTextInput
+            data-test-id='username'
+            innerRef={el => this.formKeyHandler.registerInput(el, 2)}
+            onChange={this.props.onUsernameChange}
+            value={this.props.username}
+          />
         </StyledConnectionFormEntry>
         <StyledConnectionFormEntry>
           <StyledConnectionLabel>Password</StyledConnectionLabel>
-          <StyledConnectionTextInput data-test-id='password' innerRef={(el) => this.formKeyHandler.registerInput(el, 3)} onChange={this.props.onPasswordChange} value={this.props.password} type='password' />
+          <StyledConnectionTextInput
+            data-test-id='password'
+            innerRef={el => this.formKeyHandler.registerInput(el, 3)}
+            onChange={this.props.onPasswordChange}
+            value={this.props.password}
+            type='password'
+          />
         </StyledConnectionFormEntry>
         <Render if={!this.state.connecting}>
-          <FormButton data-test-id='connect' onClick={this.onConnectClick.bind(this)}>Connect</FormButton>
+          <FormButton
+            data-test-id='connect'
+            onClick={this.onConnectClick.bind(this)}
+          >
+            Connect
+          </FormButton>
         </Render>
-        <Render if={this.state.connecting}>
-          Connecting...
-        </Render>
+        <Render if={this.state.connecting}>Connecting...</Render>
       </StyledConnectionForm>
     )
   }

--- a/src/browser/modules/Stream/Auth/ConnectedView.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectedView.jsx
@@ -18,18 +18,32 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { StyledConnectionBody, StyledCode, StyledConnectionFooter } from './styled'
+import {
+  StyledConnectionBody,
+  StyledCode,
+  StyledConnectionFooter
+} from './styled'
 import Render from 'browser-components/Render'
 
-const ConnectedView = ({host, username, storeCredentials, showHost = true}) => {
+const ConnectedView = ({
+  host,
+  username,
+  storeCredentials,
+  showHost = true
+}) => {
   return (
     <StyledConnectionBody>
-      You are connected as user <StyledCode>{username}</StyledCode><br />
+      You are connected as user <StyledCode>{username}</StyledCode>
+      <br />
       <Render if={showHost}>
-        <span>to the server <StyledCode>{host}</StyledCode><br /></span>
+        <span>
+          to the server <StyledCode>{host}</StyledCode>
+          <br />
+        </span>
       </Render>
       <StyledConnectionFooter>
-        Connection credentials are {(storeCredentials ? '' : 'not ')}stored in your web browser.
+        Connection credentials are {storeCredentials ? '' : 'not '}stored in
+        your web browser.
       </StyledConnectionFooter>
     </StyledConnectionBody>
   )

--- a/src/browser/modules/Stream/Auth/ConnectionFrame.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectionFrame.jsx
@@ -23,7 +23,7 @@ import { Component } from 'preact'
 import FrameTemplate from '../FrameTemplate'
 import ConnectionForm from './ConnectionForm'
 import FrameError from '../FrameError'
-import {H3} from 'browser-components/headers'
+import { H3 } from 'browser-components/headers'
 import { Lead } from 'browser-components/Text'
 
 import Render from 'browser-components/Render'
@@ -41,23 +41,30 @@ export class ConnectionFrame extends Component {
     }
   }
   error (e) {
-    this.setState({error: e})
+    this.setState({ error: e })
   }
   success () {
-    this.setState({success: true})
+    this.setState({ success: true })
   }
   render () {
     return (
       <FrameTemplate
         header={this.props.frame}
-        statusbar={<FrameError code={this.state.error.code} message={this.state.error.message} />}
+        statusbar={
+          <FrameError
+            code={this.state.error.code}
+            message={this.state.error.message}
+          />
+        }
         contents={
           <StyledConnectionFrame>
             <StyledConnectionAside>
               <Render if={!this.state.success}>
                 <div>
                   <H3>Connect to Neo4j</H3>
-                  <Lead>Database access requires an authenticated connection.</Lead>
+                  <Lead>
+                    Database access requires an authenticated connection.
+                  </Lead>
                 </div>
               </Render>
               <Render if={this.state.success}>
@@ -68,10 +75,14 @@ export class ConnectionFrame extends Component {
               </Render>
             </StyledConnectionAside>
             <StyledConnectionBodyContainer>
-              <ConnectionForm {...this.props} onSuccess={this.success.bind(this)} error={this.error.bind(this)} />
+              <ConnectionForm
+                {...this.props}
+                onSuccess={this.success.bind(this)}
+                error={this.error.bind(this)}
+              />
             </StyledConnectionBodyContainer>
           </StyledConnectionFrame>
-          }
+        }
       />
     )
   }

--- a/src/browser/modules/Stream/Auth/DisconnectFrame.jsx
+++ b/src/browser/modules/Stream/Auth/DisconnectFrame.jsx
@@ -24,7 +24,7 @@ import { H3 } from 'browser-components/headers'
 import { Lead } from 'browser-components/Text'
 import Render from 'browser-components/Render'
 
-const Disconnect = ({frame, activeConnectionData}) => {
+const Disconnect = ({ frame, activeConnectionData }) => {
   return (
     <FrameTemplate
       header={frame}
@@ -34,17 +34,13 @@ const Disconnect = ({frame, activeConnectionData}) => {
             <Render if={activeConnectionData}>
               <div>
                 <H3>Connected</H3>
-                <Lead>
-                  You're still connected
-                </Lead>
+                <Lead>You're still connected</Lead>
               </div>
             </Render>
             <Render if={!activeConnectionData}>
               <div>
                 <H3>Disconnected</H3>
-                <Lead>
-                  You are disconnected from the server
-                </Lead>
+                <Lead>You are disconnected from the server</Lead>
               </div>
             </Render>
           </StyledConnectionAside>

--- a/src/browser/modules/Stream/Auth/ServerStatusFrame.jsx
+++ b/src/browser/modules/Stream/Auth/ServerStatusFrame.jsx
@@ -28,9 +28,12 @@ import {
   StyledConnectionBody
 } from './styled'
 import ConnectedView from './ConnectedView'
-import {H3} from 'browser-components/headers'
+import { H3 } from 'browser-components/headers'
 import Render from 'browser-components/Render'
-import { getActiveConnectionData, getActiveConnection } from 'shared/modules/connections/connectionsDuck'
+import {
+  getActiveConnectionData,
+  getActiveConnection
+} from 'shared/modules/connections/connectionsDuck'
 import { shouldRetainConnectionCredentials } from 'shared/modules/dbMeta/dbMetaDuck'
 
 class ServerStatusFrame extends Component {
@@ -50,15 +53,27 @@ class ServerStatusFrame extends Component {
             </StyledConnectionAside>
             <StyledConnectionBodyContainer>
               <Render if={!activeConnectionData}>
-                <StyledConnectionBody>You are not connected to the server.
+                <StyledConnectionBody>
+                  You are not connected to the server.
                 </StyledConnectionBody>
               </Render>
-              <Render if={activeConnectionData && activeConnectionData.authEnabled}>
-                <ConnectedView username={activeConnectionData && activeConnectionData.username}
-                  showHost={false} storeCredentials={storeCredentials} />
+              <Render
+                if={activeConnectionData && activeConnectionData.authEnabled}
+              >
+                <ConnectedView
+                  username={
+                    activeConnectionData && activeConnectionData.username
+                  }
+                  showHost={false}
+                  storeCredentials={storeCredentials}
+                />
               </Render>
-              <Render if={activeConnectionData && !activeConnectionData.authEnabled}>
-                <StyledConnectionBody>You have a working connection with the Neo4j database and server auth is disabled.
+              <Render
+                if={activeConnectionData && !activeConnectionData.authEnabled}
+              >
+                <StyledConnectionBody>
+                  You have a working connection with the Neo4j database and
+                  server auth is disabled.
                 </StyledConnectionBody>
               </Render>
             </StyledConnectionBodyContainer>
@@ -69,7 +84,7 @@ class ServerStatusFrame extends Component {
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     activeConnection: getActiveConnection(state),
     activeConnectionData: getActiveConnectionData(state),

--- a/src/browser/modules/Stream/Auth/styled.jsx
+++ b/src/browser/modules/Stream/Auth/styled.jsx
@@ -20,9 +20,7 @@
 
 import styled from 'styled-components'
 
-export const StyledConnectionForm = styled.form`
-  padding: 0 15px;
-`
+export const StyledConnectionForm = styled.form`padding: 0 15px;`
 export const StyledConnectionAside = styled.div`
   display: table-cell;
   padding: 0 15px;
@@ -32,15 +30,9 @@ export const StyledConnectionAside = styled.div`
   font-weight: 300;
   color: ${props => props.theme.asideText};
 `
-export const StyledConnectionFrame = styled.div`
-  padding: 30px 45px;
-`
-export const StyledConnectionFormEntry = styled.div`
-  padding-bottom: 15px;
-`
-export const StyledConnectionLabel = styled.label`
-  display: block;
-`
+export const StyledConnectionFrame = styled.div`padding: 30px 45px;`
+export const StyledConnectionFormEntry = styled.div`padding-bottom: 15px;`
+export const StyledConnectionLabel = styled.label`display: block;`
 export const StyledConnectionTextInput = styled.input`
   display: block;
   height: 34px;
@@ -52,9 +44,7 @@ export const StyledConnectionTextInput = styled.input`
   border-radius: 4px;
   width: 44%;
 `
-export const StyledConnectionBodyContainer = styled.div`
-  display: table-cell;
-`
+export const StyledConnectionBodyContainer = styled.div`display: table-cell;`
 export const StyledConnectionBody = styled.div`
   font-size: 1.3em;
   line-height: 2.0em;

--- a/src/browser/modules/Stream/CypherFrame/AsciiView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/AsciiView.jsx
@@ -24,8 +24,20 @@ import { v1 as neo4j } from 'neo4j-driver-alias'
 import Render from 'browser-components/Render'
 import Ellipsis from 'browser-components/Ellipsis'
 import { debounce, shallowEquals, deepEquals } from 'services/utils'
-import { StyledStatsBar, PaddedDiv, StyledBodyMessage, StyledRightPartial, StyledWidthSliderContainer, StyledWidthSlider } from '../styled'
-import { getBodyAndStatusBarMessages, getRecordsToDisplayInTable, transformResultRecordsToResultArray, stringifyResultArray } from './helpers'
+import {
+  StyledStatsBar,
+  PaddedDiv,
+  StyledBodyMessage,
+  StyledRightPartial,
+  StyledWidthSliderContainer,
+  StyledWidthSlider
+} from '../styled'
+import {
+  getBodyAndStatusBarMessages,
+  getRecordsToDisplayInTable,
+  transformResultRecordsToResultArray,
+  stringifyResultArray
+} from './helpers'
 
 export class AsciiView extends Component {
   constructor (props) {
@@ -61,22 +73,40 @@ export class AsciiView extends Component {
   }
   makeState (props) {
     const { result, maxRows } = props
-    const { bodyMessage = null } = getBodyAndStatusBarMessages(result, maxRows) || {}
+    const { bodyMessage = null } =
+      getBodyAndStatusBarMessages(result, maxRows) || {}
     this.setState({ bodyMessage })
     if (!result || !result.records) return
     const records = getRecordsToDisplayInTable(props.result, props.maxRows)
-    const serializedRows = stringifyResultArray(neo4j.isInt, transformResultRecordsToResultArray(records)) || []
+    const serializedRows =
+      stringifyResultArray(
+        neo4j.isInt,
+        transformResultRecordsToResultArray(records)
+      ) || []
     this.setState({ serializedRows })
-    this.props.setParentState && this.props.setParentState({ _asciiSerializedRows: serializedRows })
+    this.props.setParentState &&
+      this.props.setParentState({ _asciiSerializedRows: serializedRows })
   }
   render () {
     const { _asciiMaxColWidth: maxColWidth = 70 } = this.props
     const { serializedRows, bodyMessage } = this.state
-    let contents = <StyledBodyMessage>{bodyMessage}</StyledBodyMessage>
+    let contents = (
+      <StyledBodyMessage>
+        {bodyMessage}
+      </StyledBodyMessage>
+    )
     if (serializedRows !== undefined && serializedRows.length) {
-      contents = <pre>{asciitable.tableFromSerializedData(serializedRows, maxColWidth)}</pre>
+      contents = (
+        <pre>
+          {asciitable.tableFromSerializedData(serializedRows, maxColWidth)}
+        </pre>
+      )
     }
-    return <PaddedDiv>{contents}</PaddedDiv>
+    return (
+      <PaddedDiv>
+        {contents}
+      </PaddedDiv>
+    )
   }
 }
 
@@ -90,17 +120,26 @@ export class AsciiStatusbar extends Component {
     }
   }
   componentWillReceiveProps (props) {
-    if (!deepEquals(props._asciiSerializedRows, this.props._asciiSerializedRows)) {
+    if (
+      !deepEquals(props._asciiSerializedRows, this.props._asciiSerializedRows)
+    ) {
       this.makeState(props)
     }
   }
   makeState (props) {
-    this.setMaxSliderWidth(asciitable.maxColumnWidth(props._asciiSerializedRows))
-    const { statusBarMessage = null } = getBodyAndStatusBarMessages(props.result, props.maxRows) || {}
+    this.setMaxSliderWidth(
+      asciitable.maxColumnWidth(props._asciiSerializedRows)
+    )
+    const { statusBarMessage = null } =
+      getBodyAndStatusBarMessages(props.result, props.maxRows) || {}
     this.setState({ statusBarMessage })
   }
   shouldComponentUpdate (props, state) {
-    if (!deepEquals(props._asciiSerializedRows, this.props._asciiSerializedRows)) return true
+    if (
+      !deepEquals(props._asciiSerializedRows, this.props._asciiSerializedRows)
+    ) {
+      return true
+    }
     if (!shallowEquals(state, this.state)) return true
     return false
   }
@@ -108,7 +147,11 @@ export class AsciiStatusbar extends Component {
     this.makeState(this.props)
   }
   componentWillMount () {
-    this.debouncedMaxColWidthChanged = debounce(this.maxColWidthChanged, 25, this)
+    this.debouncedMaxColWidthChanged = debounce(
+      this.maxColWidthChanged,
+      25,
+      this
+    )
   }
   maxColWidthChanged (w) {
     this.setState({ maxColWidth: w.target.value })
@@ -124,7 +167,7 @@ export class AsciiStatusbar extends Component {
       <StyledStatsBar>
         <Render if={!this.props._asciiSerializedRows}>
           <Ellipsis>
-            { this.state.statusBarMessage }
+            {this.state.statusBarMessage}
           </Ellipsis>
         </Render>
         <Render if={this.props._asciiSerializedRows}>

--- a/src/browser/modules/Stream/CypherFrame/AsciiView.test.js
+++ b/src/browser/modules/Stream/CypherFrame/AsciiView.test.js
@@ -32,9 +32,8 @@ describe('AsciiViews', () => {
       const bodyMessage = 'My message'
       const result = mount(AsciiView)
         .withProps({ setParentState: sps, result: {} })
-
         // Then
-        .then((wrapper) => {
+        .then(wrapper => {
           wrapper.setState({ bodyMessage })
           wrapper.update()
           expect(wrapper.text()).toContain('My message')
@@ -50,9 +49,8 @@ describe('AsciiViews', () => {
       const serializedRows = [['x'], ['y']]
       const result = mount(AsciiView)
         .withProps({ setParentState: sps, result: {} })
-
         // Then
-        .then((wrapper) => {
+        .then(wrapper => {
           wrapper.setState({ bodyMessage, serializedRows })
           wrapper.update()
           expect(wrapper.text()).not.toContain('My message')
@@ -70,9 +68,8 @@ describe('AsciiViews', () => {
       const statusBarMessage = 'My message'
       const result = mount(AsciiStatusbar)
         .withProps({ setParentState: sps, _asciiSerializedRows: undefined })
-
         // Then
-        .then((wrapper) => {
+        .then(wrapper => {
           wrapper.setState({ statusBarMessage })
           wrapper.update()
           expect(wrapper.text()).toContain('My message')
@@ -88,10 +85,12 @@ describe('AsciiViews', () => {
       const statusBarMessage = 'My message'
       const serializedRows = [['x'], ['y']]
       const result = mount(AsciiStatusbar)
-        .withProps({ setParentState: sps, _asciiSerializedRows: serializedRows })
-
+        .withProps({
+          setParentState: sps,
+          _asciiSerializedRows: serializedRows
+        })
         // Then
-        .then((wrapper) => {
+        .then(wrapper => {
           wrapper.setState({ statusBarMessage })
           wrapper.update()
           expect(wrapper.text()).not.toContain('My message')

--- a/src/browser/modules/Stream/CypherFrame/CodeView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/CodeView.jsx
@@ -20,7 +20,14 @@
 
 import { Component } from 'preact'
 import { deepEquals } from 'services/utils'
-import { PaddedDiv, StyledTable, StyledTBody, StyledAlteringTr, StyledStrongTd, StyledTd } from '../styled'
+import {
+  PaddedDiv,
+  StyledTable,
+  StyledTBody,
+  StyledAlteringTr,
+  StyledStrongTd,
+  StyledTd
+} from '../styled'
 import { TableStatusbar } from './TableView'
 
 export class CodeView extends Component {
@@ -36,20 +43,28 @@ export class CodeView extends Component {
           <StyledTBody>
             <StyledAlteringTr>
               <StyledStrongTd>Server version</StyledStrongTd>
-              <StyledTd>{request.result.summary.server.version}</StyledTd>
+              <StyledTd>
+                {request.result.summary.server.version}
+              </StyledTd>
             </StyledAlteringTr>
             <StyledAlteringTr>
               <StyledStrongTd>Server address</StyledStrongTd>
-              <StyledTd>{request.result.summary.server.address}</StyledTd>
+              <StyledTd>
+                {request.result.summary.server.address}
+              </StyledTd>
             </StyledAlteringTr>
             <StyledAlteringTr>
               <StyledStrongTd>Query</StyledStrongTd>
-              <StyledTd>{query}</StyledTd>
+              <StyledTd>
+                {query}
+              </StyledTd>
             </StyledAlteringTr>
             <StyledAlteringTr>
               <StyledStrongTd>Response</StyledStrongTd>
               <StyledTd>
-                <pre>{JSON.stringify(request.result.records, null, 2)}</pre>
+                <pre>
+                  {JSON.stringify(request.result.records, null, 2)}
+                </pre>
               </StyledTd>
             </StyledAlteringTr>
           </StyledTBody>

--- a/src/browser/modules/Stream/CypherFrame/CodeView.test.js
+++ b/src/browser/modules/Stream/CypherFrame/CodeView.test.js
@@ -25,13 +25,13 @@ import { CodeView, CodeStatusbar } from './CodeView'
 
 describe('CodeViews', () => {
   describe('CodeView', () => {
-    test('displays nothing if not successful query', () => { // we get no info from driver
+    test('displays nothing if not successful query', () => {
+      // we get no info from driver
       // Given
       const result = mount(CodeView)
         .withProps({ request: { status: 'error' } })
-
         // Then
-        .then((wrapper) => {
+        .then(wrapper => {
           expect(wrapper.text()).toEqual('')
         })
 
@@ -51,19 +51,14 @@ describe('CodeViews', () => {
                 address: 'xx2'
               }
             },
-            records: [
-              { res: 'xx3' },
-              { res: 'xx4' },
-              { res: 'xx5' }
-            ]
+            records: [{ res: 'xx3' }, { res: 'xx4' }, { res: 'xx5' }]
           }
         }
       }
       const result = mount(CodeView)
         .withProps(data)
-
         // Then
-        .then((wrapper) => {
+        .then(wrapper => {
           const text = wrapper.text()
           expect(text).toContain('xx0')
           expect(text).toContain('xx1')
@@ -83,9 +78,8 @@ describe('CodeViews', () => {
       const statusBarMessage = 'My message'
       const result = mount(CodeStatusbar)
         .withProps({ result: {}, maxRows: 0 })
-
         // Then
-        .then((wrapper) => {
+        .then(wrapper => {
           wrapper.setState({ statusBarMessage })
           wrapper.update()
           expect(wrapper.text()).toContain('My message')

--- a/src/browser/modules/Stream/CypherFrame/ErrorsView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/ErrorsView.jsx
@@ -21,7 +21,10 @@
 import { Component } from 'preact'
 import { withBus } from 'preact-suber'
 import Ellipsis from 'browser-components/Ellipsis'
-import { ExclamationTriangleIcon, PlayIcon } from 'browser-components/icons/Icons'
+import {
+  ExclamationTriangleIcon,
+  PlayIcon
+} from 'browser-components/icons/Icons'
 import { deepEquals } from 'services/utils'
 import Render from 'browser-components/Render'
 import { executeCommand } from 'shared/modules/commands/commandsDuck'
@@ -54,22 +57,29 @@ export class ErrorsView extends Component {
         <StyledHelpContent>
           <StyledHelpDescription>
             <StyledCypherErrorMessage>ERROR</StyledCypherErrorMessage>
-            <StyledH4>{error.code}</StyledH4>
+            <StyledH4>
+              {error.code}
+            </StyledH4>
           </StyledHelpDescription>
           <StyledDiv>
-            <StyledPreformattedArea>{error.message}</StyledPreformattedArea>
+            <StyledPreformattedArea>
+              {error.message}
+            </StyledPreformattedArea>
           </StyledDiv>
           <Render if={isUnknownProcedureError(error)}>
             <StyledLinkContainer>
-              <StyledLink onClick={() => onItemClick(bus)}><PlayIcon />&nbsp;List available procedures</StyledLink>
+              <StyledLink onClick={() => onItemClick(bus)}>
+                <PlayIcon />&nbsp;List available procedures
+              </StyledLink>
             </StyledLinkContainer>
           </Render>
         </StyledHelpContent>
-      </StyledHelpFrame>)
+      </StyledHelpFrame>
+    )
   }
 }
 
-const onItemClick = (bus) => {
+const onItemClick = bus => {
   const action = executeCommand(listAvailableProcedures)
   bus.send(action.type, action)
 }
@@ -83,10 +93,14 @@ export class ErrorsStatusbar extends Component {
   render () {
     const error = this.props.result
     if (!error || (!error.code && !error.message)) return null
-    const fullError = `${error.code}${(error.message ? ':' : '')} ${(error.message || '')}`
+    const fullError = `${error.code}${error.message
+      ? ':'
+      : ''} ${error.message || ''}`
     return (
       <Ellipsis>
-        <ErrorText title={fullError}><ExclamationTriangleIcon /> {fullError}</ErrorText>
+        <ErrorText title={fullError}>
+          <ExclamationTriangleIcon /> {fullError}
+        </ErrorText>
       </Ellipsis>
     )
   }

--- a/src/browser/modules/Stream/CypherFrame/ErrorsView.test.js
+++ b/src/browser/modules/Stream/CypherFrame/ErrorsView.test.js
@@ -30,9 +30,8 @@ describe('ErrorsViews', () => {
       // Given
       const result = mount(ErrorsView)
         .withProps({ result: {} })
-
         // Then
-        .then((wrapper) => {
+        .then(wrapper => {
           expect(wrapper.text()).toEqual('')
         })
 
@@ -42,13 +41,14 @@ describe('ErrorsViews', () => {
     test('does displays an error', () => {
       // Given
       const result = mount(ErrorsView)
-        .withProps({ result: {
-          code: 'Test.Error',
-          message: 'Test error description'
-        }})
-
+        .withProps({
+          result: {
+            code: 'Test.Error',
+            message: 'Test error description'
+          }
+        })
         // Then
-        .then((wrapper) => {
+        .then(wrapper => {
           const text = wrapper.text()
           expect(text).toContain('ERROR')
           expect(text).toContain('Test.Error')
@@ -62,13 +62,14 @@ describe('ErrorsViews', () => {
       // Given
       const procErrorCode = 'Neo.ClientError.Procedure.ProcedureNotFound'
       const result = mount(ErrorsView)
-        .withProps({ result: {
-          code: procErrorCode,
-          message: 'not found'
-        }})
-
+        .withProps({
+          result: {
+            code: procErrorCode,
+            message: 'not found'
+          }
+        })
         // Then
-        .then((wrapper) => {
+        .then(wrapper => {
           const text = wrapper.text()
           expect(text).toContain('ERROR')
           expect(text).toContain(procErrorCode)
@@ -85,9 +86,8 @@ describe('ErrorsViews', () => {
       // Given
       const result = mount(ErrorsStatusbar)
         .withProps({ result: {} })
-
         // Then
-        .then((wrapper) => {
+        .then(wrapper => {
           expect(wrapper.text()).toEqual('')
         })
 
@@ -97,13 +97,14 @@ describe('ErrorsViews', () => {
     test('displays error', () => {
       // Given
       const result = mount(ErrorsStatusbar)
-        .withProps({ result: {
-          code: 'Test.Error',
-          message: 'Test error description'
-        }})
-
+        .withProps({
+          result: {
+            code: 'Test.Error',
+            message: 'Test error description'
+          }
+        })
         // Then
-        .then((wrapper) => {
+        .then(wrapper => {
           expect(wrapper.text()).toContain('Test.Error')
           expect(wrapper.text()).toContain('Test error description')
           expect(wrapper.html()).toContain('exclamation-triangle')

--- a/src/browser/modules/Stream/CypherFrame/PlanView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/PlanView.jsx
@@ -25,7 +25,12 @@ import { deepEquals, shallowEquals } from 'services/utils'
 import bolt from 'services/bolt/bolt'
 import { FrameButton } from 'browser-components/buttons'
 import { DoubleUpIcon, DoubleDownIcon } from 'browser-components/icons/Icons'
-import { StyledOneRowStatsBar, StyledRightPartial, StyledLeftPartial, FrameTitlebarButtonSection } from '../styled'
+import {
+  StyledOneRowStatsBar,
+  StyledRightPartial,
+  StyledLeftPartial,
+  FrameTitlebarButtonSection
+} from '../styled'
 import Ellipsis from 'browser-components/Ellipsis'
 
 export class PlanView extends Component {
@@ -36,23 +41,32 @@ export class PlanView extends Component {
     }
   }
   componentDidMount () {
-    this.extractPlan(this.props.result).catch((e) => {})
+    this.extractPlan(this.props.result).catch(e => {})
   }
   componentWillReceiveProps (props) {
-    if (!deepEquals((props.result || {}).summary, (this.props.result || {}).summary)) {
-      return this.extractPlan((props.result || {}))
+    if (
+      !deepEquals(
+        (props.result || {}).summary,
+        (this.props.result || {}).summary
+      )
+    ) {
+      return this.extractPlan(props.result || {})
         .then(() => {
           this.ensureToggleExpand(props)
         })
-        .catch((e) => { console.log(e) })
+        .catch(e => {
+          console.log(e)
+        })
     }
     this.ensureToggleExpand(props)
   }
   shouldComponentUpdate (props, state) {
     if (this.props.result === undefined) return true
-    return !deepEquals(props.result.summary, this.props.result.summary) ||
+    return (
+      !deepEquals(props.result.summary, this.props.result.summary) ||
       !shallowEquals(state, this.state) ||
       props._planExpand !== this.props._planExpand
+    )
   }
   extractPlan (result) {
     if (result === undefined) return Promise.reject(new Error('No result'))
@@ -84,15 +98,15 @@ export class PlanView extends Component {
     }
   }
   toggleExpanded (expanded) {
-    const visit = (operator) => {
+    const visit = operator => {
       operator.expanded = expanded
       if (operator.children) {
-        operator.children.forEach((child) => {
+        operator.children.forEach(child => {
           visit(child)
         })
       }
     }
-    let tmpPlan = {...this.state.extractedPlan}
+    let tmpPlan = { ...this.state.extractedPlan }
     visit(tmpPlan.root)
     this.plan.display(tmpPlan)
   }
@@ -100,7 +114,11 @@ export class PlanView extends Component {
     if (!this.state.extractedPlan) return null
     return (
       <PlanSVG
-        style={(this.props.fullscreen) ? {'padding-bottom': dim.frameStatusbarHeight + 'px'} : {}}
+        style={
+          this.props.fullscreen
+            ? { 'padding-bottom': dim.frameStatusbarHeight + 'px' }
+            : {}
+        }
         innerRef={this.planInit.bind(this)}
       />
     )
@@ -121,7 +139,10 @@ export class PlanStatusbar extends Component {
   }
   componentWillReceiveProps (props) {
     if (props.result === undefined) return
-    if (this.props.result === undefined || !deepEquals(props.result.summary, this.props.result.summary)) {
+    if (
+      this.props.result === undefined ||
+      !deepEquals(props.result.summary, this.props.result.summary)
+    ) {
       const extractedPlan = bolt.extractPlan(props.result, true)
       this.setState({ extractedPlan })
     }
@@ -138,14 +159,30 @@ export class PlanStatusbar extends Component {
       <StyledOneRowStatsBar>
         <StyledLeftPartial>
           <Ellipsis>
-            Cypher version: {plan.root.version}, planner: {plan.root.planner}, runtime: {plan.root.runtime}.
-            { plan.root.totalDbHits ? ` ${plan.root.totalDbHits} total db hits in ${result.summary.resultAvailableAfter.add(result.summary.resultConsumedAfter).toNumber() || 0} ms.` : ``}
+            Cypher version: {plan.root.version}, planner: {plan.root.planner},
+            runtime: {plan.root.runtime}.
+            {plan.root.totalDbHits
+              ? ` ${plan.root
+                .totalDbHits} total db hits in ${result.summary.resultAvailableAfter
+                .add(result.summary.resultConsumedAfter)
+                .toNumber() || 0} ms.`
+              : ``}
           </Ellipsis>
         </StyledLeftPartial>
         <StyledRightPartial>
           <FrameTitlebarButtonSection>
-            <FrameButton onClick={() => this.props.setParentState({_planExpand: 'COLLAPSE'})}><DoubleUpIcon /></FrameButton>
-            <FrameButton onClick={() => this.props.setParentState({_planExpand: 'EXPAND'})}><DoubleDownIcon /></FrameButton>
+            <FrameButton
+              onClick={() =>
+                this.props.setParentState({ _planExpand: 'COLLAPSE' })}
+            >
+              <DoubleUpIcon />
+            </FrameButton>
+            <FrameButton
+              onClick={() =>
+                this.props.setParentState({ _planExpand: 'EXPAND' })}
+            >
+              <DoubleDownIcon />
+            </FrameButton>
           </FrameTitlebarButtonSection>
         </StyledRightPartial>
       </StyledOneRowStatsBar>

--- a/src/browser/modules/Stream/CypherFrame/PlanView.styled.jsx
+++ b/src/browser/modules/Stream/CypherFrame/PlanView.styled.jsx
@@ -20,6 +20,4 @@
 
 import styled from 'styled-components'
 
-export const PlanSVG = styled.svg`
-  width: 100%;
-`
+export const PlanSVG = styled.svg`width: 100%;`

--- a/src/browser/modules/Stream/CypherFrame/PlanView.test.js
+++ b/src/browser/modules/Stream/CypherFrame/PlanView.test.js
@@ -28,7 +28,7 @@ describe('PlanViews', () => {
       // Given
       const display = jest.fn()
       global.neo = {
-        queryPlan: (el) => {
+        queryPlan: el => {
           return {
             display
           }
@@ -48,9 +48,8 @@ describe('PlanViews', () => {
       }
       const result = mount(PlanView)
         .withProps(data)
-
         // Then
-        .then((wrapper) => {
+        .then(wrapper => {
           const calls = display.mock.calls
           const callObj = calls[0][0]
           expect(callObj.root).toBeDefined()
@@ -64,10 +63,10 @@ describe('PlanViews', () => {
   describe('PlanStatusbar', () => {
     test('displays statusBarMessage', () => {
       // Given
-      const intMock = (num) => {
+      const intMock = num => {
         return {
           toNumber: () => num,
-          add: (intMockInput) => intMock(num + intMockInput.toNumber())
+          add: intMockInput => intMock(num + intMockInput.toNumber())
         }
       }
       const results = {
@@ -86,9 +85,8 @@ describe('PlanViews', () => {
       }
       const result = mount(PlanStatusbar)
         .withProps({ result: results })
-
         // Then
-        .then((wrapper) => {
+        .then(wrapper => {
           wrapper.setState({ extractedPlan })
           wrapper.update()
           const text = wrapper.text()

--- a/src/browser/modules/Stream/CypherFrame/TableView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/TableView.jsx
@@ -20,44 +20,79 @@
 
 import { Component } from 'preact'
 import { v4 } from 'uuid'
-import { StyledStatsBar, PaddedTableViewDiv, StyledBodyMessage } from '../styled'
+import {
+  StyledStatsBar,
+  PaddedTableViewDiv,
+  StyledBodyMessage
+} from '../styled'
 import Ellipsis from 'browser-components/Ellipsis'
-import {StyledTable, StyledBodyTr, StyledTh, StyledTd, StyledJsonPre} from 'browser-components/DataTables'
+import {
+  StyledTable,
+  StyledBodyTr,
+  StyledTh,
+  StyledTd,
+  StyledJsonPre
+} from 'browser-components/DataTables'
 import { deepEquals, shallowEquals, stringifyMod } from 'services/utils'
 import { v1 as neo4j } from 'neo4j-driver-alias'
-import { getBodyAndStatusBarMessages, getRecordsToDisplayInTable, transformResultRecordsToResultArray } from './helpers'
+import {
+  getBodyAndStatusBarMessages,
+  getRecordsToDisplayInTable,
+  transformResultRecordsToResultArray
+} from './helpers'
 
-const intToString = (val) => {
+const intToString = val => {
   if (neo4j.isInt(val)) return val.toString()
 }
 
-const renderCell = (entry) => {
+const renderCell = entry => {
   if (Array.isArray(entry)) {
-    const children = entry.map((item, index) => <span>{renderCell(item)}{index === entry.length - 1 ? null : ', '}</span>)
-    return <span>[{children}]</span>
+    const children = entry.map((item, index) =>
+      <span>
+        {renderCell(item)}
+        {index === entry.length - 1 ? null : ', '}
+      </span>
+    )
+    return (
+      <span>
+        [{children}]
+      </span>
+    )
   } else if (typeof entry === 'object') {
     return renderObject(entry)
   } else {
     return stringifyMod(entry, intToString, true)
   }
 }
-const renderObject = (entry) => {
+const renderObject = entry => {
   if (neo4j.isInt(entry)) return entry.toString()
   if (Object.keys(entry).length === 0 && entry.constructor === Object) {
     return <em>(empty)</em>
   } else {
-    return <StyledJsonPre>{stringifyMod(entry, intToString, true)}</StyledJsonPre>
+    return (
+      <StyledJsonPre>
+        {stringifyMod(entry, intToString, true)}
+      </StyledJsonPre>
+    )
   }
 }
-const buildData = (entries) => {
-  return entries.map((entry) => {
+const buildData = entries => {
+  return entries.map(entry => {
     if (entry !== null) {
-      return <StyledTd className='table-properties' key={v4()}>{renderCell(entry)}</StyledTd>
+      return (
+        <StyledTd className='table-properties' key={v4()}>
+          {renderCell(entry)}
+        </StyledTd>
+      )
     }
-    return <StyledTd className='table-properties' key={v4()}>(empty)</StyledTd>
+    return (
+      <StyledTd className='table-properties' key={v4()}>
+        (empty)
+      </StyledTd>
+    )
   })
 }
-const buildRow = (item) => {
+const buildRow = item => {
   return (
     <StyledBodyTr className='table-row' key={v4()}>
       {buildData(item)}
@@ -78,7 +113,8 @@ export class TableView extends Component {
     this.makeState(this.props)
   }
   componentWillReceiveProps (props) {
-    if (this.props === undefined ||
+    if (
+      this.props === undefined ||
       this.props.result === undefined ||
       !deepEquals(props.result.records, this.props.result.records)
     ) {
@@ -93,15 +129,32 @@ export class TableView extends Component {
     const table = transformResultRecordsToResultArray(records) || []
     const data = table ? table.slice() : []
     const columns = data.length > 0 ? data.shift() : []
-    const { bodyMessage } = getBodyAndStatusBarMessages(props.result, props.maxRows)
+    const { bodyMessage } = getBodyAndStatusBarMessages(
+      props.result,
+      props.maxRows
+    )
     this.setState({ data, columns, bodyMessage })
   }
   render () {
-    if (!this.state.columns.length) return (<PaddedTableViewDiv><StyledBodyMessage>{this.state.bodyMessage}</StyledBodyMessage></PaddedTableViewDiv>)
-    const tableHeader = this.state.columns.map((column, i) => (
-      <StyledTh className='table-header' key={i}>{column}</StyledTh>)
+    if (!this.state.columns.length) {
+      return (
+        <PaddedTableViewDiv>
+          <StyledBodyMessage>
+            {this.state.bodyMessage}
+          </StyledBodyMessage>
+        </PaddedTableViewDiv>
+      )
+    }
+    const tableHeader = this.state.columns.map((column, i) =>
+      <StyledTh className='table-header' key={i}>
+        {column}
+      </StyledTh>
     )
-    const tableBody = <tbody>{this.state.data.map((item) => buildRow(item))}</tbody>
+    const tableBody = (
+      <tbody>
+        {this.state.data.map(item => buildRow(item))}
+      </tbody>
+    )
     return (
       <PaddedTableViewDiv>
         <StyledTable>
@@ -135,14 +188,17 @@ export class TableStatusbar extends Component {
     return false
   }
   makeState (props) {
-    const { statusBarMessage } = getBodyAndStatusBarMessages(props.result, props.maxRows)
+    const { statusBarMessage } = getBodyAndStatusBarMessages(
+      props.result,
+      props.maxRows
+    )
     if (statusBarMessage !== undefined) this.setState({ statusBarMessage })
   }
   render () {
     return (
       <StyledStatsBar>
         <Ellipsis>
-          {this.state.statusBarMessage }
+          {this.state.statusBarMessage}
         </Ellipsis>
       </StyledStatsBar>
     )

--- a/src/browser/modules/Stream/CypherFrame/TableView.test.js
+++ b/src/browser/modules/Stream/CypherFrame/TableView.test.js
@@ -32,9 +32,8 @@ describe('TableViews', () => {
       const bodyMessage = 'My message'
       const result = mount(TableView)
         .withProps({ setParentState: sps, result: {} })
-
         // Then
-        .then((wrapper) => {
+        .then(wrapper => {
           wrapper.setState({ bodyMessage })
           wrapper.update()
           expect(wrapper.text()).toContain('My message')
@@ -51,9 +50,8 @@ describe('TableViews', () => {
       const data = [['z'], ['å']]
       const result = mount(TableView)
         .withProps({ setParentState: sps, result: {} })
-
         // Then
-        .then((wrapper) => {
+        .then(wrapper => {
           wrapper.setState({ bodyMessage, columns, data })
           wrapper.update()
           expect(wrapper.text()).not.toContain('My message')
@@ -70,9 +68,8 @@ describe('TableViews', () => {
       const statusBarMessage = 'My message'
       const result = mount(TableStatusbar)
         .withProps({ result: {}, maxRows: 0 })
-
         // Then
-        .then((wrapper) => {
+        .then(wrapper => {
           wrapper.setState({ statusBarMessage })
           wrapper.update()
           expect(wrapper.text()).toContain('My message')

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView.jsx
@@ -46,22 +46,39 @@ export class Visualization extends Component {
     }
   }
   shouldComponentUpdate (props, state) {
-    return !(deepEquals(props.result.records, this.props.result.records) && deepEquals(props.graphStyleData, this.props.graphStyleData)) ||
+    return (
+      !(
+        deepEquals(props.result.records, this.props.result.records) &&
+        deepEquals(props.graphStyleData, this.props.graphStyleData)
+      ) ||
       !deepEquals(state, this.state) ||
       !deepEquals(props.visElement, this.props.visElement) ||
       this.props.frameHeight !== props.frameHeight ||
       this.props.autoComplete !== props.autoComplete
+    )
   }
   componentWillReceiveProps (props) {
-    if (!deepEquals(props.result.records, this.props.result.records) || this.props.autoComplete !== props.autoComplete) {
+    if (
+      !deepEquals(props.result.records, this.props.result.records) ||
+      this.props.autoComplete !== props.autoComplete
+    ) {
       this.populateDataToStateFromProps(props)
     }
   }
   populateDataToStateFromProps (props) {
-    this.setState({ nodesAndRelationships: bolt.extractNodesAndRelationshipsFromRecordsForOldVis(props.result.records) })
+    this.setState({
+      nodesAndRelationships: bolt.extractNodesAndRelationshipsFromRecordsForOldVis(
+        props.result.records
+      )
+    })
   }
   mergeToList (list1, list2) {
-    return list1.concat(list2.filter(itemInList2 => list1.findIndex(itemInList1 => itemInList1.id === itemInList2.id) < 0))
+    return list1.concat(
+      list2.filter(
+        itemInList2 =>
+          list1.findIndex(itemInList1 => itemInList1.id === itemInList2.id) < 0
+      )
+    )
   }
   autoCompleteRelationships (existingNodes, newNodes) {
     if (this.props.autoComplete) {
@@ -69,10 +86,11 @@ export class Visualization extends Component {
       const newNodeIds = newNodes.map(node => parseInt(node.id))
 
       this.getInternalRelationships(existingNodeIds, newNodeIds)
-        .then((graph) => {
-          this.autoCompleteCallback && this.autoCompleteCallback(graph.relationships)
+        .then(graph => {
+          this.autoCompleteCallback &&
+            this.autoCompleteCallback(graph.relationships)
         })
-        .catch((e) => {})
+        .catch(e => {})
     } else {
       this.autoCompleteCallback && this.autoCompleteCallback([])
     }
@@ -83,41 +101,52 @@ export class Visualization extends Component {
                    AND NOT (id(o) IN[${currentNeighbourIds.join(',')}])
                    RETURN path, size((a)--()) as c
                    ORDER BY id(o)
-                   LIMIT ${this.props.maxNeighbours - currentNeighbourIds.length}`
+                   LIMIT ${this.props.maxNeighbours -
+                     currentNeighbourIds.length}`
     return new Promise((resolve, reject) => {
-      this.props.bus && this.props.bus.self(
-        CYPHER_REQUEST,
-        {query: query},
-        (response) => {
+      this.props.bus &&
+        this.props.bus.self(CYPHER_REQUEST, { query: query }, response => {
           if (!response.success) {
             reject(new Error())
           } else {
-            let count = response.result.records.length > 0 ? parseInt(response.result.records[0].get('c').toString()) : 0
-            const resultGraph = bolt.extractNodesAndRelationshipsFromRecordsForOldVis(response.result.records, false)
+            let count =
+              response.result.records.length > 0
+                ? parseInt(response.result.records[0].get('c').toString())
+                : 0
+            const resultGraph = bolt.extractNodesAndRelationshipsFromRecordsForOldVis(
+              response.result.records,
+              false
+            )
             this.autoCompleteRelationships(this.graph._nodes, resultGraph.nodes)
-            resolve({...resultGraph, count: count})
+            resolve({ ...resultGraph, count: count })
           }
-        }
-      )
+        })
     })
   }
   getInternalRelationships (existingNodeIds, newNodeIds) {
     newNodeIds = newNodeIds.map(bolt.neo4j.int)
     existingNodeIds = existingNodeIds.map(bolt.neo4j.int)
     existingNodeIds = existingNodeIds.concat(newNodeIds)
-    const query = 'MATCH (a)-[r]->(b) WHERE id(a) IN $existingNodeIds AND id(b) IN $newNodeIds RETURN r;'
+    const query =
+      'MATCH (a)-[r]->(b) WHERE id(a) IN $existingNodeIds AND id(b) IN $newNodeIds RETURN r;'
     return new Promise((resolve, reject) => {
-      this.props.bus && this.props.bus.self(
-        CYPHER_REQUEST,
-        {query, params: {existingNodeIds, newNodeIds}},
-        (response) => {
-          if (!response.success) {
-            reject(new Error())
-          } else {
-            resolve({...bolt.extractNodesAndRelationshipsFromRecordsForOldVis(response.result.records, false)})
+      this.props.bus &&
+        this.props.bus.self(
+          CYPHER_REQUEST,
+          { query, params: { existingNodeIds, newNodeIds } },
+          response => {
+            if (!response.success) {
+              reject(new Error())
+            } else {
+              resolve({
+                ...bolt.extractNodesAndRelationshipsFromRecordsForOldVis(
+                  response.result.records,
+                  false
+                )
+              })
+            }
           }
-        }
-      )
+        )
     })
   }
   setGraph (graph) {
@@ -140,7 +169,9 @@ export class Visualization extends Component {
           fullscreen={this.props.fullscreen}
           frameHeight={this.props.frameHeight}
           assignVisElement={this.props.assignVisElement}
-          getAutoCompleteCallback={(callback) => { this.autoCompleteCallback = callback }}
+          getAutoCompleteCallback={callback => {
+            this.autoCompleteCallback = callback
+          }}
           setGraph={this.setGraph.bind(this)}
         />
       </StyledVisContainer>
@@ -148,18 +179,20 @@ export class Visualization extends Component {
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     graphStyleData: grassActions.getGraphStyleData(state)
   }
 }
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
-    updateStyle: (graphStyleData) => {
+    updateStyle: graphStyleData => {
       dispatch(grassActions.updateGraphStyleData(graphStyleData))
     }
   }
 }
 
-export const VisualizationConnectedBus = withBus(connect(mapStateToProps, mapDispatchToProps)(Visualization))
+export const VisualizationConnectedBus = withBus(
+  connect(mapStateToProps, mapDispatchToProps)(Visualization)
+)

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView.styled.jsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView.styled.jsx
@@ -23,7 +23,10 @@ import { dim } from 'browser-styles/constants'
 
 export const StyledVisContainer = styled.div`
   width: 100%;
-  height: ${props => (props.fullscreen ? '100vh' : (dim.frameBodyHeight - (dim.frameTitlebarHeight * 2)) + 'px')};
+  height: ${props =>
+    props.fullscreen
+      ? '100vh'
+      : dim.frameBodyHeight - dim.frameTitlebarHeight * 2 + 'px'};
   > svg {
     width: 100%;
   }
@@ -57,14 +60,16 @@ export const StyledVisContainer = styled.div`
     opacity: 0.3;
   }
 
-  > .neod3viz .remove_node, .expand_node:hover {
+  > .neod3viz .remove_node,
+  .expand_node:hover {
     border: 2px #000 solid;
   }
 
-  > .neod3viz .outline, .neod3viz .ring, .neod3viz .context-menu-item {
-    cursor: pointer
+  > .neod3viz .outline,
+  .neod3viz .ring,
+  .neod3viz .context-menu-item {
+    cursor: pointer;
   }
-
 
   > .context-menu-item:hover {
     fill: #b9b9b9;

--- a/src/browser/modules/Stream/CypherFrame/WarningsView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/WarningsView.jsx
@@ -19,16 +19,38 @@
  */
 import { Component } from 'preact'
 import { deepEquals } from 'services/utils'
-import { StyledCypherMessage, StyledCypherWarningMessage, StyledCypherErrorMessage, StyledHelpContent,
-  StyledH4, StyledPreformattedArea, StyledHelpDescription, StyledDiv, StyledBr, StyledHelpFrame} from '../styled'
+import {
+  StyledCypherMessage,
+  StyledCypherWarningMessage,
+  StyledCypherErrorMessage,
+  StyledHelpContent,
+  StyledH4,
+  StyledPreformattedArea,
+  StyledHelpDescription,
+  StyledDiv,
+  StyledBr,
+  StyledHelpFrame
+} from '../styled'
 
-const getWarningComponent = (severity) => {
+const getWarningComponent = severity => {
   if (severity === 'ERROR') {
-    return (<StyledCypherErrorMessage>{severity}</StyledCypherErrorMessage>)
+    return (
+      <StyledCypherErrorMessage>
+        {severity}
+      </StyledCypherErrorMessage>
+    )
   } else if (severity === 'WARNING') {
-    return (<StyledCypherWarningMessage>{severity}</StyledCypherWarningMessage>)
+    return (
+      <StyledCypherWarningMessage>
+        {severity}
+      </StyledCypherWarningMessage>
+    )
   } else {
-    return (<StyledCypherMessage>{severity}</StyledCypherMessage>)
+    return (
+      <StyledCypherMessage>
+        {severity}
+      </StyledCypherMessage>
+    )
   }
 }
 
@@ -49,18 +71,24 @@ export class WarningsView extends Component {
     let cypherLines = cypher.split('\n')
     cypherLines[0] = cypherLines[0].replace(/^EXPLAIN /, '')
 
-    let notificationsList = notifications.map((notification) => {
+    let notificationsList = notifications.map(notification => {
       return (
         <StyledHelpContent>
           <StyledHelpDescription>
             {getWarningComponent(notification.severity)}
-            <StyledH4>{notification.title}</StyledH4>
+            <StyledH4>
+              {notification.title}
+            </StyledH4>
           </StyledHelpDescription>
           <StyledDiv>
-            <StyledHelpDescription>{notification.description}</StyledHelpDescription>
+            <StyledHelpDescription>
+              {notification.description}
+            </StyledHelpDescription>
             <StyledDiv>
-              <StyledPreformattedArea>{cypherLines[notification.position.line - 1]}
-                <StyledBr />{Array(notification.position.column).join(' ')}^
+              <StyledPreformattedArea>
+                {cypherLines[notification.position.line - 1]}
+                <StyledBr />
+                {Array(notification.position.column).join(' ')}^
               </StyledPreformattedArea>
             </StyledDiv>
           </StyledDiv>
@@ -70,7 +98,8 @@ export class WarningsView extends Component {
     return (
       <StyledHelpFrame>
         {notificationsList}
-      </StyledHelpFrame>)
+      </StyledHelpFrame>
+    )
   }
 }
 

--- a/src/browser/modules/Stream/CypherFrame/WarningsView.test.js
+++ b/src/browser/modules/Stream/CypherFrame/WarningsView.test.js
@@ -30,9 +30,8 @@ describe('WarningsViews', () => {
       // Given
       const result = mount(WarningsView)
         .withProps({ result: {} })
-
         // Then
-        .then((wrapper) => {
+        .then(wrapper => {
           expect(wrapper.text()).toEqual('')
         })
 
@@ -40,29 +39,30 @@ describe('WarningsViews', () => {
       return result
     })
     test('does displays a warning', () => {
-     // Given
+      // Given
       const result = mount(WarningsView)
-        .withProps({result: {
-          summary: {
-            notifications: [
-              {
-                severity: 'WARNING xx0',
-                title: 'My xx1 warning',
-                description: 'This is xx2 warning',
-                position: {
-                  column: 7,
-                  line: 1
+        .withProps({
+          result: {
+            summary: {
+              notifications: [
+                {
+                  severity: 'WARNING xx0',
+                  title: 'My xx1 warning',
+                  description: 'This is xx2 warning',
+                  position: {
+                    column: 7,
+                    line: 1
+                  }
                 }
+              ],
+              statement: {
+                text: 'EXPLAIN MATCH xx3'
               }
-            ],
-            statement: {
-              text: 'EXPLAIN MATCH xx3'
             }
           }
-        }})
-
+        })
         // Then
-        .then((wrapper) => {
+        .then(wrapper => {
           const text = wrapper.text()
           expect(text).toContain('xx0')
           expect(text).toContain('xx1')
@@ -76,37 +76,39 @@ describe('WarningsViews', () => {
       return result
     })
     test('does displays multiple warnings', () => {
-     // Given
+      // Given
       const result = mount(WarningsView)
-        .withProps({result: {
-          summary: {
-            notifications: [
-              {
-                severity: 'WARNING xx0',
-                title: 'My xx1 warning',
-                description: 'This is xx2 warning',
-                position: {
-                  column: 7,
-                  line: 1
+        .withProps({
+          result: {
+            summary: {
+              notifications: [
+                {
+                  severity: 'WARNING xx0',
+                  title: 'My xx1 warning',
+                  description: 'This is xx2 warning',
+                  position: {
+                    column: 7,
+                    line: 1
+                  }
+                },
+                {
+                  severity: 'WARNING yy0',
+                  title: 'My yy1 warning',
+                  description: 'This is yy2 warning',
+                  position: {
+                    column: 3,
+                    line: 1
+                  }
                 }
-              }, {
-                severity: 'WARNING yy0',
-                title: 'My yy1 warning',
-                description: 'This is yy2 warning',
-                position: {
-                  column: 3,
-                  line: 1
-                }
+              ],
+              statement: {
+                text: 'EXPLAIN MATCH zz3'
               }
-            ],
-            statement: {
-              text: 'EXPLAIN MATCH zz3'
             }
           }
-        }})
-
+        })
         // Then
-        .then((wrapper) => {
+        .then(wrapper => {
           const text = wrapper.text()
           expect(text).toContain('xx0')
           expect(text).toContain('xx1')
@@ -125,10 +127,9 @@ describe('WarningsViews', () => {
     test('displays nothing', () => {
       // Given
       const result = mount(WarningsStatusbar)
-        .withProps({ })
-
+        .withProps({})
         // Then
-        .then((wrapper) => {
+        .then(wrapper => {
           expect(wrapper.text()).toEqual('')
         })
 

--- a/src/browser/modules/Stream/CypherFrame/helpers.test.js
+++ b/src/browser/modules/Stream/CypherFrame/helpers.test.js
@@ -46,8 +46,10 @@ describe('helpers', () => {
     ]
     // When
     // Then
-    items.forEach((item) => {
-      expect(getRecordsToDisplayInTable(item.request.result, maxRows).length).toEqual(item.expect)
+    items.forEach(item => {
+      expect(
+        getRecordsToDisplayInTable(item.request.result, maxRows).length
+      ).toEqual(item.expect)
     })
   })
   test('resultHasRows should report if there are rows or not in the result', () => {
@@ -62,7 +64,7 @@ describe('helpers', () => {
     ]
     // When
     // Then
-    items.forEach((item) => {
+    items.forEach(item => {
       expect(resultHasRows(item.request)).toEqual(item.expect)
     })
   })
@@ -74,14 +76,26 @@ describe('helpers', () => {
       { request: { result: true }, expect: false },
       { request: { result: { summary: true } }, expect: false },
       { request: { result: { summary: {} } }, expect: false },
-      { request: { result: { summary: { notifications: null } } }, expect: false },
-      { request: { result: { summary: { notifications: true } } }, expect: false },
-      { request: { result: { summary: { notifications: [] } } }, expect: false },
-      { request: { result: { summary: { notifications: ['yes!'] } } }, expect: true }
+      {
+        request: { result: { summary: { notifications: null } } },
+        expect: false
+      },
+      {
+        request: { result: { summary: { notifications: true } } },
+        expect: false
+      },
+      {
+        request: { result: { summary: { notifications: [] } } },
+        expect: false
+      },
+      {
+        request: { result: { summary: { notifications: ['yes!'] } } },
+        expect: true
+      }
     ]
     // When
     // Then
-    items.forEach((item) => {
+    items.forEach(item => {
       expect(resultHasWarnings(item.request)).toEqual(item.expect)
     })
   })
@@ -100,7 +114,7 @@ describe('helpers', () => {
     ]
     // When
     // Then
-    items.forEach((item) => {
+    items.forEach(item => {
       expect(resultHasPlan(item.request)).toEqual(item.expect)
     })
   })
@@ -114,7 +128,7 @@ describe('helpers', () => {
     ]
     // When
     // Then
-    items.forEach((item) => {
+    items.forEach(item => {
       expect(resultIsError(item.request)).toEqual(item.expect)
     })
   })
@@ -141,17 +155,17 @@ describe('helpers', () => {
     })
     test('should return false if no nodes are found', () => {
       // Given
-      const mappedGet = (map) => (key) => map[key]
+      const mappedGet = map => key => map[key]
       const request = {
         result: {
           records: [
             {
               keys: ['name', 'city'],
-              get: mappedGet({name: 'Oskar', city: 'Borås'})
+              get: mappedGet({ name: 'Oskar', city: 'Borås' })
             },
             {
               keys: ['name', 'city'],
-              get: mappedGet({name: 'Stella', city: 'Borås'})
+              get: mappedGet({ name: 'Stella', city: 'Borås' })
             }
           ]
         }
@@ -165,18 +179,21 @@ describe('helpers', () => {
     })
     test('should return true if nodes are found, even nested', () => {
       // Given
-      let node = new neo4j.types.Node('2', ['Movie'], {prop2: 'prop2'})
-      const mappedGet = (map) => (key) => map[key]
+      let node = new neo4j.types.Node('2', ['Movie'], { prop2: 'prop2' })
+      const mappedGet = map => key => map[key]
       const request = {
         result: {
           records: [
             {
               keys: ['name', 'maybeNode'],
-              get: mappedGet({name: 'Oskar', maybeNode: false})
+              get: mappedGet({ name: 'Oskar', maybeNode: false })
             },
             {
               keys: ['name', 'maybeNode'],
-              get: mappedGet({name: 'Stella', maybeNode: { deeper: [1, node] }})
+              get: mappedGet({
+                name: 'Stella',
+                maybeNode: { deeper: [1, node] }
+              })
             }
           ]
         }
@@ -263,18 +280,21 @@ describe('helpers', () => {
     })
     test('should return the viz view if nodes are existent', () => {
       // Given
-      let node = new neo4j.types.Node('2', ['Movie'], {prop2: 'prop2'})
-      const mappedGet = (map) => (key) => map[key]
+      let node = new neo4j.types.Node('2', ['Movie'], { prop2: 'prop2' })
+      const mappedGet = map => key => map[key]
       const request = {
         result: {
           records: [
             {
               keys: ['name', 'maybeNode'],
-              get: mappedGet({name: 'Oskar', maybeNode: false})
+              get: mappedGet({ name: 'Oskar', maybeNode: false })
             },
             {
               keys: ['name', 'maybeNode'],
-              get: mappedGet({name: 'Stella', maybeNode: { deeper: [1, node] }})
+              get: mappedGet({
+                name: 'Stella',
+                maybeNode: { deeper: [1, node] }
+              })
             }
           ]
         }
@@ -290,17 +310,17 @@ describe('helpers', () => {
     })
     test('should return the table view if nodes are not existent', () => {
       // Given
-      const mappedGet = (map) => (key) => map[key]
+      const mappedGet = map => key => map[key]
       const request = {
         result: {
           records: [
             {
               keys: ['name', 'maybeNode'],
-              get: mappedGet({name: 'Oskar', maybeNode: false})
+              get: mappedGet({ name: 'Oskar', maybeNode: false })
             },
             {
               keys: ['name', 'maybeNode'],
-              get: mappedGet({name: 'Stella', maybeNode: false})
+              get: mappedGet({ name: 'Stella', maybeNode: false })
             }
           ]
         }
@@ -346,18 +366,21 @@ describe('helpers', () => {
     })
     test('should return the ascii if thats the last view', () => {
       // Given
-      let node = new neo4j.types.Node('2', ['Movie'], {prop2: 'prop2'})
-      const mappedGet = (map) => (key) => map[key]
+      let node = new neo4j.types.Node('2', ['Movie'], { prop2: 'prop2' })
+      const mappedGet = map => key => map[key]
       const request = {
         result: {
           records: [
             {
               keys: ['name', 'maybeNode'],
-              get: mappedGet({name: 'Oskar', maybeNode: false})
+              get: mappedGet({ name: 'Oskar', maybeNode: false })
             },
             {
               keys: ['name', 'maybeNode'],
-              get: mappedGet({name: 'Stella', maybeNode: { deeper: [1, node] }})
+              get: mappedGet({
+                name: 'Stella',
+                maybeNode: { deeper: [1, node] }
+              })
             }
           ]
         }
@@ -373,17 +396,17 @@ describe('helpers', () => {
     })
     test('should return the table if viz the last view but no viz elements exists', () => {
       // Given
-      const mappedGet = (map) => (key) => map[key]
+      const mappedGet = map => key => map[key]
       const request = {
         result: {
           records: [
             {
               keys: ['name', 'maybeNode'],
-              get: mappedGet({name: 'Oskar', maybeNode: false})
+              get: mappedGet({ name: 'Oskar', maybeNode: false })
             },
             {
               keys: ['name', 'maybeNode'],
-              get: mappedGet({name: 'Stella', maybeNode: false})
+              get: mappedGet({ name: 'Stella', maybeNode: false })
             }
           ]
         }
@@ -399,17 +422,17 @@ describe('helpers', () => {
     })
     test('should not change view if state.openView exists', () => {
       // Given
-      const mappedGet = (map) => (key) => map[key]
+      const mappedGet = map => key => map[key]
       const request = {
         result: {
           records: [
             {
               keys: ['name', 'maybeNode'],
-              get: mappedGet({name: 'Oskar', maybeNode: false})
+              get: mappedGet({ name: 'Oskar', maybeNode: false })
             },
             {
               keys: ['name', 'maybeNode'],
-              get: mappedGet({name: 'Stella', maybeNode: false})
+              get: mappedGet({ name: 'Stella', maybeNode: false })
             }
           ]
         }
@@ -425,18 +448,21 @@ describe('helpers', () => {
     })
     test('should return viz if the last view was plan but no plan exists and viz elements exists', () => {
       // Given
-      let node = new neo4j.types.Node('2', ['Movie'], {prop2: 'prop2'})
-      const mappedGet = (map) => (key) => map[key]
+      let node = new neo4j.types.Node('2', ['Movie'], { prop2: 'prop2' })
+      const mappedGet = map => key => map[key]
       const request = {
         result: {
           records: [
             {
               keys: ['name', 'maybeNode'],
-              get: mappedGet({name: 'Oskar', maybeNode: false})
+              get: mappedGet({ name: 'Oskar', maybeNode: false })
             },
             {
               keys: ['name', 'maybeNode'],
-              get: mappedGet({name: 'Stella', maybeNode: { deeper: [1, node] }})
+              get: mappedGet({
+                name: 'Stella',
+                maybeNode: { deeper: [1, node] }
+              })
             }
           ]
         }
@@ -452,17 +478,17 @@ describe('helpers', () => {
     })
     test('should return table if the last view was plan but no plan exists and no viz elements exists', () => {
       // Given
-      const mappedGet = (map) => (key) => map[key]
+      const mappedGet = map => key => map[key]
       const request = {
         result: {
           records: [
             {
               keys: ['name', 'maybeNode'],
-              get: mappedGet({name: 'Oskar', maybeNode: false})
+              get: mappedGet({ name: 'Oskar', maybeNode: false })
             },
             {
               keys: ['name', 'maybeNode'],
-              get: mappedGet({name: 'Stella', maybeNode: { deeper: [1, 2] }})
+              get: mappedGet({ name: 'Stella', maybeNode: { deeper: [1, 2] } })
             }
           ]
         }
@@ -490,16 +516,20 @@ describe('helpers', () => {
     })
     test('extractRecordsToResultArray handles regular records', () => {
       // Given
-      const start = new neo4j.types.Node(1, ['X'], {x: 1})
-      const end = new neo4j.types.Node(2, ['Y'], {y: new neo4j.Int(1)})
-      const rel = new neo4j.types.Relationship(3, 1, 2, 'REL', {rel: 1})
+      const start = new neo4j.types.Node(1, ['X'], { x: 1 })
+      const end = new neo4j.types.Node(2, ['Y'], { y: new neo4j.Int(1) })
+      const rel = new neo4j.types.Relationship(3, 1, 2, 'REL', { rel: 1 })
       const segments = [new neo4j.types.PathSegment(start, rel, end)]
       const path = new neo4j.types.Path(start, end, segments)
 
       const records = [
         {
           keys: ['"x"', '"y"', '"n"'],
-          _fields: ['x', 'y', new neo4j.types.Node('1', ['Person'], {prop1: 'prop1'})]
+          _fields: [
+            'x',
+            'y',
+            new neo4j.types.Node('1', ['Person'], { prop1: 'prop1' })
+          ]
         },
         {
           keys: ['"x"', '"y"', '"n"'],
@@ -513,38 +543,46 @@ describe('helpers', () => {
       // Then
       expect(res).toEqual([
         ['"x"', '"y"', '"n"'],
-        ['x', 'y', new neo4j.types.Node('1', ['Person'], {prop1: 'prop1'})],
+        ['x', 'y', new neo4j.types.Node('1', ['Person'], { prop1: 'prop1' })],
         ['xx', 'yy', path]
       ])
     })
     test('flattenGraphItemsInResultArray extracts props from graph items', () => {
       // Given
-      const start = new neo4j.types.Node(1, ['X'], {x: 1})
-      const end = new neo4j.types.Node(2, ['Y'], {y: 1})
-      const rel = new neo4j.types.Relationship(3, 1, 2, 'REL', {rel: 1})
+      const start = new neo4j.types.Node(1, ['X'], { x: 1 })
+      const end = new neo4j.types.Node(2, ['Y'], { y: 1 })
+      const rel = new neo4j.types.Relationship(3, 1, 2, 'REL', { rel: 1 })
       const segments = [new neo4j.types.PathSegment(start, rel, end)]
       const path = new neo4j.types.Path(start, end, segments)
 
       const records = [
         {
           keys: ['"x"', '"y"', '"n"'],
-          _fields: ['x', 'y', new neo4j.types.Node('1', ['Person'], {prop1: 'prop1'})]
+          _fields: [
+            'x',
+            'y',
+            new neo4j.types.Node('1', ['Person'], { prop1: 'prop1' })
+          ]
         },
         {
           keys: ['"x"', '"y"', '"n"'],
-          _fields: ['xx', 'yy', {prop: path}]
+          _fields: ['xx', 'yy', { prop: path }]
         }
       ]
 
       // When
       const step1 = extractRecordsToResultArray(records)
-      const res = flattenGraphItemsInResultArray(neo4j.types, neo4j.isInt, step1)
+      const res = flattenGraphItemsInResultArray(
+        neo4j.types,
+        neo4j.isInt,
+        step1
+      )
 
       // Then
       expect(res).toEqual([
         ['"x"', '"y"', '"n"'],
-        ['x', 'y', {prop1: 'prop1'}],
-        ['xx', 'yy', {prop: [{x: 1}, {rel: 1}, {y: 1}]}]
+        ['x', 'y', { prop1: 'prop1' }],
+        ['xx', 'yy', { prop: [{ x: 1 }, { rel: 1 }, { y: 1 }] }]
       ])
     })
     test('stringifyResultArray uses stringifyMod to serialize', () => {
@@ -562,43 +600,63 @@ describe('helpers', () => {
 
       // When
       const step1 = extractRecordsToResultArray(records)
-      const step2 = flattenGraphItemsInResultArray(neo4j.types, neo4j.isInt, step1)
+      const step2 = flattenGraphItemsInResultArray(
+        neo4j.types,
+        neo4j.isInt,
+        step1
+      )
       const res = stringifyResultArray(neo4j.isInt, step2)
       // Then
       expect(res).toEqual([
-        [JSON.stringify('"neoInt"'), JSON.stringify('"int"'), JSON.stringify('"any"')],
+        [
+          JSON.stringify('"neoInt"'),
+          JSON.stringify('"int"'),
+          JSON.stringify('"any"')
+        ],
         ['882573709873217509', '100', '0.5'],
         ['300', '100', '"string"']
       ])
     })
     test('stringifyResultArray handles neo4j integers nested within graph items', () => {
       // Given
-      const start = new neo4j.types.Node(1, ['X'], {x: 1})
-      const end = new neo4j.types.Node(2, ['Y'], {y: new neo4j.Int(2)}) // <-- Neo4j integer
-      const rel = new neo4j.types.Relationship(3, 1, 2, 'REL', {rel: 1})
+      const start = new neo4j.types.Node(1, ['X'], { x: 1 })
+      const end = new neo4j.types.Node(2, ['Y'], { y: new neo4j.Int(2) }) // <-- Neo4j integer
+      const rel = new neo4j.types.Relationship(3, 1, 2, 'REL', { rel: 1 })
       const segments = [new neo4j.types.PathSegment(start, rel, end)]
       const path = new neo4j.types.Path(start, end, segments)
 
       const records = [
         {
           keys: ['"x"', '"y"', '"n"'],
-          _fields: ['x', 'y', new neo4j.types.Node('1', ['Person'], {prop1: 'prop1'})]
+          _fields: [
+            'x',
+            'y',
+            new neo4j.types.Node('1', ['Person'], { prop1: 'prop1' })
+          ]
         },
         {
           keys: ['"x"', '"y"', '"n"'],
-          _fields: ['xx', 'yy', {prop: path}]
+          _fields: ['xx', 'yy', { prop: path }]
         }
       ]
 
       // When
       const step1 = extractRecordsToResultArray(records)
-      const step2 = flattenGraphItemsInResultArray(neo4j.types, neo4j.isInt, step1)
+      const step2 = flattenGraphItemsInResultArray(
+        neo4j.types,
+        neo4j.isInt,
+        step1
+      )
       const res = stringifyResultArray(neo4j.isInt, step2)
       // Then
       expect(res).toEqual([
         [JSON.stringify('"x"'), JSON.stringify('"y"'), JSON.stringify('"n"')],
-        ['"x"', '"y"', JSON.stringify({prop1: 'prop1'})],
-        ['"xx"', '"yy"', JSON.stringify({prop: [{x: 1}, {rel: 1}, {y: 2}]})] // <--
+        ['"x"', '"y"', JSON.stringify({ prop1: 'prop1' })],
+        [
+          '"xx"',
+          '"yy"',
+          JSON.stringify({ prop: [{ x: 1 }, { rel: 1 }, { y: 2 }] })
+        ] // <--
       ])
     })
   })

--- a/src/browser/modules/Stream/CypherFrame/index.jsx
+++ b/src/browser/modules/Stream/CypherFrame/index.jsx
@@ -27,7 +27,16 @@ import { v1 as neo4j } from 'neo4j-driver-alias'
 import { deepEquals } from 'services/utils'
 import { getRequest } from 'shared/modules/requests/requestsDuck'
 import FrameSidebar from '../FrameSidebar'
-import { VisualizationIcon, TableIcon, AsciiIcon, CodeIcon, PlanIcon, AlertIcon, ErrorIcon, Spinner } from 'browser-components/icons/Icons'
+import {
+  VisualizationIcon,
+  TableIcon,
+  AsciiIcon,
+  CodeIcon,
+  PlanIcon,
+  AlertIcon,
+  ErrorIcon,
+  Spinner
+} from 'browser-components/icons/Icons'
 import { AsciiView, AsciiStatusbar } from './AsciiView'
 import { TableView, TableStatusbar } from './TableView'
 import { CodeView, CodeStatusbar } from './CodeView'
@@ -38,9 +47,27 @@ import { VisualizationConnectedBus } from './VisualizationView'
 import Render from 'browser-components/Render'
 import Display from 'browser-components/Display'
 import * as viewTypes from 'shared/modules/stream/frameViewTypes'
-import { resultHasRows, resultHasWarnings, resultHasPlan, resultIsError, resultHasNodes, initialView, transformResultRecordsToResultArray, stringifyResultArray } from './helpers'
-import { StyledFrameBody, SpinnerContainer, StyledStatsBarContainer } from '../styled'
-import { getMaxRows, getInitialNodeDisplay, getMaxNeighbours, shouldAutoComplete } from 'shared/modules/settings/settingsDuck'
+import {
+  resultHasRows,
+  resultHasWarnings,
+  resultHasPlan,
+  resultIsError,
+  resultHasNodes,
+  initialView,
+  transformResultRecordsToResultArray,
+  stringifyResultArray
+} from './helpers'
+import {
+  StyledFrameBody,
+  SpinnerContainer,
+  StyledStatsBarContainer
+} from '../styled'
+import {
+  getMaxRows,
+  getInitialNodeDisplay,
+  getMaxNeighbours,
+  shouldAutoComplete
+} from 'shared/modules/settings/settingsDuck'
 import { setRecentView, getRecentView } from 'shared/modules/stream/streamDuck'
 
 export class CypherFrame extends Component {
@@ -53,19 +80,22 @@ export class CypherFrame extends Component {
     }
   }
   makeExportData (records) {
-    return stringifyResultArray(neo4j.isInt, transformResultRecordsToResultArray(records))
+    return stringifyResultArray(
+      neo4j.isInt,
+      transformResultRecordsToResultArray(records)
+    )
   }
   changeView (view) {
-    this.setState({openView: view})
+    this.setState({ openView: view })
     if (this.props.onRecentViewChanged) {
       this.props.onRecentViewChanged(view)
     }
   }
   onResize (fullscreen, collapse, frameHeight) {
     if (frameHeight) {
-      this.setState({fullscreen, collapse, frameHeight})
+      this.setState({ fullscreen, collapse, frameHeight })
     } else {
-      this.setState({fullscreen, collapse})
+      this.setState({ fullscreen, collapse })
     }
   }
   shouldComponentUpdate (props, state) {
@@ -73,13 +103,25 @@ export class CypherFrame extends Component {
   }
   componentWillReceiveProps (props) {
     const newState = {}
-    if (props.request.status !== 'pending' && this.state.openView === undefined) {
+    if (
+      props.request.status !== 'pending' &&
+      this.state.openView === undefined
+    ) {
       const view = initialView(props, this.state)
       if (view) newState['openView'] = view
     }
-    if (this.props.request === undefined || !deepEquals(props.request.result, this.props.request.result)) {
-      if (props.request.result && props.request.result.records && props.request.result.records.length) {
-        newState['exportData'] = this.makeExportData(props.request.result.records)
+    if (
+      this.props.request === undefined ||
+      !deepEquals(props.request.result, this.props.request.result)
+    ) {
+      if (
+        props.request.result &&
+        props.request.result.records &&
+        props.request.result.records.length
+      ) {
+        newState['exportData'] = this.makeExportData(
+          props.request.result.records
+        )
       } else {
         newState['exportData'] = null
       }
@@ -89,47 +131,92 @@ export class CypherFrame extends Component {
   componentDidMount () {
     const view = initialView(this.props, this.state)
     if (view) this.setState({ openView: view })
-    if (this.props.request && this.props.request.result && this.props.request.result.records && this.props.request.result.records.length) {
-      this.setState({ exportData: this.makeExportData(this.props.request.result.records) })
+    if (
+      this.props.request &&
+      this.props.request.result &&
+      this.props.request.result.records &&
+      this.props.request.result.records.length
+    ) {
+      this.setState({
+        exportData: this.makeExportData(this.props.request.result.records)
+      })
     }
   }
   sidebar () {
     return (
       <FrameSidebar>
         <Render if={resultHasNodes(this.props.request) && !this.state.errors}>
-          <CypherFrameButton selected={this.state.openView === viewTypes.VISUALIZATION} onClick={() => {
-            this.changeView(viewTypes.VISUALIZATION)
-          }}><VisualizationIcon /></CypherFrameButton>
+          <CypherFrameButton
+            selected={this.state.openView === viewTypes.VISUALIZATION}
+            onClick={() => {
+              this.changeView(viewTypes.VISUALIZATION)
+            }}
+          >
+            <VisualizationIcon />
+          </CypherFrameButton>
         </Render>
         <Render if={!resultIsError(this.props.request)}>
-          <CypherFrameButton selected={this.state.openView === viewTypes.TABLE} onClick={() => {
-            this.changeView(viewTypes.TABLE)
-          }}><TableIcon /></CypherFrameButton>
+          <CypherFrameButton
+            selected={this.state.openView === viewTypes.TABLE}
+            onClick={() => {
+              this.changeView(viewTypes.TABLE)
+            }}
+          >
+            <TableIcon />
+          </CypherFrameButton>
         </Render>
-        <Render if={resultHasRows(this.props.request) && !resultIsError(this.props.request)}>
-          <CypherFrameButton selected={this.state.openView === viewTypes.TEXT} onClick={() => {
-            this.changeView(viewTypes.TEXT)
-          }}><AsciiIcon /></CypherFrameButton>
+        <Render
+          if={
+            resultHasRows(this.props.request) &&
+            !resultIsError(this.props.request)
+          }
+        >
+          <CypherFrameButton
+            selected={this.state.openView === viewTypes.TEXT}
+            onClick={() => {
+              this.changeView(viewTypes.TEXT)
+            }}
+          >
+            <AsciiIcon />
+          </CypherFrameButton>
         </Render>
         <Render if={resultHasPlan(this.props.request)}>
-          <CypherFrameButton selected={this.state.openView === viewTypes.PLAN} onClick={() =>
-            this.changeView(viewTypes.PLAN)
-          }><PlanIcon /></CypherFrameButton>
+          <CypherFrameButton
+            selected={this.state.openView === viewTypes.PLAN}
+            onClick={() => this.changeView(viewTypes.PLAN)}
+          >
+            <PlanIcon />
+          </CypherFrameButton>
         </Render>
         <Render if={resultHasWarnings(this.props.request)}>
-          <CypherFrameButton selected={this.state.openView === viewTypes.WARNINGS} onClick={() => {
-            this.changeView(viewTypes.WARNINGS)
-          }}><AlertIcon /></CypherFrameButton>
+          <CypherFrameButton
+            selected={this.state.openView === viewTypes.WARNINGS}
+            onClick={() => {
+              this.changeView(viewTypes.WARNINGS)
+            }}
+          >
+            <AlertIcon />
+          </CypherFrameButton>
         </Render>
         <Render if={resultIsError(this.props.request)}>
-          <CypherFrameButton selected={this.state.openView === viewTypes.ERRORS} onClick={() => {
-            this.changeView(viewTypes.ERRORS)
-          }}><ErrorIcon /></CypherFrameButton>
+          <CypherFrameButton
+            selected={this.state.openView === viewTypes.ERRORS}
+            onClick={() => {
+              this.changeView(viewTypes.ERRORS)
+            }}
+          >
+            <ErrorIcon />
+          </CypherFrameButton>
         </Render>
         <Render if={!resultIsError(this.props.request)}>
-          <CypherFrameButton selected={this.state.openView === viewTypes.CODE} onClick={() => {
-            this.changeView(viewTypes.CODE)
-          }}><CodeIcon /></CypherFrameButton>
+          <CypherFrameButton
+            selected={this.state.openView === viewTypes.CODE}
+            onClick={() => {
+              this.changeView(viewTypes.CODE)
+            }}
+          >
+            <CodeIcon />
+          </CypherFrameButton>
         </Render>
       </FrameSidebar>
     )
@@ -145,24 +232,55 @@ export class CypherFrame extends Component {
   }
   getFrameContents (request, result, query) {
     return (
-      <StyledFrameBody fullscreen={this.state.fullscreen} collapsed={this.state.collapse}>
+      <StyledFrameBody
+        fullscreen={this.state.fullscreen}
+        collapsed={this.state.collapse}
+      >
         <Display if={this.state.openView === viewTypes.TEXT} lazy>
-          <AsciiView {...this.state} maxRows={this.props.maxRows} result={result} setParentState={this.setState.bind(this)} />
+          <AsciiView
+            {...this.state}
+            maxRows={this.props.maxRows}
+            result={result}
+            setParentState={this.setState.bind(this)}
+          />
         </Display>
         <Display if={this.state.openView === viewTypes.TABLE} lazy>
-          <TableView {...this.state} maxRows={this.props.maxRows} result={result} setParentState={this.setState.bind(this)} />
+          <TableView
+            {...this.state}
+            maxRows={this.props.maxRows}
+            result={result}
+            setParentState={this.setState.bind(this)}
+          />
         </Display>
         <Display if={this.state.openView === viewTypes.CODE} lazy>
-          <CodeView {...this.state} result={result} request={request} query={query} setParentState={this.setState.bind(this)} />
+          <CodeView
+            {...this.state}
+            result={result}
+            request={request}
+            query={query}
+            setParentState={this.setState.bind(this)}
+          />
         </Display>
         <Display if={this.state.openView === viewTypes.ERRORS} lazy>
-          <ErrorsView {...this.state} result={result} setParentState={this.setState.bind(this)} />
+          <ErrorsView
+            {...this.state}
+            result={result}
+            setParentState={this.setState.bind(this)}
+          />
         </Display>
         <Display if={this.state.openView === viewTypes.WARNINGS} lazy>
-          <WarningsView {...this.state} result={result} setParentState={this.setState.bind(this)} />
+          <WarningsView
+            {...this.state}
+            result={result}
+            setParentState={this.setState.bind(this)}
+          />
         </Display>
         <Display if={this.state.openView === viewTypes.PLAN} lazy>
-          <PlanView {...this.state} result={result} setParentState={this.setState.bind(this)} />
+          <PlanView
+            {...this.state}
+            result={result}
+            setParentState={this.setState.bind(this)}
+          />
         </Display>
         <Display if={this.state.openView === viewTypes.VISUALIZATION} lazy>
           <VisualizationConnectedBus
@@ -171,8 +289,8 @@ export class CypherFrame extends Component {
             setParentState={this.setState.bind(this)}
             frameHeight={this.state.frameHeight}
             assignVisElement={(svgElement, graphElement) => {
-              this.visElement = {svgElement, graphElement}
-              this.setState({hasVis: true})
+              this.visElement = { svgElement, graphElement }
+              this.setState({ hasVis: true })
             }}
             initialNodeDisplay={this.props.initialNodeDisplay}
             autoComplete={this.props.autoComplete}
@@ -186,22 +304,48 @@ export class CypherFrame extends Component {
     return (
       <StyledStatsBarContainer>
         <Display if={this.state.openView === viewTypes.TEXT} lazy>
-          <AsciiStatusbar {...this.state} maxRows={this.props.maxRows} result={result} setParentState={this.setState.bind(this)} />
+          <AsciiStatusbar
+            {...this.state}
+            maxRows={this.props.maxRows}
+            result={result}
+            setParentState={this.setState.bind(this)}
+          />
         </Display>
         <Display if={this.state.openView === viewTypes.TABLE} lazy>
-          <TableStatusbar {...this.state} maxRows={this.props.maxRows} result={result} setParentState={this.setState.bind(this)} />
+          <TableStatusbar
+            {...this.state}
+            maxRows={this.props.maxRows}
+            result={result}
+            setParentState={this.setState.bind(this)}
+          />
         </Display>
         <Display if={this.state.openView === viewTypes.CODE} lazy>
-          <CodeStatusbar {...this.state} result={result} setParentState={this.setState.bind(this)} />
+          <CodeStatusbar
+            {...this.state}
+            result={result}
+            setParentState={this.setState.bind(this)}
+          />
         </Display>
         <Display if={this.state.openView === viewTypes.ERRORS} lazy>
-          <ErrorsStatusbar {...this.state} result={result} setParentState={this.setState.bind(this)} />
+          <ErrorsStatusbar
+            {...this.state}
+            result={result}
+            setParentState={this.setState.bind(this)}
+          />
         </Display>
         <Display if={this.state.openView === viewTypes.WARNINGS} lazy>
-          <WarningsStatusbar {...this.state} result={result} setParentState={this.setState.bind(this)} />
+          <WarningsStatusbar
+            {...this.state}
+            result={result}
+            setParentState={this.setState.bind(this)}
+          />
         </Display>
         <Display if={this.state.openView === viewTypes.PLAN} lazy>
-          <PlanStatusbar {...this.state} result={result} setParentState={this.setState.bind(this)} />
+          <PlanStatusbar
+            {...this.state}
+            result={result}
+            setParentState={this.setState.bind(this)}
+          />
         </Display>
       </StyledStatsBarContainer>
     )
@@ -211,8 +355,14 @@ export class CypherFrame extends Component {
     const { cmd: query = '' } = frame
     const { result = {}, status: requestStatus } = request
 
-    const frameContents = requestStatus !== 'pending' ? this.getFrameContents(request, result, query) : this.getSpinner()
-    const statusBar = this.state.openView !== viewTypes.VISUALIZATION ? this.getStatusbar(result) : null
+    const frameContents =
+      requestStatus !== 'pending'
+        ? this.getFrameContents(request, result, query)
+        : this.getSpinner()
+    const statusBar =
+      this.state.openView !== viewTypes.VISUALIZATION
+        ? this.getStatusbar(result)
+        : null
 
     return (
       <FrameTemplate
@@ -220,9 +370,17 @@ export class CypherFrame extends Component {
         header={frame}
         contents={frameContents}
         statusbar={statusBar}
-        exportData={(this.state.openView !== viewTypes.VISUALIZATION) ? this.state.exportData : null}
+        exportData={
+          this.state.openView !== viewTypes.VISUALIZATION
+            ? this.state.exportData
+            : null
+        }
         onResize={this.onResize.bind(this)}
-        visElement={(this.state.hasVis && (this.state.openView === viewTypes.VISUALIZATION)) ? this.visElement : null}
+        visElement={
+          this.state.hasVis && this.state.openView === viewTypes.VISUALIZATION
+            ? this.visElement
+            : null
+        }
       />
     )
   }
@@ -241,7 +399,7 @@ const mapStateToProps = (state, ownProps) => {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    onRecentViewChanged: (view) => {
+    onRecentViewChanged: view => {
       dispatch(setRecentView(view))
     }
   }

--- a/src/browser/modules/Stream/CypherFrame/index.test.js
+++ b/src/browser/modules/Stream/CypherFrame/index.test.js
@@ -24,13 +24,13 @@ import { mount } from 'services/testUtils'
 import { CypherFrame } from './index'
 import * as viewTypes from 'shared/modules/stream/frameViewTypes'
 
-const toBoltRecord = (obj) => {
+const toBoltRecord = obj => {
   const keys = Object.keys(obj)
-  const vals = keys.map((key) => obj[key])
+  const vals = keys.map(key => obj[key])
   return {
-    get: (x) => obj[x],
-    forEach: (fn) => {
-      keys.forEach((key) => fn(obj[key], key))
+    get: x => obj[x],
+    forEach: fn => {
+      keys.forEach(key => fn(obj[key], key))
     },
     keys,
     _fields: vals
@@ -48,12 +48,12 @@ jest.mock('./VisualizationView', () => {
 })
 jest.mock('preact-suber', () => {
   return {
-    withBus: (a) => a
+    withBus: a => a
   }
 })
 jest.mock('preact-redux', () => {
   return {
-    connect: (msp, mdp) => (a) => a
+    connect: (msp, mdp) => a => a
   }
 })
 describe('CypherFrame', () => {
@@ -67,13 +67,12 @@ describe('CypherFrame', () => {
     }
     const result = mount(CypherFrame)
       .withProps({ request, frame: { cmd: '' } })
-
       // Then
-      .then((wrapper) => {
+      .then(wrapper => {
         expect(wrapper.html()).toContain('fa-spinner')
         return wrapper
       })
-      .then((wrapper) => {
+      .then(wrapper => {
         wrapper.setProps({ request: failedRequest })
         wrapper.update()
         expect(wrapper.html()).not.toContain('fa-spinner')
@@ -83,22 +82,19 @@ describe('CypherFrame', () => {
     // Return test result (promise)
     return result
   })
-  test.skip('renders table view if no nodes', () => { // I have no idea why this doesn't work
+  test.skip('renders table view if no nodes', () => {
+    // I have no idea why this doesn't work
     // Given
     const request = {
       status: 'success',
       result: {
-        records: [
-          toBoltRecord({x: 'x'}),
-          toBoltRecord({y: 'y'})
-        ]
+        records: [toBoltRecord({ x: 'x' }), toBoltRecord({ y: 'y' })]
       }
     }
     const result = mount(CypherFrame)
       .withProps({ request, maxRows: 100, frame: { cmd: '' } })
-
       // Then
-      .then((wrapper) => {
+      .then(wrapper => {
         wrapper.update()
         expect(wrapper.html()).toContain('<table>')
         expect(wrapper.instance().state.openView).toEqual(viewTypes.TABLE)
@@ -117,9 +113,8 @@ describe('CypherFrame', () => {
     }
     const result = mount(CypherFrame)
       .withProps({ request, maxRows: 100, frame: { cmd: '' } })
-
       // Then
-      .then((wrapper) => {
+      .then(wrapper => {
         wrapper.update()
         expect(wrapper.text()).toContain('Test.Error')
         expect(wrapper.instance().state.openView).toEqual(viewTypes.ERRORS)
@@ -127,22 +122,23 @@ describe('CypherFrame', () => {
     // Return test result (promise)
     return result
   })
-  test('renders text view if it\'s the recent one', () => {
+  test("renders text view if it's the recent one", () => {
     // Given
     const request = {
       status: 'success',
       result: {
-        records: [
-          toBoltRecord({x: 'x'}),
-          toBoltRecord({y: 'y'})
-        ]
+        records: [toBoltRecord({ x: 'x' }), toBoltRecord({ y: 'y' })]
       }
     }
     const result = mount(CypherFrame)
-      .withProps({ request, maxRows: 100, recentView: viewTypes.TEXT, frame: { cmd: '' } })
-
+      .withProps({
+        request,
+        maxRows: 100,
+        recentView: viewTypes.TEXT,
+        frame: { cmd: '' }
+      })
       // Then
-      .then((wrapper) => {
+      .then(wrapper => {
         wrapper.update()
         expect(wrapper.text()).toContain('Max column width')
         expect(wrapper.instance().state.openView).toEqual(viewTypes.TEXT)

--- a/src/browser/modules/Stream/ErrorFrame.jsx
+++ b/src/browser/modules/Stream/ErrorFrame.jsx
@@ -23,7 +23,7 @@ import * as e from 'services/exceptionMessages'
 import { getErrorMessage } from 'services/exceptions'
 import { PaddedDiv } from './styled'
 
-const ErrorFrame = ({frame}) => {
+const ErrorFrame = ({ frame }) => {
   const error = frame.error || false
   let errorContents = error.message || 'No error message found'
   if (error.type && typeof e[error.type] !== 'undefined') {
@@ -32,7 +32,13 @@ const ErrorFrame = ({frame}) => {
   return (
     <FrameTemplate
       header={frame}
-      contents={<PaddedDiv><pre>{errorContents}</pre></PaddedDiv>}
+      contents={
+        <PaddedDiv>
+          <pre>
+            {errorContents}
+          </pre>
+        </PaddedDiv>
+      }
     />
   )
 }

--- a/src/browser/modules/Stream/Frame.jsx
+++ b/src/browser/modules/Stream/Frame.jsx
@@ -20,24 +20,21 @@
 
 import FrameTemplate from './FrameTemplate'
 
-const Frame = ({frame}) => {
+const Frame = ({ frame }) => {
   const errors = frame.errors || false
   const contents = frame.contents || false
   let frameContents = contents
   if (errors) {
     frameContents = (
       <div>
-        <pre>{errors.message}</pre>
+        <pre>
+          {errors.message}
+        </pre>
       </div>
     )
   } else if (frame.type === 'unknown') {
     frameContents = 'Unknown command'
   }
-  return (
-    <FrameTemplate
-      header={frame}
-      contents={frameContents}
-    />
-  )
+  return <FrameTemplate header={frame} contents={frameContents} />
 }
 export default Frame

--- a/src/browser/modules/Stream/FrameError.jsx
+++ b/src/browser/modules/Stream/FrameError.jsx
@@ -22,12 +22,15 @@ import { ExclamationTriangleIcon } from 'browser-components/icons/Icons'
 import Ellipsis from 'browser-components/Ellipsis'
 import { ErrorText } from './styled'
 
-const FrameError = (props) => {
+const FrameError = props => {
   if (!props || (!props.code && !props.message)) return null
-  const fullError = `${props.code}${(props.message ? ':' : '')} ${(props.message || '')}`
+  const fullError = `${props.code}${props.message ? ':' : ''} ${props.message ||
+    ''}`
   return (
     <Ellipsis>
-      <ErrorText title={fullError}><ExclamationTriangleIcon /> {fullError}</ErrorText>
+      <ErrorText title={fullError}>
+        <ExclamationTriangleIcon /> {fullError}
+      </ErrorText>
     </Ellipsis>
   )
 }

--- a/src/browser/modules/Stream/FrameError.test.js
+++ b/src/browser/modules/Stream/FrameError.test.js
@@ -28,7 +28,7 @@ describe('FrameError', () => {
     const result = mount(FrameError)
       // When
       .withProps({})
-      .then((wrapper) => {
+      .then(wrapper => {
         expect(wrapper.text()).toBe('')
       })
     return result
@@ -38,8 +38,8 @@ describe('FrameError', () => {
     const code = 'foo'
     const result = mount(FrameError)
       // When
-      .withProps({code})
-      .then((wrapper) => {
+      .withProps({ code })
+      .then(wrapper => {
         expect(wrapper.text().trim()).toBe(code)
       })
     return result
@@ -50,8 +50,8 @@ describe('FrameError', () => {
     const code = undefined
     const result = mount(FrameError)
       // When
-      .withProps({message})
-      .then((wrapper) => {
+      .withProps({ message })
+      .then(wrapper => {
         expect(wrapper.text().trim()).toBe(`${code}: ${message}`)
       })
     return result
@@ -62,8 +62,8 @@ describe('FrameError', () => {
     const code = 'for'
     const result = mount(FrameError)
       // When
-      .withProps({message, code})
-      .then((wrapper) => {
+      .withProps({ message, code })
+      .then(wrapper => {
         expect(wrapper.text().trim()).toBe(`${code}: ${message}`)
       })
     return result

--- a/src/browser/modules/Stream/FrameSidebar.jsx
+++ b/src/browser/modules/Stream/FrameSidebar.jsx
@@ -20,9 +20,13 @@
 
 import { StyledFrameSidebar } from './styled'
 
-const FrameSidebar = (props) => {
+const FrameSidebar = props => {
   if (!props || !props.children) return null
-  return <StyledFrameSidebar>{props.children}</StyledFrameSidebar>
+  return (
+    <StyledFrameSidebar>
+      {props.children}
+    </StyledFrameSidebar>
+  )
 }
 
 export default FrameSidebar

--- a/src/browser/modules/Stream/FrameSuccess.jsx
+++ b/src/browser/modules/Stream/FrameSuccess.jsx
@@ -18,9 +18,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const FrameSuccess = (props) => {
+const FrameSuccess = props => {
   if (!props || !props.message) return null
-  return <span style={{color: 'green'}}>{props.message}</span>
+  return (
+    <span style={{ color: 'green' }}>
+      {props.message}
+    </span>
+  )
 }
 
 export default FrameSuccess

--- a/src/browser/modules/Stream/FrameSuccess.test.js
+++ b/src/browser/modules/Stream/FrameSuccess.test.js
@@ -28,7 +28,7 @@ describe('FrameSuccess', () => {
     const result = mount(FrameSuccess)
       // When
       .withProps({})
-      .then((wrapper) => {
+      .then(wrapper => {
         expect(wrapper.text()).toBe('')
       })
     return result
@@ -38,8 +38,8 @@ describe('FrameSuccess', () => {
     const message = 'bar'
     const result = mount(FrameSuccess)
       // When
-      .withProps({message})
-      .then((wrapper) => {
+      .withProps({ message })
+      .then(wrapper => {
         expect(wrapper.text().trim()).toBe(message)
       })
     return result

--- a/src/browser/modules/Stream/FrameTemplate.jsx
+++ b/src/browser/modules/Stream/FrameTemplate.jsx
@@ -21,7 +21,13 @@
 import { Component } from 'preact'
 import FrameTitlebar from './FrameTitlebar'
 import Render from 'browser-components/Render'
-import { StyledFrame, StyledFrameBody, StyledFrameContents, StyledFrameStatusbar, StyledFrameMainSection } from './styled'
+import {
+  StyledFrame,
+  StyledFrameBody,
+  StyledFrameContents,
+  StyledFrameStatusbar,
+  StyledFrameMainSection
+} from './styled'
 
 class FrameTemplate extends Component {
   constructor (props) {
@@ -34,18 +40,53 @@ class FrameTemplate extends Component {
     }
   }
   toggleFullScreen () {
-    this.setState({fullscreen: !this.state.fullscreen}, () => this.props.onResize && this.props.onResize(this.state.fullscreen, this.state.collapse, this.state.lastHeight))
+    this.setState(
+      { fullscreen: !this.state.fullscreen },
+      () =>
+        this.props.onResize &&
+        this.props.onResize(
+          this.state.fullscreen,
+          this.state.collapse,
+          this.state.lastHeight
+        )
+    )
   }
   toggleCollapse () {
-    this.setState({collapse: !this.state.collapse}, () => this.props.onResize && this.props.onResize(this.state.fullscreen, this.state.collapse, this.state.lastHeight))
+    this.setState(
+      { collapse: !this.state.collapse },
+      () =>
+        this.props.onResize &&
+        this.props.onResize(
+          this.state.fullscreen,
+          this.state.collapse,
+          this.state.lastHeight
+        )
+    )
   }
   togglePin () {
-    this.setState({pinned: !this.state.pinned}, () => this.props.onResize && this.props.onResize(this.state.fullscreen, this.state.collapse, this.state.lastHeight))
+    this.setState(
+      { pinned: !this.state.pinned },
+      () =>
+        this.props.onResize &&
+        this.props.onResize(
+          this.state.fullscreen,
+          this.state.collapse,
+          this.state.lastHeight
+        )
+    )
   }
   componentDidUpdate () {
     if (this.frameContentElement.clientHeight < 300) return // No need to report a transition
-    if (this.frameContentElement && this.state.lastHeight !== this.frameContentElement.clientHeight) {
-      this.props.onResize && this.props.onResize(this.state.fullscreen, this.state.collapse, this.frameContentElement.clientHeight)
+    if (
+      this.frameContentElement &&
+      this.state.lastHeight !== this.frameContentElement.clientHeight
+    ) {
+      this.props.onResize &&
+        this.props.onResize(
+          this.state.fullscreen,
+          this.state.collapse,
+          this.frameContentElement.clientHeight
+        )
       this.setState({ lastHeight: this.frameContentElement.clientHeight })
     }
   }
@@ -65,15 +106,23 @@ class FrameTemplate extends Component {
           togglePin={this.togglePin.bind(this)}
           exportData={this.props.exportData}
           visElement={this.props.visElement}
-          />
-        <StyledFrameBody fullscreen={this.state.fullscreen} collapsed={this.state.collapse}>
-          {(this.props.sidebar) ? this.props.sidebar() : null}
+        />
+        <StyledFrameBody
+          fullscreen={this.state.fullscreen}
+          collapsed={this.state.collapse}
+        >
+          {this.props.sidebar ? this.props.sidebar() : null}
           <StyledFrameMainSection>
-            <StyledFrameContents fullscreen={this.state.fullscreen} innerRef={this.setFrameContentElement.bind(this)}>
+            <StyledFrameContents
+              fullscreen={this.state.fullscreen}
+              innerRef={this.setFrameContentElement.bind(this)}
+            >
               {this.props.contents}
             </StyledFrameContents>
             <Render if={this.props.statusbar}>
-              <StyledFrameStatusbar fullscreen={this.state.fullscreen}>{this.props.statusbar}</StyledFrameStatusbar>
+              <StyledFrameStatusbar fullscreen={this.state.fullscreen}>
+                {this.props.statusbar}
+              </StyledFrameStatusbar>
             </Render>
           </StyledFrameMainSection>
         </StyledFrameBody>

--- a/src/browser/modules/Stream/FrameTitlebar.jsx
+++ b/src/browser/modules/Stream/FrameTitlebar.jsx
@@ -29,11 +29,29 @@ import { removeComments } from 'shared/services/utils'
 import { FrameButton } from 'browser-components/buttons'
 import Render from 'browser-components/Render'
 import { CSVSerializer } from 'services/serializer'
-import { ExpandIcon, ContractIcon, RefreshIcon, CloseIcon, UpIcon, DownIcon, PinIcon, DownloadIcon } from 'browser-components/icons/Icons'
-import { StyledFrameTitleBar, StyledFrameCommand, DottedLineHover, FrameTitlebarButtonSection, DropdownList, DropdownContent, DropdownButton, DropdownItem } from './styled'
+import {
+  ExpandIcon,
+  ContractIcon,
+  RefreshIcon,
+  CloseIcon,
+  UpIcon,
+  DownIcon,
+  PinIcon,
+  DownloadIcon
+} from 'browser-components/icons/Icons'
+import {
+  StyledFrameTitleBar,
+  StyledFrameCommand,
+  DottedLineHover,
+  FrameTitlebarButtonSection,
+  DropdownList,
+  DropdownContent,
+  DropdownButton,
+  DropdownItem
+} from './styled'
 import { downloadPNGFromSVG } from 'shared/services/exporting/pngUtils'
 
-const getCsvData = (exportData) => {
+const getCsvData = exportData => {
   if (exportData && exportData.length > 0) {
     let data = exportData.slice()
     const csv = CSVSerializer(data.shift())
@@ -54,12 +72,14 @@ class FrameTitlebar extends Component {
 
   componentWillReceiveProps (nextProps) {
     if (this.props.exportData !== nextProps.exportData) {
-      this.setState({csvData: nextProps.exportData ? getCsvData(nextProps.exportData) : null})
+      this.setState({
+        csvData: nextProps.exportData ? getCsvData(nextProps.exportData) : null
+      })
     }
   }
 
   exportPNG () {
-    const {svgElement, graphElement} = this.props.visElement
+    const { svgElement, graphElement } = this.props.visElement
     const fileName = 'graph'
     downloadPNGFromSVG(svgElement, graphElement, fileName)
   }
@@ -67,44 +87,87 @@ class FrameTitlebar extends Component {
   render () {
     let props = this.props
     const { frame = {} } = props
-    const fullscreenIcon = (props.fullscreen) ? <ContractIcon /> : <ExpandIcon />
-    const expandCollapseIcon = (props.collapse) ? <DownIcon /> : <UpIcon />
+    const fullscreenIcon = props.fullscreen ? <ContractIcon /> : <ExpandIcon />
+    const expandCollapseIcon = props.collapse ? <DownIcon /> : <UpIcon />
     const cmd = removeComments(frame.cmd)
     return (
       <StyledFrameTitleBar>
         <StyledFrameCommand>
-          <DottedLineHover data-test-id='frameCommand' onClick={() => props.onTitlebarClick(frame.cmd)}>
+          <DottedLineHover
+            data-test-id='frameCommand'
+            onClick={() => props.onTitlebarClick(frame.cmd)}
+          >
             {cmd}
           </DottedLineHover>
         </StyledFrameCommand>
         <FrameTitlebarButtonSection>
-          <Render if={frame.type === 'cypher' && (props.exportData || props.visElement)}>
+          <Render
+            if={
+              frame.type === 'cypher' && (props.exportData || props.visElement)
+            }
+          >
             <DropdownButton>
               <DownloadIcon />
               <DropdownList>
                 <DropdownContent>
                   <Render if={props.visElement}>
-                    <DropdownItem onClick={() => this.exportPNG()}>Export PNG</DropdownItem>
+                    <DropdownItem onClick={() => this.exportPNG()}>
+                      Export PNG
+                    </DropdownItem>
                   </Render>
                   <Render if={props.exportData}>
-                    <DropdownItem download='export.csv' href={this.state.csvData}>Export CSV</DropdownItem>
+                    <DropdownItem
+                      download='export.csv'
+                      href={this.state.csvData}
+                    >
+                      Export CSV
+                    </DropdownItem>
                   </Render>
                 </DropdownContent>
               </DropdownList>
             </DropdownButton>
           </Render>
-          <FrameButton title='Pin at top' onClick={() => {
-            props.togglePin()
-            props.togglePinning(frame.id, frame.isPinned)
-          }} pressed={props.pinned}><PinIcon /></FrameButton>
-          <Render if={['cypher', 'play', 'play-remote'].indexOf(frame.type) > -1}>
-            <FrameButton title={(props.fullscreen) ? 'Close fullscreen' : 'Fullscreen'} onClick={() => props.fullscreenToggle()}>{fullscreenIcon}</FrameButton>
+          <FrameButton
+            title='Pin at top'
+            onClick={() => {
+              props.togglePin()
+              props.togglePinning(frame.id, frame.isPinned)
+            }}
+            pressed={props.pinned}
+          >
+            <PinIcon />
+          </FrameButton>
+          <Render
+            if={['cypher', 'play', 'play-remote'].indexOf(frame.type) > -1}
+          >
+            <FrameButton
+              title={props.fullscreen ? 'Close fullscreen' : 'Fullscreen'}
+              onClick={() => props.fullscreenToggle()}
+            >
+              {fullscreenIcon}
+            </FrameButton>
           </Render>
-          <FrameButton title={(props.collapse) ? 'Expand' : 'Collapse'}onClick={() => props.collapseToggle()}>{expandCollapseIcon}</FrameButton>
+          <FrameButton
+            title={props.collapse ? 'Expand' : 'Collapse'}
+            onClick={() => props.collapseToggle()}
+          >
+            {expandCollapseIcon}
+          </FrameButton>
           <Render if={frame.type === 'cypher'}>
-            <FrameButton title='Rerun' onClick={() => props.onReRunClick(frame.cmd, frame.id, frame.requestId)}><RefreshIcon /></FrameButton>
+            <FrameButton
+              title='Rerun'
+              onClick={() =>
+                props.onReRunClick(frame.cmd, frame.id, frame.requestId)}
+            >
+              <RefreshIcon />
+            </FrameButton>
           </Render>
-          <FrameButton title='Close' onClick={() => props.onCloseClick(frame.id, frame.requestId)}><CloseIcon /></FrameButton>
+          <FrameButton
+            title='Close'
+            onClick={() => props.onCloseClick(frame.id, frame.requestId)}
+          >
+            <CloseIcon />
+          </FrameButton>
         </FrameTitlebarButtonSection>
       </StyledFrameTitleBar>
     )
@@ -113,7 +176,7 @@ class FrameTitlebar extends Component {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    onTitlebarClick: (cmd) => {
+    onTitlebarClick: cmd => {
       ownProps.bus.send(editor.SET_CONTENT, editor.setContent(cmd))
     },
     onCloseClick: (id, requestId) => {
@@ -125,9 +188,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
       dispatch(commands.executeCommand(cmd, id))
     },
     togglePinning: (id, isPinned) => {
-      isPinned
-        ? dispatch(unpin(id))
-        : dispatch(pin(id))
+      isPinned ? dispatch(unpin(id)) : dispatch(pin(id))
     }
   }
 }

--- a/src/browser/modules/Stream/HelpFrame.jsx
+++ b/src/browser/modules/Stream/HelpFrame.jsx
@@ -24,7 +24,7 @@ import Directives from 'browser-components/Directives'
 import FrameTemplate from './FrameTemplate'
 import { transformCommandToHelpTopic } from 'services/commandUtils'
 
-const HelpFrame = ({frame}) => {
+const HelpFrame = ({ frame }) => {
   let help = 'Help topic not specified'
   if (frame.result) {
     help = <Slide html={frame.result} />

--- a/src/browser/modules/Stream/HistoryFrame.jsx
+++ b/src/browser/modules/Stream/HistoryFrame.jsx
@@ -24,18 +24,24 @@ import FrameTemplate from './FrameTemplate'
 import { StyledHistoryList } from './styled'
 import HistoryRow from './HistoryRow'
 
-export const HistoryFrame = (props) => {
-  const {frame, bus} = props
-  const onHistoryClick = (cmd) => {
+export const HistoryFrame = props => {
+  const { frame, bus } = props
+  const onHistoryClick = cmd => {
     bus.send(editor.SET_CONTENT, editor.setContent(cmd))
   }
   const historyRows = frame.result.map((entry, index) => {
-    return <HistoryRow key={index} handleEntryClick={onHistoryClick} entry={entry} />
+    return (
+      <HistoryRow key={index} handleEntryClick={onHistoryClick} entry={entry} />
+    )
   })
   return (
     <FrameTemplate
       header={frame}
-      contents={<StyledHistoryList>{historyRows}</StyledHistoryList>}
+      contents={
+        <StyledHistoryList>
+          {historyRows}
+        </StyledHistoryList>
+      }
     />
   )
 }

--- a/src/browser/modules/Stream/HistoryRow.jsx
+++ b/src/browser/modules/Stream/HistoryRow.jsx
@@ -20,7 +20,11 @@
 
 import { StyledHistoryRow } from './styled'
 
-const HistoryRow = ({entry, handleEntryClick}) => {
-  return <StyledHistoryRow onClick={() => handleEntryClick(entry)}>{entry}</StyledHistoryRow>
+const HistoryRow = ({ entry, handleEntryClick }) => {
+  return (
+    <StyledHistoryRow onClick={() => handleEntryClick(entry)}>
+      {entry}
+    </StyledHistoryRow>
+  )
 }
 export default HistoryRow

--- a/src/browser/modules/Stream/HistoryRow.test.js
+++ b/src/browser/modules/Stream/HistoryRow.test.js
@@ -30,8 +30,8 @@ describe('HistoryRow', () => {
 
     // When
     const result = mount(HistoryRow)
-      .withProps({handleEntryClick: myFn, entry: entry})
-      .then((wrapper) => {
+      .withProps({ handleEntryClick: myFn, entry: entry })
+      .then(wrapper => {
         wrapper.simulate('click')
         expect(wrapper.text()).toBe(entry)
         expect(myFn).toHaveBeenCalledWith(entry)

--- a/src/browser/modules/Stream/ParamsFrame.jsx
+++ b/src/browser/modules/Stream/ParamsFrame.jsx
@@ -24,40 +24,34 @@ import { ExclamationTriangleIcon } from 'browser-components/icons/Icons'
 import Ellipsis from 'browser-components/Ellipsis'
 import { PaddedDiv, ErrorText, SuccessText, StyledStatsBar } from './styled'
 
-const ParamsFrame = ({frame, params}) => {
+const ParamsFrame = ({ frame, params }) => {
   const contents = (
     <PaddedDiv>
       <Render if={frame.success !== false}>
-        <pre>{JSON.stringify(frame.params, null, 2)}</pre>
+        <pre>
+          {JSON.stringify(frame.params, null, 2)}
+        </pre>
       </Render>
     </PaddedDiv>
   )
-  const statusbar = (
+  const statusbar =
     typeof frame['success'] === 'undefined'
-    ? null
-    : (
-      <StyledStatsBar>
+      ? null
+      : <StyledStatsBar>
         <Ellipsis>
           <Render if={frame.success === true}>
-            <SuccessText>
-              Successfully set your parameters.
-            </SuccessText>
+            <SuccessText>Successfully set your parameters.</SuccessText>
           </Render>
           <Render if={frame.success === false}>
             <ErrorText>
-              <ExclamationTriangleIcon /> Something went wrong. Read help pages.
+              <ExclamationTriangleIcon /> Something went wrong. Read help
+                pages.
             </ErrorText>
           </Render>
         </Ellipsis>
       </StyledStatsBar>
-    )
-  )
   return (
-    <FrameTemplate
-      header={frame}
-      contents={contents}
-      statusbar={statusbar}
-    />
+    <FrameTemplate header={frame} contents={contents} statusbar={statusbar} />
   )
 }
 export default ParamsFrame

--- a/src/browser/modules/Stream/PlayFrame.jsx
+++ b/src/browser/modules/Stream/PlayFrame.jsx
@@ -36,31 +36,56 @@ export class PlayFrame extends Component {
     }
   }
   componentDidMount () {
-    if (this.props.frame.result) { // Found remote guide
-      this.setState({ guide: <Guides withDirectives html={this.props.frame.result} /> })
+    if (this.props.frame.result) {
+      // Found remote guide
+      this.setState({
+        guide: <Guides withDirectives html={this.props.frame.result} />
+      })
       return
     }
-    if (this.props.frame.response && this.props.frame.error && this.props.frame.error.error) { // Not found remotely (or other error)
-      if (this.props.frame.response.status === 404) return this.setState({ guide: <Guides withDirectives html={html['unfound']} /> })
+    if (
+      this.props.frame.response &&
+      this.props.frame.error &&
+      this.props.frame.error.error
+    ) {
+      // Not found remotely (or other error)
+      if (this.props.frame.response.status === 404) {
+        return this.setState({
+          guide: <Guides withDirectives html={html['unfound']} />
+        })
+      }
       return this.setState({
         guide: (
           <ErrorsView
             result={{
-              message: 'Error: The remote server responded with the following error: ' + this.props.frame.response.status,
+              message:
+                'Error: The remote server responded with the following error: ' +
+                this.props.frame.response.status,
               code: 'Remote guide error'
             }}
-          />)
+          />
+        )
       })
     }
-    if (this.props.frame.error && this.props.frame.error.error) { // Some other error. Whitelist error etc.
-      return this.setState({ guide: <ErrorsView result={{
-        message: this.props.frame.error.error,
-        code: 'Remote guide error'
-      }} /> })
+    if (this.props.frame.error && this.props.frame.error.error) {
+      // Some other error. Whitelist error etc.
+      return this.setState({
+        guide: (
+          <ErrorsView
+            result={{
+              message: this.props.frame.error.error,
+              code: 'Remote guide error'
+            }}
+          />
+        )
+      })
     }
-    const topicInput = (splitStringOnFirst(this.props.frame.cmd, ' ')[1] || 'start').trim()
+    const topicInput = (splitStringOnFirst(this.props.frame.cmd, ' ')[1] ||
+      'start')
+      .trim()
     const guideName = topicInput.toLowerCase().replace(/\s|-/g, '')
-    if (html[guideName] !== undefined) { // Found it locally
+    if (html[guideName] !== undefined) {
+      // Found it locally
       this.setState({ guide: <Guides withDirectives html={html[guideName]} /> })
       return
     }
@@ -68,14 +93,20 @@ export class PlayFrame extends Component {
     // Try to find it remotely by name
     if (this.props.bus) {
       const action = fetchGuideFromWhitelistAction(topicInput)
-      this.props.bus.self(action.type, action, (res) => {
-        if (!res.success) { // No luck
-          return this.setState({ guide: <Guides withDirectives html={html['unfound']} /> })
+      this.props.bus.self(action.type, action, res => {
+        if (!res.success) {
+          // No luck
+          return this.setState({
+            guide: <Guides withDirectives html={html['unfound']} />
+          })
         }
         this.setState({ guide: <Guides withDirectives html={res.result} /> })
       })
-    } else { // No bus. Give up
-      return this.setState({ guide: <Guides withDirectives html={html['unfound']} /> })
+    } else {
+      // No bus. Give up
+      return this.setState({
+        guide: <Guides withDirectives html={html['unfound']} />
+      })
     }
   }
   render () {

--- a/src/browser/modules/Stream/PlayFrame.test.jsx
+++ b/src/browser/modules/Stream/PlayFrame.test.jsx
@@ -26,25 +26,30 @@ import Guides from '../Guides/Guides'
 
 describe('PlayFrame', () => {
   test.skip('should render PlayFrame', () => {
-    const wrapper = shallow(<PlayFrame frame={{cmd: ':play movies'}} />)
+    const wrapper = shallow(<PlayFrame frame={{ cmd: ':play movies' }} />)
     expect(wrapper.find('.playFrame').length).toBe(1)
   })
   test.skip('should render play guide when not guide name is provided', () => {
-    const wrapper = shallow(<PlayFrame frame={{cmd: ':play'}} />)
+    const wrapper = shallow(<PlayFrame frame={{ cmd: ':play' }} />)
     expect(wrapper.find('.playFrame').length).toBe(1)
     const card = shallow(wrapper.find('.playFrame').node)
     expect(card.find('.frame-contents').text()).to.match(/not\sspecified/)
   })
   test.skip('should render play guide not found', () => {
-    const wrapper = shallow(<PlayFrame frame={{cmd: ':play i-do-not-exist'}} />)
+    const wrapper = shallow(
+      <PlayFrame frame={{ cmd: ':play i-do-not-exist' }} />
+    )
     expect(wrapper.find('.playFrame').length).toBe(1)
     const card = shallow(wrapper.find('.playFrame').node)
     expect(card.find('.frame-contents').text()).to.match(/not\sfound/)
   })
-  test.skip('should render contents when contents is passed to PlayFrame', () => {
-    const wrapper = shallow(<PlayFrame frame={{result: 'Hello'}} />)
-    expect(wrapper.find('.playFrame').length).toBe(1)
-    const card = shallow(wrapper.find('.playFrame').node)
-    expect(card.find(Guides).props().html).to.eql('Hello')
-  })
+  test.skip(
+    'should render contents when contents is passed to PlayFrame',
+    () => {
+      const wrapper = shallow(<PlayFrame frame={{ result: 'Hello' }} />)
+      expect(wrapper.find('.playFrame').length).toBe(1)
+      const card = shallow(wrapper.find('.playFrame').node)
+      expect(card.find(Guides).props().html).to.eql('Hello')
+    }
+  )
 })

--- a/src/browser/modules/Stream/PreFrame.jsx
+++ b/src/browser/modules/Stream/PreFrame.jsx
@@ -21,11 +21,17 @@
 import FrameTemplate from './FrameTemplate'
 import { PaddedDiv } from './styled'
 
-const PreFrame = ({frame}) => {
+const PreFrame = ({ frame }) => {
   return (
     <FrameTemplate
       header={frame}
-      contents={<PaddedDiv><pre>{frame.result || frame.contents}</pre></PaddedDiv>}
+      contents={
+        <PaddedDiv>
+          <pre>
+            {frame.result || frame.contents}
+          </pre>
+        </PaddedDiv>
+      }
     />
   )
 }

--- a/src/browser/modules/Stream/Queries/QueriesFrame.jsx
+++ b/src/browser/modules/Stream/Queries/QueriesFrame.jsx
@@ -18,19 +18,40 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import {Component} from 'preact'
-import {connect} from 'preact-redux'
-import {withBus} from 'preact-suber'
+import { Component } from 'preact'
+import { connect } from 'preact-redux'
+import { withBus } from 'preact-suber'
 import FrameTemplate from '../FrameTemplate'
 import bolt from 'services/bolt/bolt'
-import {listQueriesProcedure, killQueriesProcedure} from 'shared/modules/cypher/queriesProcedureHelper'
-import {getAvailableProcedures} from 'shared/modules/features/featuresDuck'
-import {CYPHER_REQUEST, CLUSTER_CYPHER_REQUEST, AD_HOC_CYPHER_REQUEST} from 'shared/modules/cypher/cypherDuck'
-import {getConnectionState, CONNECTED_STATE} from 'shared/modules/connections/connectionsDuck'
-import {ConfirmationButton} from 'browser-components/buttons/ConfirmationButton'
-import {StyledTh, StyledHeaderRow, StyledTable, StyledTd, Code, StyledStatusBar, AutoRefreshToogle, RefreshQueriesButton, AutoRefreshSpan, StatusbarWrapper} from './styled'
-import {EnterpriseOnlyFrame} from 'browser-components/EditionView'
-import {RefreshIcon} from 'browser-components/icons/Icons'
+import {
+  listQueriesProcedure,
+  killQueriesProcedure
+} from 'shared/modules/cypher/queriesProcedureHelper'
+import { getAvailableProcedures } from 'shared/modules/features/featuresDuck'
+import {
+  CYPHER_REQUEST,
+  CLUSTER_CYPHER_REQUEST,
+  AD_HOC_CYPHER_REQUEST
+} from 'shared/modules/cypher/cypherDuck'
+import {
+  getConnectionState,
+  CONNECTED_STATE
+} from 'shared/modules/connections/connectionsDuck'
+import { ConfirmationButton } from 'browser-components/buttons/ConfirmationButton'
+import {
+  StyledTh,
+  StyledHeaderRow,
+  StyledTable,
+  StyledTd,
+  Code,
+  StyledStatusBar,
+  AutoRefreshToogle,
+  RefreshQueriesButton,
+  AutoRefreshSpan,
+  StatusbarWrapper
+} from './styled'
+import { EnterpriseOnlyFrame } from 'browser-components/EditionView'
+import { RefreshIcon } from 'browser-components/icons/Icons'
 import Render from 'browser-components/Render'
 import FrameError from '../FrameError'
 
@@ -51,14 +72,17 @@ export class QueriesFrame extends Component {
     if (this.props.connectionState === CONNECTED_STATE) {
       this.getRunningQueries()
     } else {
-      this.setState({errors: ['Unable to connect to bolt server']})
+      this.setState({ errors: ['Unable to connect to bolt server'] })
     }
   }
 
   componentDidUpdate (prevProps, prevState) {
     if (prevState.autoRefresh !== this.state.autoRefresh) {
       if (this.state.autoRefresh) {
-        this.timer = setInterval(this.getRunningQueries.bind(this), this.state.autoRefreshInterval * 1000)
+        this.timer = setInterval(
+          this.getRunningQueries.bind(this),
+          this.state.autoRefreshInterval * 1000
+        )
       } else {
         clearInterval(this.timer)
       }
@@ -74,19 +98,28 @@ export class QueriesFrame extends Component {
 
   getRunningQueries (suppressQuerySuccessMessage = false) {
     this.props.bus.self(
-      (this.isCC()) ? CLUSTER_CYPHER_REQUEST : CYPHER_REQUEST,
-      {query: listQueriesProcedure()},
-      (response) => {
+      this.isCC() ? CLUSTER_CYPHER_REQUEST : CYPHER_REQUEST,
+      { query: listQueriesProcedure() },
+      response => {
         if (response.success) {
           let queries = this.extractQueriesFromBoltResult(response.result)
           let resultMessage = this.constructSuccessMessage(queries)
 
           this.setState((prevState, props) => {
-            return {queries: queries, errors: null, success: suppressQuerySuccessMessage ? prevState.success : resultMessage}
+            return {
+              queries: queries,
+              errors: null,
+              success: suppressQuerySuccessMessage
+                ? prevState.success
+                : resultMessage
+            }
           })
         } else {
           let errors = this.state.errors || []
-          this.setState({errors: errors.concat([response.error]), success: false})
+          this.setState({
+            errors: errors.concat([response.error]),
+            success: false
+          })
         }
       }
     )
@@ -94,22 +127,28 @@ export class QueriesFrame extends Component {
 
   killQueries (host, queryIdList) {
     this.props.bus.self(
-      (this.isCC()) ? AD_HOC_CYPHER_REQUEST : CYPHER_REQUEST,
-      {host, query: killQueriesProcedure(queryIdList)},
-      (response) => {
+      this.isCC() ? AD_HOC_CYPHER_REQUEST : CYPHER_REQUEST,
+      { host, query: killQueriesProcedure(queryIdList) },
+      response => {
         if (response.success) {
-          this.setState({success: 'Query successfully cancelled', errors: null})
+          this.setState({
+            success: 'Query successfully cancelled',
+            errors: null
+          })
           this.getRunningQueries(true)
         } else {
           let errors = this.state.errors || []
-          this.setState({errors: errors.concat([response.error]), success: false})
+          this.setState({
+            errors: errors.concat([response.error]),
+            success: false
+          })
         }
       }
     )
   }
 
   extractQueriesFromBoltResult (result) {
-    return result.records.map((queryRecord) => {
+    return result.records.map(queryRecord => {
       let queryInfo = {}
       queryRecord.keys.forEach((key, idx) => {
         queryInfo[key] = bolt.itemIntToNumber(queryRecord._fields[idx])
@@ -129,13 +168,16 @@ export class QueriesFrame extends Component {
 
   constructSuccessMessage (queries) {
     let hosts = queries.map(query => query.host).reduce((acc, host) => {
-      if (acc.host) { return acc } else {
+      if (acc.host) {
+        return acc
+      } else {
         acc[host] = 1
         return acc
       }
     }, {})
 
-    let clusterCount = Object.keys(hosts).map(key => hosts.hasOwnProperty(key)).length
+    let clusterCount = Object.keys(hosts).map(key => hosts.hasOwnProperty(key))
+      .length
     let numMachinesMsg = 'running on one server'
 
     if (clusterCount > 1) {
@@ -160,22 +202,54 @@ export class QueriesFrame extends Component {
       ['Elapsed time', '95px'],
       ['Kill', '95px']
     ]
-    const tableRows = queries.map((query) => {
+    const tableRows = queries.map(query => {
       return (
         <tr>
-          <StyledTd title={query.host} width={tableHeaderSizes[0][1]}><Code>{query.host}</Code></StyledTd>
-          <StyledTd width={tableHeaderSizes[1][1]}>{query.username}</StyledTd>
-          <StyledTd title={query.query} width={tableHeaderSizes[2][1]}><Code>{query.query}</Code></StyledTd>
-          <StyledTd width={tableHeaderSizes[3][1]}><Code>{query.parameters}</Code></StyledTd>
-          <StyledTd width={tableHeaderSizes[4][1]}><Code>{query.metaData}</Code></StyledTd>
-          <StyledTd width={tableHeaderSizes[5][1]}>{query.elapsedTimeMillis} ms</StyledTd>
-          <StyledTd width={tableHeaderSizes[6][1]}><ConfirmationButton
-            onConfirmed={this.onCancelQuery.bind(this, query.host, query.queryId)} /></StyledTd>
-        </tr>)
+          <StyledTd title={query.host} width={tableHeaderSizes[0][1]}>
+            <Code>
+              {query.host}
+            </Code>
+          </StyledTd>
+          <StyledTd width={tableHeaderSizes[1][1]}>
+            {query.username}
+          </StyledTd>
+          <StyledTd title={query.query} width={tableHeaderSizes[2][1]}>
+            <Code>
+              {query.query}
+            </Code>
+          </StyledTd>
+          <StyledTd width={tableHeaderSizes[3][1]}>
+            <Code>
+              {query.parameters}
+            </Code>
+          </StyledTd>
+          <StyledTd width={tableHeaderSizes[4][1]}>
+            <Code>
+              {query.metaData}
+            </Code>
+          </StyledTd>
+          <StyledTd width={tableHeaderSizes[5][1]}>
+            {query.elapsedTimeMillis} ms
+          </StyledTd>
+          <StyledTd width={tableHeaderSizes[6][1]}>
+            <ConfirmationButton
+              onConfirmed={this.onCancelQuery.bind(
+                this,
+                query.host,
+                query.queryId
+              )}
+            />
+          </StyledTd>
+        </tr>
+      )
     })
 
     const tableHeaders = tableHeaderSizes.map((heading, i) => {
-      return <StyledTh width={heading[1]} key={i}>{heading[0]}</StyledTh>
+      return (
+        <StyledTh width={heading[1]} key={i}>
+          {heading[0]}
+        </StyledTh>
+      )
     })
     return (
       <StyledTable>
@@ -192,7 +266,7 @@ export class QueriesFrame extends Component {
   }
 
   setAutoRefresh (autoRefresh) {
-    this.setState({autoRefresh: autoRefresh})
+    this.setState({ autoRefresh: autoRefresh })
 
     if (autoRefresh) {
       this.getRunningQueries()
@@ -213,16 +287,21 @@ export class QueriesFrame extends Component {
           <Render if={this.state.success}>
             <StyledStatusBar>
               {this.state.success}
-              <RefreshQueriesButton onClick={() => this.getRunningQueries()}><RefreshIcon /></RefreshQueriesButton>
+              <RefreshQueriesButton onClick={() => this.getRunningQueries()}>
+                <RefreshIcon />
+              </RefreshQueriesButton>
               <AutoRefreshSpan>
-                <AutoRefreshToogle checked={this.state.autoRefresh} onClick={(e) => this.setAutoRefresh(e.target.checked)} />
+                <AutoRefreshToogle
+                  checked={this.state.autoRefresh}
+                  onClick={e => this.setAutoRefresh(e.target.checked)}
+                />
               </AutoRefreshSpan>
             </StyledStatusBar>
           </Render>
         </StatusbarWrapper>
       )
     } else {
-      frameContents = (<EnterpriseOnlyFrame command={this.props.frame.cmd} />)
+      frameContents = <EnterpriseOnlyFrame command={this.props.frame.cmd} />
     }
     return (
       <FrameTemplate
@@ -234,7 +313,7 @@ export class QueriesFrame extends Component {
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     availableProcedures: getAvailableProcedures(state) || [],
     connectionState: getConnectionState(state)

--- a/src/browser/modules/Stream/Queries/styled.jsx
+++ b/src/browser/modules/Stream/Queries/styled.jsx
@@ -19,7 +19,7 @@
  */
 
 import styled from 'styled-components'
-import {FrameButton} from 'browser-components/buttons'
+import { FrameButton } from 'browser-components/buttons'
 import styles from './toggleStyles.css'
 
 export const Code = styled.code`
@@ -52,13 +52,11 @@ export const StyledHeaderRow = styled.tr`
   border-bottom: ${props => props.theme.inFrameBorder};
 `
 
-export const StatusbarWrapper = styled.div`
-  width: 100%;
-`
+export const StatusbarWrapper = styled.div`width: 100%;`
 
 export const StyledStatusBar = styled.div`
   min-height: 39px;
-  line-height:  39px;
+  line-height: 39px;
   color: #788185;
   background-color: #fff;
   white-space: nowrap;
@@ -82,15 +80,18 @@ export const AutoRefreshSpan = styled.span`
   margin-right: 5px;
 `
 
-const ToggleLabel = styled.label`
-  cursor: pointer;
-`
+const ToggleLabel = styled.label`cursor: pointer;`
 
-export const AutoRefreshToogle = (props) => {
+export const AutoRefreshToogle = props => {
   return (
     <ToggleLabel>
       AUTO-REFRESH &nbsp;
-      <input type='checkbox' checked={props.checked} onClick={props.onClick} className={styles['toggle-check-input']} />
+      <input
+        type='checkbox'
+        checked={props.checked}
+        onClick={props.onClick}
+        className={styles['toggle-check-input']}
+      />
       <span className={styles['toggle-check-text']} />
     </ToggleLabel>
   )

--- a/src/browser/modules/Stream/SchemaFrame.jsx
+++ b/src/browser/modules/Stream/SchemaFrame.jsx
@@ -33,15 +33,17 @@ export class SchemaFrame extends Component {
     }
   }
   responseHandler (name) {
-    return (res) => {
+    return res => {
       if (!res.success || !res.result || !res.result.records.length) {
         this.setState({ [name]: [] })
         return
       }
-      const out = res.result.records.map((rec) => rec.keys.reduce((acc, key) => {
-        acc[key] = rec.get(key)
-        return acc
-      }, {}))
+      const out = res.result.records.map(rec =>
+        rec.keys.reduce((acc, key) => {
+          acc[key] = rec.get(key)
+          return acc
+        }, {})
+      )
       this.setState({ [name]: out })
     }
   }
@@ -70,10 +72,17 @@ export class SchemaFrame extends Component {
     let indexString
     let constraintsString
 
-    if (indexes.length === 0) { indexString = 'No indexes' } else {
+    if (indexes.length === 0) {
+      indexString = 'No indexes'
+    } else {
       indexString = 'Indexes'
       indexString += indexes.reduce((acc, index) => {
-        acc += `\n  ${index.description.replace('INDEX', '')} ${index.state.toUpperCase()} ${index.type === 'node_unique_property' ? ' (for uniqueness constraint)' : ''}`
+        acc += `\n  ${index.description.replace(
+          'INDEX',
+          ''
+        )} ${index.state.toUpperCase()} ${index.type === 'node_unique_property'
+          ? ' (for uniqueness constraint)'
+          : ''}`
         return acc
       }, '')
     }
@@ -92,14 +101,16 @@ export class SchemaFrame extends Component {
   }
 
   render () {
-    const contents = <StyledSchemaBody>{this.formatIndexAndConstraints(this.state.indexes, this.state.constraints)}</StyledSchemaBody>
-
-    return (
-      <FrameTemplate
-        header={this.props.frame}
-        contents={contents}
-      />
+    const contents = (
+      <StyledSchemaBody>
+        {this.formatIndexAndConstraints(
+          this.state.indexes,
+          this.state.constraints
+        )}
+      </StyledSchemaBody>
     )
+
+    return <FrameTemplate header={this.props.frame} contents={contents} />
   }
 }
 export default withBus(SchemaFrame)

--- a/src/browser/modules/Stream/Stream.jsx
+++ b/src/browser/modules/Stream/Stream.jsx
@@ -44,7 +44,7 @@ import { getActiveConnectionData } from 'shared/modules/connections/connectionsD
 import { getScrollToTop } from 'shared/modules/settings/settingsDuck'
 import { deepEquals } from 'services/utils'
 
-const getFrame = (type) => {
+const getFrame = type => {
   const trans = {
     error: ErrorFrame,
     cypher: CypherFrame,
@@ -81,20 +81,24 @@ class Stream extends Component {
   render () {
     return (
       <StyledStream>
-        {this.props.frames.map((frame) => {
+        {this.props.frames.map(frame => {
           const frameProps = {
             frame,
             activeConnectionData: this.props.activeConnectionData
           }
           const MyFrame = getFrame(frame.type)
-          return <div key={frame.id}><MyFrame {...frameProps} /></div>
+          return (
+            <div key={frame.id}>
+              <MyFrame {...frameProps} />
+            </div>
+          )
         })}
       </StyledStream>
     )
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     frames: getFrames(state),
     activeConnectionData: getActiveConnectionData(state),

--- a/src/browser/modules/Stream/Stream.test.jsx
+++ b/src/browser/modules/Stream/Stream.test.jsx
@@ -25,7 +25,10 @@ import { Stream as StreamComponent } from './Stream'
 
 describe('Stream', () => {
   test('should render a stream of frames', () => {
-    const frames = [{id: 1, cmd: ':first', type: 'x'}, {id: 2, cmd: ':second', type: 'x'}]
+    const frames = [
+      { id: 1, cmd: ':first', type: 'x' },
+      { id: 2, cmd: ':second', type: 'x' }
+    ]
     const wrapper = shallow(<StreamComponent frames={frames} />)
     expect(wrapper.find('Frame').length).toBe(frames.length)
   })

--- a/src/browser/modules/Stream/SysInfoFrame/index.jsx
+++ b/src/browser/modules/Stream/SysInfoFrame/index.jsx
@@ -25,7 +25,11 @@ import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
 import { isACausalCluster } from 'shared/modules/features/featuresDuck'
 import FrameTemplate from 'browser/modules/Stream/FrameTemplate'
 import FrameError from 'browser/modules/Stream/FrameError'
-import { SysInfoTableContainer, SysInfoTable, SysInfoTableEntry } from 'browser-components/Tables'
+import {
+  SysInfoTableContainer,
+  SysInfoTable,
+  SysInfoTableEntry
+} from 'browser-components/Tables'
 import { toHumanReadableBytes } from 'services/utils'
 import { mapSysInfoRecords, getTableDataFromRecords } from './sysinfo'
 import Render from 'browser-components/Render'
@@ -40,79 +44,122 @@ export class SysInfoFrame extends Component {
   }
   clusterResponseHandler (res) {
     if (!res.success) {
-      this.setState({error: 'No causal cluster results'})
+      this.setState({ error: 'No causal cluster results' })
       return
     }
     const mappedResult = mapSysInfoRecords(res.result.records)
-    const mappedTableComponents = mappedResult.map((ccRecord) => {
-      const httpUrlForMember = ccRecord.addresses.filter((address) => {
-        return address.startsWith('http://') && !address.includes(window.location.href)
+    const mappedTableComponents = mappedResult.map(ccRecord => {
+      const httpUrlForMember = ccRecord.addresses.filter(address => {
+        return (
+          address.startsWith('http://') &&
+          !address.includes(window.location.href)
+        )
       })
       return [
         ccRecord.role,
         ccRecord.addresses.join(', '),
-        <Render if={httpUrlForMember.length !== 0}><a taget='_blank' href={httpUrlForMember[0]}>Open</a></Render>
+        <Render if={httpUrlForMember.length !== 0}>
+          <a taget='_blank' href={httpUrlForMember[0]}>
+            Open
+          </a>
+        </Render>
       ]
     })
-    this.setState({cc: [{ value: mappedTableComponents }]})
+    this.setState({ cc: [{ value: mappedTableComponents }] })
   }
   responseHandler (res) {
     if (!res.success) {
-      this.setState({error: 'No results'})
+      this.setState({ error: 'No results' })
       return
     }
-    const {ha, kernel, cache, tx, primitive} = getTableDataFromRecords(res.result.records)
+    const { ha, kernel, cache, tx, primitive } = getTableDataFromRecords(
+      res.result.records
+    )
 
     if (ha) {
-      const instancesInCluster = ha.InstancesInCluster.map(({properties}) => {
-        return [properties.instanceId, properties.alive.toString(), properties.available.toString(), (properties.haRole === 'master') ? 'yes' : '-']
+      const instancesInCluster = ha.InstancesInCluster.map(({ properties }) => {
+        return [
+          properties.instanceId,
+          properties.alive.toString(),
+          properties.available.toString(),
+          properties.haRole === 'master' ? 'yes' : '-'
+        ]
       })
 
-      this.setState({ha: [
-        {label: 'InstanceId', value: ha.InstanceId},
-        {label: 'Role', value: ha.Role},
-        {label: 'Alive', value: ha.Alive.toString()},
-        {label: 'Available', value: ha.Available.toString()},
-        {label: 'Last Committed Tx Id', value: ha.LastCommittedTxId},
-        {label: 'Last Update Time', value: ha.LastUpdateTime}
-      ],
-        haInstances: [
-        { value: instancesInCluster }
-        ]})
+      this.setState({
+        ha: [
+          { label: 'InstanceId', value: ha.InstanceId },
+          { label: 'Role', value: ha.Role },
+          { label: 'Alive', value: ha.Alive.toString() },
+          { label: 'Available', value: ha.Available.toString() },
+          { label: 'Last Committed Tx Id', value: ha.LastCommittedTxId },
+          { label: 'Last Update Time', value: ha.LastUpdateTime }
+        ],
+        haInstances: [{ value: instancesInCluster }]
+      })
     }
 
-    this.setState({storeSizes: [
-      {label: 'Array Store', value: toHumanReadableBytes(kernel.ArrayStoreSize)},
-      {label: 'Logical Log', value: toHumanReadableBytes(kernel.LogicalLogSize)},
-      {label: 'Node Store', value: toHumanReadableBytes(kernel.NodeStoreSize)},
-      {label: 'Property Store', value: toHumanReadableBytes(kernel.PropertyStoreSize)},
-      {label: 'Relationship Store', value: toHumanReadableBytes(kernel.RelationshipStoreSize)},
-      {label: 'String Store', value: toHumanReadableBytes(kernel.StringStoreSize)},
-      {label: 'Total Store Size', value: toHumanReadableBytes(kernel.TotalStoreSize)}
-    ],
+    this.setState({
+      storeSizes: [
+        {
+          label: 'Array Store',
+          value: toHumanReadableBytes(kernel.ArrayStoreSize)
+        },
+        {
+          label: 'Logical Log',
+          value: toHumanReadableBytes(kernel.LogicalLogSize)
+        },
+        {
+          label: 'Node Store',
+          value: toHumanReadableBytes(kernel.NodeStoreSize)
+        },
+        {
+          label: 'Property Store',
+          value: toHumanReadableBytes(kernel.PropertyStoreSize)
+        },
+        {
+          label: 'Relationship Store',
+          value: toHumanReadableBytes(kernel.RelationshipStoreSize)
+        },
+        {
+          label: 'String Store',
+          value: toHumanReadableBytes(kernel.StringStoreSize)
+        },
+        {
+          label: 'Total Store Size',
+          value: toHumanReadableBytes(kernel.TotalStoreSize)
+        }
+      ],
       idAllocation: [
-      {label: 'Node ID', value: primitive.NumberOfNodeIdsInUse},
-      {label: 'Property ID', value: primitive.NumberOfPropertyIdsInUse},
-      {label: 'Relationship ID', value: primitive.NumberOfRelationshipIdsInUse},
-      {label: 'Relationship Type ID', value: primitive.NumberOfRelationshipTypeIdsInUse}
+        { label: 'Node ID', value: primitive.NumberOfNodeIdsInUse },
+        { label: 'Property ID', value: primitive.NumberOfPropertyIdsInUse },
+        {
+          label: 'Relationship ID',
+          value: primitive.NumberOfRelationshipIdsInUse
+        },
+        {
+          label: 'Relationship Type ID',
+          value: primitive.NumberOfRelationshipTypeIdsInUse
+        }
       ],
       pageCache: [
-      {label: 'Faults', value: cache.Faults},
-      {label: 'Evictions', value: cache.Evictions},
-      {label: 'File Mappings', value: cache.FileMappings},
-      {label: 'Bytes Read', value: cache.BytesRead},
-      {label: 'Flushes', value: cache.Flushes},
-      {label: 'Eviction Exceptions', value: cache.EvictionExceptions},
-      {label: 'File Unmappings', value: cache.FileUnmappings},
-      {label: 'Bytes Written', value: cache.BytesWritten}
+        { label: 'Faults', value: cache.Faults },
+        { label: 'Evictions', value: cache.Evictions },
+        { label: 'File Mappings', value: cache.FileMappings },
+        { label: 'Bytes Read', value: cache.BytesRead },
+        { label: 'Flushes', value: cache.Flushes },
+        { label: 'Eviction Exceptions', value: cache.EvictionExceptions },
+        { label: 'File Unmappings', value: cache.FileUnmappings },
+        { label: 'Bytes Written', value: cache.BytesWritten }
       ],
       transactions: [
-      {label: 'Last Tx Id', value: tx.LastCommittedTxId},
-      {label: 'Current', value: tx.NumberOfOpenTransactions},
-      {label: 'Peak', value: tx.PeakNumberOfConcurrentTransactions},
-      {label: 'Opened', value: tx.NumberOfOpenedTransactions},
-      {label: 'Committed', value: tx.NumberOfCommittedTransactions}
-      ]})
+        { label: 'Last Tx Id', value: tx.LastCommittedTxId },
+        { label: 'Current', value: tx.NumberOfOpenTransactions },
+        { label: 'Peak', value: tx.PeakNumberOfConcurrentTransactions },
+        { label: 'Opened', value: tx.NumberOfOpenedTransactions },
+        { label: 'Committed', value: tx.NumberOfCommittedTransactions }
+      ]
+    })
   }
   componentDidMount () {
     if (this.props.bus) {
@@ -136,7 +183,7 @@ export class SysInfoFrame extends Component {
   }
   buildTableData (data) {
     if (!data) return null
-    return data.map(({label, value}) => {
+    return data.map(({ label, value }) => {
       if (value instanceof Array) {
         return value.map(v => <SysInfoTableEntry values={v} />)
       }
@@ -171,7 +218,9 @@ export class SysInfoFrame extends Component {
         </Render>
         <Render if={this.state.haInstances}>
           <SysInfoTable header='Cluster' colspan='4'>
-            <SysInfoTableEntry headers={['Id', 'Alive', 'Available', 'Is Master']} />
+            <SysInfoTableEntry
+              headers={['Id', 'Alive', 'Available', 'Is Master']}
+            />
             {this.buildTableData(this.state.haInstances)}
           </SysInfoTable>
         </Render>
@@ -179,17 +228,14 @@ export class SysInfoFrame extends Component {
     )
 
     return (
-      <FrameTemplate
-        header={this.props.frame}
-        contents={content}
-      >
+      <FrameTemplate header={this.props.frame} contents={content}>
         <FrameError message={this.state.error} />
       </FrameTemplate>
     )
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     isACausalCluster: isACausalCluster(state)
   }

--- a/src/browser/modules/Stream/SysInfoFrame/index.test.js
+++ b/src/browser/modules/Stream/SysInfoFrame/index.test.js
@@ -24,28 +24,38 @@ import uuid from 'uuid'
 import { mount } from 'services/testUtils'
 import { SysInfoFrame } from './index'
 
-jest.mock('browser/modules/Stream/FrameTemplate',
-  () => ({contents, children}) => <div>{contents}{children}</div>)
+jest.mock(
+  'browser/modules/Stream/FrameTemplate',
+  () => ({ contents, children }) =>
+    <div>
+      {contents}
+      {children}
+    </div>
+)
 
 describe('sysinfo component', () => {
   test('should render causal cluster table', () => {
-    return mount(SysInfoFrame).withProps({ isACausalCluster: true }).then((wrapper) => {
-      expect(wrapper.html()).toContain('Causal Cluster Members')
-    })
+    return mount(SysInfoFrame)
+      .withProps({ isACausalCluster: true })
+      .then(wrapper => {
+        expect(wrapper.html()).toContain('Causal Cluster Members')
+      })
   })
   test('should not render causal cluster table', () => {
-    return mount(SysInfoFrame).withProps({ isACausalCluster: false }).then((wrapper) => {
-      expect(wrapper.html()).not.toContain('Causal Cluster Members')
-    })
+    return mount(SysInfoFrame)
+      .withProps({ isACausalCluster: false })
+      .then(wrapper => {
+        expect(wrapper.html()).not.toContain('Causal Cluster Members')
+      })
   })
   test('should not render ha table', () => {
     const value = uuid.v4()
     const label = 'InstanceId'
-    return mount(SysInfoFrame).withProps({}).then((wrapper) => {
+    return mount(SysInfoFrame).withProps({}).then(wrapper => {
       expect(wrapper.html()).not.toContain(label)
       expect(wrapper.html()).not.toContain(value)
 
-      wrapper.setState({ha: [{ label, value }]})
+      wrapper.setState({ ha: [{ label, value }] })
       wrapper.update()
 
       expect(wrapper.html()).toContain(label)

--- a/src/browser/modules/Stream/SysInfoFrame/sysinfo.js
+++ b/src/browser/modules/Stream/SysInfoFrame/sysinfo.js
@@ -19,22 +19,34 @@
  */
 
 import bolt from 'services/bolt/bolt'
-import { itemIntToString, extractFromNeoObjects } from 'services/bolt/boltMappings'
+import {
+  itemIntToString,
+  extractFromNeoObjects
+} from 'services/bolt/boltMappings'
 
-export const getTableDataFromRecords = (records) => {
+export const getTableDataFromRecords = records => {
   const mappedJMXresults = mappedJMXresult(records)
   const jmxQueryPrefix = mappedJMXresults[0].name.split(',')[0]
-  const result = Object.assign({}, ...mappedJMXresults.map((item) => {
-    return { [item.name]: item }
-  }))
-  const cache = flattenAttributes(result[`${jmxQueryPrefix},name=Page cache`]) || {}
-  const primitive = flattenAttributes(result[`${jmxQueryPrefix},name=Primitive count`])
-  const tx = flattenAttributes(result[`${jmxQueryPrefix},name=Transactions`]) || {}
-  const kernel = Object.assign({},
+  const result = Object.assign(
+    {},
+    ...mappedJMXresults.map(item => {
+      return { [item.name]: item }
+    })
+  )
+  const cache =
+    flattenAttributes(result[`${jmxQueryPrefix},name=Page cache`]) || {}
+  const primitive = flattenAttributes(
+    result[`${jmxQueryPrefix},name=Primitive count`]
+  )
+  const tx =
+    flattenAttributes(result[`${jmxQueryPrefix},name=Transactions`]) || {}
+  const kernel = Object.assign(
+    {},
     flattenAttributes(result[`${jmxQueryPrefix},name=Configuration`]),
     flattenAttributes(result[`${jmxQueryPrefix},name=Kernel`]),
-    flattenAttributes(result[`${jmxQueryPrefix},name=Store file sizes`]))
-  const ha = (result[`${jmxQueryPrefix},name=High Availability`])
+    flattenAttributes(result[`${jmxQueryPrefix},name=Store file sizes`])
+  )
+  const ha = result[`${jmxQueryPrefix},name=High Availability`]
     ? flattenAttributes(result[`${jmxQueryPrefix},name=High Availability`])
     : null
 
@@ -47,13 +59,13 @@ export const getTableDataFromRecords = (records) => {
   }
 }
 
-const mappedJMXresult = (records) => {
-  return records.map((record) => {
+const mappedJMXresult = records => {
+  return records.map(record => {
     const origAttributes = record.get('attributes')
     return {
       name: record.get('name'),
       description: record.get('description'),
-      attributes: Object.keys(record.get('attributes')).map((attributeName) => {
+      attributes: Object.keys(record.get('attributes')).map(attributeName => {
         return {
           name: attributeName,
           description: origAttributes[attributeName].description,
@@ -64,8 +76,8 @@ const mappedJMXresult = (records) => {
   })
 }
 
-export const mapSysInfoRecords = (records) => {
-  return records.map((record) => {
+export const mapSysInfoRecords = records => {
+  return records.map(record => {
     return {
       id: record.get('id'),
       addresses: record.get('addresses'),
@@ -75,9 +87,18 @@ export const mapSysInfoRecords = (records) => {
   })
 }
 
-export const flattenAttributes = (data) => {
+export const flattenAttributes = data => {
   if (data && data.attributes) {
-    return Object.assign({}, ...data.attributes.map(({name, value}) => ({ [name]: itemIntToString(value, {intChecker: bolt.neo4j.isInt, intConverter: (val) => val.toString(), objectConverter: extractFromNeoObjects}) })))
+    return Object.assign(
+      {},
+      ...data.attributes.map(({ name, value }) => ({
+        [name]: itemIntToString(value, {
+          intChecker: bolt.neo4j.isInt,
+          intConverter: val => val.toString(),
+          objectConverter: extractFromNeoObjects
+        })
+      }))
+    )
   } else {
     return null
   }

--- a/src/browser/modules/Stream/SysInfoFrame/sysinfo.test.js
+++ b/src/browser/modules/Stream/SysInfoFrame/sysinfo.test.js
@@ -24,15 +24,17 @@ import { flattenAttributes } from './sysinfo'
 
 describe('sysinfo attribute types', () => {
   test('should handle string value', () => {
-    const attributeData = {attributes: [{ name: 'foo', value: 'bar' }]}
-    expect(flattenAttributes(attributeData)).toEqual({foo: 'bar'})
+    const attributeData = { attributes: [{ name: 'foo', value: 'bar' }] }
+    expect(flattenAttributes(attributeData)).toEqual({ foo: 'bar' })
   })
   test('should handle int value', () => {
-    const attributeData = {attributes: [{ name: 'foo', value: 0 }]}
-    expect(flattenAttributes(attributeData)).toEqual({foo: 0})
+    const attributeData = { attributes: [{ name: 'foo', value: 0 }] }
+    expect(flattenAttributes(attributeData)).toEqual({ foo: 0 })
   })
   test('should handle object value', () => {
-    const attributeData = {attributes: [{ name: 'foo', value: {bar: 'baz'} }]}
-    expect(flattenAttributes(attributeData)).toEqual({foo: {bar: 'baz'}})
+    const attributeData = {
+      attributes: [{ name: 'foo', value: { bar: 'baz' } }]
+    }
+    expect(flattenAttributes(attributeData)).toEqual({ foo: { bar: 'baz' } })
   })
 })

--- a/src/browser/modules/Stream/styled.jsx
+++ b/src/browser/modules/Stream/styled.jsx
@@ -45,22 +45,27 @@ const rollDownAnimation = keyframes`
 export const StyledFrame = styled.article`
   width: auto;
   background-color: ${props => props.theme.secondaryBackground};
-  box-shadow: 0 1px 4px rgba(0,0,0,.1);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, .1);
   animation: ${rollDownAnimation} .4s ease-in;
   border: ${props => props.theme.frameBorder};
-  margin: ${props => props.fullscreen ? '0' : '10px 0px 10px 0px'};
-  ${props => props.fullscreen ? 'position: fixed' : null};
-  ${props => props.fullscreen ? 'left: 0' : null};
-  ${props => props.fullscreen ? 'top: 0' : null};
-  ${props => props.fullscreen ? 'bottom: 0' : null};
-  ${props => props.fullscreen ? 'right: 0' : null};
-  ${props => props.fullscreen ? 'z-index: 1030' : null};
+  margin: ${props => (props.fullscreen ? '0' : '10px 0px 10px 0px')};
+  ${props => (props.fullscreen ? 'position: fixed' : null)};
+  ${props => (props.fullscreen ? 'left: 0' : null)};
+  ${props => (props.fullscreen ? 'top: 0' : null)};
+  ${props => (props.fullscreen ? 'bottom: 0' : null)};
+  ${props => (props.fullscreen ? 'right: 0' : null)};
+  ${props => (props.fullscreen ? 'z-index: 1030' : null)};
 `
 
 export const StyledFrameBody = styled.div`
   min-height: ${dim.frameBodyHeight / 2}px;
-  max-height: ${props => props.collapsed ? 0 : (props.fullscreen ? '100%' : (dim.frameBodyHeight - dim.frameStatusbarHeight) + 1 + 'px')};
-  display: ${props => props.collapsed ? 'none' : 'flex'};
+  max-height: ${props =>
+    props.collapsed
+      ? 0
+      : props.fullscreen
+        ? '100%'
+        : dim.frameBodyHeight - dim.frameStatusbarHeight + 1 + 'px'};
+  display: ${props => (props.collapsed ? 'none' : 'flex')};
   flex-direction: row;
   width: 100%;
 `
@@ -76,15 +81,18 @@ export const StyledFrameMainSection = styled.div`
 export const StyledFrameContents = styled.div`
   overflow: auto;
   min-height: ${dim.frameBodyHeight / 2}px;
-  max-height: ${props => (props.fullscreen ? '100vh' : (dim.frameBodyHeight - (dim.frameStatusbarHeight * 2)) + 'px')};
-  ${props => props.fullscreen ? 'height: 100vh' : null};
+  max-height: ${props =>
+    props.fullscreen
+      ? '100vh'
+      : dim.frameBodyHeight - dim.frameStatusbarHeight * 2 + 'px'};
+  ${props => (props.fullscreen ? 'height: 100vh' : null)};
   flex: auto;
 `
 
 export const StyledFrameStatusbar = styled.div`
   border-top: ${props => props.theme.inFrameBorder};
   height: ${dim.frameStatusbarHeight + 1}px;
-  ${props => props.fullscreen ? 'margin-top: -78px;' : ''};
+  ${props => (props.fullscreen ? 'margin-top: -78px;' : '')};
   display: flex;
   flex-direction: row;
   flex: none;
@@ -92,7 +100,8 @@ export const StyledFrameStatusbar = styled.div`
 
 export const PaddedDiv = styled.div`
   padding: 0 20px 20px 20px;
-  padding-bottom: ${props => (props.fullscreen ? (dim.frameTitlebarHeight + 20) + 'px' : '20px')};
+  padding-bottom: ${props =>
+    props.fullscreen ? dim.frameTitlebarHeight + 20 + 'px' : '20px'};
 `
 
 export const PaddedTableViewDiv = styled(PaddedDiv)`
@@ -147,9 +156,7 @@ export const StyledFrameCommand = styled.label`
   }
 `
 
-export const StyledFrameStatusbarText = styled.label`
-  flex: 1 1 auto;
-`
+export const StyledFrameStatusbarText = styled.label`flex: 1 1 auto;`
 
 export const DottedLineHover = styled.span`
   cursor: pointer;
@@ -160,9 +167,7 @@ export const DottedLineHover = styled.span`
   }
 `
 
-export const StyledHelpFrame = styled.div`
-  padding: 30px;
-`
+export const StyledHelpFrame = styled.div`padding: 30px;`
 export const StyledHelpContent = styled.div`
   padding-top: 10px;
   padding-bottom: 10px;
@@ -172,8 +177,7 @@ export const StyledHelpDescription = styled.div`
   font-size: 15px;
 `
 
-export const StyledDiv = styled.div`
-`
+export const StyledDiv = styled.div``
 
 export const StyledLink = styled.a`
   cursor: pointer;
@@ -184,9 +188,7 @@ export const StyledLink = styled.a`
   }
 `
 
-export const StyledLinkContainer = styled.div`
-  margin: 16px 0;
-`
+export const StyledLinkContainer = styled.div`margin: 16px 0;`
 
 export const StyledCypherMessage = styled.div`
   font-weight: bold;
@@ -211,11 +213,9 @@ export const StyledCypherErrorMessage = styled(StyledCypherMessage)`
   color: #FFFFFF;
 `
 
-export const StyledH4 = styled.h4`
-`
+export const StyledH4 = styled.h4``
 
-export const StyledBr = styled.br`
-`
+export const StyledBr = styled.br``
 
 export const StyledPreformattedArea = styled.pre`
   font-family: Monaco, "Courier New", Terminal, monospace;
@@ -273,9 +273,7 @@ export const StyledBodyMessage = styled.div`
   color: #666;
 `
 
-export const SpinnerContainer = styled.div`
-  padding-top: 20px;
-`
+export const SpinnerContainer = styled.div`padding-top: 20px;`
 
 export const DropdownButton = styled.li`
   color: ${props => props.theme.secondaryButtonText};
@@ -297,14 +295,12 @@ export const DropdownButton = styled.li`
   display: inline-block;
   &:hover {
     > ul li {
-    display: block;
+      display: block;
     }
-  };
+  }
 `
 
-export const DropdownList = styled.ul`
-
-`
+export const DropdownList = styled.ul``
 
 export const DropdownContent = styled.li`
   display: none;
@@ -312,7 +308,7 @@ export const DropdownContent = styled.li`
   background-color: ${props => props.theme.secondaryBackground};
   color: ${props => props.theme.secondaryButtonText};
   width: 100px;
-  box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+  box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
   border-radius: 6px;
   z-index: 1;
   line-height: 30px;
@@ -331,13 +327,9 @@ export const DropdownItem = styled.a`
   }
 `
 
-export const StyledRightPartial = styled.div`
-  float: right;
-`
+export const StyledRightPartial = styled.div`float: right;`
 
-export const StyledLeftPartial = styled.div`
-  float: left;
-`
+export const StyledLeftPartial = styled.div`float: left;`
 
 export const StyledWidthSliderContainer = styled.div`
   margin-right: 10px;
@@ -366,7 +358,8 @@ export const StyledWidthSlider = styled.input`
     color: transparent;
     background: transparent;
   }
-  &::-ms-fill-lower, &::-ms-fill-upper {
+  &::-ms-fill-lower,
+  &::-ms-fill-upper {
     background: transparent;
   }
   &::-ms-tooltip {
@@ -379,7 +372,7 @@ export const StyledWidthSlider = styled.input`
     border-radius: 7px;
     cursor: pointer;
     border: none;
-    background-color: #008BC3;
+    background-color: #008bc3;
     outline: none;
   }
   &::-moz-range-thumb {
@@ -388,7 +381,7 @@ export const StyledWidthSlider = styled.input`
     border-radius: 7px;
     cursor: pointer;
     border: none;
-    background-color: #008BC3;
+    background-color: #008bc3;
     outline: none;
   }
   &::-ms-thumb {
@@ -397,14 +390,12 @@ export const StyledWidthSlider = styled.input`
     border-radius: 7px;
     cursor: pointer;
     border: none;
-    background-color: #008BC3;
+    background-color: #008bc3;
     outline: none;
   }
 `
 
-export const StyledTable = styled.table`
-  margin-top: 30px;
-`
+export const StyledTable = styled.table`margin-top: 30px;`
 
 export const StyledTBody = styled.tbody`
   & td:first-child {
@@ -419,22 +410,17 @@ export const StyledAlteringTr = styled.tr`
   }
 `
 
-export const StyledStrongTd = styled.td`
-  font-weight: bold;
-`
+export const StyledStrongTd = styled.td`font-weight: bold;`
 
-export const StyledTd = styled.td`
-`
+export const StyledTd = styled.td``
 
-export const StyledHistoryList = styled.ul`
-  list-style: none;
-`
+export const StyledHistoryList = styled.ul`list-style: none;`
 
 export const StyledHistoryRow = styled.li`
-    border: 1px solid black;
-    margin: 10px;
-    padding: 10px;
-    cursor: pointer;
+  border: 1px solid black;
+  margin: 10px;
+  padding: 10px;
+  cursor: pointer;
   &:hover {
     background-color: ${props => props.theme.primaryBackground};
   }

--- a/src/browser/modules/Sync/BrowserSync.jsx
+++ b/src/browser/modules/Sync/BrowserSync.jsx
@@ -23,14 +23,34 @@ import { connect } from 'preact-redux'
 import { withBus } from 'preact-suber'
 import TimeAgo from 'react-timeago'
 
-import { setSync, clearSync, clearSyncAndLocal, consentSync, authorizedAs } from 'shared/modules/sync/syncDuck'
+import {
+  setSync,
+  clearSync,
+  clearSyncAndLocal,
+  consentSync,
+  authorizedAs
+} from 'shared/modules/sync/syncDuck'
 import { signOut } from 'services/browserSyncService'
 import { setContent as setEditorContent } from 'shared/modules/editor/editorDuck'
 import { getBrowserSyncConfig } from 'shared/modules/settings/settingsDuck'
-import {Drawer, DrawerBody, DrawerHeader, DrawerSection, DrawerSubHeader, DrawerSectionBody, DrawerToppedHeader} from 'browser-components/drawer'
+import {
+  Drawer,
+  DrawerBody,
+  DrawerHeader,
+  DrawerSection,
+  DrawerSubHeader,
+  DrawerSectionBody,
+  DrawerToppedHeader
+} from 'browser-components/drawer'
 import { FormButton, SyncSignInButton } from 'browser-components/buttons'
 import { BinIcon } from 'browser-components/icons/Icons'
-import {ConsentCheckBox, AlertBox, ClearLocalConfirmationBox, StyledSyncLink, SmallHeaderText} from './styled'
+import {
+  ConsentCheckBox,
+  AlertBox,
+  ClearLocalConfirmationBox,
+  StyledSyncLink,
+  SmallHeaderText
+} from './styled'
 import BrowserSyncAuthWindow from './BrowserSyncAuthWindow'
 import SyncSignInManager from 'shared/modules/sync/SyncSignInManager'
 
@@ -52,38 +72,58 @@ export class BrowserSync extends Component {
   componentWillMount () {
     this.syncManager = new SyncSignInManager({
       dbConfig: this.props.browserSyncConfig.firebaseConfig,
-      serviceReadyCallback: (status) => this.setState({status}),
+      serviceReadyCallback: status => this.setState({ status }),
       onSyncCallback: this.props.onSync
     })
   }
   logIn () {
     if (this.state.userConsented === true) {
       const { onSignIn } = this.props
-      const signInCallback = (data) => onSignIn(data.profile)
-      BrowserSyncAuthWindow(this.props.browserSyncConfig.authWindowUrl, (data, error) => {
-        this.syncManager.authCallBack.bind(this.syncManager)(data, error, signInCallback)
-      })
+      const signInCallback = data => onSignIn(data.profile)
+      BrowserSyncAuthWindow(
+        this.props.browserSyncConfig.authWindowUrl,
+        (data, error) => {
+          this.syncManager.authCallBack.bind(this.syncManager)(
+            data,
+            error,
+            signInCallback
+          )
+        }
+      )
     } else {
-      this.setState({showConsentAlert: true})
+      this.setState({ showConsentAlert: true })
     }
   }
   signOutAndClearLocalStorage () {
     if (this.state.clearLocalRequested) {
-      this.setState({clearLocalRequested: false, authData: null, serviceAuthenticated: false, userConsented: false})
+      this.setState({
+        clearLocalRequested: false,
+        authData: null,
+        serviceAuthenticated: false,
+        userConsented: false
+      })
       this.props.onSignOutAndClear()
     } else {
-      this.setState({clearLocalRequested: true})
+      this.setState({ clearLocalRequested: true })
     }
   }
   signOutFromSync () {
-    this.setState({authData: null, serviceAuthenticated: false})
+    this.setState({ authData: null, serviceAuthenticated: false })
     this.props.onSignOut()
   }
   render () {
     if (this.state.status === 'PENDING') {
-      return <Drawer id='sync-drawer'><DrawerHeader>Connecting sync service... </DrawerHeader></Drawer>
+      return (
+        <Drawer id='sync-drawer'>
+          <DrawerHeader>Connecting sync service... </DrawerHeader>
+        </Drawer>
+      )
     } else if (this.state.status === 'DOWN') {
-      return <Drawer id='sync-drawer'><DrawerHeader>Sync service is down</DrawerHeader></Drawer>
+      return (
+        <Drawer id='sync-drawer'>
+          <DrawerHeader>Sync service is down</DrawerHeader>
+        </Drawer>
+      )
     }
 
     let offlineContent = null
@@ -94,26 +134,43 @@ export class BrowserSync extends Component {
 
     const serviceAuthenticated = !!this.props.authData
     if (serviceAuthenticated) {
-      headerContent =
+      headerContent = (
         <DrawerToppedHeader>
-          {this.props.authData.profile.name}<br />
-          <SmallHeaderText>Connected</SmallHeaderText><br />
+          {this.props.authData.profile.name}
+          <br />
+          <SmallHeaderText>Connected</SmallHeaderText>
+          <br />
           <SmallHeaderText>
-            Synced <TimeAgo date={new Date(this.props.lastSyncedAt)} minPeriod='5' />
+            Synced{' '}
+            <TimeAgo date={new Date(this.props.lastSyncedAt)} minPeriod='5' />
           </SmallHeaderText>
         </DrawerToppedHeader>
+      )
     } else {
       headerContent = <DrawerHeader>Neo4j Browser Sync</DrawerHeader>
     }
 
     if (this.state.clearLocalRequested === true) {
-      clearLocalDataContent = <ClearLocalConfirmationBox onClick={() => { this.setState({clearLocalRequested: false}) }} />
+      clearLocalDataContent = (
+        <ClearLocalConfirmationBox
+          onClick={() => {
+            this.setState({ clearLocalRequested: false })
+          }}
+        />
+      )
     } else {
-      clearLocalDataContent = 'This will reset your local storage, clearing favorite scripts, grass, command history and settings.'
+      clearLocalDataContent =
+        'This will reset your local storage, clearing favorite scripts, grass, command history and settings.'
     }
 
     if (this.state.showConsentAlert) {
-      consentAlertContent = <AlertBox onClick={() => { this.setState({showConsentAlert: false}) }} />
+      consentAlertContent = (
+        <AlertBox
+          onClick={() => {
+            this.setState({ showConsentAlert: false })
+          }}
+        />
+      )
     }
 
     if (serviceAuthenticated === true) {
@@ -122,12 +179,25 @@ export class BrowserSync extends Component {
           <DrawerSection>
             <DrawerSubHeader>Manage local data</DrawerSubHeader>
             <DrawerSectionBody>
-              <DrawerSection>{clearLocalDataContent}</DrawerSection>
-              <FormButton label={this.state.clearLocalRequested ? 'Sign out + clear' : 'Clear local data'} onClick={() => this.signOutAndClearLocalStorage()}
-                icon={<BinIcon suppressIconStyles='true' />} buttonType='drawer' />
+              <DrawerSection>
+                {clearLocalDataContent}
+              </DrawerSection>
+              <FormButton
+                label={
+                  this.state.clearLocalRequested
+                    ? 'Sign out + clear'
+                    : 'Clear local data'
+                }
+                onClick={() => this.signOutAndClearLocalStorage()}
+                icon={<BinIcon suppressIconStyles='true' />}
+                buttonType='drawer'
+              />
               <p>&nbsp;</p>
-              <FormButton label='Sign Out' onClick={() => this.signOutFromSync()}
-                buttonType='drawer' />
+              <FormButton
+                label='Sign Out'
+                onClick={() => this.signOutFromSync()}
+                buttonType='drawer'
+              />
             </DrawerSectionBody>
           </DrawerSection>
         </DrawerBody>
@@ -139,30 +209,45 @@ export class BrowserSync extends Component {
             <DrawerSubHeader>Sign In or Register</DrawerSubHeader>
             <DrawerSectionBody>
               <DrawerSection>
-                Neo4j Browser Sync is a companion cloud service for Neo4j Browser. Connect through a simple social
-                sign-in to get started. <StyledSyncLink onClick={() => this.props.onSyncHelpClick()}>About Neo4j Browser Sync</StyledSyncLink>
+                Neo4j Browser Sync is a companion cloud service for Neo4j
+                Browser. Connect through a simple social sign-in to get started.{' '}
+                <StyledSyncLink onClick={() => this.props.onSyncHelpClick()}>
+                  About Neo4j Browser Sync
+                </StyledSyncLink>
               </DrawerSection>
               <DrawerSection>
-                <ConsentCheckBox checked={this.state.userConsented === true} onChange={(e) => {
-                  this.setState({
-                    userConsented: e.target.checked,
-                    showConsentAlert: this.state.showConsentAlert && !e.target.checked
-                  })
-                  this.props.onConsentSyncChanged(e.target.checked)
-                }} />
+                <ConsentCheckBox
+                  checked={this.state.userConsented === true}
+                  onChange={e => {
+                    this.setState({
+                      userConsented: e.target.checked,
+                      showConsentAlert:
+                        this.state.showConsentAlert && !e.target.checked
+                    })
+                    this.props.onConsentSyncChanged(e.target.checked)
+                  }}
+                />
                 {consentAlertContent}
               </DrawerSection>
               <DrawerSection>
-                <SyncSignInButton onClick={this.logIn.bind(this)}>Sign In / Register</SyncSignInButton>
+                <SyncSignInButton onClick={this.logIn.bind(this)}>
+                  Sign In / Register
+                </SyncSignInButton>
               </DrawerSection>
             </DrawerSectionBody>
           </DrawerSection>
           <DrawerSection>
             <DrawerSubHeader>Manage local data</DrawerSubHeader>
             <DrawerSectionBody>
-              <DrawerSection>{clearLocalDataContent}</DrawerSection>
-              <FormButton label='Clear local data' onClick={this.signOutAndClearLocalStorage.bind(this)}
-                icon={<BinIcon suppressIconStyles='true' />} buttonType='drawer' />
+              <DrawerSection>
+                {clearLocalDataContent}
+              </DrawerSection>
+              <FormButton
+                label='Clear local data'
+                onClick={this.signOutAndClearLocalStorage.bind(this)}
+                icon={<BinIcon suppressIconStyles='true' />}
+                buttonType='drawer'
+              />
             </DrawerSectionBody>
           </DrawerSection>
         </DrawerBody>
@@ -179,7 +264,7 @@ export class BrowserSync extends Component {
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     lastSyncedAt: state.sync ? state.sync.lastSyncedAt : null,
     authData: state.sync ? state.sync.authData : null,
@@ -190,14 +275,14 @@ const mapStateToProps = (state) => {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    onSignIn: (data) => {
+    onSignIn: data => {
       const action = authorizedAs(data)
       ownProps.bus.send(action.type, action)
     },
-    onSync: (syncObject) => {
+    onSync: syncObject => {
       dispatch(setSync(syncObject))
     },
-    onSyncHelpClick: (play) => {
+    onSyncHelpClick: play => {
       const action = setEditorContent(':play neo4j sync')
       ownProps.bus.send(action.type, action)
     },
@@ -211,9 +296,11 @@ const mapDispatchToProps = (dispatch, ownProps) => {
       const action = clearSync()
       ownProps.bus.send(action.type, action)
     },
-    onConsentSyncChanged: (consent) => {
+    onConsentSyncChanged: consent => {
       dispatch(consentSync(consent))
     }
   }
 }
-export default withBus(connect(mapStateToProps, mapDispatchToProps)(BrowserSync))
+export default withBus(
+  connect(mapStateToProps, mapDispatchToProps)(BrowserSync)
+)

--- a/src/browser/modules/Sync/BrowserSyncAuthWindow.jsx
+++ b/src/browser/modules/Sync/BrowserSyncAuthWindow.jsx
@@ -19,7 +19,11 @@
  */
 
 const BrowserSyncAuthWindow = (url, callback) => {
-  const win = window.open(url, 'loginWindow', 'location=0,status=0,scrollbars=0, width=1080,height=720')
+  const win = window.open(
+    url,
+    'loginWindow',
+    'location=0,status=0,scrollbars=0, width=1080,height=720'
+  )
   const pollInterval = setInterval(() => {
     win.postMessage('Polling for results', url)
   }, 6000)
@@ -28,11 +32,15 @@ const BrowserSyncAuthWindow = (url, callback) => {
   } catch (e) {
     callback(null, e)
   }
-  window.addEventListener('message', (event) => {
-    clearInterval(pollInterval)
-    callback(event.data)
-    win.close()
-  }, false)
+  window.addEventListener(
+    'message',
+    event => {
+      clearInterval(pollInterval)
+      callback(event.data)
+      win.close()
+    },
+    false
+  )
 }
 
 export default BrowserSyncAuthWindow

--- a/src/browser/modules/Sync/styled.jsx
+++ b/src/browser/modules/Sync/styled.jsx
@@ -21,51 +21,69 @@
 import styled from 'styled-components'
 import { PlayIcon } from 'browser-components/icons/Icons'
 
-export const ConsentCheckBox = (props) => {
+export const ConsentCheckBox = props => {
   return (
     <StyledP>
       <CheckBoxLabel for='syncConsentCheckbox'>
-        <StyledCheckBox {...props} type='checkbox' id='syncConsentCheckbox' value='first_checkbox' />
+        <StyledCheckBox
+          {...props}
+          type='checkbox'
+          id='syncConsentCheckbox'
+          value='first_checkbox'
+        />
         &nbsp; By checking this box you are agreeing to the &nbsp;
-        <StyledSimpleLink href='http://neo4j.com/terms/neo4j-browser-sync/' target='blank'>Neo4j Browser Sync Terms of Use</StyledSimpleLink>
+        <StyledSimpleLink
+          href='http://neo4j.com/terms/neo4j-browser-sync/'
+          target='blank'
+        >
+          Neo4j Browser Sync Terms of Use
+        </StyledSimpleLink>
         &nbsp; and our &nbsp;
-        <StyledSimpleLink href='http://neo4j.com/privacy-policy/' target='blank'>Privacy Policy</StyledSimpleLink>.
+        <StyledSimpleLink
+          href='http://neo4j.com/privacy-policy/'
+          target='blank'
+        >
+          Privacy Policy
+        </StyledSimpleLink>.
       </CheckBoxLabel>
     </StyledP>
   )
 }
 
-export const AlertBox = (props) => {
+export const AlertBox = props => {
   return (
     <AlertDiv>
       <CloseButton {...props}>×</CloseButton>
-      <span>Before you can sign in, please check the box above to agree to the terms of use and privacy policy.</span>
+      <span>
+        Before you can sign in, please check the box above to agree to the terms
+        of use and privacy policy.
+      </span>
     </AlertDiv>
   )
 }
 
-export const ClearLocalConfirmationBox = (props) => {
+export const ClearLocalConfirmationBox = props => {
   return (
     <div>
-      <AlertP><strong>WARNING</strong>: This WILL erase your data stored in this web browsers local storage</AlertP>
+      <AlertP>
+        <strong>WARNING</strong>: This WILL erase your data stored in this web
+        browsers local storage
+      </AlertP>
       <AlertP>
         What do you want to do?<br />
-        <SmallText>(nothing, <StyledSimpleLink onClick={props.onClick}>cancel</StyledSimpleLink>)</SmallText>
+        <SmallText>
+          (nothing,{' '}
+          <StyledSimpleLink onClick={props.onClick}>cancel</StyledSimpleLink>)
+        </SmallText>
       </AlertP>
     </div>
   )
 }
 
-const StyledP = styled.p`
-  
-`
-const StyledCheckBox = styled.input`
+const StyledP = styled.p``
+const StyledCheckBox = styled.input``
 
-`
-
-const CheckBoxLabel = styled.label`
-  display: inline-block;
-`
+const CheckBoxLabel = styled.label`display: inline-block;`
 
 const AlertDiv = styled.div`
   color: #8a6d3b;
@@ -76,28 +94,22 @@ const AlertDiv = styled.div`
 `
 
 const CloseButton = styled.button`
-  float:right;
+  float: right;
   vertical-align: top;
   background: transparent;
   border: 0px;
-  font-size : 21px;
+  font-size: 21px;
   outline: 0;
   line-height: 1;
 `
 
-export const SmallText = styled.span`
-  font-size: 85%;
-`
+export const SmallText = styled.span`font-size: 85%;`
 
-export const SmallHeaderText = styled.span`
-  font-size : 11px;
-`
+export const SmallHeaderText = styled.span`font-size: 11px;`
 
-const AlertP = styled.p`
-  margin: 10px;
-`
+const AlertP = styled.p`margin: 10px;`
 
-export const StyledSyncLink = (props) => {
+export const StyledSyncLink = props => {
   return (
     <StyledSimpleLink onClick={props.onClick}>
       <PlayIcon />&nbsp;{props.children}

--- a/src/browser/modules/User/RolesSelector.jsx
+++ b/src/browser/modules/User/RolesSelector.jsx
@@ -20,10 +20,18 @@
 
 import { StyledSelect } from './styled'
 
-const RolesSelector = ({roles = [], onChange = null, selectedValue = undefined}) => {
+const RolesSelector = ({
+  roles = [],
+  onChange = null,
+  selectedValue = undefined
+}) => {
   if (roles.length > 0) {
     const options = roles.map((role, i) => {
-      return (<option key={i} value={role}>{role}</option>)
+      return (
+        <option key={i} value={role}>
+          {role}
+        </option>
+      )
     })
     return (
       <StyledSelect
@@ -35,6 +43,8 @@ const RolesSelector = ({roles = [], onChange = null, selectedValue = undefined})
         {options}
       </StyledSelect>
     )
-  } else { return null }
+  } else {
+    return null
+  }
 }
 export default RolesSelector

--- a/src/browser/modules/User/UserAdd.test.jsx
+++ b/src/browser/modules/User/UserAdd.test.jsx
@@ -23,18 +23,34 @@ import React from 'react'
 import { UserAdd } from './UserAdd'
 import { shallow } from 'enzyme'
 
-const mockBus = {self: () => {}}
+const mockBus = { self: () => {} }
 
 describe('UserAdd', () => {
   test('should show filtered list of roles', () => {
-    const user = {username: 'user', roles: ['a', 'b'], status: []}
-    const wrapper = shallow(<UserAdd bus={mockBus} username={user.username} availableRoles={['a', 'b', 'c']} roles={user.roles} status={user.status} />)
+    const user = { username: 'user', roles: ['a', 'b'], status: [] }
+    const wrapper = shallow(
+      <UserAdd
+        bus={mockBus}
+        username={user.username}
+        availableRoles={['a', 'b', 'c']}
+        roles={user.roles}
+        status={user.status}
+      />
+    )
     expect(wrapper.instance().availableRoles()).toEqual(['c'])
     expect(wrapper.state().roles).toEqual(['a', 'b'])
   })
   test('should remove role from the users assigned roles', () => {
-    const user = {username: 'user', roles: ['a', 'b', 'c'], status: []}
-    const wrapper = shallow(<UserAdd bus={mockBus} username={user.username} availableRoles={user.roles} roles={user.roles} status={user.status} />)
+    const user = { username: 'user', roles: ['a', 'b', 'c'], status: [] }
+    const wrapper = shallow(
+      <UserAdd
+        bus={mockBus}
+        username={user.username}
+        availableRoles={user.roles}
+        roles={user.roles}
+        status={user.status}
+      />
+    )
     expect(wrapper.instance().removeRole('a')).toEqual(['b', 'c'])
   })
 })

--- a/src/browser/modules/User/UserInfo.jsx
+++ b/src/browser/modules/User/UserInfo.jsx
@@ -22,12 +22,15 @@ import { Component } from 'preact'
 import { connect } from 'preact-redux'
 import { withBus } from 'preact-suber'
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
-import { getCurrentUser, updateCurrentUser } from 'shared/modules/currentUser/currentUserDuck'
+import {
+  getCurrentUser,
+  updateCurrentUser
+} from 'shared/modules/currentUser/currentUserDuck'
 
 export class UserInfoComponent extends Component {
   constructor (props) {
     super(props)
-    this.state = {user: this.props.info}
+    this.state = { user: this.props.info }
   }
   extractUserNameAndRolesFromBolt (r) {
     return {
@@ -36,13 +39,13 @@ export class UserInfoComponent extends Component {
     }
   }
   componentWillReceiveProps (newProps) {
-    this.setState({user: newProps.info})
+    this.setState({ user: newProps.info })
   }
   componentWillMount () {
     this.props.bus.self(
       CYPHER_REQUEST,
       'CALL dbms.showCurrentUser',
-      (response) => {
+      response => {
         if (!response.success) return
         const user = this.extractUserNameAndRolesFromBolt(response)
         this.props.updateCurrentUser(user.username, user.roles)
@@ -51,23 +54,25 @@ export class UserInfoComponent extends Component {
   }
   render () {
     const currentUser = this.state.user
-    const result = (currentUser == null) ? null : JSON.stringify(currentUser)
+    const result = currentUser == null ? null : JSON.stringify(currentUser)
     return (
       <div id='db-user'>
         <h4>User Information</h4>
-        <p>Current user: {result}</p>
+        <p>
+          Current user: {result}
+        </p>
       </div>
     )
   }
 }
 
-const mapStateToProps = (state) => {
+const mapStateToProps = state => {
   return {
     info: getCurrentUser(state)
   }
 }
 
-const mapDispatchToProps = (dispatch) => {
+const mapDispatchToProps = dispatch => {
   return {
     updateCurrentUser: (username, roles) => {
       dispatch(updateCurrentUser(username, roles))
@@ -75,5 +80,7 @@ const mapDispatchToProps = (dispatch) => {
   }
 }
 
-const UserInfo = withBus(connect(mapStateToProps, mapDispatchToProps)(UserInfoComponent))
+const UserInfo = withBus(
+  connect(mapStateToProps, mapDispatchToProps)(UserInfoComponent)
+)
 export default UserInfo

--- a/src/browser/modules/User/UserInfo.test.jsx
+++ b/src/browser/modules/User/UserInfo.test.jsx
@@ -26,7 +26,7 @@ import { shallow } from 'enzyme'
 describe('UserInfo', () => {
   const mockBus = { self: () => {} }
   test('should show username and role of logged in user', () => {
-    const info = {username: 'Admin', roles: ['admin']}
+    const info = { username: 'Admin', roles: ['admin'] }
     const wrapper = shallow(<UserInfoComponent bus={mockBus} info={info} />)
     expect(wrapper.find('#db-user').length).toBe(1)
     expect(wrapper.find('#db-user').text()).toMatch(info.username)

--- a/src/browser/modules/User/UserInformation.jsx
+++ b/src/browser/modules/User/UserInformation.jsx
@@ -19,16 +19,22 @@
  */
 
 import { Component } from 'preact'
-import {v4} from 'uuid'
+import { v4 } from 'uuid'
 
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
 import { withBus } from 'preact-suber'
-import { deleteUser, addRoleToUser, removeRoleFromUser, activateUser, suspendUser } from 'shared/modules/cypher/boltUserHelper'
+import {
+  deleteUser,
+  addRoleToUser,
+  removeRoleFromUser,
+  activateUser,
+  suspendUser
+} from 'shared/modules/cypher/boltUserHelper'
 
 import { FormButton } from 'browser-components/buttons'
 import { CloseIcon } from 'browser-components/icons/Icons'
-import {StyledBodyTr} from 'browser-components/DataTables'
-import {StyledUserTd, StyledButtonContainer} from './styled'
+import { StyledBodyTr } from 'browser-components/DataTables'
+import { StyledUserTd, StyledButtonContainer } from './styled'
 
 import RolesSelector from './RolesSelector'
 
@@ -45,60 +51,74 @@ export class UserInformation extends Component {
   removeClick (thing) {
     this.props.bus.self(
       CYPHER_REQUEST,
-      {query: deleteUser(this.state.username)},
+      { query: deleteUser(this.state.username) },
       this.handleResponse.bind(this)
     )
   }
   suspendUser () {
     this.props.bus.self(
       CYPHER_REQUEST,
-      {query: suspendUser(this.state.username)},
+      { query: suspendUser(this.state.username) },
       this.handleResponse.bind(this)
     )
   }
   activateUser () {
     this.props.bus.self(
       CYPHER_REQUEST,
-      {query: activateUser(this.state.username)},
+      { query: activateUser(this.state.username) },
       this.handleResponse.bind(this)
     )
   }
   statusButton (statusList) {
     if (statusList.indexOf('is_suspended') !== -1) {
-      return (<FormButton label='Suspend user' onClick={this.activateUser.bind(this)} />)
+      return (
+        <FormButton
+          label='Suspend user'
+          onClick={this.activateUser.bind(this)}
+        />
+      )
     } else {
-      return (<FormButton label='Active user' onClick={this.suspendUser.bind(this)} />)
+      return (
+        <FormButton label='Active user' onClick={this.suspendUser.bind(this)} />
+      )
     }
   }
   passwordChange () {
     return '-'
   }
   listRoles () {
-    return this.state.roles.map((role) => {
+    return this.state.roles.map(role => {
       return (
-        <FormButton key={v4()} label={role} icon={<CloseIcon />} onClick={() => {
-          this.props.bus.self(
-            CYPHER_REQUEST,
-            {query: removeRoleFromUser(role, this.state.username)},
-            this.handleResponse.bind(this)
-          )
-        }} />
+        <FormButton
+          key={v4()}
+          label={role}
+          icon={<CloseIcon />}
+          onClick={() => {
+            this.props.bus.self(
+              CYPHER_REQUEST,
+              { query: removeRoleFromUser(role, this.state.username) },
+              this.handleResponse.bind(this)
+            )
+          }}
+        />
       )
     })
   }
   onRoleSelect (event) {
     this.props.bus.self(
       CYPHER_REQUEST,
-      {query: addRoleToUser(this.state.username, event.target.value)},
+      { query: addRoleToUser(this.state.username, event.target.value) },
       this.handleResponse.bind(this)
     )
   }
   handleResponse (response) {
-    if (!response.success) return this.setState({errors: [response.error]})
+    if (!response.success) return this.setState({ errors: [response.error] })
     return this.props.refresh()
   }
   availableRoles () {
-    return this.state.availableRoles.filter((role) => this.props.roles.indexOf(role) < 0)
+    return this.state.availableRoles.filter(
+      role => this.props.roles.indexOf(role) < 0
+    )
   }
   render () {
     return (
@@ -109,7 +129,10 @@ export class UserInformation extends Component {
           </StyledButtonContainer>
         </StyledUserTd>
         <StyledUserTd className='roles'>
-          <RolesSelector roles={this.availableRoles()} onChange={this.onRoleSelect.bind(this)} />
+          <RolesSelector
+            roles={this.availableRoles()}
+            onChange={this.onRoleSelect.bind(this)}
+          />
           <span>
             {this.listRoles()}
           </span>
@@ -121,7 +144,11 @@ export class UserInformation extends Component {
           {this.passwordChange()}
         </StyledUserTd>
         <StyledUserTd>
-          <FormButton className='delete' label='Remove' onClick={this.removeClick.bind(this)} />
+          <FormButton
+            className='delete'
+            label='Remove'
+            onClick={this.removeClick.bind(this)}
+          />
         </StyledUserTd>
       </StyledBodyTr>
     )

--- a/src/browser/modules/User/UserInformation.test.jsx
+++ b/src/browser/modules/User/UserInformation.test.jsx
@@ -23,12 +23,19 @@ import React from 'react'
 import { UserInformation } from './UserInformation'
 import { shallow } from 'enzyme'
 
-const mockBus = {self: () => {}}
+const mockBus = { self: () => {} }
 
 describe('UserInformation', () => {
   test('should show username and role of a user', () => {
-    const user = {username: 'user', roles: ['roles'], status: []}
-    const wrapper = shallow(<UserInformation bus={mockBus} username={user.username} roles={user.roles} status={user.status} />)
+    const user = { username: 'user', roles: ['roles'], status: [] }
+    const wrapper = shallow(
+      <UserInformation
+        bus={mockBus}
+        username={user.username}
+        roles={user.roles}
+        status={user.status}
+      />
+    )
     expect(wrapper.find('.user-info').length).toBe(1)
     expect(wrapper.find('.user-info .username').text()).toMatch(user.username)
     expect(wrapper.find('.roles').first().html()).toMatch(user.roles[0])

--- a/src/browser/modules/User/UserList.jsx
+++ b/src/browser/modules/User/UserList.jsx
@@ -22,12 +22,15 @@ import { executeCommand } from 'shared/modules/commands/commandsDuck'
 import { Component } from 'preact'
 import uuid from 'uuid'
 import { withBus } from 'preact-suber'
-import { listUsersQuery, listRolesQuery } from 'shared/modules/cypher/boltUserHelper'
+import {
+  listUsersQuery,
+  listRolesQuery
+} from 'shared/modules/cypher/boltUserHelper'
 import UserInformation from './UserInformation'
 import bolt from 'services/bolt/bolt'
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
 import { StyledLink } from 'browser-components/buttons'
-import {StyledTable, StyledTh} from 'browser-components/DataTables'
+import { StyledTable, StyledTh } from 'browser-components/DataTables'
 import { StyledButtonContainer } from './styled'
 
 import FrameTemplate from '../Stream/FrameTemplate'
@@ -48,28 +51,59 @@ export class UserList extends Component {
   getUserList () {
     this.props.bus.self(
       CYPHER_REQUEST,
-      {query: listUsersQuery()},
-      (response) => {
-        if (response.success) this.setState({userList: this.extractUserNameAndRolesFromBolt(response.result)})
-      })
+      { query: listUsersQuery() },
+      response => {
+        if (response.success) {
+          this.setState({
+            userList: this.extractUserNameAndRolesFromBolt(response.result)
+          })
+        }
+      }
+    )
   }
   getRoles () {
     this.props.bus.self(
       CYPHER_REQUEST,
-      {query: listRolesQuery()},
-      (response) => {
-        const flatten = arr => arr.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), [])
-        if (response.success) this.setState({listRoles: flatten(this.extractUserNameAndRolesFromBolt(response.result))})
-      })
+      { query: listRolesQuery() },
+      response => {
+        const flatten = arr =>
+          arr.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), [])
+        if (response.success) {
+          this.setState({
+            listRoles: flatten(
+              this.extractUserNameAndRolesFromBolt(response.result)
+            )
+          })
+        }
+      }
+    )
   }
   makeTable (data) {
-    const items = data.map((row) => {
+    const items = data.map(row => {
       return (
-        <UserInformation className='user-information' key={uuid.v4()} username={row[0]} roles={row[1]} status={row[2]} refresh={this.getUserList.bind(this)} availableRoles={this.state.listRoles} />
+        <UserInformation
+          className='user-information'
+          key={uuid.v4()}
+          username={row[0]}
+          roles={row[1]}
+          status={row[2]}
+          refresh={this.getUserList.bind(this)}
+          availableRoles={this.state.listRoles}
+        />
       )
     })
-    const tableHeaders = ['Username', 'Roles(s)', 'Status', 'Password Change', 'Delete'].map((heading, i) => {
-      return <StyledTh key={i}>{heading}</StyledTh>
+    const tableHeaders = [
+      'Username',
+      'Roles(s)',
+      'Status',
+      'Password Change',
+      'Delete'
+    ].map((heading, i) => {
+      return (
+        <StyledTh key={i}>
+          {heading}
+        </StyledTh>
+      )
     })
     return (
       <StyledTable>
@@ -104,19 +138,15 @@ export class UserList extends Component {
     this.getRoles()
   }
   render () {
-    const renderedListOfUsers = (this.state.userList) ? this.makeTable(this.state.userList) : 'No users'
+    const renderedListOfUsers = this.state.userList
+      ? this.makeTable(this.state.userList)
+      : 'No users'
     const frameContents = (
       <div className='db-list-users'>
         {renderedListOfUsers}
-
       </div>
     )
-    return (
-      <FrameTemplate
-        header={this.props.frame}
-        contents={frameContents}
-      />
-    )
+    return <FrameTemplate header={this.props.frame} contents={frameContents} />
   }
 }
 

--- a/src/browser/modules/User/UserList.test.jsx
+++ b/src/browser/modules/User/UserList.test.jsx
@@ -24,24 +24,25 @@ import { shallow } from 'enzyme'
 
 import { UserList } from './UserList'
 
-const mockBus = {self: () => {}}
+const mockBus = { self: () => {} }
 
 describe('UserList', () => {
   test('should show list of database users by username', () => {
     const props = {
-      users: [
-        ['Admin', ['admin'], []],
-        ['Thing', ['thing'], []]
-      ]
+      users: [['Admin', ['admin'], []], ['Thing', ['thing'], []]]
     }
-    const wrapper = shallow(shallow(<UserList bus={mockBus} {...props} />).props().contents)
+    const wrapper = shallow(
+      shallow(<UserList bus={mockBus} {...props} />).props().contents
+    )
     expect(wrapper.find('.user-information').length).toBe(2)
   })
 
   test.skip('should show list of database users by role', () => {
     const roles = ['user1', 'user2']
-    const props = {roles: roles}
-    const wrapper = shallow(shallow(<UserList bus={mockBus} {...props} />).contents)
+    const props = { roles: roles }
+    const wrapper = shallow(
+      shallow(<UserList bus={mockBus} {...props} />).contents
+    )
     expect(wrapper.find('.roles').text()).toEqual('user1, user2')
   })
 })

--- a/src/browser/modules/UserInteraction/index.jsx
+++ b/src/browser/modules/UserInteraction/index.jsx
@@ -23,7 +23,7 @@ import { withBus } from 'preact-suber'
 import { throttle } from 'services/utils'
 import { USER_INTERACTION } from 'shared/modules/userInteraction/userInteractionDuck'
 
-const reportInteraction = (bus) => {
+const reportInteraction = bus => {
   if (!bus) return
   bus.send(USER_INTERACTION)
 }
@@ -31,12 +31,20 @@ const throttledReportInteraction = throttle(reportInteraction, 5000)
 
 export class UserInteraction extends Component {
   componentDidMount () {
-    document.addEventListener('keyup', () => throttledReportInteraction(this.props.bus))
-    document.addEventListener('click', () => throttledReportInteraction(this.props.bus))
+    document.addEventListener('keyup', () =>
+      throttledReportInteraction(this.props.bus)
+    )
+    document.addEventListener('click', () =>
+      throttledReportInteraction(this.props.bus)
+    )
   }
   componentWillUnmount () {
-    document.removeEventListener('keyup', () => throttledReportInteraction(this.props.bus))
-    document.removeEventListener('click', () => throttledReportInteraction(this.props.bus))
+    document.removeEventListener('keyup', () =>
+      throttledReportInteraction(this.props.bus)
+    )
+    document.removeEventListener('click', () =>
+      throttledReportInteraction(this.props.bus)
+    )
   }
 }
 

--- a/src/browser/services/localstorageMiddleware.js
+++ b/src/browser/services/localstorageMiddleware.js
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export const makeConnectionsInitialState = (connectionsReducer) => {
+export const makeConnectionsInitialState = connectionsReducer => {
   return (key, val) => {
     if (key !== 'connections') return val
     if (!val) {
@@ -34,7 +34,9 @@ export const makeConnectionsInitialState = (connectionsReducer) => {
 
     // If not, add it
     out.allConnectionIds = ['offline'].concat(out.allConnectionIds)
-    out.connectionsById = Object.assign(out.connectionsById, {'offline': {name: 'Offline', type: 'offline', id: 'offline'}})
+    out.connectionsById = Object.assign(out.connectionsById, {
+      offline: { name: 'Offline', type: 'offline', id: 'offline' }
+    })
     return out
   }
 }

--- a/src/browser/services/localstorageMiddleware.test.js
+++ b/src/browser/services/localstorageMiddleware.test.js
@@ -19,7 +19,10 @@
  */
 
 /* global test, expect */
-import { makeConnectionsInitialState, makeConnectionsPersistedState } from './localstorageMiddleware'
+import {
+  makeConnectionsInitialState,
+  makeConnectionsPersistedState
+} from './localstorageMiddleware'
 
 const connection = {
   reducer: (initialState, action) => {
@@ -47,7 +50,7 @@ describe('localstorageMiddleware', () => {
     const before = {
       activeConnection: 'anything',
       allConnectionIds: ['x'],
-      connectionsById: {'x': {name: 'x'}}
+      connectionsById: { x: { name: 'x' } }
     }
     const key = 'connections'
 

--- a/src/browser/styles/constants.js
+++ b/src/browser/styles/constants.js
@@ -18,9 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export const font = {
-
-}
+export const font = {}
 
 export const dim = {
   // Editor bar

--- a/src/browser/styles/themes.js
+++ b/src/browser/styles/themes.js
@@ -43,7 +43,8 @@ export const base = {
 
   // Fonts
   primaryFontFamily: '"Helvetica Neue", Helvetica, Arial, sans-serif',
-  drawerHeaderFontFamily: "'Open Sans', 'HelveticaNeue-Light', 'Helvetica Neue Light', 'Helvetica Neue', Helvetica, Arial, sans-serif",
+  drawerHeaderFontFamily:
+    "'Open Sans', 'HelveticaNeue-Light', 'Helvetica Neue Light', 'Helvetica Neue', Helvetica, Arial, sans-serif",
   streamlineFontFamily: 'streamline',
   editorFont: '"Inconsolata", "Monaco", "Lucida Console", Courier, monospace;',
 

--- a/src/shared/modules/app/appDuck.js
+++ b/src/shared/modules/app/appDuck.js
@@ -24,13 +24,13 @@ export const APP_START = `${NAME}/APP_START`
 export const USER_CLEAR = `${NAME}/USER_CLEAR`
 
 // Selectors
-export const getHostedUrl = (state) => (state[NAME] || {}).hostedUrl || null
+export const getHostedUrl = state => (state[NAME] || {}).hostedUrl || null
 
 // Reducer
 export default function reducer (state = { hostedUrl: null }, action) {
   switch (action.type) {
     case APP_START:
-      return {...state, hostedUrl: action.url}
+      return { ...state, hostedUrl: action.url }
     default:
       return state
   }

--- a/src/shared/modules/app/appDuck.test.js
+++ b/src/shared/modules/app/appDuck.test.js
@@ -41,11 +41,11 @@ test('selector getHostedUrl returns whats in the store', () => {
   const action = { type: APP_START, url }
 
   // Then
-  expect(getHostedUrl({[NAME]: initState})).toEqual(null)
+  expect(getHostedUrl({ [NAME]: initState })).toEqual(null)
 
   // When
   const state = reducer(initState, action)
 
   // Then
-  expect(getHostedUrl({[NAME]: state})).toEqual(url)
+  expect(getHostedUrl({ [NAME]: state })).toEqual(url)
 })

--- a/src/shared/modules/commands/helpers/config.js
+++ b/src/shared/modules/commands/helpers/config.js
@@ -18,7 +18,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { getSettings, update, replace } from 'shared/modules/settings/settingsDuck'
+import {
+  getSettings,
+  update,
+  replace
+} from 'shared/modules/settings/settingsDuck'
 import { splitStringOnFirst } from 'services/commandUtils'
 import { getRemoteContentHostnameWhitelist } from 'shared/modules/dbMeta/dbMetaDuck'
 import { hostIsAllowed } from 'services/utils'
@@ -38,37 +42,50 @@ export function handleUpdateConfigCommand (action, cmdchar, put, store) {
   const p = new Promise((resolve, reject) => {
     if (parts[1] === undefined || parts[1] === '') return resolve(true) // Nothing to do
     const param = parts[1].trim()
-    if (!isValidURL(param)) { // Not an URL. Parse as command line params
-      if (/^"?\{[^}]*\}"?$/.test(param)) { // JSON object string {"x": 2, "y":"string"}
+    if (!isValidURL(param)) {
+      // Not an URL. Parse as command line params
+      if (/^"?\{[^}]*\}"?$/.test(param)) {
+        // JSON object string {"x": 2, "y":"string"}
         try {
           const res = jsonic(param.replace(/^"/, '').replace(/"$/, '')) // Remove any surrounding quotes
           put(replace(res))
           return resolve(res)
         } catch (e) {
-          return reject(new Error('Could not parse input. Usage: `:config {"x":1,"y":"string"}`. ' + e))
+          return reject(
+            new Error(
+              'Could not parse input. Usage: `:config {"x":1,"y":"string"}`. ' +
+                e
+            )
+          )
         }
-      } else { // Single param
+      } else {
+        // Single param
         try {
           const json = '{' + param + '}'
           const res = jsonic(json)
           put(update(res))
           return resolve(res)
         } catch (e) {
-          return reject(new Error('Could not parse input. Usage: `:config "x": 2`. ' + e))
+          return reject(
+            new Error('Could not parse input. Usage: `:config "x": 2`. ' + e)
+          )
         }
       }
     }
     // It's an URL
     const whitelist = getRemoteContentHostnameWhitelist(store.getState())
-    if (!hostIsAllowed(param, whitelist)) { // Make sure we're allowed to request entities on this host
-      return reject(new Error('Hostname is not allowed according to server whitelist'))
+    if (!hostIsAllowed(param, whitelist)) {
+      // Make sure we're allowed to request entities on this host
+      return reject(
+        new Error('Hostname is not allowed according to server whitelist')
+      )
     }
     getJSON(param)
-      .then((res) => {
+      .then(res => {
         put(replace(res))
         resolve(res)
       })
-      .catch((e) => {
+      .catch(e => {
         reject(e)
       })
   })

--- a/src/shared/modules/commands/helpers/config.test.js
+++ b/src/shared/modules/commands/helpers/config.test.js
@@ -56,8 +56,12 @@ describe('commandsDuck config helper', () => {
     const p = config.handleUpdateConfigCommand(action, cmdchar, put, store)
 
     // Then
-    return expect(p)
-      .rejects.toEqual(new Error('Could not parse input. Usage: `:config "x": 2`. SyntaxError: Expected ":" but "x" found.'))
+    return expect(p).rejects
+      .toEqual(
+        new Error(
+          'Could not parse input. Usage: `:config "x": 2`. SyntaxError: Expected ":" but "x" found.'
+        )
+      )
       .then(() => expect(put).not.toHaveBeenCalled())
   })
   test('handles :config "x": 2 and calls the update action creator', () => {
@@ -70,9 +74,9 @@ describe('commandsDuck config helper', () => {
     const p = config.handleUpdateConfigCommand(action, cmdchar, put, store)
 
     // Then
-    return p.then((res) => {
-      expect(res).toEqual({x: 2})
-      expect(put).toHaveBeenCalledWith(update({x: 2}))
+    return p.then(res => {
+      expect(res).toEqual({ x: 2 })
+      expect(put).toHaveBeenCalledWith(update({ x: 2 }))
     })
   })
   test('handles :config x: 2 and calls the update action creator', () => {
@@ -85,9 +89,9 @@ describe('commandsDuck config helper', () => {
     const p = config.handleUpdateConfigCommand(action, cmdchar, put, store)
 
     // Then
-    return p.then((res) => {
-      expect(res).toEqual({x: 2})
-      expect(put).toHaveBeenCalledWith(update({x: 2}))
+    return p.then(res => {
+      expect(res).toEqual({ x: 2 })
+      expect(put).toHaveBeenCalledWith(update({ x: 2 }))
     })
   })
   test('handles :config "x y": 2 and calls the update action creator', () => {
@@ -100,9 +104,9 @@ describe('commandsDuck config helper', () => {
     const p = config.handleUpdateConfigCommand(action, cmdchar, put, store)
 
     // Then
-    return p.then((res) => {
-      expect(res).toEqual({'x y': 2})
-      expect(put).toHaveBeenCalledWith(update({'x y': 2}))
+    return p.then(res => {
+      expect(res).toEqual({ 'x y': 2 })
+      expect(put).toHaveBeenCalledWith(update({ 'x y': 2 }))
     })
   })
   test('handles :config {"hej": "ho", "let\'s": "go"} and calls the replace action creator', () => {
@@ -115,9 +119,9 @@ describe('commandsDuck config helper', () => {
     const p = config.handleUpdateConfigCommand(action, cmdchar, put, store)
 
     // Then
-    return p.then((res) => {
-      expect(res).toEqual({hej: 'ho', "let's": 'go'})
-      expect(put).toHaveBeenCalledWith(replace({hej: 'ho', "let's": 'go'}))
+    return p.then(res => {
+      expect(res).toEqual({ hej: 'ho', "let's": 'go' })
+      expect(put).toHaveBeenCalledWith(replace({ hej: 'ho', "let's": 'go' }))
     })
   })
   test('handles :config {x: 1, y: 2} and calls the replace action creator', () => {
@@ -130,9 +134,9 @@ describe('commandsDuck config helper', () => {
     const p = config.handleUpdateConfigCommand(action, cmdchar, put, store)
 
     // Then
-    return p.then((res) => {
-      expect(res).toEqual({x: 1, y: 2})
-      expect(put).toHaveBeenCalledWith(replace({x: 1, y: 2}))
+    return p.then(res => {
+      expect(res).toEqual({ x: 1, y: 2 })
+      expect(put).toHaveBeenCalledWith(replace({ x: 1, y: 2 }))
     })
   })
   test('rejects hostnames not in whitelist', () => {
@@ -145,13 +149,15 @@ describe('commandsDuck config helper', () => {
     const p = config.handleUpdateConfigCommand(action, cmdchar, put, store)
 
     // Then
-    return expect(p)
-      .rejects.toEqual(new Error('Hostname is not allowed according to server whitelist'))
+    return expect(p).rejects
+      .toEqual(
+        new Error('Hostname is not allowed according to server whitelist')
+      )
       .then(() => expect(put).not.toHaveBeenCalled())
   })
   test('handles :config https://okurl.com/cnf.json and calls the replace action creator', () => {
     // Given
-    const json = JSON.stringify({x: 1, y: 'hello'})
+    const json = JSON.stringify({ x: 1, y: 'hello' })
     nock('https://okurl.com').get('/cnf.json').reply(200, json)
     const action = { cmd: ':config https://okurl.com/cnf.json' }
     const cmdchar = ':'
@@ -161,7 +167,7 @@ describe('commandsDuck config helper', () => {
     const p = config.handleUpdateConfigCommand(action, cmdchar, put, store)
 
     // Then
-    return p.then((res) => {
+    return p.then(res => {
       expect(res).toEqual(JSON.parse(json))
       expect(put).toHaveBeenCalledWith(replace(JSON.parse(json)))
     })
@@ -178,8 +184,14 @@ describe('commandsDuck config helper', () => {
     const p = config.handleUpdateConfigCommand(action, cmdchar, put, store)
 
     // Then
-    return expect(p)
-      .rejects.toEqual(new Error(new FetchError('invalid json response body at https://okurl.com/cnf.json reason: Unexpected token o in JSON at position 1')))
+    return expect(p).rejects
+      .toEqual(
+        new Error(
+          new FetchError(
+            'invalid json response body at https://okurl.com/cnf.json reason: Unexpected token o in JSON at position 1'
+          )
+        )
+      )
       .then(() => expect(put).not.toHaveBeenCalled())
   })
 })

--- a/src/shared/modules/commands/helpers/cypher.js
+++ b/src/shared/modules/commands/helpers/cypher.js
@@ -21,8 +21,19 @@
 import bolt from 'services/bolt/bolt'
 import { send } from 'shared/modules/requests/requestsDuck'
 
-export const handleCypherCommand = (action, put, params = {}, shouldUseCypherThread = false) => {
-  const [id, request] = bolt.routedWriteTransaction(action.cmd, params, action.requestId, true, shouldUseCypherThread)
+export const handleCypherCommand = (
+  action,
+  put,
+  params = {},
+  shouldUseCypherThread = false
+) => {
+  const [id, request] = bolt.routedWriteTransaction(
+    action.cmd,
+    params,
+    action.requestId,
+    true,
+    shouldUseCypherThread
+  )
   put(send('cypher', id))
   return [id, request]
 }

--- a/src/shared/modules/commands/helpers/grass.js
+++ b/src/shared/modules/commands/helpers/grass.js
@@ -24,11 +24,13 @@ import remote from 'services/remote'
 export const fetchRemoteGrass = (url, whitelist = null) => {
   return new Promise((resolve, reject) => {
     if (!hostIsAllowed(url, whitelist)) {
-      return reject(new Error('Hostname is not allowed according to server whitelist'))
+      return reject(
+        new Error('Hostname is not allowed according to server whitelist')
+      )
     }
     resolve()
   }).then(() => {
-    return remote.get(url).then((r) => {
+    return remote.get(url).then(r => {
       return r
     })
   })

--- a/src/shared/modules/commands/helpers/grass.test.js
+++ b/src/shared/modules/commands/helpers/grass.test.js
@@ -18,13 +18,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
- /* global jest */
+/* global jest */
 
 import { fetchRemoteGrass, parseGrass } from './grass'
 
 jest.mock('services/remote', () => {
   return {
-    get: (url) => {
+    get: url => {
       return new Promise((resolve, reject) => {
         resolve(url)
       })
@@ -36,14 +36,18 @@ describe('Grass remote fetch', () => {
   test('should not fetch from url not in the whitelist', () => {
     const whitelist = 'foo'
     const urlNotInWhitelist = 'bar'
-    return expect(fetchRemoteGrass(urlNotInWhitelist, whitelist)).rejects.toMatchObject({
+    return expect(
+      fetchRemoteGrass(urlNotInWhitelist, whitelist)
+    ).rejects.toMatchObject({
       message: 'Hostname is not allowed according to server whitelist'
     })
   })
   test('should fetch from url in the whitelist', () => {
     const whitelist = 'foo'
     const urlInWhitelist = 'foo'
-    return expect(fetchRemoteGrass(urlInWhitelist, whitelist)).resolves.toBe(urlInWhitelist)
+    return expect(fetchRemoteGrass(urlInWhitelist, whitelist)).resolves.toBe(
+      urlInWhitelist
+    )
   })
 })
 
@@ -83,14 +87,16 @@ describe('Grass parser', () => {
   })
 
   test('Parsing grass with odd whitespace', () => {
-    const data = 'node {border-color : #9AA1AC ; \n\r\t  diameter:50px;color:#A5ABB6; border-width : 2px ; } relationship{ color : #A5ABB6 ; shaft-width : 1px ; font-size : 8px ; padding : 3px ; text-color-external : #000000 ; text-color-internal : #FFFFFF ; caption : <type>; }'
+    const data =
+      'node {border-color : #9AA1AC ; \n\r\t  diameter:50px;color:#A5ABB6; border-width : 2px ; } relationship{ color : #A5ABB6 ; shaft-width : 1px ; font-size : 8px ; padding : 3px ; text-color-external : #000000 ; text-color-internal : #FFFFFF ; caption : <type>; }'
     const parsed = parseGrass(data)
     expect(parsed.node.diameter).toEqual('50px')
     expect(parsed.relationship.color).toEqual('#A5ABB6')
   })
 
   test('Handles JSON data', () => {
-    const data = '{"node": {"diameter":"50px", "color":"#A5ABB6"}, "relationship":{"color":"#A5ABB6","shaft-width":"1px"}}'
+    const data =
+      '{"node": {"diameter":"50px", "color":"#A5ABB6"}, "relationship":{"color":"#A5ABB6","shaft-width":"1px"}}'
     const parsed = parseGrass(data)
     expect(parsed.node.diameter).toEqual('50px')
     expect(parsed.relationship.color).toEqual('#A5ABB6')

--- a/src/shared/modules/commands/helpers/http.js
+++ b/src/shared/modules/commands/helpers/http.js
@@ -18,13 +18,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export const parseHttpVerbCommand = (input) => {
+export const parseHttpVerbCommand = input => {
   const p = new Promise((resolve, reject) => {
     const re = /^[^\w]*(get|post|put|delete|head)\s+(\S+)?\s*([\S\s]+)?$/i
     const result = re.exec(input)
     let method, url, data
     try {
-      [method, url, data] = [result[1], (result[2] || null), (result[3] || null)]
+      ;[method, url, data] = [result[1], result[2] || null, result[3] || null]
     } catch (e) {
       reject(new Error('Unparseable http request'))
       return
@@ -50,11 +50,14 @@ export const parseHttpVerbCommand = (input) => {
 
 // Check if valid url, from http://stackoverflow.com/questions/5717093/check-if-a-javascript-string-is-a-url
 export function isValidURL (str) {
-  var pattern = new RegExp('^(https?:\\/\\/)?' + // protocol
-  '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.?)+[a-z]{2,}|' + // domain name
-  '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
-  '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
-  '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
-  '(\\#[-a-z\\d_]*)?$', 'i') // fragment locator
+  var pattern = new RegExp(
+    '^(https?:\\/\\/)?' + // protocol
+    '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.?)+[a-z]{2,}|' + // domain name
+    '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
+    '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
+    '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
+      '(\\#[-a-z\\d_]*)?$',
+    'i'
+  ) // fragment locator
   return pattern.test(str)
 }

--- a/src/shared/modules/commands/helpers/http.test.js
+++ b/src/shared/modules/commands/helpers/http.test.js
@@ -22,7 +22,7 @@
 import { parseHttpVerbCommand } from './http'
 
 describe('HTTP verbs command', () => {
-  test('Fails with error on wrong command', (done) => {
+  test('Fails with error on wrong command', done => {
     // Given
     const input = 'xxx '
 
@@ -30,16 +30,17 @@ describe('HTTP verbs command', () => {
     const p = parseHttpVerbCommand(input)
 
     // Then
-    p.then((r) => {
-      expect(1).toBe(2)
-      done()
-    })
-      .catch((e) => {
+    p
+      .then(r => {
+        expect(1).toBe(2)
+        done()
+      })
+      .catch(e => {
         expect(e.message).toEqual('Unparseable http request')
         done()
       })
   })
-  test('Fails without url', (done) => {
+  test('Fails without url', done => {
     // Given
     const input = 'get '
 
@@ -47,16 +48,17 @@ describe('HTTP verbs command', () => {
     const p = parseHttpVerbCommand(input)
 
     // Then
-    p.then((r) => {
-      expect(1).toBe(2)
-      done()
-    })
-      .catch((e) => {
+    p
+      .then(r => {
+        expect(1).toBe(2)
+        done()
+      })
+      .catch(e => {
         expect(e.message).toEqual('Missing path')
         done()
       })
   })
-  test('Fails with non JSON data for post/put', (done) => {
+  test('Fails with non JSON data for post/put', done => {
     // Given
     const input = 'post /test my-data'
 
@@ -64,16 +66,19 @@ describe('HTTP verbs command', () => {
     const p = parseHttpVerbCommand(input)
 
     // Then
-    p.then((r) => {
-      expect(1).toBe(2)
-      done()
-    })
-      .catch((e) => {
-        expect(e.message).toEqual('Payload does not seem to be valid (JSON) data')
+    p
+      .then(r => {
+        expect(1).toBe(2)
+        done()
+      })
+      .catch(e => {
+        expect(e.message).toEqual(
+          'Payload does not seem to be valid (JSON) data'
+        )
         done()
       })
   })
-  test('Passes post/put without data', (done) => {
+  test('Passes post/put without data', done => {
     // Given
     const input = 'post /test'
 
@@ -81,16 +86,17 @@ describe('HTTP verbs command', () => {
     const p = parseHttpVerbCommand(input)
 
     // Then
-    p.then((r) => {
-      expect(r.method).toBe('post')
-      done()
-    })
-      .catch((e) => {
+    p
+      .then(r => {
+        expect(r.method).toBe('post')
+        done()
+      })
+      .catch(e => {
         expect(1).toEqual(2)
         done()
       })
   })
-  test('Passes post/put with JSON data', (done) => {
+  test('Passes post/put with JSON data', done => {
     // Given
     const data = '{"x": 1}'
     const input = 'post /test ' + data
@@ -99,12 +105,13 @@ describe('HTTP verbs command', () => {
     const p = parseHttpVerbCommand(input)
 
     // Then
-    p.then((r) => {
-      expect(r.method).toBe('post')
-      expect(r.data).toEqual(data)
-      done()
-    })
-      .catch((e) => {
+    p
+      .then(r => {
+        expect(r.method).toBe('post')
+        expect(r.data).toEqual(data)
+        done()
+      })
+      .catch(e => {
         expect(1).toEqual(2)
         done()
       })

--- a/src/shared/modules/commands/helpers/params.js
+++ b/src/shared/modules/commands/helpers/params.js
@@ -26,22 +26,30 @@ export const handleParamsCommand = (action, cmdchar, put, store) => {
   const parts = splitStringOnFirst(strippedCmd, ' ')
   const param = parts[1].trim()
   const p = new Promise((resolve, reject) => {
-    if (/^"?\{[^}]*\}"?$/.test(param)) { // JSON object string {"x": 2, "y":"string"}
+    if (/^"?\{[^}]*\}"?$/.test(param)) {
+      // JSON object string {"x": 2, "y":"string"}
       try {
         const res = jsonic(param.replace(/^"/, '').replace(/"$/, '')) // Remove any surrounding quotes
         put(replace(res))
         return resolve({ result: res, type: 'params' })
       } catch (e) {
-        return reject(new Error('Could not parse input. Usage: `:params {"x":1,"y":"string"}`. ' + e))
+        return reject(
+          new Error(
+            'Could not parse input. Usage: `:params {"x":1,"y":"string"}`. ' + e
+          )
+        )
       }
-    } else { // Single param
+    } else {
+      // Single param
       try {
         const json = '{' + param + '}'
         const res = jsonic(json)
         put(update(res))
         return resolve({ result: res, type: 'param' })
       } catch (e) {
-        return reject(new Error('Could not parse input. Usage: `:param "x": 2`. ' + e))
+        return reject(
+          new Error('Could not parse input. Usage: `:param "x": 2`. ' + e)
+        )
       }
     }
   })

--- a/src/shared/modules/commands/helpers/params.test.js
+++ b/src/shared/modules/commands/helpers/params.test.js
@@ -34,8 +34,12 @@ describe('commandsDuck params helper', () => {
     const p = params.handleParamsCommand(action, cmdchar, put)
 
     // Then
-    return expect(p)
-      .rejects.toEqual(new Error('Could not parse input. Usage: `:param "x": 2`. SyntaxError: Expected ":" but "x" found.'))
+    return expect(p).rejects
+      .toEqual(
+        new Error(
+          'Could not parse input. Usage: `:param "x": 2`. SyntaxError: Expected ":" but "x" found.'
+        )
+      )
       .then(() => expect(put).not.toHaveBeenCalled())
   })
   test('handles :param "x": 2 and calls the update action creator', () => {
@@ -48,9 +52,9 @@ describe('commandsDuck params helper', () => {
     const p = params.handleParamsCommand(action, cmdchar, put)
 
     // Then
-    return p.then((res) => {
-      expect(res.result).toEqual({x: 2})
-      expect(put).toHaveBeenCalledWith(update({x: 2}))
+    return p.then(res => {
+      expect(res.result).toEqual({ x: 2 })
+      expect(put).toHaveBeenCalledWith(update({ x: 2 }))
     })
   })
   test('handles :param x: 2 and calls the update action creator', () => {
@@ -63,9 +67,9 @@ describe('commandsDuck params helper', () => {
     const p = params.handleParamsCommand(action, cmdchar, put)
 
     // Then
-    return p.then((res) => {
-      expect(res.result).toEqual({x: 2})
-      expect(put).toHaveBeenCalledWith(update({x: 2}))
+    return p.then(res => {
+      expect(res.result).toEqual({ x: 2 })
+      expect(put).toHaveBeenCalledWith(update({ x: 2 }))
     })
   })
   test('handles :param "x y": 2 and calls the update action creator', () => {
@@ -78,9 +82,9 @@ describe('commandsDuck params helper', () => {
     const p = params.handleParamsCommand(action, cmdchar, put)
 
     // Then
-    return p.then((res) => {
-      expect(res.result).toEqual({'x y': 2})
-      expect(put).toHaveBeenCalledWith(update({'x y': 2}))
+    return p.then(res => {
+      expect(res.result).toEqual({ 'x y': 2 })
+      expect(put).toHaveBeenCalledWith(update({ 'x y': 2 }))
     })
   })
   test('handles :params {"hej": "ho", "let\'s": "go"} and calls the replace action creator', () => {
@@ -93,9 +97,9 @@ describe('commandsDuck params helper', () => {
     const p = params.handleParamsCommand(action, cmdchar, put)
 
     // Then
-    return p.then((res) => {
-      expect(res.result).toEqual({hej: 'ho', "let's": 'go'})
-      expect(put).toHaveBeenCalledWith(replace({hej: 'ho', "let's": 'go'}))
+    return p.then(res => {
+      expect(res.result).toEqual({ hej: 'ho', "let's": 'go' })
+      expect(put).toHaveBeenCalledWith(replace({ hej: 'ho', "let's": 'go' }))
     })
   })
   test('handles :params {x: 1, y: 2} and calls the replace action creator', () => {
@@ -108,9 +112,9 @@ describe('commandsDuck params helper', () => {
     const p = params.handleParamsCommand(action, cmdchar, put)
 
     // Then
-    return p.then((res) => {
-      expect(res.result).toEqual({x: 1, y: 2})
-      expect(put).toHaveBeenCalledWith(replace({x: 1, y: 2}))
+    return p.then(res => {
+      expect(res.result).toEqual({ x: 1, y: 2 })
+      expect(put).toHaveBeenCalledWith(replace({ x: 1, y: 2 }))
     })
   })
 })

--- a/src/shared/modules/commands/helpers/play.js
+++ b/src/shared/modules/commands/helpers/play.js
@@ -25,11 +25,13 @@ import remote from 'services/remote'
 export const fetchRemoteGuide = (url, whitelist = null) => {
   return new Promise((resolve, reject) => {
     if (!hostIsAllowed(url, whitelist)) {
-      return reject(new Error('Hostname is not allowed according to server whitelist'))
+      return reject(
+        new Error('Hostname is not allowed according to server whitelist')
+      )
     }
     resolve()
   }).then(() => {
-    return remote.get(url).then((r) => {
+    return remote.get(url).then(r => {
       return cleanHtml(r)
     })
   })

--- a/src/shared/modules/commands/helpers/server.js
+++ b/src/shared/modules/commands/helpers/server.js
@@ -22,10 +22,17 @@ import { splitStringOnFirst, splitStringOnLast } from 'services/commandUtils'
 import * as connections from 'shared/modules/connections/connectionsDuck'
 import { add as addFrameAction } from 'shared/modules/stream/streamDuck'
 import { CONNECTION_ID as DISCOVERY_CONNECTION_ID } from 'shared/modules/discovery/discoveryDuck'
-import { UnknownCommandError, getErrorMessage, AddServerValidationError } from 'services/exceptions'
+import {
+  UnknownCommandError,
+  getErrorMessage,
+  AddServerValidationError
+} from 'services/exceptions'
 
 export function handleServerCommand (action, cmdchar, put, store) {
-  const [serverCmd, props] = splitStringOnFirst(splitStringOnFirst(action.cmd.substr(cmdchar.length), ' ')[1], ' ')
+  const [serverCmd, props] = splitStringOnFirst(
+    splitStringOnFirst(action.cmd.substr(cmdchar.length), ' ')[1],
+    ' '
+  )
   if (serverCmd === 'list') {
     return handleServerListCommand(action, cmdchar, put, store)
   }
@@ -47,11 +54,15 @@ export function handleServerCommand (action, cmdchar, put, store) {
   if (serverCmd === 'status') {
     return handleServerStatusCommand(action)
   }
-  return {...action, type: 'error', error: {message: getErrorMessage(UnknownCommandError(action.cmd))}}
+  return {
+    ...action,
+    type: 'error',
+    error: { message: getErrorMessage(UnknownCommandError(action.cmd)) }
+  }
 }
 
 function handleDisconnectCommand (action, cmdchar, put, store) {
-  put(addFrameAction({...action, type: 'disconnect'}))
+  put(addFrameAction({ ...action, type: 'disconnect' }))
   const activeConnection = connections.getActiveConnection(store.getState())
   const disconnectAction = connections.disconnectAction(activeConnection)
   put(disconnectAction)
@@ -60,33 +71,38 @@ function handleDisconnectCommand (action, cmdchar, put, store) {
 
 function handleServerListCommand (action, cmdchar, put, store) {
   const state = connections.getConnections(store.getState())
-  return {...action, type: 'pre', result: JSON.stringify(state, null, 2)}
+  return { ...action, type: 'pre', result: JSON.stringify(state, null, 2) }
 }
 
 function handleUserCommand (action, props, cmdchar) {
   switch (props) {
     case 'list':
-      return {...action, type: 'user-list'}
+      return { ...action, type: 'user-list' }
     case 'add':
-      return {...action, type: 'user-add'}
+      return { ...action, type: 'user-add' }
   }
 }
 
 function handleChangePasswordCommand (action, props, cmdchar) {
-  return {...action, type: 'change-password'}
+  return { ...action, type: 'change-password' }
 }
 
 export function connectToConnection (action, connectionName, put, store) {
   const state = store.getState()
   connectionName = connectionName || DISCOVERY_CONNECTION_ID
-  const foundConnections = connections.getConnections(state).filter((c) => c && c.name === connectionName)
+  const foundConnections = connections
+    .getConnections(state)
+    .filter(c => c && c.name === connectionName)
   const connectionData = (foundConnections && foundConnections[0]) || {}
-  return {...action, type: 'connection', connectionData}
+  return { ...action, type: 'connection', connectionData }
 }
 
 function handleServerAddCommand (action, cmdchar, put, store) {
   // :server add name username:password@host:port
-  const [serverCmd, props] = splitStringOnFirst(splitStringOnFirst(action.cmd.substr(cmdchar.length), ' ')[1], ' ')
+  const [serverCmd, props] = splitStringOnFirst(
+    splitStringOnFirst(action.cmd.substr(cmdchar.length), ' ')[1],
+    ' '
+  )
   const [name, creds] = splitStringOnFirst(props, ' ')
   let [userCreds, host] = splitStringOnLast(creds, '@')
   const [username, password] = splitStringOnFirst(userCreds, ':')
@@ -96,14 +112,18 @@ function handleServerAddCommand (action, cmdchar, put, store) {
     if (!userCreds || !host) throw new AddServerValidationError()
     if (!username || !password) throw new AddServerValidationError()
   } catch (e) {
-    return {...action, type: 'error', error: {message: getErrorMessage(e)}}
+    return { ...action, type: 'error', error: { message: getErrorMessage(e) } }
   }
   host = 'bolt://' + host.replace(/bolt:\/\//, '')
-  put(connections.addConnection({name, username, password, host}))
+  put(connections.addConnection({ name, username, password, host }))
   const state = store.getState()
-  return {...action, type: 'pre', result: JSON.stringify(connections.getConnections(state), null, 2)}
+  return {
+    ...action,
+    type: 'pre',
+    result: JSON.stringify(connections.getConnections(state), null, 2)
+  }
 }
 
 function handleServerStatusCommand (action) {
-  return {...action, type: 'status'}
+  return { ...action, type: 'status' }
 }

--- a/src/shared/modules/commands/postConnectCmdEpic.test.js
+++ b/src/shared/modules/commands/postConnectCmdEpic.test.js
@@ -28,11 +28,16 @@ import * as commands from './commandsDuck'
 import { CONNECTION_SUCCESS } from 'shared/modules/connections/connectionsDuck'
 
 describe('postConnectCmdEpic', () => {
-  test('creates a SYSTEM_COMMAND_QUEUED if found', (done) => {
+  test('creates a SYSTEM_COMMAND_QUEUED if found', done => {
     // Given
     const bus = createBus()
-    const epicMiddlewareLocal = createEpicMiddleware(commands.postConnectCmdEpic)
-    const mockStoreLocal = configureMockStore([epicMiddlewareLocal, createReduxMiddleware(bus)])
+    const epicMiddlewareLocal = createEpicMiddleware(
+      commands.postConnectCmdEpic
+    )
+    const mockStoreLocal = configureMockStore([
+      epicMiddlewareLocal,
+      createReduxMiddleware(bus)
+    ])
     const command = 'play hello'
     const store = mockStoreLocal({
       settings: {
@@ -46,7 +51,7 @@ describe('postConnectCmdEpic', () => {
     })
     const action = { type: CONNECTION_SUCCESS }
     const action2 = { type: UPDATE_SETTINGS }
-    bus.take('NOOP', (currentAction) => {
+    bus.take('NOOP', currentAction => {
       // Then
       expect(store.getActions()).toEqual([
         action,
@@ -61,14 +66,19 @@ describe('postConnectCmdEpic', () => {
     store.dispatch(action)
     store.dispatch(action2)
   })
-  test('supports multiple commands', (done) => {
+  test('supports multiple commands', done => {
     // Given
     const command1 = 'play hello'
     const command2 = 'play intro'
     const command = command1 + '; ' + command2
     const bus = createBus()
-    const epicMiddlewareLocal = createEpicMiddleware(commands.postConnectCmdEpic)
-    const mockStoreLocal = configureMockStore([epicMiddlewareLocal, createReduxMiddleware(bus)])
+    const epicMiddlewareLocal = createEpicMiddleware(
+      commands.postConnectCmdEpic
+    )
+    const mockStoreLocal = configureMockStore([
+      epicMiddlewareLocal,
+      createReduxMiddleware(bus)
+    ])
     const store = mockStoreLocal({
       settings: {
         cmdchar: ':'
@@ -81,7 +91,7 @@ describe('postConnectCmdEpic', () => {
     })
     const action = { type: CONNECTION_SUCCESS }
     const action2 = { type: UPDATE_SETTINGS }
-    bus.take('NOOP', (currentAction) => {
+    bus.take('NOOP', currentAction => {
       // Then
       expect(store.getActions()).toEqual([
         action,
@@ -97,11 +107,16 @@ describe('postConnectCmdEpic', () => {
     store.dispatch(action)
     store.dispatch(action2)
   })
-  test('does nothing if settings not found', (done) => {
+  test('does nothing if settings not found', done => {
     // Given
     const bus = createBus()
-    const epicMiddlewareLocal = createEpicMiddleware(commands.postConnectCmdEpic)
-    const mockStoreLocal = configureMockStore([epicMiddlewareLocal, createReduxMiddleware(bus)])
+    const epicMiddlewareLocal = createEpicMiddleware(
+      commands.postConnectCmdEpic
+    )
+    const mockStoreLocal = configureMockStore([
+      epicMiddlewareLocal,
+      createReduxMiddleware(bus)
+    ])
     const store = mockStoreLocal({
       settings: {
         cmdchar: ':'
@@ -114,13 +129,9 @@ describe('postConnectCmdEpic', () => {
     })
     const action = { type: CONNECTION_SUCCESS }
     const action2 = { type: UPDATE_SETTINGS }
-    bus.take('NOOP', (currentAction) => {
+    bus.take('NOOP', currentAction => {
       // Then
-      expect(store.getActions()).toEqual([
-        action,
-        action2,
-        { type: 'NOOP' }
-      ])
+      expect(store.getActions()).toEqual([action, action2, { type: 'NOOP' }])
       done()
     })
 

--- a/src/shared/modules/connections/connectionsDuck.js
+++ b/src/shared/modules/connections/connectionsDuck.js
@@ -23,7 +23,12 @@ import bolt from 'services/bolt/bolt'
 import { getEncryptionMode } from 'services/bolt/boltHelpers'
 import * as discovery from 'shared/modules/discovery/discoveryDuck'
 import { executeSystemCommand } from 'shared/modules/commands/commandsDuck'
-import { getInitCmd, getSettings, getUseBoltRouting, UPDATE as SETTINGS_UPDATE } from 'shared/modules/settings/settingsDuck'
+import {
+  getInitCmd,
+  getSettings,
+  getUseBoltRouting,
+  UPDATE as SETTINGS_UPDATE
+} from 'shared/modules/settings/settingsDuck'
 import { USER_CLEAR, APP_START } from 'shared/modules/app/appDuck'
 
 export const NAME = 'connections'
@@ -34,7 +39,8 @@ export const REMOVE = 'connections/REMOVE'
 export const MERGE = 'connections/MERGE'
 export const CONNECT = 'connections/CONNECT'
 export const DISCONNECT = 'connections/DISCONNECT'
-export const STARTUP_CONNECTION_SUCCESS = 'connections/STARTUP_CONNECTION_SUCCESS'
+export const STARTUP_CONNECTION_SUCCESS =
+  'connections/STARTUP_CONNECTION_SUCCESS'
 export const STARTUP_CONNECTION_FAILED = 'connections/STARTUP_CONNECTION_FAILED'
 export const CONNECTION_SUCCESS = 'connections/CONNECTION_SUCCESS'
 export const DISCONNECTION_SUCCESS = 'connections/DISCONNECTION_SUCCESS'
@@ -58,7 +64,9 @@ const initialState = {
  * Selectors
 */
 export function getConnection (state, id) {
-  let connections = getConnections(state).filter((connection) => connection && connection.id === id)
+  let connections = getConnections(state).filter(
+    connection => connection && connection.id === id
+  )
   if (connections && connections.length > 0) {
     return connections[0]
   } else {
@@ -67,7 +75,7 @@ export function getConnection (state, id) {
 }
 
 export function getConnections (state) {
-  return state[NAME].allConnectionIds.map((id) => state[NAME].connectionsById[id])
+  return state[NAME].allConnectionIds.map(id => state[NAME].connectionsById[id])
 }
 
 export function getConnectionState (state) {
@@ -82,14 +90,15 @@ export function getActiveConnectionData (state) {
   if (!state[NAME].activeConnection) return null
   let data = state[NAME].connectionsById[state[NAME].activeConnection]
   if (data.username && data.password) return data
-  if (!(data.username && data.password) && (memoryUsername && memoryPassword)) { // No retain state
-    return {...data, username: memoryUsername, password: memoryPassword}
+  if (!(data.username && data.password) && (memoryUsername && memoryPassword)) {
+    // No retain state
+    return { ...data, username: memoryUsername, password: memoryPassword }
   }
   return data
 }
 
 const addConnectionHelper = (state, obj) => {
-  const connectionsById = {...state.connectionsById, [obj.id]: obj}
+  const connectionsById = { ...state.connectionsById, [obj.id]: obj }
   let allConnectionIds = state.allConnectionIds
   if (state.allConnectionIds.indexOf(obj.id) < 0) {
     allConnectionIds = state.allConnectionIds.concat([obj.id])
@@ -97,13 +106,13 @@ const addConnectionHelper = (state, obj) => {
   return Object.assign(
     {},
     state,
-    {allConnectionIds: allConnectionIds},
-    {connectionsById: connectionsById}
+    { allConnectionIds: allConnectionIds },
+    { connectionsById: connectionsById }
   )
 }
 
 const removeConnectionHelper = (state, connectionId) => {
-  const connectionsById = {...state.connectionsById}
+  const connectionsById = { ...state.connectionsById }
   let allConnectionIds = state.allConnectionIds
   const index = allConnectionIds.indexOf(connectionId)
   if (index > 0) {
@@ -113,14 +122,14 @@ const removeConnectionHelper = (state, connectionId) => {
   return Object.assign(
     {},
     state,
-    {allConnectionIds: allConnectionIds},
-    {connectionsById: connectionsById}
+    { allConnectionIds: allConnectionIds },
+    { connectionsById: connectionsById }
   )
 }
 
 const mergeConnectionHelper = (state, connection) => {
   const connectionId = connection.id
-  const connectionsById = {...state.connectionsById}
+  const connectionsById = { ...state.connectionsById }
   let allConnectionIds = state.allConnectionIds
   const index = allConnectionIds.indexOf(connectionId)
   if (index >= 0) {
@@ -136,8 +145,8 @@ const mergeConnectionHelper = (state, connection) => {
   return Object.assign(
     {},
     state,
-    {allConnectionIds: allConnectionIds},
-    {connectionsById: connectionsById}
+    { allConnectionIds: allConnectionIds },
+    { connectionsById: connectionsById }
   )
 }
 
@@ -151,11 +160,7 @@ const updateAuthEnabledHelper = (state, authEnabled) => {
   const updatedConnectionByIds = Object.assign({}, state.connectionsById)
   updatedConnectionByIds[connectionId] = updatedConnection
 
-  return Object.assign(
-    {},
-    state,
-    {connectionsById: updatedConnectionByIds}
-  )
+  return Object.assign({}, state, { connectionsById: updatedConnectionByIds })
 }
 
 // Local vars
@@ -174,13 +179,17 @@ export default function (state = initialState, action) {
     case SET_ACTIVE:
       let cState = CONNECTED_STATE
       if (!action.connectionId) cState = DISCONNECTED_STATE
-      return {...state, activeConnection: action.connectionId, connectionState: cState}
+      return {
+        ...state,
+        activeConnection: action.connectionId,
+        connectionState: cState
+      }
     case REMOVE:
       return removeConnectionHelper(state, action.connectionId)
     case MERGE:
       return mergeConnectionHelper(state, action.connection)
     case UPDATE_CONNECTION_STATE:
-      return {...state, connectionState: action.state}
+      return { ...state, connectionState: action.state }
     case UPDATE_AUTH_ENABLED:
       return updateAuthEnabledHelper(state, action.authEnabled)
     case USER_CLEAR:
@@ -191,51 +200,51 @@ export default function (state = initialState, action) {
 }
 
 // Actions
-export const selectConnection = (id) => {
+export const selectConnection = id => {
   return {
     type: SELECT,
     connectionId: id
   }
 }
 
-export const setActiveConnection = (id) => {
+export const setActiveConnection = id => {
   return {
     type: SET_ACTIVE,
     connectionId: id
   }
 }
 
-export const addConnection = ({name, username, password, host}) => {
+export const addConnection = ({ name, username, password, host }) => {
   return {
     type: ADD,
-    connection: {id: name, name, username, password, host, type: 'bolt'}
+    connection: { id: name, name, username, password, host, type: 'bolt' }
   }
 }
 
-export const updateConnection = (connection) => {
+export const updateConnection = connection => {
   return {
     type: MERGE,
     connection
   }
 }
 
-export const disconnectAction = (id) => {
+export const disconnectAction = id => {
   return {
     type: DISCONNECT,
     id
   }
 }
 
-export const updateConnectionState = (state) => ({
+export const updateConnectionState = state => ({
   state,
   type: UPDATE_CONNECTION_STATE
 })
 
-const onLostConnection = (dispatch) => (e) => {
+const onLostConnection = dispatch => e => {
   dispatch({ type: LOST_CONNECTION, error: e })
 }
 
-export const connectionLossFilter = (action) => {
+export const connectionLossFilter = action => {
   const notLostCodes = [
     'Neo.ClientError.Security.Unauthorized',
     'Neo.ClientError.Security.AuthenticationRateLimit'
@@ -243,14 +252,14 @@ export const connectionLossFilter = (action) => {
   return notLostCodes.indexOf(action.error.code) < 0
 }
 
-export const setRetainCredentials = (shouldRetain) => {
+export const setRetainCredentials = shouldRetain => {
   return {
     type: UPDATE_RETAIN_CREDENTIALS,
     shouldRetain
   }
 }
 
-export const setAuthEnabled = (authEnabled) => {
+export const setAuthEnabled = authEnabled => {
   return {
     type: UPDATE_AUTH_ENABLED,
     authEnabled
@@ -259,57 +268,95 @@ export const setAuthEnabled = (authEnabled) => {
 
 // Epics
 export const connectEpic = (action$, store) => {
-  return action$.ofType(CONNECT)
-    .mergeMap((action) => {
-      if (!action.$$responseChannel) return Rx.Observable.of(null)
-      memoryUsername = ''
-      memoryPassword = ''
-      return bolt.openConnection(action, { encrypted: getEncryptionMode() }, onLostConnection(store.dispatch))
-        .then((res) => ({ type: action.$$responseChannel, success: true }))
-        .catch((e) => ({ type: action.$$responseChannel, success: false, error: e }))
-    })
+  return action$.ofType(CONNECT).mergeMap(action => {
+    if (!action.$$responseChannel) return Rx.Observable.of(null)
+    memoryUsername = ''
+    memoryPassword = ''
+    return bolt
+      .openConnection(
+        action,
+        { encrypted: getEncryptionMode() },
+        onLostConnection(store.dispatch)
+      )
+      .then(res => ({ type: action.$$responseChannel, success: true }))
+      .catch(e => ({
+        type: action.$$responseChannel,
+        success: false,
+        error: e
+      }))
+  })
 }
 export const startupConnectEpic = (action$, store) => {
-  return action$.ofType(discovery.DONE)
-    .mergeMap((action) => {
-      const connection = getConnection(store.getState(), discovery.CONNECTION_ID)
-      if (!connection || !connection.host) {
-        store.dispatch(setActiveConnection(null))
-        store.dispatch(discovery.updateDiscoveryConnection({ username: 'neo4j', password: '' }))
-        return Promise.resolve({ type: STARTUP_CONNECTION_FAILED })
-      }
-      return new Promise((resolve, reject) => {
-        bolt.openConnection(connection, { withoutCredentials: true, encrypted: getEncryptionMode() }, onLostConnection(store.dispatch)) // Try without creds
-          .then((r) => {
-            store.dispatch(discovery.updateDiscoveryConnection({ username: undefined, password: undefined }))
-            store.dispatch(setActiveConnection(discovery.CONNECTION_ID))
-            resolve({ type: STARTUP_CONNECTION_SUCCESS })
-          })
-          .catch(() => {
-            if (!connection || (!connection.username && !connection.password)) { // No creds stored
-              store.dispatch(setActiveConnection(null))
-              store.dispatch(discovery.updateDiscoveryConnection({ username: 'neo4j', password: '' }))
-              return resolve({ type: STARTUP_CONNECTION_FAILED })
-            }
-            bolt.openConnection(connection, { encrypted: getEncryptionMode() }, onLostConnection(store.dispatch)) // Try with stored creds
-              .then((connection) => {
-                store.dispatch(setActiveConnection(discovery.CONNECTION_ID))
-                resolve({ type: STARTUP_CONNECTION_SUCCESS })
-              }).catch((e) => {
-                store.dispatch(setActiveConnection(null))
-                store.dispatch(discovery.updateDiscoveryConnection({ username: 'neo4j', password: '' }))
-                resolve({ type: STARTUP_CONNECTION_FAILED })
+  return action$.ofType(discovery.DONE).mergeMap(action => {
+    const connection = getConnection(store.getState(), discovery.CONNECTION_ID)
+    if (!connection || !connection.host) {
+      store.dispatch(setActiveConnection(null))
+      store.dispatch(
+        discovery.updateDiscoveryConnection({ username: 'neo4j', password: '' })
+      )
+      return Promise.resolve({ type: STARTUP_CONNECTION_FAILED })
+    }
+    return new Promise((resolve, reject) => {
+      bolt
+        .openConnection(
+          connection,
+          { withoutCredentials: true, encrypted: getEncryptionMode() },
+          onLostConnection(store.dispatch)
+        ) // Try without creds
+        .then(r => {
+          store.dispatch(
+            discovery.updateDiscoveryConnection({
+              username: undefined,
+              password: undefined
+            })
+          )
+          store.dispatch(setActiveConnection(discovery.CONNECTION_ID))
+          resolve({ type: STARTUP_CONNECTION_SUCCESS })
+        })
+        .catch(() => {
+          if (!connection || (!connection.username && !connection.password)) {
+            // No creds stored
+            store.dispatch(setActiveConnection(null))
+            store.dispatch(
+              discovery.updateDiscoveryConnection({
+                username: 'neo4j',
+                password: ''
               })
-          })
-      })
+            )
+            return resolve({ type: STARTUP_CONNECTION_FAILED })
+          }
+          bolt
+            .openConnection(
+              connection,
+              { encrypted: getEncryptionMode() },
+              onLostConnection(store.dispatch)
+            ) // Try with stored creds
+            .then(connection => {
+              store.dispatch(setActiveConnection(discovery.CONNECTION_ID))
+              resolve({ type: STARTUP_CONNECTION_SUCCESS })
+            })
+            .catch(e => {
+              store.dispatch(setActiveConnection(null))
+              store.dispatch(
+                discovery.updateDiscoveryConnection({
+                  username: 'neo4j',
+                  password: ''
+                })
+              )
+              resolve({ type: STARTUP_CONNECTION_FAILED })
+            })
+        })
     })
+  })
 }
 export const startupConnectionSuccessEpic = (action$, store) => {
-  return action$.ofType(STARTUP_CONNECTION_SUCCESS)
+  return action$
+    .ofType(STARTUP_CONNECTION_SUCCESS)
     .mapTo(executeSystemCommand(getInitCmd(store.getState()))) // execute initCmd from settings
 }
 export const startupConnectionFailEpic = (action$, store) => {
-  return action$.ofType(STARTUP_CONNECTION_FAILED)
+  return action$
+    .ofType(STARTUP_CONNECTION_FAILED)
     .mapTo(
       executeSystemCommand(
         getSettings(store.getState()).cmdchar + 'server connect'
@@ -319,71 +366,104 @@ export const startupConnectionFailEpic = (action$, store) => {
 
 let lastActiveConnectionId = null
 export const detectActiveConnectionChangeEpic = (action$, store) => {
-  return action$.ofType(SET_ACTIVE)
-    .mergeMap((action) => {
-      if (lastActiveConnectionId === action.connectionId) return Rx.Observable.never() // no change
-      lastActiveConnectionId = action.connectionId
-      if (!action.connectionId) return Rx.Observable.of({ type: DISCONNECTION_SUCCESS }) // disconnect
-      return Rx.Observable.of({ type: CONNECTION_SUCCESS }) // connect
-    })
+  return action$.ofType(SET_ACTIVE).mergeMap(action => {
+    if (lastActiveConnectionId === action.connectionId) {
+      return Rx.Observable.never()
+    } // no change
+    lastActiveConnectionId = action.connectionId
+    if (!action.connectionId) {
+      return Rx.Observable.of({ type: DISCONNECTION_SUCCESS })
+    } // disconnect
+    return Rx.Observable.of({ type: CONNECTION_SUCCESS }) // connect
+  })
 }
 export const disconnectEpic = (action$, store) => {
-  return action$.ofType(DISCONNECT).merge(action$.ofType(USER_CLEAR))
+  return action$
+    .ofType(DISCONNECT)
+    .merge(action$.ofType(USER_CLEAR))
     .do(() => bolt.closeConnection())
-    .do((action) => store.dispatch(updateConnection({ id: action.id, password: '' })))
+    .do(action =>
+      store.dispatch(updateConnection({ id: action.id, password: '' }))
+    )
     .mapTo(setActiveConnection(null))
 }
 export const disconnectSuccessEpic = (action$, store) => {
-  return action$.ofType(DISCONNECTION_SUCCESS)
+  return action$
+    .ofType(DISCONNECTION_SUCCESS)
     .mapTo(
-      executeSystemCommand(getSettings(store.getState()).cmdchar + 'server connect')
+      executeSystemCommand(
+        getSettings(store.getState()).cmdchar + 'server connect'
+      )
     )
 }
 export const connectionLostEpic = (action$, store) =>
-  action$.ofType(LOST_CONNECTION)
+  action$
+    .ofType(LOST_CONNECTION)
     .filter(connectionLossFilter)
     .throttleTime(5000)
     .do(() => store.dispatch(updateConnectionState(PENDING_STATE)))
-    .mergeMap((action) => {
+    .mergeMap(action => {
       const connection = getActiveConnectionData(store.getState())
       if (!connection) return Rx.Observable.of(1)
-      return Rx.Observable.of(1).mergeMap(() => {
-        return new Promise((resolve, reject) => {
-          bolt.directConnect(connection, {}, (e) => setTimeout(() => reject(new Error('Couldnt reconnect. Lost.')), 4000))
-            .then((s) => {
-              bolt.closeConnection()
-              bolt.openConnection(connection, {}, onLostConnection(store.dispatch))
-              .then(() => {
-                store.dispatch(updateConnectionState(CONNECTED_STATE))
-                resolve()
-              }).catch((e) => reject(new Error('Error on connect')))
-            })
-            .catch((e) => setTimeout(() => reject(new Error('Couldnt reconnect.')), 4000))
+      return Rx.Observable
+        .of(1)
+        .mergeMap(() => {
+          return new Promise((resolve, reject) => {
+            bolt
+              .directConnect(connection, {}, e =>
+                setTimeout(
+                  () => reject(new Error('Couldnt reconnect. Lost.')),
+                  4000
+                )
+              )
+              .then(s => {
+                bolt.closeConnection()
+                bolt
+                  .openConnection(
+                    connection,
+                    {},
+                    onLostConnection(store.dispatch)
+                  )
+                  .then(() => {
+                    store.dispatch(updateConnectionState(CONNECTED_STATE))
+                    resolve()
+                  })
+                  .catch(e => reject(new Error('Error on connect')))
+              })
+              .catch(e =>
+                setTimeout(() => reject(new Error('Couldnt reconnect.')), 4000)
+              )
+          })
         })
-      })
-      .retry(5)
-      .catch((e) => {
-        bolt.closeConnection()
-        store.dispatch(setActiveConnection(null))
-        return Rx.Observable.of(1)
-      })
-      .map(() => Rx.Observable.of(1))
+        .retry(5)
+        .catch(e => {
+          bolt.closeConnection()
+          store.dispatch(setActiveConnection(null))
+          return Rx.Observable.of(1)
+        })
+        .map(() => Rx.Observable.of(1))
     })
     .mapTo({ type: 'NOOP' })
 
 export const checkSettingsForRoutingDriver = (action$, store) => {
-  return action$.ofType(SETTINGS_UPDATE).merge(action$.ofType(APP_START))
-    .map((action) => {
+  return action$
+    .ofType(SETTINGS_UPDATE)
+    .merge(action$.ofType(APP_START))
+    .map(action => {
       bolt.useRoutingConfig(getUseBoltRouting(store.getState()))
       return { type: 'NOOP' }
     })
 }
 
 export const retainCredentialsSettingsEpic = (action$, store) => {
-  return action$.ofType(UPDATE_RETAIN_CREDENTIALS)
-    .do((action) => {
+  return action$
+    .ofType(UPDATE_RETAIN_CREDENTIALS)
+    .do(action => {
       const connection = getActiveConnectionData(store.getState())
-      if (!action.shouldRetain && (connection.username || connection.password)) {
+      if (
+        !action.shouldRetain &&
+        (connection.username || connection.password)
+      ) {
         memoryUsername = connection.username
         memoryPassword = connection.password
         connection.username = ''

--- a/src/shared/modules/connections/connectionsDuck.test.js
+++ b/src/shared/modules/connections/connectionsDuck.test.js
@@ -23,7 +23,11 @@ import configureMockStore from 'redux-mock-store'
 import { createEpicMiddleware } from 'redux-observable'
 import { createBus, createReduxMiddleware } from 'suber'
 import reducer, * as connections from './connectionsDuck'
-import { DONE as DISCOVERY_DONE, CONNECTION_ID, updateDiscoveryConnection } from 'shared/modules/discovery/discoveryDuck'
+import {
+  DONE as DISCOVERY_DONE,
+  CONNECTION_ID,
+  updateDiscoveryConnection
+} from 'shared/modules/discovery/discoveryDuck'
 
 import bolt from 'services/bolt/bolt'
 jest.mock('services/bolt/bolt', () => {
@@ -44,19 +48,21 @@ describe('connections reducer', () => {
     }
     const nextState = reducer(undefined, action)
     expect(nextState.allConnectionIds).toEqual(['x'])
-    expect(nextState.connectionsById).toEqual({'x': {
-      id: 'x',
-      name: 'bm'
-    }})
+    expect(nextState.connectionsById).toEqual({
+      x: {
+        id: 'x',
+        name: 'bm'
+      }
+    })
   })
 
   test('handles connections.SET_ACTIVE', () => {
     const initialState = {
       allConnectionIds: [1, 2, 3],
       connectionsById: {
-        '1': {id: 1, name: 'bm1'},
-        '2': {id: 2, name: 'bm2'},
-        '3': {id: 3, name: 'bm3'}
+        '1': { id: 1, name: 'bm1' },
+        '2': { id: 2, name: 'bm2' },
+        '3': { id: 3, name: 'bm3' }
       }
     }
     const action = {
@@ -71,9 +77,9 @@ describe('connections reducer', () => {
     const initialState = {
       allConnectionIds: [1, 2, 3],
       connectionsById: {
-        '1': {id: 1, name: 'bm1'},
-        '2': {id: 2, name: 'bm2'},
-        '3': {id: 3, name: 'bm3'}
+        '1': { id: 1, name: 'bm1' },
+        '2': { id: 2, name: 'bm2' },
+        '3': { id: 3, name: 'bm3' }
       }
     }
     const action = {
@@ -89,9 +95,9 @@ describe('connections reducer', () => {
     const initialState = {
       allConnectionIds: [1, 2, 3],
       connectionsById: {
-        '1': {id: 1, name: 'bm1'},
-        '2': {id: 2, name: 'bm2'},
-        '3': {id: 3, name: 'bm3'}
+        '1': { id: 1, name: 'bm1' },
+        '2': { id: 2, name: 'bm2' },
+        '3': { id: 3, name: 'bm3' }
       }
     }
     const action = {
@@ -105,7 +111,12 @@ describe('connections reducer', () => {
     }
     const nextState = reducer(initialState, action)
     expect(nextState.allConnectionIds).toEqual([1, 2, 3])
-    expect(nextState.connectionsById['1']).toEqual({id: 1, name: 'bm1', username: 'new user', password: 'different password'})
+    expect(nextState.connectionsById['1']).toEqual({
+      id: 1,
+      name: 'bm1',
+      username: 'new user',
+      password: 'different password'
+    })
   })
 
   test('handles connections.MERGE (add connection)', () => {
@@ -118,17 +129,22 @@ describe('connections reducer', () => {
     }
     const nextState = reducer(undefined, action)
     expect(nextState.allConnectionIds).toEqual(['x'])
-    expect(nextState.connectionsById).toEqual({'x': {
-      id: 'x',
-      name: 'bm'
-    }})
+    expect(nextState.connectionsById).toEqual({
+      x: {
+        id: 'x',
+        name: 'bm'
+      }
+    })
   })
 })
 
 describe('connectionsDucks Epics', () => {
   const bus = createBus()
   const epicMiddleware = createEpicMiddleware(connections.disconnectEpic)
-  const mockStore = configureMockStore([epicMiddleware, createReduxMiddleware(bus)])
+  const mockStore = configureMockStore([
+    epicMiddleware,
+    createReduxMiddleware(bus)
+  ])
   let store
   beforeAll(() => {
     store = mockStore({
@@ -150,7 +166,7 @@ describe('connectionsDucks Epics', () => {
     store.clearActions()
     bus.reset()
   })
-  test('disconnectEpic', (done) => {
+  test('disconnectEpic', done => {
     // Given
     const id = 'xxx'
     const action = connections.disconnectAction(id)
@@ -159,7 +175,7 @@ describe('connectionsDucks Epics', () => {
     epicMiddleware.replaceEpic(connections.disconnectEpic)
     store.dispatch(connections.setActiveConnection(id)) // set an active connection
     store.clearActions()
-    bus.take(connections.SET_ACTIVE, (currentAction) => {
+    bus.take(connections.SET_ACTIVE, currentAction => {
       // Then
       expect(store.getActions()).toEqual([
         action,
@@ -178,7 +194,7 @@ describe('connectionsDucks Epics', () => {
     bolt.openConnection.mockReturnValueOnce(Promise.resolve())
 
     const p = new Promise((resolve, reject) => {
-      bus.take(connections.STARTUP_CONNECTION_FAILED, (currentAction) => {
+      bus.take(connections.STARTUP_CONNECTION_FAILED, currentAction => {
         // Then
         try {
           expect(store.getActions()).toEqual([
@@ -204,15 +220,12 @@ describe('connectionsDucks Epics', () => {
     // Return
     return p
   })
-  test('detectActiveConnectionChangeEpic', (done) => {
+  test('detectActiveConnectionChangeEpic', done => {
     // Given
     const action = connections.setActiveConnection(null)
-    bus.take(connections.DISCONNECTION_SUCCESS, (currentAction) => {
+    bus.take(connections.DISCONNECTION_SUCCESS, currentAction => {
       // Then
-      expect(store.getActions()).toEqual([
-        action,
-        currentAction
-      ])
+      expect(store.getActions()).toEqual([action, currentAction])
       expect(bolt.closeConnection).toHaveBeenCalledTimes(1)
       done()
     })
@@ -228,7 +241,10 @@ describe('connectionsDucks Epics', () => {
 describe('startupConnectEpic', () => {
   const bus = createBus()
   const epicMiddleware = createEpicMiddleware(connections.startupConnectEpic)
-  const mockStore = configureMockStore([epicMiddleware, createReduxMiddleware(bus)])
+  const mockStore = configureMockStore([
+    epicMiddleware,
+    createReduxMiddleware(bus)
+  ])
   let store
   beforeAll(() => {
     bolt.openConnection.mockReset()
@@ -259,7 +275,7 @@ describe('startupConnectEpic', () => {
     bolt.openConnection.mockReturnValue(Promise.reject()) // eslint-disable-line
 
     const p = new Promise((resolve, reject) => {
-      bus.take(connections.STARTUP_CONNECTION_FAILED, (currentAction) => {
+      bus.take(connections.STARTUP_CONNECTION_FAILED, currentAction => {
         // Then
         const actions = store.getActions()
         try {
@@ -290,8 +306,13 @@ describe('startupConnectEpic', () => {
 describe('retainCredentialsSettingsEpic', () => {
   // Given
   const bus = createBus()
-  const epicMiddleware = createEpicMiddleware(connections.retainCredentialsSettingsEpic)
-  const myMockStore = configureMockStore([epicMiddleware, createReduxMiddleware(bus)])
+  const epicMiddleware = createEpicMiddleware(
+    connections.retainCredentialsSettingsEpic
+  )
+  const myMockStore = configureMockStore([
+    epicMiddleware,
+    createReduxMiddleware(bus)
+  ])
   let store
   beforeAll(() => {
     bus.reset()
@@ -299,7 +320,7 @@ describe('retainCredentialsSettingsEpic', () => {
       connections: {
         activeConnection: 'xxx',
         connectionsById: {
-          xxx: {id: 'xxx', username: 'usr', password: 'pw'}
+          xxx: { id: 'xxx', username: 'usr', password: 'pw' }
         },
         allConnectionIds: ['xxx']
       }
@@ -309,10 +330,10 @@ describe('retainCredentialsSettingsEpic', () => {
     store.clearActions()
     bus.reset()
   })
-  test('Dispatches an action to remove credentials from localstorage', (done) => {
+  test('Dispatches an action to remove credentials from localstorage', done => {
     // Given
     const action = connections.setRetainCredentials(false)
-    bus.take('NOOP', (currentAction) => {
+    bus.take('NOOP', currentAction => {
       // Then
       expect(store.getActions()).toEqual([
         action,

--- a/src/shared/modules/credentialsPolicy/credentialsPolicyDuck.js
+++ b/src/shared/modules/credentialsPolicy/credentialsPolicyDuck.js
@@ -20,7 +20,10 @@
 
 import { USER_INTERACTION } from 'shared/modules/userInteraction/userInteractionDuck'
 import { credentialsTimeout } from 'shared/modules/dbMeta/dbMetaDuck'
-import { disconnectAction, getActiveConnection } from 'shared/modules/connections/connectionsDuck'
+import {
+  disconnectAction,
+  getActiveConnection
+} from 'shared/modules/connections/connectionsDuck'
 import { parseTimeMillis } from 'services/utils'
 
 // Local variables (used in epics)
@@ -28,8 +31,9 @@ let timer = null
 
 // Epics
 export const credentialsTimeoutEpic = (action$, store) =>
-  action$.ofType(USER_INTERACTION)
-    .do((action) => {
+  action$
+    .ofType(USER_INTERACTION)
+    .do(action => {
       const cTimeout = parseTimeMillis(credentialsTimeout(store.getState()))
       if (!cTimeout) return clearTimeout(timer)
       clearTimeout(timer)
@@ -40,4 +44,4 @@ export const credentialsTimeoutEpic = (action$, store) =>
         }
       }, cTimeout)
     })
-    .mapTo({type: 'NOOP'})
+    .mapTo({ type: 'NOOP' })

--- a/src/shared/modules/currentUser/currentUserDuck.test.js
+++ b/src/shared/modules/currentUser/currentUserDuck.test.js
@@ -29,7 +29,7 @@ describe('user reducer current info', () => {
       info: {}
     }
     const nextState = reducer(undefined, action)
-    expect(dehydrate(nextState)).toEqual({info: null})
+    expect(dehydrate(nextState)).toEqual({ info: null })
   })
   test('should have no info', () => {
     const action = {
@@ -43,10 +43,10 @@ describe('user reducer current info', () => {
   test('should set info', () => {
     const action = {
       type: currentUser.UPDATE_CURRENT_USER,
-      info: {username: 'username', roles: ['king']}
+      info: { username: 'username', roles: ['king'] }
     }
-    const nextState = reducer({a: 'b'}, action)
-    expect(nextState.info).toEqual({username: 'username', roles: ['king']})
+    const nextState = reducer({ a: 'b' }, action)
+    expect(nextState.info).toEqual({ username: 'username', roles: ['king'] })
   })
 })
 
@@ -54,7 +54,7 @@ describe('User info actions', () => {
   test('should handle updating current user', () => {
     const username = 'username'
     const roles = 'roles'
-    const expectedUser = {username, roles}
+    const expectedUser = { username, roles }
     expect(currentUser.updateCurrentUser(username, roles)).toEqual({
       type: currentUser.UPDATE_CURRENT_USER,
       info: expectedUser

--- a/src/shared/modules/cypher/boltUserHelper.js
+++ b/src/shared/modules/cypher/boltUserHelper.js
@@ -24,7 +24,11 @@ export function listUsersQuery () {
 export function listRolesQuery () {
   return 'CALL dbms.security.listRoles YIELD role'
 }
-export function createDatabaseUser ({username, password, forcePasswordChange}) {
+export function createDatabaseUser ({
+  username,
+  password,
+  forcePasswordChange
+}) {
   return `CALL dbms.security.createUser("${username}", "${password}", ${forcePasswordChange})`
 }
 export function deleteUser (username) {

--- a/src/shared/modules/cypher/procedureFactory.js
+++ b/src/shared/modules/cypher/procedureFactory.js
@@ -18,9 +18,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export const changeCurrentUsersPasswordQueryObj = (newPw) => ({
+export const changeCurrentUsersPasswordQueryObj = newPw => ({
   query: 'CALL dbms.security.changePassword($password)',
-  parameters: {password: newPw}
+  parameters: { password: newPw }
 })
 
 export const listAvailableProcedures = 'CALL dbms.procedures()'

--- a/src/shared/modules/cypher/queriesProcedureHelper.js
+++ b/src/shared/modules/cypher/queriesProcedureHelper.js
@@ -18,12 +18,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export const getCausalClusterAddresses = 'CALL dbms.cluster.overview YIELD addresses'
+export const getCausalClusterAddresses =
+  'CALL dbms.cluster.overview YIELD addresses'
 
 export function listQueriesProcedure () {
   return 'CALL dbms.listQueries'
 }
 
 export function killQueriesProcedure (queryIdList) {
-  return 'CALL dbms.killQueries([' + queryIdList.map(q => '"' + q + '"').join() + '])'
+  return (
+    'CALL dbms.killQueries([' +
+    queryIdList.map(q => '"' + q + '"').join() +
+    '])'
+  )
 }

--- a/src/shared/modules/dbMeta/dbMetaDuck.js
+++ b/src/shared/modules/dbMeta/dbMetaDuck.js
@@ -20,7 +20,11 @@
 
 import Rx from 'rxjs/Rx'
 import bolt from 'services/bolt/bolt'
-import { getJmxValues, getServerConfig, isConfigValFalsy } from 'services/bolt/boltHelpers'
+import {
+  getJmxValues,
+  getServerConfig,
+  isConfigValFalsy
+} from 'services/bolt/boltHelpers'
 import { APP_START } from 'shared/modules/app/appDuck'
 import {
   CONNECTED_STATE,
@@ -45,7 +49,7 @@ export const FORCE_FETCH = 'meta/FORCE_FETCH'
  * Selectors
  */
 export function getMetaInContext (state, context) {
-  const inCurrentContext = (e) => e.context === context
+  const inCurrentContext = e => e.context === context
 
   const labels = state.labels.filter(inCurrentContext)
   const relationshipTypes = state.relationshipTypes.filter(inCurrentContext)
@@ -62,21 +66,27 @@ export function getMetaInContext (state, context) {
   }
 }
 
-export const getVersion = (state) => state[NAME].server.version
-export const getEdition = (state) => state[NAME].server.edition
-export const getDbName = (state) => state[NAME].server.dbName
-export const getStoreSize = (state) => state[NAME].server.storeSize
-export const getClusterRole = (state) => state[NAME].role
-export const isEnterprise = (state) => state[NAME].server.edition === 'enterprise'
-export const isBeta = (state) => /-/.test(state[NAME].server.version)
-export const getStoreId = (state) => state[NAME].server.storeId
+export const getVersion = state => state[NAME].server.version
+export const getEdition = state => state[NAME].server.edition
+export const getDbName = state => state[NAME].server.dbName
+export const getStoreSize = state => state[NAME].server.storeSize
+export const getClusterRole = state => state[NAME].role
+export const isEnterprise = state => state[NAME].server.edition === 'enterprise'
+export const isBeta = state => /-/.test(state[NAME].server.version)
+export const getStoreId = state => state[NAME].server.storeId
 
-export const getAvailableSettings = (state) => (state[NAME] || initialState).settings
-export const allowOutgoingConnections = (state) => getAvailableSettings(state)['browser.allow_outgoing_connections']
-export const credentialsTimeout = (state) => getAvailableSettings(state)['browser.credential_timeout'] || 0
-export const getRemoteContentHostnameWhitelist = (state) => getAvailableSettings(state)['browser.remote_content_hostname_whitelist'] || initialState.settings['browser.remote_content_hostname_whitelist']
-export const shouldRetainConnectionCredentials = (state) => {
-  const conf = getAvailableSettings(state)['browser.retain_connection_credentials']
+export const getAvailableSettings = state =>
+  (state[NAME] || initialState).settings
+export const allowOutgoingConnections = state =>
+  getAvailableSettings(state)['browser.allow_outgoing_connections']
+export const credentialsTimeout = state =>
+  getAvailableSettings(state)['browser.credential_timeout'] || 0
+export const getRemoteContentHostnameWhitelist = state =>
+  getAvailableSettings(state)['browser.remote_content_hostname_whitelist'] ||
+  initialState.settings['browser.remote_content_hostname_whitelist']
+export const shouldRetainConnectionCredentials = state => {
+  const settings = getAvailableSettings(state)
+  const conf = settings['browser.retain_connection_credentials']
   if (conf === null || typeof conf === 'undefined') return true
   return !isConfigValFalsy(conf)
 }
@@ -85,39 +95,39 @@ export const shouldRetainConnectionCredentials = (state) => {
  * Helpers
  */
 function updateMetaForContext (state, meta, context) {
-  const notInCurrentContext = (e) => e.context !== context
-  const mapResult = (metaIndex, mapFunction) => meta.records[metaIndex].get(1).map(mapFunction)
-  const mapSingleValue = (r) => ({ val: r, context })
-  const mapInvokableValue = (r) => {
+  const notInCurrentContext = e => e.context !== context
+  const mapResult = (metaIndex, mapFunction) =>
+    meta.records[metaIndex].get(1).map(mapFunction)
+  const mapSingleValue = r => ({ val: r, context })
+  const mapInvokableValue = r => {
     const { name, signature, description } = r
     return {
-      val: name, context, signature, description
+      val: name,
+      context,
+      signature,
+      description
     }
   }
 
-  const compareMetaItems = (a, b) => a.val < b.val ? -1 : (a.val > b.val ? 1 : 0)
+  const compareMetaItems = (a, b) =>
+    a.val < b.val ? -1 : a.val > b.val ? 1 : 0
 
-  const labels = state
-    .labels
+  const labels = state.labels
     .filter(notInCurrentContext)
     .concat(mapResult(0, mapSingleValue))
     .sort(compareMetaItems)
-  const relationshipTypes = state
-    .relationshipTypes
+  const relationshipTypes = state.relationshipTypes
     .filter(notInCurrentContext)
     .concat(mapResult(1, mapSingleValue))
     .sort(compareMetaItems)
-  const properties = state
-    .properties
+  const properties = state.properties
     .filter(notInCurrentContext)
     .concat(mapResult(2, mapSingleValue))
     .sort(compareMetaItems)
-  const functions = state
-    .functions
+  const functions = state.functions
     .filter(notInCurrentContext)
     .concat(mapResult(3, mapInvokableValue))
-  const procedures = state
-    .procedures
+  const procedures = state.procedures
     .filter(notInCurrentContext)
     .concat(mapResult(4, mapInvokableValue))
 
@@ -164,12 +174,18 @@ export default function meta (state = initialState, action) {
       const { type, ...rest } = action // eslint-disable-line
       return { ...state, ...rest }
     case UPDATE_META:
-      return {...state, ...updateMetaForContext(state, action.meta, action.context)}
+      return {
+        ...state,
+        ...updateMetaForContext(state, action.meta, action.context)
+      }
     case UPDATE_SERVER:
       const { version, edition, storeId, dbName, storeSize } = action
-      return {...state, server: { version, edition, storeId, dbName, storeSize }}
+      return {
+        ...state,
+        server: { version, edition, storeId, dbName, storeSize }
+      }
     case UPDATE_SETTINGS:
-      return {...state, settings: { ...action.settings }}
+      return { ...state, settings: { ...action.settings } }
     case CLEAR:
       return { ...initialState }
     default:
@@ -191,14 +207,14 @@ export function fetchMetaData () {
   }
 }
 
-export const update = (obj) => {
+export const update = obj => {
   return {
     type: UPDATE,
     ...obj
   }
 }
 
-export const updateSettings = (settings) => {
+export const updateSettings = settings => {
   return {
     type: UPDATE_SETTINGS,
     settings
@@ -229,95 +245,110 @@ RETURN 'procedures' as a, procedures as result
 `
 
 export const dbMetaEpic = (some$, store) =>
-  some$.ofType(UPDATE_CONNECTION_STATE).filter((s) => s.state === CONNECTED_STATE)
+  some$
+    .ofType(UPDATE_CONNECTION_STATE)
+    .filter(s => s.state === CONNECTED_STATE)
     .merge(some$.ofType(CONNECTION_SUCCESS))
     .mergeMap(() => {
-      return Rx.Observable.timer(0, 20000)
-        .merge(some$.ofType(FORCE_FETCH))
-        // Labels, types and propertyKeys
-        .mergeMap(() =>
-          Rx.Observable
-            .fromPromise(bolt.routedReadTransaction(metaQuery))
-            .catch((e) => Rx.Observable.of(null))
-        )
-        .filter((r) => r)
-        .do((res) => store.dispatch(updateMeta(res)))
-        // Version and edition
-        .mergeMap(() => {
-          return Rx.Observable
-            .fromPromise(getJmxValues([
-              ['Kernel', 'KernelVersion'],
-              ['Kernel', 'StoreId'],
-              ['Kernel', 'DatabaseName'],
-              ['Configuration', 'unsupported.dbms.edition'],
-              ['Store file sizes', 'TotalStoreSize']
-            ]))
-            .catch((e) => Rx.Observable.of(null))
-        })
-        .do((res) => {
-          if (!res) return
-          const [ kvObj, storeObj, nameObj, edObj, sizeObj ] = res
-          const versionMatch = kvObj.KernelVersion.match(/version:\s([^,$]+)/)
-          const version = (versionMatch !== null && versionMatch.length > 1) ? versionMatch[1] : null
-          const edition = edObj['unsupported.dbms.edition']
-          const storeId = storeObj['StoreId']
-          const dbName = nameObj['DatabaseName']
-          const storeSize = sizeObj['TotalStoreSize']
-          store.dispatch({
-            type: UPDATE_SERVER,
-            version,
-            edition,
-            storeId,
-            dbName,
-            storeSize
+      return (
+        Rx.Observable
+          .timer(0, 20000)
+          .merge(some$.ofType(FORCE_FETCH))
+          // Labels, types and propertyKeys
+          .mergeMap(() =>
+            Rx.Observable
+              .fromPromise(bolt.routedReadTransaction(metaQuery))
+              .catch(e => Rx.Observable.of(null))
+          )
+          .filter(r => r)
+          .do(res => store.dispatch(updateMeta(res)))
+          // Version and edition
+          .mergeMap(() => {
+            return Rx.Observable
+              .fromPromise(
+                getJmxValues([
+                  ['Kernel', 'KernelVersion'],
+                  ['Kernel', 'StoreId'],
+                  ['Kernel', 'DatabaseName'],
+                  ['Configuration', 'unsupported.dbms.edition'],
+                  ['Store file sizes', 'TotalStoreSize']
+                ])
+              )
+              .catch(e => Rx.Observable.of(null))
           })
-        })
-        // Server config for browser
-        .mergeMap(() => {
-          return getServerConfig(['browser.'])
-            .then((settings) => {
+          .do(res => {
+            if (!res) return
+            const [kvObj, storeObj, nameObj, edObj, sizeObj] = res
+            const versionMatch = kvObj.KernelVersion.match(/version:\s([^,$]+)/)
+            const version =
+              versionMatch !== null && versionMatch.length > 1
+                ? versionMatch[1]
+                : null
+            const edition = edObj['unsupported.dbms.edition']
+            const storeId = storeObj['StoreId']
+            const dbName = nameObj['DatabaseName']
+            const storeSize = sizeObj['TotalStoreSize']
+            store.dispatch({
+              type: UPDATE_SERVER,
+              version,
+              edition,
+              storeId,
+              dbName,
+              storeSize
+            })
+          })
+          // Server config for browser
+          .mergeMap(() => {
+            return getServerConfig(['browser.']).then(settings => {
               if (!settings) return
               let retainCredentials = true
-              if ( // Check if we should wipe user creds from localstorage
-                typeof settings['browser.retain_connection_credentials'] !== 'undefined' &&
-                isConfigValFalsy(settings['browser.retain_connection_credentials'])
+              if (
+                // Check if we should wipe user creds from localstorage
+                typeof settings['browser.retain_connection_credentials'] !==
+                  'undefined' &&
+                isConfigValFalsy(
+                  settings['browser.retain_connection_credentials']
+                )
               ) {
                 retainCredentials = false
               }
               store.dispatch(setRetainCredentials(retainCredentials))
               store.dispatch(updateSettings(settings))
             })
-        })
-        // Server security settings
-        .mergeMap(() => {
-          return getServerConfig(['dbms.security'])
-            .then((settings) => {
+          })
+          // Server security settings
+          .mergeMap(() => {
+            return getServerConfig(['dbms.security']).then(settings => {
               if (!settings) return
               const authEnabledSetting = 'dbms.security.auth_enabled'
               let authEnabled = true
-              if (typeof settings[authEnabledSetting] !== 'undefined' && isConfigValFalsy(settings[authEnabledSetting])) {
+              if (
+                typeof settings[authEnabledSetting] !== 'undefined' &&
+                isConfigValFalsy(settings[authEnabledSetting])
+              ) {
                 authEnabled = false
               }
               store.dispatch(setAuthEnabled(authEnabled))
             })
-        })
-        // Cluster role
-        .mergeMap(() =>
-          Rx.Observable
-            .fromPromise(bolt.directTransaction('CALL dbms.cluster.role() YIELD role'))
-            .catch((e) => Rx.Observable.of(null))
-            .do((res) => {
-              if (!res) return Rx.Observable.of(null)
-              const role = res.records[0].get(0)
-              store.dispatch(update({ role }))
-              return Rx.Observable.of(null)
-            })
-        )
-
-        .takeUntil(some$.ofType(LOST_CONNECTION).filter(connectionLossFilter))
-        .mapTo({ type: 'NOOP' })
+          })
+          // Cluster role
+          .mergeMap(() =>
+            Rx.Observable
+              .fromPromise(
+                bolt.directTransaction('CALL dbms.cluster.role() YIELD role')
+              )
+              .catch(e => Rx.Observable.of(null))
+              .do(res => {
+                if (!res) return Rx.Observable.of(null)
+                const role = res.records[0].get(0)
+                store.dispatch(update({ role }))
+                return Rx.Observable.of(null)
+              })
+          )
+          .takeUntil(some$.ofType(LOST_CONNECTION).filter(connectionLossFilter))
+          .mapTo({ type: 'NOOP' })
+      )
     })
 
 export const clearMetaOnDisconnectEpic = (some$, store) =>
-  some$.ofType(DISCONNECTION_SUCCESS)
-    .mapTo({ type: CLEAR })
+  some$.ofType(DISCONNECTION_SUCCESS).mapTo({ type: CLEAR })

--- a/src/shared/modules/dbMeta/dbMetaDuck.test.js
+++ b/src/shared/modules/dbMeta/dbMetaDuck.test.js
@@ -25,10 +25,10 @@ import { APP_START } from 'shared/modules/app/appDuck'
 describe('hydrating state', () => {
   test('should merge inital state and state on load', () => {
     // Given
-    const action = {type: APP_START}
+    const action = { type: APP_START }
 
     // When
-    const hydratedState = reducer({'foo': 'bar'}, action)
+    const hydratedState = reducer({ foo: 'bar' }, action)
 
     // Then
     expect(hydratedState).toMatchSnapshot()
@@ -58,7 +58,11 @@ describe('updating metadata', () => {
       a: 'functions',
       get: () => {
         return [
-          { name: 'ns.functionName', signature: 'functionSignature', description: 'functionDescription' }
+          {
+            name: 'ns.functionName',
+            signature: 'functionSignature',
+            description: 'functionDescription'
+          }
         ]
       }
     }
@@ -66,7 +70,11 @@ describe('updating metadata', () => {
       a: 'procedures',
       get: () => {
         return [
-          { name: 'ns.procedureName', signature: 'procedureSignature', description: 'procedureDescription' }
+          {
+            name: 'ns.procedureName',
+            signature: 'procedureSignature',
+            description: 'procedureDescription'
+          }
         ]
       }
     }
@@ -182,7 +190,7 @@ describe('updating metadata', () => {
     // Given
     const initState = {
       shouldKeep: false,
-      'server': {
+      server: {
         edition: 'enterprise',
         storeId: 'xxxx',
         version: '3.2.0-RC2'

--- a/src/shared/modules/discovery/discoveryDuck.test.js
+++ b/src/shared/modules/discovery/discoveryDuck.test.js
@@ -31,7 +31,10 @@ import { getDiscoveryEndpoint } from 'services/bolt/boltHelpers'
 
 const bus = createBus()
 const epicMiddleware = createEpicMiddleware(discovery.discoveryOnStartupEpic)
-const mockStore = configureMockStore([epicMiddleware, createReduxMiddleware(bus)])
+const mockStore = configureMockStore([
+  epicMiddleware,
+  createReduxMiddleware(bus)
+])
 
 describe('discoveryOnStartupEpic', () => {
   let store
@@ -46,17 +49,16 @@ describe('discoveryOnStartupEpic', () => {
     store.clearActions()
   })
 
-  test('listens on APP_START and tries to find a bolt host and sets it to default when bolt discovery not found', (done) => {
+  test('listens on APP_START and tries to find a bolt host and sets it to default when bolt discovery not found', done => {
     // Given
     const action = { type: APP_START }
-    nock(getDiscoveryEndpoint()).get('/').reply(200, { http: 'http://localhost:7474' })
+    nock(getDiscoveryEndpoint())
+      .get('/')
+      .reply(200, { http: 'http://localhost:7474' })
 
-    bus.take(discovery.DONE, (currentAction) => {
+    bus.take(discovery.DONE, currentAction => {
       // Then
-      expect(store.getActions()).toEqual([
-        action,
-        { type: discovery.DONE }
-      ])
+      expect(store.getActions()).toEqual([action, { type: discovery.DONE }])
       done()
     })
 
@@ -64,17 +66,14 @@ describe('discoveryOnStartupEpic', () => {
     store.dispatch(action)
   })
 
-  test('listens on APP_START and tries to find a bolt host and sets it to default when fail on server error', (done) => {
+  test('listens on APP_START and tries to find a bolt host and sets it to default when fail on server error', done => {
     // Given
     const action = { type: APP_START }
     nock(getDiscoveryEndpoint()).get('/').reply(500)
 
-    bus.take(discovery.DONE, (currentAction) => {
+    bus.take(discovery.DONE, currentAction => {
       // Then
-      expect(store.getActions()).toEqual([
-        action,
-        { type: discovery.DONE }
-      ])
+      expect(store.getActions()).toEqual([action, { type: discovery.DONE }])
       done()
     })
 
@@ -82,12 +81,12 @@ describe('discoveryOnStartupEpic', () => {
     store.dispatch(action)
   })
 
-  test('listens on APP_START and finds a bolt host and dispatches an action with the found host', (done) => {
+  test('listens on APP_START and finds a bolt host and dispatches an action with the found host', done => {
     // Given
     const action = { type: APP_START }
     const expectedHost = 'bolt://myhost:7777'
     nock(getDiscoveryEndpoint()).get('/').reply(200, { bolt: expectedHost })
-    bus.take(discovery.DONE, (currentAction) => {
+    bus.take(discovery.DONE, currentAction => {
       // Then
       expect(store.getActions()).toEqual([
         action,
@@ -100,11 +99,14 @@ describe('discoveryOnStartupEpic', () => {
     // When
     store.dispatch(action)
   })
-  test('listens on APP_START and reads bolt URL from location URL and dispatches an action with the found host', (done) => {
+  test('listens on APP_START and reads bolt URL from location URL and dispatches an action with the found host', done => {
     // Given
-    const action = { type: APP_START, url: 'http://localhost/?connectURL=myhost:8888' }
+    const action = {
+      type: APP_START,
+      url: 'http://localhost/?connectURL=myhost:8888'
+    }
     const expectedURL = 'bolt://myhost:8888'
-    bus.take(discovery.DONE, (currentAction) => {
+    bus.take(discovery.DONE, currentAction => {
       // Then
       expect(store.getActions()).toEqual([
         action,
@@ -117,11 +119,14 @@ describe('discoveryOnStartupEpic', () => {
     // When
     store.dispatch(action)
   })
-  test('listens on APP_START and reads bolt URL from location URL and dispatches an action with the found host, incl protocol', (done) => {
+  test('listens on APP_START and reads bolt URL from location URL and dispatches an action with the found host, incl protocol', done => {
     // Given
-    const action = { type: APP_START, url: 'http://localhost/?connectURL=bolt%2Brouting%3A%2F%2Fmyhost%3A8889' }
+    const action = {
+      type: APP_START,
+      url: 'http://localhost/?connectURL=bolt%2Brouting%3A%2F%2Fmyhost%3A8889'
+    }
     const expectedURL = 'bolt://myhost:8889'
-    bus.take(discovery.DONE, (currentAction) => {
+    bus.take(discovery.DONE, currentAction => {
       // Then
       expect(store.getActions()).toEqual([
         action,

--- a/src/shared/modules/editor/editorDuck.js
+++ b/src/shared/modules/editor/editorDuck.js
@@ -29,18 +29,27 @@ export const EDIT_CONTENT = NAME + '/EDIT_CONTENT'
 export const FOCUS = `${NAME}/FOCUS`
 export const EXPAND = `${NAME}/EXPAND`
 
-export const setContent = (newContent) => ({ type: SET_CONTENT, message: newContent })
-export const editContent = (id, message) => ({ type: EDIT_CONTENT, message, id })
+export const setContent = newContent => ({
+  type: SET_CONTENT,
+  message: newContent
+})
+export const editContent = (id, message) => ({
+  type: EDIT_CONTENT,
+  message,
+  id
+})
 
 export const populateEditorFromUrlEpic = (some$, store) => {
-  return some$.ofType(APP_START)
+  return some$
+    .ofType(APP_START)
     .delay(1) // Timing issue. Needs to be detached like this
-    .mergeMap((action) => {
+    .mergeMap(action => {
       if (!action.url) return Rx.Observable.never()
       const cmdParam = getUrlParamValue('cmd', action.url)
       if (!cmdParam || cmdParam[0] !== 'play') return Rx.Observable.never()
       const cmdCommand = getSettings(store.getState()).cmdchar + cmdParam[0]
-      const cmdArgs = getUrlParamValue('arg', decodeURIComponent(action.url)) || []
+      const cmdArgs =
+        getUrlParamValue('arg', decodeURIComponent(action.url)) || []
       const fullCommand = `${cmdCommand} ${cmdArgs.join(' ')}`
       return Rx.Observable.of({ type: SET_CONTENT, ...setContent(fullCommand) })
     })

--- a/src/shared/modules/favorites/favoritesDuck.js
+++ b/src/shared/modules/favorites/favoritesDuck.js
@@ -32,23 +32,31 @@ export const SYNC_FAVORITES = 'favorites/SYNC_FAVORITES'
 export const UPDATE_FAVORITE = 'favorites/UPDATE_FAVORITE'
 export const UPDATE_FAVORITES = 'favorites/UPDATE_FAVORITES'
 
-export const getFavorites = (state) => state[NAME]
-export const getFavorite = (state, id) => state.filter((favorite) => favorite.id === id)[0]
-export const removeFavoriteById = (state, id) => state.filter((favorite) => favorite.id !== id)
+export const getFavorites = state => state[NAME]
+export const getFavorite = (state, id) =>
+  state.filter(favorite => favorite.id === id)[0]
+export const removeFavoriteById = (state, id) =>
+  state.filter(favorite => favorite.id !== id)
 const versionSize = 20
 
 // reducer
-const initialState = staticScriptsList.map(script => Object.assign({}, script, {isStatic: true}))
+const initialState = staticScriptsList.map(script =>
+  Object.assign({}, script, { isStatic: true })
+)
 
 export default function reducer (state = initialState, action) {
   switch (action.type) {
     case REMOVE_FAVORITE:
       return removeFavoriteById(state, action.id)
     case ADD_FAVORITE:
-      return state.concat([{id: uuid.v4(), content: action.cmd}])
+      return state.concat([{ id: uuid.v4(), content: action.cmd }])
     case UPDATE_FAVORITE:
-      const mergedFavorite = Object.assign({}, getFavorite(state, action.id), {content: action.cmd})
-      const updatedFavorites = state.map((_) => _.id === action.id ? mergedFavorite : _)
+      const mergedFavorite = Object.assign({}, getFavorite(state, action.id), {
+        content: action.cmd
+      })
+      const updatedFavorites = state.map(
+        _ => (_.id === action.id ? mergedFavorite : _)
+      )
       return mergeFavorites(initialState, updatedFavorites)
     case LOAD_FAVORITES:
     case UPDATE_FAVORITES:
@@ -104,32 +112,54 @@ export const composeDocumentsToSync = (store, syncValue) => {
   const documents = syncValue.syncObj.documents
   const favorites = getFavorites(store.getState()).filter(fav => !fav.isStatic)
 
-  let newDocuments = [{
-    'client': getBrowserName(),
-    'data': favorites,
-    'syncedAt': Date.now()
-  }].concat(documents.slice(0, versionSize))
+  let newDocuments = [
+    {
+      client: getBrowserName(),
+      data: favorites,
+      syncedAt: Date.now()
+    }
+  ].concat(documents.slice(0, versionSize))
 
   return newDocuments
 }
 
 export const mergeFavorites = (list1, list2) => {
-  return list1.concat(list2.filter(favInList2 => list1.findIndex(favInList1 => favInList1.id === favInList2.id) < 0))
+  return list1.concat(
+    list2.filter(
+      favInList2 =>
+        list1.findIndex(favInList1 => favInList1.id === favInList2.id) < 0
+    )
+  )
 }
 
 export const favoritesToLoad = (action, store) => {
-  let favoritesFromSync = (action.obj.syncObj && action.obj.syncObj.documents.length > 0)
-    ? (action.obj.syncObj.documents[0].data || [])
-    : null
+  let favoritesFromSync =
+    action.obj.syncObj && action.obj.syncObj.documents.length > 0
+      ? action.obj.syncObj.documents[0].data || []
+      : null
 
   if (favoritesFromSync) {
     const existingFavs = getFavorites(store.getState())
     const allFavorites = mergeFavorites(favoritesFromSync, existingFavs)
 
-    if (existingFavs.every(exFav => exFav.isStatic || favoritesFromSync.findIndex(syncFav => syncFav.id === exFav.id) >= 0)) {
-      return { favorites: allFavorites, syncFavorites: false, loadFavorites: true }
+    if (
+      existingFavs.every(
+        exFav =>
+          exFav.isStatic ||
+          favoritesFromSync.findIndex(syncFav => syncFav.id === exFav.id) >= 0
+      )
+    ) {
+      return {
+        favorites: allFavorites,
+        syncFavorites: false,
+        loadFavorites: true
+      }
     } else {
-      return { favorites: allFavorites, syncFavorites: true, loadFavorites: true }
+      return {
+        favorites: allFavorites,
+        syncFavorites: true,
+        loadFavorites: true
+      }
     }
   } else {
     return { favorites: null, syncFavorites: false, loadFavorites: false }

--- a/src/shared/modules/favorites/favoritesDuck.test.js
+++ b/src/shared/modules/favorites/favoritesDuck.test.js
@@ -24,7 +24,10 @@ import reducer, * as favorites from './favoritesDuck'
 
 describe('favorites reducer', () => {
   test('should update state for favorites when favorite is removed and only one item is in the list', () => {
-    const favoriteScript = { name: 'Test1', content: 'match (n) return n limit 1' }
+    const favoriteScript = {
+      name: 'Test1',
+      content: 'match (n) return n limit 1'
+    }
     const initialState = [favoriteScript]
     const action = {
       type: favorites.REMOVE_FAVORITE,
@@ -35,14 +38,22 @@ describe('favorites reducer', () => {
   })
 
   test('should update state for favorites when favorite is removed when there is more than one item in the list', () => {
-    const favoriteScript1 = { id: uuid.v4(), name: 'Test1', content: 'match (n) return n limit 1' }
-    const favoriteScript2 = { id: uuid.v4(), name: 'Test2', content: 'match (a) return a' }
-    const favoriteScript3 = { id: uuid.v4(), name: 'Test3', content: 'match (a) return a' }
-    const initialState = [
-      favoriteScript1,
-      favoriteScript2,
-      favoriteScript3
-    ]
+    const favoriteScript1 = {
+      id: uuid.v4(),
+      name: 'Test1',
+      content: 'match (n) return n limit 1'
+    }
+    const favoriteScript2 = {
+      id: uuid.v4(),
+      name: 'Test2',
+      content: 'match (a) return a'
+    }
+    const favoriteScript3 = {
+      id: uuid.v4(),
+      name: 'Test3',
+      content: 'match (a) return a'
+    }
+    const initialState = [favoriteScript1, favoriteScript2, favoriteScript3]
     const action = {
       type: favorites.REMOVE_FAVORITE,
       id: favoriteScript2.id
@@ -51,24 +62,38 @@ describe('favorites reducer', () => {
     expect(nextState).toEqual([favoriteScript1, favoriteScript3])
   })
   test('should return favorite by id', () => {
-    const favoriteScript1 = { id: uuid.v4(), name: 'Test1', content: 'match (n) return n limit 1' }
-    const favoriteScript2 = { id: uuid.v4(), name: 'Test2', content: 'match (a) return a' }
-    const initialState = [
-      favoriteScript1,
-      favoriteScript2
-    ]
+    const favoriteScript1 = {
+      id: uuid.v4(),
+      name: 'Test1',
+      content: 'match (n) return n limit 1'
+    }
+    const favoriteScript2 = {
+      id: uuid.v4(),
+      name: 'Test2',
+      content: 'match (a) return a'
+    }
+    const initialState = [favoriteScript1, favoriteScript2]
 
     const nextState = reducer(initialState, {})
-    expect(favorites.getFavorite(nextState, favoriteScript1.id)).toEqual(favoriteScript1)
-    expect(favorites.getFavorite(nextState, favoriteScript2.id)).toEqual(favoriteScript2)
+    expect(favorites.getFavorite(nextState, favoriteScript1.id)).toEqual(
+      favoriteScript1
+    )
+    expect(favorites.getFavorite(nextState, favoriteScript2.id)).toEqual(
+      favoriteScript2
+    )
   })
   test('should update favorite by id', () => {
-    const favoriteScript1 = { id: uuid.v4(), name: 'Test1', content: 'match (n) return n limit 1' }
-    const favoriteScript2 = { id: uuid.v4(), name: 'Test2', content: 'match (a) return a' }
-    const initialState = [
-      favoriteScript1,
-      favoriteScript2
-    ]
+    const favoriteScript1 = {
+      id: uuid.v4(),
+      name: 'Test1',
+      content: 'match (n) return n limit 1'
+    }
+    const favoriteScript2 = {
+      id: uuid.v4(),
+      name: 'Test2',
+      content: 'match (a) return a'
+    }
+    const initialState = [favoriteScript1, favoriteScript2]
     const newContent = '//Foobar'
     const action = {
       type: favorites.UPDATE_FAVORITE,
@@ -76,8 +101,13 @@ describe('favorites reducer', () => {
       cmd: newContent
     }
     const nextState = reducer(initialState, action)
-    expect(favorites.getFavorite(nextState, favoriteScript1.id)).toEqual({...favoriteScript1, content: newContent})
-    expect(favorites.getFavorite(nextState, favoriteScript2.id)).toEqual(favoriteScript2)
+    expect(favorites.getFavorite(nextState, favoriteScript1.id)).toEqual({
+      ...favoriteScript1,
+      content: newContent
+    })
+    expect(favorites.getFavorite(nextState, favoriteScript2.id)).toEqual(
+      favoriteScript2
+    )
   })
 })
 

--- a/src/shared/modules/favorites/foldersDuck.js
+++ b/src/shared/modules/favorites/foldersDuck.js
@@ -19,8 +19,8 @@
  */
 import uuid from 'uuid'
 
-import {APP_START, USER_CLEAR} from 'shared/modules/app/appDuck'
-import {getBrowserName} from 'services/utils'
+import { APP_START, USER_CLEAR } from 'shared/modules/app/appDuck'
+import { getBrowserName } from 'services/utils'
 import { folders } from './staticScripts'
 
 export const NAME = 'folders'
@@ -30,44 +30,49 @@ export const ADD_FOLDER = 'folders/ADD_FOLDER'
 export const REMOVE_FOLDER = 'folders/REMOVE_FOLDER'
 export const UPDATE_FOLDERS = 'folders/UPDATE_FOLDERS'
 
-export const getFolders = (state) => state[NAME]
+export const getFolders = state => state[NAME]
 
 const versionSize = 20
 const initialState = folders
 
 const mergeFolders = (list1, list2) => {
-  return list1.concat(list2.filter(favInList2 => list1.findIndex(favInList1 => favInList1.id === favInList2.id) < 0))
+  return list1.concat(
+    list2.filter(
+      favInList2 =>
+        list1.findIndex(favInList1 => favInList1.id === favInList2.id) < 0
+    )
+  )
 }
 
 export const addFolder = () => {
-  return {type: ADD_FOLDER}
+  return { type: ADD_FOLDER }
 }
-export const updateFolders = (folders) => {
-  return {type: UPDATE_FOLDERS, folders}
+export const updateFolders = folders => {
+  return { type: UPDATE_FOLDERS, folders }
 }
-export const removeFolder = (id) => {
-  return {type: REMOVE_FOLDER, id}
-}
-
-export const loadFolders = (folders) => {
-  return {type: LOAD_FOLDERS, folders}
+export const removeFolder = id => {
+  return { type: REMOVE_FOLDER, id }
 }
 
-export const syncFolders = (folders) => {
-  return {type: SYNC_FOLDERS, folders}
+export const loadFolders = folders => {
+  return { type: LOAD_FOLDERS, folders }
+}
+
+export const syncFolders = folders => {
+  return { type: SYNC_FOLDERS, folders }
 }
 
 export default function reducer (state = initialState, action) {
   switch (action.type) {
-    case LOAD_FOLDERS :
+    case LOAD_FOLDERS:
     case UPDATE_FOLDERS:
       return mergeFolders(initialState, action.folders)
     case APP_START:
       return mergeFolders(initialState, state)
     case REMOVE_FOLDER:
-      return state.filter((folder) => folder.id !== action.id)
+      return state.filter(folder => folder.id !== action.id)
     case ADD_FOLDER:
-      return state.concat([{id: uuid.v4(), name: 'Unnamed Folder'}])
+      return state.concat([{ id: uuid.v4(), name: 'Unnamed Folder' }])
     case USER_CLEAR:
       return initialState
     default:
@@ -77,32 +82,45 @@ export default function reducer (state = initialState, action) {
 
 export const composeFoldersToSync = (store, syncValue) => {
   const folders = syncValue.syncObj.folders
-  const stateFolders = getFolders(store.getState()).filter(fold => !fold.isStatic)
+  const stateFolders = getFolders(store.getState()).filter(
+    fold => !fold.isStatic
+  )
 
-  let newFolders = [{
-    'client': getBrowserName(),
-    'data': stateFolders,
-    'syncedAt': Date.now()
-  }].concat(folders.slice(0, versionSize))
+  let newFolders = [
+    {
+      client: getBrowserName(),
+      data: stateFolders,
+      syncedAt: Date.now()
+    }
+  ].concat(folders.slice(0, versionSize))
 
   return newFolders
 }
 
 export const foldersToLoad = (action, store) => {
-  const foldersFromSync = (action.obj.syncObj && action.obj.syncObj.folders && action.obj.syncObj.folders.length > 0)
-    ? action.obj.syncObj.folders[0].data
-    : null
+  const foldersFromSync =
+    action.obj.syncObj &&
+    action.obj.syncObj.folders &&
+    action.obj.syncObj.folders.length > 0
+      ? action.obj.syncObj.folders[0].data
+      : null
 
   if (foldersFromSync) {
     const existingFolders = getFolders(store.getState())
     const allFolders = mergeFolders(foldersFromSync, existingFolders)
 
-    if (existingFolders.every(exFold => exFold.isStatic || foldersFromSync.findIndex(syncFold => syncFold.id === exFold.id) >= 0)) {
-      return {folders: allFolders, syncFolders: false, loadFolders: true}
+    if (
+      existingFolders.every(
+        exFold =>
+          exFold.isStatic ||
+          foldersFromSync.findIndex(syncFold => syncFold.id === exFold.id) >= 0
+      )
+    ) {
+      return { folders: allFolders, syncFolders: false, loadFolders: true }
     } else {
-      return {folders: allFolders, syncFolders: true, loadFolders: true}
+      return { folders: allFolders, syncFolders: true, loadFolders: true }
     }
   } else {
-    return {folders: null, syncFolders: false, loadFolders: false}
+    return { folders: null, syncFolders: false, loadFolders: false }
   }
 }

--- a/src/shared/modules/favorites/staticScripts.js
+++ b/src/shared/modules/favorites/staticScripts.js
@@ -21,68 +21,89 @@
 export const scripts = [
   {
     folder: 'basics',
-    content: '// Hello World!\nCREATE (database:Database {name:"Neo4j"})-[r:SAYS]->(message:Message {name:"Hello World!"}) RETURN database, message, r'
-  }, {
+    content:
+      '// Hello World!\nCREATE (database:Database {name:"Neo4j"})-[r:SAYS]->(message:Message {name:"Hello World!"}) RETURN database, message, r'
+  },
+  {
     folder: 'basics',
     content: '// Get some data\nMATCH (n1)-[r]->(n2) RETURN r, n1, n2 LIMIT 25'
-  }, {
+  },
+  {
     folder: 'basics',
     not_executable: true,
-    content: "// Create an index\n// Replace:\n//   'LabelName' with label to index\n//   'propertyKey' with property to be indexed\nCREATE INDEX ON :<LabelName>(<propertyKey>)"
-  }, {
+    content:
+      "// Create an index\n// Replace:\n//   'LabelName' with label to index\n//   'propertyKey' with property to be indexed\nCREATE INDEX ON :<LabelName>(<propertyKey>)"
+  },
+  {
     folder: 'basics',
     not_executable: true,
-    content: "// Create unique property constraint\n// Replace:\n//   'LabelName' with node label\n//   'propertyKey' with property that should be unique\nCREATE CONSTRAINT ON (n:<LabelName>) ASSERT n.<propertyKey> IS UNIQUE"
+    content:
+      "// Create unique property constraint\n// Replace:\n//   'LabelName' with node label\n//   'propertyKey' with property that should be unique\nCREATE CONSTRAINT ON (n:<LabelName>) ASSERT n.<propertyKey> IS UNIQUE"
   },
   {
     folder: 'profile',
     content: '// Count all nodes\nMATCH (n)\nRETURN count(n)'
-  }, {
+  },
+  {
     folder: 'profile',
     content: '// Count all relationships\nMATCH ()-->() RETURN count(*);'
-  }, {
+  },
+  {
     folder: 'profile',
-    content: '// What kind of nodes exist\n// Sample some nodes, reporting on property and relationship counts per node.\nMATCH (n) WHERE rand() <= 0.1\nRETURN\nDISTINCT labels(n),\ncount(*) AS SampleSize,\navg(size(keys(n))) as Avg_PropertyCount,\nmin(size(keys(n))) as Min_PropertyCount,\nmax(size(keys(n))) as Max_PropertyCount,\navg(size( (n)-[]-() ) ) as Avg_RelationshipCount,\nmin(size( (n)-[]-() ) ) as Min_RelationshipCount,\nmax(size( (n)-[]-() ) ) as Max_RelationshipCount'
-  }, {
+    content:
+      '// What kind of nodes exist\n// Sample some nodes, reporting on property and relationship counts per node.\nMATCH (n) WHERE rand() <= 0.1\nRETURN\nDISTINCT labels(n),\ncount(*) AS SampleSize,\navg(size(keys(n))) as Avg_PropertyCount,\nmin(size(keys(n))) as Min_PropertyCount,\nmax(size(keys(n))) as Max_PropertyCount,\navg(size( (n)-[]-() ) ) as Avg_RelationshipCount,\nmin(size( (n)-[]-() ) ) as Min_RelationshipCount,\nmax(size( (n)-[]-() ) ) as Max_RelationshipCount'
+  },
+  {
     folder: 'profile',
     content: '// What is related, and how\nCALL db.schema()'
-  }, {
+  },
+  {
     folder: 'profile',
     content: '// List node labels\nCALL db.labels()'
-  }, {
+  },
+  {
     folder: 'profile',
     content: '// List relationship types\nCALL db.relationshipTypes()'
-  }, {
+  },
+  {
     folder: 'profile',
     content: '// Display contraints and indexes\n:schema'
   },
   {
     folder: 'graphs',
     content: '// Movie Graph\n:play movie-graph'
-  }, {
+  },
+  {
     folder: 'graphs',
     content: '// Northwind Graph\n:play northwind-graph'
   },
   {
     folder: 'procedures',
     content: '// List procedures\nCALL dbms.procedures()'
-  }, {
+  },
+  {
     folder: 'procedures',
     content: '// List functions\nCALL dbms.functions()'
-  }, {
+  },
+  {
     folder: 'procedures',
     content: '// Show meta-graph\nCALL db.schema()'
-  }, {
+  },
+  {
     folder: 'procedures',
     content: '// List running queries\nCALL dbms.listQueries()'
-  }, {
+  },
+  {
     folder: 'procedures',
     not_executable: true,
-    content: '// Wait for index to come online\n// E.g. db.awaitIndex(":Person(name)"))\nCALL db.awaitIndex(<param>)'
-  }, {
+    content:
+      '// Wait for index to come online\n// E.g. db.awaitIndex(":Person(name)"))\nCALL db.awaitIndex(<param>)'
+  },
+  {
     folder: 'procedures',
     not_executable: true,
-    content: '// Schedule resampling of an index\n// E.g. db.resampleIndex(":Person(name)"))\nCALL db.resampleIndex(<param>)'
+    content:
+      '// Schedule resampling of an index\n// E.g. db.resampleIndex(":Person(name)"))\nCALL db.resampleIndex(<param>)'
   }
 ]
 
@@ -91,15 +112,18 @@ export const folders = [
     id: 'basics',
     name: 'Basic Queries',
     isStatic: true
-  }, {
+  },
+  {
     id: 'graphs',
     name: 'Example Graphs',
     isStatic: true
-  }, {
+  },
+  {
     id: 'profile',
     name: 'Data Profiling',
     isStatic: true
-  }, {
+  },
+  {
     id: 'procedures',
     name: 'Common Procedures',
     isStatic: true

--- a/src/shared/modules/features/featuresDuck.js
+++ b/src/shared/modules/features/featuresDuck.js
@@ -26,9 +26,11 @@ export const NAME = 'features'
 export const RESET = 'features/RESET'
 export const UPDATE_ALL_FEATURES = 'features/UPDATE_ALL_FEATURES'
 
-export const getAvailableProcedures = (state) => state[NAME].availableProcedures
-export const isACausalCluster = (state) => getAvailableProcedures(state).includes('dbms.cluster.overview')
-export const canAssignRolesToUser = (state) => getAvailableProcedures(state).includes('dbms.security.addRoleToUser')
+export const getAvailableProcedures = state => state[NAME].availableProcedures
+export const isACausalCluster = state =>
+  getAvailableProcedures(state).includes('dbms.cluster.overview')
+export const canAssignRolesToUser = state =>
+  getAvailableProcedures(state).includes('dbms.security.addRoleToUser')
 
 const initialState = {
   availableProcedures: []
@@ -41,7 +43,7 @@ export default function (state = initialState, action) {
 
   switch (action.type) {
     case UPDATE_ALL_FEATURES:
-      return {...state, availableProcedures: [...action.availableProcedures]}
+      return { ...state, availableProcedures: [...action.availableProcedures] }
     case RESET:
       return initialState
     default:
@@ -50,7 +52,7 @@ export default function (state = initialState, action) {
 }
 
 // Action creators
-export const updateFeatures = (availableProcedures) => {
+export const updateFeatures = availableProcedures => {
   return {
     type: UPDATE_ALL_FEATURES,
     availableProcedures
@@ -58,14 +60,18 @@ export const updateFeatures = (availableProcedures) => {
 }
 
 export const featuresDiscoveryEpic = (action$, store) => {
-  return action$.ofType(CONNECTION_SUCCESS)
+  return action$
+    .ofType(CONNECTION_SUCCESS)
     .mergeMap(() => {
-      return bolt.routedReadTransaction('CALL dbms.procedures YIELD name')
-        .then((res) => {
-          store.dispatch(updateFeatures(res.records.map((record) => record.get('name'))))
+      return bolt
+        .routedReadTransaction('CALL dbms.procedures YIELD name')
+        .then(res => {
+          store.dispatch(
+            updateFeatures(res.records.map(record => record.get('name')))
+          )
           return null
         })
-        .catch((e) => {
+        .catch(e => {
           return null
         })
     })

--- a/src/shared/modules/features/featuresDuck.test.js
+++ b/src/shared/modules/features/featuresDuck.test.js
@@ -24,8 +24,8 @@ import { dehydrate } from 'services/duckUtils'
 
 describe('features reducer', () => {
   test('handles initial value', () => {
-    const nextState = reducer(undefined, {type: ''})
-    expect(dehydrate(nextState)).toEqual({availableProcedures: []})
+    const nextState = reducer(undefined, { type: '' })
+    expect(dehydrate(nextState)).toEqual({ availableProcedures: [] })
   })
 
   test('handles UPDATE_ALL_FEATURES without initial state', () => {
@@ -50,27 +50,38 @@ describe('features reducer', () => {
 
 describe('feature getters', () => {
   test('should return empty list of availableProcedures by default', () => {
-    const nextState = reducer(undefined, {type: ''})
-    expect(features.getAvailableProcedures({features: nextState})).toEqual([])
+    const nextState = reducer(undefined, { type: '' })
+    expect(features.getAvailableProcedures({ features: nextState })).toEqual([])
   })
   test('should return list of availableProcedures', () => {
-    const nextState = reducer({availableProcedures: ['foo.bar']}, {type: ''})
-    expect(features.getAvailableProcedures({features: nextState})).toContain('foo.bar')
+    const nextState = reducer(
+      { availableProcedures: ['foo.bar'] },
+      { type: '' }
+    )
+    expect(features.getAvailableProcedures({ features: nextState })).toContain(
+      'foo.bar'
+    )
   })
   test('should not be a causal cluster', () => {
-    const nextState = reducer(undefined, {type: ''})
-    expect(features.isACausalCluster({features: nextState})).toBe(false)
+    const nextState = reducer(undefined, { type: '' })
+    expect(features.isACausalCluster({ features: nextState })).toBe(false)
   })
   test('should be in a causal cluster', () => {
-    const nextState = reducer({availableProcedures: ['dbms.cluster.overview']}, {type: ''})
-    expect(features.isACausalCluster({features: nextState})).toBe(true)
+    const nextState = reducer(
+      { availableProcedures: ['dbms.cluster.overview'] },
+      { type: '' }
+    )
+    expect(features.isACausalCluster({ features: nextState })).toBe(true)
   })
   test('should not be able to assign roles to user', () => {
-    const nextState = reducer(undefined, {type: ''})
-    expect(features.canAssignRolesToUser({features: nextState})).toBe(false)
+    const nextState = reducer(undefined, { type: '' })
+    expect(features.canAssignRolesToUser({ features: nextState })).toBe(false)
   })
   test('should be able to assign roles to user', () => {
-    const nextState = reducer({availableProcedures: ['dbms.security.addRoleToUser']}, {type: ''})
-    expect(features.canAssignRolesToUser({features: nextState})).toBe(true)
+    const nextState = reducer(
+      { availableProcedures: ['dbms.security.addRoleToUser'] },
+      { type: '' }
+    )
+    expect(features.canAssignRolesToUser({ features: nextState })).toBe(true)
   })
 })

--- a/src/shared/modules/grass/grassDuck.js
+++ b/src/shared/modules/grass/grassDuck.js
@@ -32,7 +32,7 @@ function updateStyleData (state, styleData) {
 
 export default function visualization (state = initialState, action) {
   if (action.type === APP_START) {
-    state = (!state) ? state : { ...initialState, ...state }
+    state = !state ? state : { ...initialState, ...state }
   }
 
   switch (action.type) {
@@ -43,7 +43,7 @@ export default function visualization (state = initialState, action) {
   }
 }
 
-export const updateGraphStyleData = (graphStyleData) => {
+export const updateGraphStyleData = graphStyleData => {
   return {
     type: UPDATE_GRAPH_STYLE_DATA,
     styleData: graphStyleData

--- a/src/shared/modules/grass/grassDuck.test.js
+++ b/src/shared/modules/grass/grassDuck.test.js
@@ -23,7 +23,7 @@ import reducer, { UPDATE_GRAPH_STYLE_DATA } from './grassDuck'
 
 describe('grass reducer', () => {
   test('handles initial value', () => {
-    const nextState = reducer(undefined, {type: ''})
+    const nextState = reducer(undefined, { type: '' })
     expect(nextState).toBeNull()
   })
   test('handles UPDATE_GRAPH_STYLE_DATA without initial state', () => {

--- a/src/shared/modules/history/historyDuck.js
+++ b/src/shared/modules/history/historyDuck.js
@@ -24,7 +24,7 @@ export const NAME = 'history'
 export const ADD = 'history/ADD'
 
 // Selectors
-export const getHistory = (state) => state[NAME]
+export const getHistory = state => state[NAME]
 
 function addHistoryHelper (state, newState, maxHistory) {
   // If it's the same as the last entry, don't add it

--- a/src/shared/modules/history/historyDuck.test.js
+++ b/src/shared/modules/history/historyDuck.test.js
@@ -52,18 +52,10 @@ describe('editor reducer', () => {
   })
 
   test('takes editor.actionTypes.SET_MAX_HISTORY into account', () => {
-    const initalState = [
-      ':help',
-      ':help',
-      ':help']
+    const initalState = [':help', ':help', ':help']
 
     const helpAction = actions.addHistory(':history', 3)
     const nextState = reducer(initalState, helpAction)
-    expect(nextState).toEqual([
-      ':history',
-      ':help',
-      ':help'
-    ]
-    )
+    expect(nextState).toEqual([':history', ':help', ':help'])
   })
 })

--- a/src/shared/modules/localstorage/localstorageDuck.js
+++ b/src/shared/modules/localstorage/localstorageDuck.js
@@ -19,18 +19,20 @@
  */
 
 import { USER_CLEAR } from 'shared/modules/app/appDuck'
-import { disconnectAction, getActiveConnection } from 'shared/modules/connections/connectionsDuck'
+import {
+  disconnectAction,
+  getActiveConnection
+} from 'shared/modules/connections/connectionsDuck'
 
 export const NAME = 'localstorage'
 export const CLEAR_LOCALSTORAGE = `${NAME}/CLEAR_LOCALSTORAGE`
 
 // Epics
 export const clearLocalstorageEpic = (some$, store) =>
-  some$.ofType(CLEAR_LOCALSTORAGE)
-    .map(() => {
-      const activeConnection = getActiveConnection(store.getState())
-      if (activeConnection) {
-        store.dispatch(disconnectAction(activeConnection))
-      }
-      return { type: USER_CLEAR }
-    })
+  some$.ofType(CLEAR_LOCALSTORAGE).map(() => {
+    const activeConnection = getActiveConnection(store.getState())
+    if (activeConnection) {
+      store.dispatch(disconnectAction(activeConnection))
+    }
+    return { type: USER_CLEAR }
+  })

--- a/src/shared/modules/params/paramsDuck.js
+++ b/src/shared/modules/params/paramsDuck.js
@@ -27,7 +27,7 @@ const REPLACE = `${NAME}/REPLACE`
 const initialState = {}
 
 // Selectors
-export const getParams = (state) => state[NAME]
+export const getParams = state => state[NAME]
 
 // Reducer
 export default function reducer (state = initialState, action) {
@@ -37,7 +37,7 @@ export default function reducer (state = initialState, action) {
 
   switch (action.type) {
     case UPDATE:
-      return {...state, ...action.params}
+      return { ...state, ...action.params }
     case REPLACE:
       return action.params
     default:
@@ -46,13 +46,13 @@ export default function reducer (state = initialState, action) {
 }
 
 // Action creators
-export const update = (obj) => {
+export const update = obj => {
   return {
     type: UPDATE,
     params: obj
   }
 }
-export const replace = (obj) => {
+export const replace = obj => {
   return {
     type: REPLACE,
     params: obj

--- a/src/shared/modules/params/paramsDuck.test.js
+++ b/src/shared/modules/params/paramsDuck.test.js
@@ -31,7 +31,7 @@ describe('paramsDuck', () => {
   test('Can add a param to empty state', () => {
     // Given
     const state = {}
-    const param = {x: 1}
+    const param = { x: 1 }
     const action = params.update(param)
 
     // When
@@ -43,9 +43,9 @@ describe('paramsDuck', () => {
 
   test('Can add a param to non-empty state', () => {
     // Given
-    const state = {y: 2}
-    const param = {x: 1}
-    const expected = {...state, ...param}
+    const state = { y: 2 }
+    const param = { x: 1 }
+    const expected = { ...state, ...param }
     const action = params.update(param)
 
     // When
@@ -57,8 +57,8 @@ describe('paramsDuck', () => {
 
   test('Can overwrite a param to non-empty state', () => {
     // Given
-    const state = {y: 2}
-    const param = {y: 1}
+    const state = { y: 2 }
+    const param = { y: 1 }
     const action = params.update(param)
 
     // When

--- a/src/shared/modules/requests/requestsDuck.js
+++ b/src/shared/modules/requests/requestsDuck.js
@@ -31,7 +31,7 @@ export const REQUEST_UPDATED = NAME + '/UPDATED'
 const initialState = {}
 
 export const getRequest = (state, id) => state[NAME][id]
-export const getRequests = (state) => state[NAME]
+export const getRequests = state => state[NAME]
 
 export default function reducer (state = initialState, action) {
   if (action.type === APP_START) {
@@ -40,11 +40,20 @@ export default function reducer (state = initialState, action) {
 
   switch (action.type) {
     case REQUEST_SENT:
-      return Object.assign({}, state, {[action.id]: {result: undefined, status: 'pending', type: action.requestType}})
+      return Object.assign({}, state, {
+        [action.id]: {
+          result: undefined,
+          status: 'pending',
+          type: action.requestType
+        }
+      })
     case REQUEST_CANCELED:
     case REQUEST_UPDATED:
-      const newRequest = Object.assign({}, state[action.id], {result: action.result, status: action.status})
-      return Object.assign({}, state, {[action.id]: newRequest})
+      const newRequest = Object.assign({}, state[action.id], {
+        result: action.result,
+        status: action.status
+      })
+      return Object.assign({}, state, { [action.id]: newRequest })
     default:
       return state
   }
@@ -67,14 +76,14 @@ export const update = (id, result, status) => {
   }
 }
 
-export const cancel = (id) => {
+export const cancel = id => {
   return {
     type: CANCEL_REQUEST,
     id
   }
 }
 
-const canceled = (id) => {
+const canceled = id => {
   return {
     type: REQUEST_CANCELED,
     status: 'canceled',
@@ -85,11 +94,10 @@ const canceled = (id) => {
 
 // Epics
 export const cancelRequestEpic = (action$, store) =>
-  action$.ofType(CANCEL_REQUEST)
-    .mergeMap((action) => {
-      return new Promise((resolve, reject) => {
-        bolt.cancelTransaction(action.id, () => {
-          resolve(canceled(action.id))
-        })
+  action$.ofType(CANCEL_REQUEST).mergeMap(action => {
+    return new Promise((resolve, reject) => {
+      bolt.cancelTransaction(action.id, () => {
+        resolve(canceled(action.id))
       })
     })
+  })

--- a/src/shared/modules/settings/settingsDuck.js
+++ b/src/shared/modules/settings/settingsDuck.js
@@ -24,22 +24,29 @@ export const NAME = 'settings'
 export const UPDATE = 'settings/UPDATE'
 export const REPLACE = 'settings/REPLACE'
 
-export const getSettings = (state) => state[NAME]
-export const getMaxHistory = (state) => state[NAME].maxHistory || initialState.maxHistory
-export const getInitCmd = (state) => state[NAME].initCmd || initialState.initCmd
-export const getTheme = (state) => state[NAME].theme || initialState.theme
-export const getUseBoltRouting = (state) => state[NAME].useBoltRouting || initialState.useBoltRouting
-export const getBrowserSyncConfig = (state) => {
+export const getSettings = state => state[NAME]
+export const getMaxHistory = state =>
+  state[NAME].maxHistory || initialState.maxHistory
+export const getInitCmd = state => state[NAME].initCmd || initialState.initCmd
+export const getTheme = state => state[NAME].theme || initialState.theme
+export const getUseBoltRouting = state =>
+  state[NAME].useBoltRouting || initialState.useBoltRouting
+export const getBrowserSyncConfig = state => {
   return getSettings(state).browserSyncDebugServer
-    ? {...browserSyncConfig, authWindowUrl: getSettings(state).browserSyncDebugServer}
+    ? {
+      ...browserSyncConfig,
+      authWindowUrl: getSettings(state).browserSyncDebugServer
+    }
     : browserSyncConfig
 }
-export const getMaxNeighbours = (state) => state[NAME].maxNeighbours || initialState.maxNeighbours
-export const getMaxRows = (state) => state[NAME].maxRows || initialState.maxRows
-export const getInitialNodeDisplay = (state) => state[NAME].initialNodeDisplay || initialState.initialNodeDisplay
-export const getScrollToTop = (state) => state[NAME].scrollToTop
-export const shouldReportUdc = (state) => state[NAME].shouldReportUdc !== false
-export const shouldAutoComplete = (state) => state[NAME].autoComplete !== false
+export const getMaxNeighbours = state =>
+  state[NAME].maxNeighbours || initialState.maxNeighbours
+export const getMaxRows = state => state[NAME].maxRows || initialState.maxRows
+export const getInitialNodeDisplay = state =>
+  state[NAME].initialNodeDisplay || initialState.initialNodeDisplay
+export const getScrollToTop = state => state[NAME].scrollToTop
+export const shouldReportUdc = state => state[NAME].shouldReportUdc !== false
+export const shouldAutoComplete = state => state[NAME].autoComplete !== false
 
 const browserSyncConfig = {
   authWindowUrl: 'https://auth.neo4j.com/indexNewBrowser.html',
@@ -49,10 +56,11 @@ const browserSyncConfig = {
     messagingSenderId: '352959348981'
   }
 }
-export const getUseNewVisualization = (state) => state[NAME].useNewVis
-export const getCmdChar = (state) => state[NAME].cmdchar || initialState.cmdchar
-export const shouldEditorAutocomplete = (state) => state[NAME].editorAutocomplete !== false
-export const shouldUseCypherThread = (state) => state[NAME].useCypherThread
+export const getUseNewVisualization = state => state[NAME].useNewVis
+export const getCmdChar = state => state[NAME].cmdchar || initialState.cmdchar
+export const shouldEditorAutocomplete = state =>
+  state[NAME].editorAutocomplete !== false
+export const shouldUseCypherThread = state => state[NAME].useCypherThread
 
 const initialState = {
   cmdchar: ':',
@@ -82,7 +90,7 @@ export default function settings (state = initialState, action) {
     case UPDATE:
       return Object.assign({}, state, action.state)
     case REPLACE:
-      return Object.assign({}, {...initialState}, action.state)
+      return Object.assign({}, { ...initialState }, action.state)
     case USER_CLEAR:
       return initialState
     default:
@@ -90,7 +98,7 @@ export default function settings (state = initialState, action) {
   }
 }
 
-export const updateBoltRouting = (useRouting) => {
+export const updateBoltRouting = useRouting => {
   return {
     type: UPDATE,
     state: {
@@ -99,14 +107,14 @@ export const updateBoltRouting = (useRouting) => {
   }
 }
 
-export const update = (settings) => {
+export const update = settings => {
   return {
     type: UPDATE,
     state: settings
   }
 }
 
-export const replace = (settings) => {
+export const replace = settings => {
   return {
     type: REPLACE,
     state: settings

--- a/src/shared/modules/settings/settingsDuck.test.js
+++ b/src/shared/modules/settings/settingsDuck.test.js
@@ -24,7 +24,7 @@ import { dehydrate } from 'services/duckUtils'
 
 describe('settings reducer', () => {
   test('handles initial value', () => {
-    const nextState = dehydrate(reducer(undefined, {type: ''}))
+    const nextState = dehydrate(reducer(undefined, { type: '' }))
     expect(nextState.cmdchar).toEqual(':')
   })
 
@@ -58,7 +58,7 @@ describe('settings reducer', () => {
     const action = {
       type: REPLACE,
       state: {
-        'new': 'conf'
+        new: 'conf'
       }
     }
     const nextState = dehydrate(reducer(initialState, action))
@@ -82,7 +82,7 @@ describe('Selectors', () => {
     ]
 
     // When && Then
-    tests.forEach((t) => {
+    tests.forEach(t => {
       const state = {
         [NAME]: { shouldReportUdc: t.test }
       }

--- a/src/shared/modules/sidebar/sidebarDuck.js
+++ b/src/shared/modules/sidebar/sidebarDuck.js
@@ -43,6 +43,6 @@ export default function reducer (state = '', action) {
 export function toggle (id) {
   return {
     type: TOGGLE,
-    state: {drawer: id}
+    state: { drawer: id }
   }
 }

--- a/src/shared/modules/sidebar/sidebarDuck.test.js
+++ b/src/shared/modules/sidebar/sidebarDuck.test.js
@@ -34,7 +34,7 @@ describe('sidebar reducer', () => {
   test('should set to undefined if drawer in payload is falsy', () => {
     const action = {
       type: sidebar.TOGGLE,
-      state: {drawer: ''}
+      state: { drawer: '' }
     }
     const nextState = reducer(undefined, action)
     expect(nextState).toEqual(null)
@@ -43,7 +43,7 @@ describe('sidebar reducer', () => {
   test('should open a drawer when closed', () => {
     const action = {
       type: sidebar.TOGGLE,
-      state: {drawer: 'db'}
+      state: { drawer: 'db' }
     }
     const nextState = reducer(undefined, action)
     expect(nextState).toEqual('db')
@@ -53,7 +53,7 @@ describe('sidebar reducer', () => {
     const initialState = 'profile'
     const action = {
       type: sidebar.TOGGLE,
-      state: {drawer: 'db'}
+      state: { drawer: 'db' }
     }
     const nextState = reducer(initialState, action)
     expect(nextState).toEqual('db')
@@ -63,7 +63,7 @@ describe('sidebar reducer', () => {
     const initialState = 'db'
     const action = {
       type: sidebar.TOGGLE,
-      state: {drawer: 'db'}
+      state: { drawer: 'db' }
     }
     const nextState = reducer(initialState, action)
     expect(nextState).toEqual(null)
@@ -75,7 +75,7 @@ describe('Sidebar actions', () => {
     const drawerId = 'db'
     expect(sidebar.toggle(drawerId)).toEqual({
       type: sidebar.TOGGLE,
-      state: {drawer: drawerId}
+      state: { drawer: drawerId }
     })
   })
 })

--- a/src/shared/modules/stream/epics.test.js
+++ b/src/shared/modules/stream/epics.test.js
@@ -28,7 +28,10 @@ import { update as updateSettings } from 'shared/modules/settings/settingsDuck'
 
 const bus = createBus()
 const epicMiddleware = createEpicMiddleware(stream.maxFramesConfigEpic)
-const mockStore = configureMockStore([epicMiddleware, createReduxMiddleware(bus)])
+const mockStore = configureMockStore([
+  epicMiddleware,
+  createReduxMiddleware(bus)
+])
 
 describe('streamDuckEpics', () => {
   let store
@@ -50,10 +53,10 @@ describe('streamDuckEpics', () => {
     bus.reset()
   })
 
-  test('listens on UPDATE and sets new maxFrames', (done) => {
+  test('listens on UPDATE and sets new maxFrames', done => {
     // Given
-    const action = updateSettings({maxFrames: 3})
-    bus.take('NOOP', (currentAction) => {
+    const action = updateSettings({ maxFrames: 3 })
+    bus.take('NOOP', currentAction => {
       // Then
       expect(store.getActions()).toEqual([
         action,

--- a/src/shared/modules/stream/streamDuck.js
+++ b/src/shared/modules/stream/streamDuck.js
@@ -39,11 +39,11 @@ export const SET_MAX_FRAMES = NAME + '/SET_MAX_FRAMES'
  * Selectors
 */
 export function getFrames (state) {
-  return state[NAME].allIds.map((id) => state[NAME].byId[id])
+  return state[NAME].allIds.map(id => state[NAME].byId[id])
 }
 
 export function getFramesInContext (state, context) {
-  return getFrames(state).filter((f) => f.context === context)
+  return getFrames(state).filter(f => f.context === context)
 }
 
 export function getRecentView (state) {
@@ -54,9 +54,10 @@ export function getRecentView (state) {
  * Reducer helpers
 */
 function addFrame (state, newState) {
-  const byId = Object.assign({}, state.byId, {[newState.id]: newState})
+  const byId = Object.assign({}, state.byId, { [newState.id]: newState })
   let allIds = [].concat(state.allIds)
-  if (allIds.indexOf(newState.id) < 0) { // new frame
+  if (allIds.indexOf(newState.id) < 0) {
+    // new frame
     const pos = findFirstFreePos(state)
     allIds.splice(pos, 0, newState.id)
   }
@@ -70,8 +71,8 @@ function addFrame (state, newState) {
 function removeFrame (state, id) {
   const byId = Object.assign({}, state.byId)
   delete byId[id]
-  const allIds = state.allIds.filter((fid) => fid !== id)
-  return Object.assign({}, state, {allIds, byId})
+  const allIds = state.allIds.filter(fid => fid !== id)
+  return Object.assign({}, state, { allIds, byId })
 }
 
 function pinFrame (state, id) {
@@ -109,16 +110,18 @@ function findFirstFreePos ({ byId, allIds }) {
 }
 
 function setRecentViewHelper (state, recentView) {
-  return Object.assign({}, state, {recentView})
+  return Object.assign({}, state, { recentView })
 }
 
 function ensureFrameLimit (state) {
   const limit = state.maxFrames || 1
   if (state.allIds.length <= limit) return state
   let numToRemove = state.allIds.length - limit
-  let removeIds = state.allIds.slice(-1 * numToRemove).filter((id) => !state.byId[id].isPinned)
-  let byId = {...state.byId}
-  removeIds.forEach((id) => delete byId[id])
+  let removeIds = state.allIds
+    .slice(-1 * numToRemove)
+    .filter(id => !state.byId[id].isPinned)
+  let byId = { ...state.byId }
+  removeIds.forEach(id => delete byId[id])
   return {
     ...state,
     allIds: state.allIds.slice(0, state.allIds.length - removeIds.length),
@@ -148,7 +151,7 @@ export default function reducer (state = initialState, action) {
     case REMOVE:
       return removeFrame(state, action.id)
     case CLEAR_ALL:
-      return {...initialState}
+      return { ...initialState }
     case PIN:
       return pinFrame(state, action.id)
     case UNPIN:
@@ -156,7 +159,7 @@ export default function reducer (state = initialState, action) {
     case SET_RECENT_VIEW:
       return setRecentViewHelper(state, action.view)
     case SET_MAX_FRAMES:
-      const newState = {...state, maxFrames: action.maxFrames}
+      const newState = { ...state, maxFrames: action.maxFrames }
       return ensureFrameLimit(newState)
     default:
       return state
@@ -167,7 +170,7 @@ export default function reducer (state = initialState, action) {
 export function add (payload) {
   return {
     type: ADD,
-    state: Object.assign({}, payload, {id: (payload.id || uuid.v1())})
+    state: Object.assign({}, payload, { id: payload.id || uuid.v1() })
   }
 }
 
@@ -207,8 +210,9 @@ export function setRecentView (view) {
 
 // Epics
 export const maxFramesConfigEpic = (action$, store) =>
-  action$.ofType(SETTINGS_UPDATE)
-    .do((action) => {
+  action$
+    .ofType(SETTINGS_UPDATE)
+    .do(action => {
       const newMaxFrames = action.state.maxFrames
       if (!newMaxFrames) return
       store.dispatch({ type: SET_MAX_FRAMES, maxFrames: newMaxFrames })

--- a/src/shared/modules/stream/streamDuck.test.js
+++ b/src/shared/modules/stream/streamDuck.test.js
@@ -24,9 +24,9 @@ import reducer, { add, SET_MAX_FRAMES, initialState } from './streamDuck'
 describe('streamDuck', () => {
   test('limits the number of frames in the reducer', () => {
     // Given
-    const init = {...initialState, maxFrames: 1}
-    const action = add({cmd: 'xxx', id: 1})
-    const action2 = add({cmd: 'yyy', id: 2})
+    const init = { ...initialState, maxFrames: 1 }
+    const action = add({ cmd: 'xxx', id: 1 })
+    const action2 = add({ cmd: 'yyy', id: 2 })
 
     // When
     const newState = reducer(init, action)
@@ -42,7 +42,12 @@ describe('streamDuck', () => {
   })
   test('cuts the number of frames when config is set', () => {
     // Given
-    const init = {...initialState, maxFrames: 2, allIds: [1, 2], byId: {'1': {id: 1}, '2': {id: 2}}}
+    const init = {
+      ...initialState,
+      maxFrames: 2,
+      allIds: [1, 2],
+      byId: { '1': { id: 1 }, '2': { id: 2 } }
+    }
     const action = { type: SET_MAX_FRAMES, maxFrames: 1 }
 
     // When
@@ -55,8 +60,8 @@ describe('streamDuck', () => {
   })
   test('dont remove pinned frames when cutting frames', () => {
     // Given
-    const byId = {'1': {isPinned: 1}, '2': {isPinned: 1}}
-    const init = {...initialState, maxFrames: 2, allIds: [1, 2], byId}
+    const byId = { '1': { isPinned: 1 }, '2': { isPinned: 1 } }
+    const init = { ...initialState, maxFrames: 2, allIds: [1, 2], byId }
     const action = { type: SET_MAX_FRAMES, maxFrames: 1 }
 
     // When

--- a/src/shared/modules/sync/SyncSignInManager.js
+++ b/src/shared/modules/sync/SyncSignInManager.js
@@ -18,20 +18,26 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { authenticate, initialize, status, getResourceFor, setupUser } from 'services/browserSyncService'
+import {
+  authenticate,
+  initialize,
+  status,
+  getResourceFor,
+  setupUser
+} from 'services/browserSyncService'
 import { getBrowserName } from 'services/utils'
 
 export const UP = 'UP'
 export const DOWN = 'DOWN'
 
 class SyncSignInManager {
-  constructor ({dbConfig, serviceReadyCallback, onSyncCallback}) {
+  constructor ({ dbConfig, serviceReadyCallback, onSyncCallback }) {
     initialize(dbConfig)
     this.isServiceUp(serviceReadyCallback)
     this.onSync = onSyncCallback
   }
   isServiceUp (serviceReadyCallback) {
-    status().on('value', (v) => {
+    status().on('value', v => {
       if (v.val()) {
         if (this._downTimer) {
           clearTimeout(this._downTimer)
@@ -40,10 +46,7 @@ class SyncSignInManager {
         serviceReadyCallback(UP)
       } else {
         // During connecting, the status is always down for a short time. So wait before setting state to be sure its really down
-        this._downTimer = setTimeout(
-          () => serviceReadyCallback(DOWN),
-          10000
-        )
+        this._downTimer = setTimeout(() => serviceReadyCallback(DOWN), 10000)
       }
     })
   }
@@ -54,13 +57,14 @@ class SyncSignInManager {
       errorFn && errorFn(error)
     } else {
       this.authData = data
-      authenticate(this.authData.data_token).then((a) => {
-        this.serviceAuthenticated = true
-        this.error = null
-        this.bindToResource()
-        successFn && successFn(data)
-      })
-        .catch((e) => {
+      authenticate(this.authData.data_token)
+        .then(a => {
+          this.serviceAuthenticated = true
+          this.error = null
+          this.bindToResource()
+          successFn && successFn(data)
+        })
+        .catch(e => {
           this.serviceAuthenticated = false
           this.error = e
           errorFn && errorFn(e)
@@ -69,13 +73,15 @@ class SyncSignInManager {
   }
   bindToResource () {
     this.syncRef = getResourceFor(this.authData.profile.user_id)
-    this.syncRef.on('value', (v) => {
+    this.syncRef.on('value', v => {
       if (v.val() == null) {
         setupUser(this.authData.profile.user_id, {
-          documents: [{
-            'client': getBrowserName(),
-            'syncedAt': Date.now()
-          }]
+          documents: [
+            {
+              client: getBrowserName(),
+              syncedAt: Date.now()
+            }
+          ]
         })
       } else {
         this.setSynCData(v.val())
@@ -83,7 +89,12 @@ class SyncSignInManager {
     })
   }
   setSynCData (value) {
-    this.onSync({key: this.authData.profile.user_id, syncObj: value, lastSyncedAt: new Date(), authData: this.authData})
+    this.onSync({
+      key: this.authData.profile.user_id,
+      syncObj: value,
+      lastSyncedAt: new Date(),
+      authData: this.authData
+    })
   }
 }
 

--- a/src/shared/modules/sync/syncDuck.js
+++ b/src/shared/modules/sync/syncDuck.js
@@ -21,8 +21,26 @@
 import { syncResourceFor } from 'services/browserSyncService'
 import { setItem } from 'services/localstorage'
 import { APP_START } from 'shared/modules/app/appDuck'
-import { composeDocumentsToSync, favoritesToLoad, loadFavorites, syncFavorites, ADD_FAVORITE, REMOVE_FAVORITE, SYNC_FAVORITES, UPDATE_FAVORITES } from 'shared/modules/favorites/favoritesDuck'
-import { REMOVE_FOLDER, ADD_FOLDER, UPDATE_FOLDERS, SYNC_FOLDERS, composeFoldersToSync, foldersToLoad, loadFolders, syncFolders } from 'shared/modules/favorites/foldersDuck'
+import {
+  composeDocumentsToSync,
+  favoritesToLoad,
+  loadFavorites,
+  syncFavorites,
+  ADD_FAVORITE,
+  REMOVE_FAVORITE,
+  SYNC_FAVORITES,
+  UPDATE_FAVORITES
+} from 'shared/modules/favorites/favoritesDuck'
+import {
+  REMOVE_FOLDER,
+  ADD_FOLDER,
+  UPDATE_FOLDERS,
+  SYNC_FOLDERS,
+  composeFoldersToSync,
+  foldersToLoad,
+  loadFolders,
+  syncFolders
+} from 'shared/modules/favorites/foldersDuck'
 import { CLEAR_LOCALSTORAGE } from 'shared/modules/localstorage/localstorageDuck'
 
 export const NAME = 'sync'
@@ -125,7 +143,7 @@ export function optOutSync () {
   }
 }
 
-export const authorizedAs = (userData) => {
+export const authorizedAs = userData => {
   return {
     type: AUTHORIZED,
     userData
@@ -134,16 +152,18 @@ export const authorizedAs = (userData) => {
 
 // Epics
 export const syncItemsEpic = (action$, store) =>
-  action$.ofType(SYNC_ITEMS)
-    .do((action) => {
+  action$
+    .ofType(SYNC_ITEMS)
+    .do(action => {
       const userId = store.getState().sync.key
       syncResourceFor(userId, action.itemKey, action.items)
     })
     .mapTo({ type: 'NOOP' })
 
 export const clearSyncEpic = (action$, store) =>
-  action$.ofType(CLEAR_SYNC_AND_LOCAL)
-    .do((action) => {
+  action$
+    .ofType(CLEAR_SYNC_AND_LOCAL)
+    .do(action => {
       setItem('documents', null)
       setItem('folders', null)
       setItem('syncConsent', false)
@@ -151,8 +171,16 @@ export const clearSyncEpic = (action$, store) =>
     .mapTo({ type: CLEAR_LOCALSTORAGE })
 
 export const syncFavoritesEpic = (action$, store) =>
-  action$.filter((action) => [ADD_FAVORITE, REMOVE_FAVORITE, SYNC_FAVORITES, UPDATE_FAVORITES].includes(action.type))
-    .map((action) => {
+  action$
+    .filter(action =>
+      [
+        ADD_FAVORITE,
+        REMOVE_FAVORITE,
+        SYNC_FAVORITES,
+        UPDATE_FAVORITES
+      ].includes(action.type)
+    )
+    .map(action => {
       const syncValue = getSync(store.getState())
 
       if (syncValue && syncValue.syncObj) {
@@ -163,8 +191,9 @@ export const syncFavoritesEpic = (action$, store) =>
     })
 
 export const loadFavoritesFromSyncEpic = (action$, store) =>
-  action$.ofType(SET_SYNC)
-    .do((action) => {
+  action$
+    .ofType(SET_SYNC)
+    .do(action => {
       const favoritesStatus = favoritesToLoad(action, store)
 
       if (favoritesStatus.loadFavorites) {
@@ -178,8 +207,13 @@ export const loadFavoritesFromSyncEpic = (action$, store) =>
     .mapTo({ type: 'NOOP' })
 
 export const syncFoldersEpic = (action$, store) =>
-  action$.filter((action) => [ADD_FOLDER, REMOVE_FOLDER, SYNC_FOLDERS, UPDATE_FOLDERS].includes(action.type))
-    .map((action) => {
+  action$
+    .filter(action =>
+      [ADD_FOLDER, REMOVE_FOLDER, SYNC_FOLDERS, UPDATE_FOLDERS].includes(
+        action.type
+      )
+    )
+    .map(action => {
       const syncValue = getSync(store.getState())
 
       if (syncValue && syncValue.syncObj) {
@@ -190,8 +224,9 @@ export const syncFoldersEpic = (action$, store) =>
     })
 
 export const loadFoldersFromSyncEpic = (action$, store) =>
-  action$.ofType(SET_SYNC)
-    .do((action) => {
+  action$
+    .ofType(SET_SYNC)
+    .do(action => {
       const folderStatus = foldersToLoad(action, store)
 
       if (folderStatus.loadFolders) {
@@ -202,4 +237,4 @@ export const loadFoldersFromSyncEpic = (action$, store) =>
         store.dispatch(syncFolders(folderStatus.folders))
       }
     })
-    .mapTo({type: 'NOOP'})
+    .mapTo({ type: 'NOOP' })

--- a/src/shared/modules/udc/udcDuck.test.js
+++ b/src/shared/modules/udc/udcDuck.test.js
@@ -22,7 +22,7 @@
 
 import reducer, { addToEventQueue } from './udcDuck'
 
-test('Doesn\'t break if there are no events in state', () => {
+test("Doesn't break if there are no events in state", () => {
   // Given
   const initialState = { uuid: 'x' }
   const action = addToEventQueue('my-event', 'now')
@@ -38,7 +38,7 @@ test('Can add events', () => {
   // Given
   const initialState = {
     uuid: 'x',
-    events: [{name: 'first-event', data: 1}]
+    events: [{ name: 'first-event', data: 1 }]
   }
   const action = addToEventQueue('my-event', 'now')
 

--- a/src/shared/rootEpic.js
+++ b/src/shared/rootEpic.js
@@ -19,18 +19,55 @@
  */
 
 import { combineEpics } from 'redux-observable'
-import { handleCommandsEpic, postConnectCmdEpic, fetchGuideFromWhitelistEpic } from './modules/commands/commandsDuck'
-import { retainCredentialsSettingsEpic, checkSettingsForRoutingDriver, connectEpic, disconnectEpic, startupConnectEpic, disconnectSuccessEpic, startupConnectionSuccessEpic, startupConnectionFailEpic, detectActiveConnectionChangeEpic, connectionLostEpic } from './modules/connections/connectionsDuck'
-import { dbMetaEpic, clearMetaOnDisconnectEpic } from './modules/dbMeta/dbMetaDuck'
+import {
+  handleCommandsEpic,
+  postConnectCmdEpic,
+  fetchGuideFromWhitelistEpic
+} from './modules/commands/commandsDuck'
+import {
+  retainCredentialsSettingsEpic,
+  checkSettingsForRoutingDriver,
+  connectEpic,
+  disconnectEpic,
+  startupConnectEpic,
+  disconnectSuccessEpic,
+  startupConnectionSuccessEpic,
+  startupConnectionFailEpic,
+  detectActiveConnectionChangeEpic,
+  connectionLostEpic
+} from './modules/connections/connectionsDuck'
+import {
+  dbMetaEpic,
+  clearMetaOnDisconnectEpic
+} from './modules/dbMeta/dbMetaDuck'
 import { cancelRequestEpic } from './modules/requests/requestsDuck'
 import { discoveryOnStartupEpic } from './modules/discovery/discoveryDuck'
 import { clearLocalstorageEpic } from './modules/localstorage/localstorageDuck'
 import { populateEditorFromUrlEpic } from './modules/editor/editorDuck'
-import { adHocCypherRequestEpic, cypherRequestEpic, clusterCypherRequestEpic, handleForcePasswordChangeEpic } from './modules/cypher/cypherDuck'
+import {
+  adHocCypherRequestEpic,
+  cypherRequestEpic,
+  clusterCypherRequestEpic,
+  handleForcePasswordChangeEpic
+} from './modules/cypher/cypherDuck'
 import { featuresDiscoveryEpic } from './modules/features/featuresDuck'
-import { syncItemsEpic, clearSyncEpic, syncFavoritesEpic, loadFavoritesFromSyncEpic, loadFoldersFromSyncEpic, syncFoldersEpic } from './modules/sync/syncDuck'
+import {
+  syncItemsEpic,
+  clearSyncEpic,
+  syncFavoritesEpic,
+  loadFavoritesFromSyncEpic,
+  loadFoldersFromSyncEpic,
+  syncFoldersEpic
+} from './modules/sync/syncDuck'
 import { credentialsTimeoutEpic } from './modules/credentialsPolicy/credentialsPolicyDuck'
-import { bootEpic, incrementEventEpic, udcStartupEpic, trackSyncLogoutEpic, trackConnectsEpic, eventFiredEpic } from './modules/udc/udcDuck'
+import {
+  bootEpic,
+  incrementEventEpic,
+  udcStartupEpic,
+  trackSyncLogoutEpic,
+  trackConnectsEpic,
+  eventFiredEpic
+} from './modules/udc/udcDuck'
 import { maxFramesConfigEpic } from './modules/stream/streamDuck'
 
 export default combineEpics(

--- a/src/shared/rootReducer.js
+++ b/src/shared/rootReducer.js
@@ -18,21 +18,46 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import settingsReducer, { NAME as settings } from 'shared/modules/settings/settingsDuck'
-import featuresReducer, { NAME as features } from 'shared/modules/features/featuresDuck'
+import settingsReducer, {
+  NAME as settings
+} from 'shared/modules/settings/settingsDuck'
+import featuresReducer, {
+  NAME as features
+} from 'shared/modules/features/featuresDuck'
 import streamReducer, { NAME as stream } from 'shared/modules/stream/streamDuck'
-import historyReducer, { NAME as history } from 'shared/modules/history/historyDuck'
-import userReducer, { NAME as currentUser } from 'shared/modules/currentUser/currentUserDuck'
+import historyReducer, {
+  NAME as history
+} from 'shared/modules/history/historyDuck'
+import userReducer, {
+  NAME as currentUser
+} from 'shared/modules/currentUser/currentUserDuck'
 import dbMetaReducer, { NAME as dbMeta } from 'shared/modules/dbMeta/dbMetaDuck'
-import favoritesReducer, { NAME as documents } from 'shared/modules/favorites/favoritesDuck'
-import connectionsReducer, { NAME as connections } from 'shared/modules/connections/connectionsDuck'
-import sidebarReducer, { NAME as sidebar } from 'shared/modules/sidebar/sidebarDuck'
-import requestsReducer, { NAME as requests } from 'shared/modules/requests/requestsDuck'
+import favoritesReducer, {
+  NAME as documents
+} from 'shared/modules/favorites/favoritesDuck'
+import connectionsReducer, {
+  NAME as connections
+} from 'shared/modules/connections/connectionsDuck'
+import sidebarReducer, {
+  NAME as sidebar
+} from 'shared/modules/sidebar/sidebarDuck'
+import requestsReducer, {
+  NAME as requests
+} from 'shared/modules/requests/requestsDuck'
 import paramsReducer, { NAME as params } from 'shared/modules/params/paramsDuck'
 import grassReducer, { NAME as grass } from 'shared/modules/grass/grassDuck'
-import { syncReducer, syncConsentReducer, NAME_CONSENT as syncConsent, NAME as sync } from 'shared/modules/sync/syncDuck'
-import foldersReducer, { NAME as folders } from 'shared/modules/favorites/foldersDuck'
-import commandsReducer, { NAME as commands } from 'shared/modules/commands/commandsDuck'
+import {
+  syncReducer,
+  syncConsentReducer,
+  NAME_CONSENT as syncConsent,
+  NAME as sync
+} from 'shared/modules/sync/syncDuck'
+import foldersReducer, {
+  NAME as folders
+} from 'shared/modules/favorites/foldersDuck'
+import commandsReducer, {
+  NAME as commands
+} from 'shared/modules/commands/commandsDuck'
 import udcReducer, { NAME as udc } from 'shared/modules/udc/udcDuck'
 import appReducer, { NAME as app } from 'shared/modules/app/appDuck'
 

--- a/src/shared/services/bolt/applyGraphTypes.test.js
+++ b/src/shared/services/bolt/applyGraphTypes.test.js
@@ -145,7 +145,11 @@ describe('applyGraphTypes', () => {
       prop6: { prop1: 1, prop2: 'test' },
       prop7: { prop1: { low: 3, high: 0 }, prop2: 'test' },
       prop8: { prop1: { low: 3, high: 0 }, prop2: { str: 'Some string' } },
-      prop9: { prop1: ['array str', 'me too'], prop2: [12, 32, 44], prop3: [ { p1: true, p2: 'tenant' }, { p1: null } ] },
+      prop9: {
+        prop1: ['array str', 'me too'],
+        prop2: [12, 32, 44],
+        prop3: [{ p1: true, p2: 'tenant' }, { p1: null }]
+      },
       prop10: undefined
     }
 
@@ -187,15 +191,18 @@ describe('applyGraphTypes', () => {
   })
 
   test('should apply node type to array of data', () => {
-    const rawNodes = [{
-      labels: ['Test'],
-      properties: [],
-      identity: { low: 5, high: 0 }
-    }, {
-      labels: ['Test2'],
-      properties: [],
-      identity: { low: 15, high: 0 }
-    }]
+    const rawNodes = [
+      {
+        labels: ['Test'],
+        properties: [],
+        identity: { low: 5, high: 0 }
+      },
+      {
+        labels: ['Test2'],
+        properties: [],
+        identity: { low: 15, high: 0 }
+      }
+    ]
 
     const typedNodes = applyGraphTypes(rawNodes)
     expect(typedNodes.length).toEqual(2)
@@ -220,19 +227,22 @@ describe('applyGraphTypes', () => {
   })
 
   test('should apply relationship type to array of data', () => {
-    const rawRelationships = [{
-      type: 'TestType',
-      properties: [],
-      identity: { low: 1, high: 0 },
-      start: { low: 5, high: 0 },
-      end: { low: 10, high: 0 }
-    }, {
-      type: 'TestType_2',
-      properties: [],
-      identity: { low: 2, high: 0 },
-      start: { low: 15, high: 0 },
-      end: { low: 20, high: 0 }
-    }]
+    const rawRelationships = [
+      {
+        type: 'TestType',
+        properties: [],
+        identity: { low: 1, high: 0 },
+        start: { low: 5, high: 0 },
+        end: { low: 10, high: 0 }
+      },
+      {
+        type: 'TestType_2',
+        properties: [],
+        identity: { low: 2, high: 0 },
+        start: { low: 15, high: 0 },
+        end: { low: 20, high: 0 }
+      }
+    ]
 
     const typedRelationships = applyGraphTypes(rawRelationships)
     expect(typedRelationships.length).toEqual(2)
@@ -277,7 +287,10 @@ describe('applyGraphTypes', () => {
       identity: { low: 10, high: 0 }
     }
 
-    const typedObjects = applyGraphTypes([{ num: rawNumber1, node: rawNode1 }, { num: rawNumber2, node: rawNode2 }])
+    const typedObjects = applyGraphTypes([
+      { num: rawNumber1, node: rawNode1 },
+      { num: rawNumber2, node: rawNode2 }
+    ])
     expect(typedObjects.length).toEqual(2)
     expect(typedObjects[0].node).toBeInstanceOf(neo4j.types.Node)
     expect(typedObjects[0].num).toBeInstanceOf(neo4j.Integer)
@@ -291,7 +304,9 @@ describe('applyGraphTypes', () => {
     expect(typedPathSegment).toBeInstanceOf(neo4j.types.PathSegment)
     expect(typedPathSegment.start).toBeInstanceOf(neo4j.types.Node)
     expect(typedPathSegment.end).toBeInstanceOf(neo4j.types.Node)
-    expect(typedPathSegment.relationship).toBeInstanceOf(neo4j.types.Relationship)
+    expect(typedPathSegment.relationship).toBeInstanceOf(
+      neo4j.types.Relationship
+    )
   })
 
   test('should apply to array of PathSegment type', () => {
@@ -304,20 +319,29 @@ describe('applyGraphTypes', () => {
     expect(typedPathSegments[0]).toBeInstanceOf(neo4j.types.PathSegment)
     expect(typedPathSegments[0].start).toBeInstanceOf(neo4j.types.Node)
     expect(typedPathSegments[0].end).toBeInstanceOf(neo4j.types.Node)
-    expect(typedPathSegments[0].relationship).toBeInstanceOf(neo4j.types.Relationship)
+    expect(typedPathSegments[0].relationship).toBeInstanceOf(
+      neo4j.types.Relationship
+    )
 
     expect(typedPathSegments[1]).toBeInstanceOf(neo4j.types.PathSegment)
     expect(typedPathSegments[1].start).toBeInstanceOf(neo4j.types.Node)
     expect(typedPathSegments[1].end).toBeInstanceOf(neo4j.types.Node)
-    expect(typedPathSegments[1].relationship).toBeInstanceOf(neo4j.types.Relationship)
+    expect(typedPathSegments[1].relationship).toBeInstanceOf(
+      neo4j.types.Relationship
+    )
   })
 
   test('should apply Path type', () => {
-    const typedPath = applyGraphTypes(getAPath([{ start: 5, end: 10, relationship: 1 }, {
-      start: 10,
-      end: 15,
-      relationship: 2
-    }]))
+    const typedPath = applyGraphTypes(
+      getAPath([
+        { start: 5, end: 10, relationship: 1 },
+        {
+          start: 10,
+          end: 15,
+          relationship: 2
+        }
+      ])
+    )
     expect(typedPath).toBeTruthy()
     expect(typedPath).toBeInstanceOf(neo4j.types.Path)
     expect(typedPath.start).toBeInstanceOf(neo4j.types.Node)
@@ -335,7 +359,10 @@ describe('applyGraphTypes', () => {
       identity: { low: 5, high: 0 }
     }
     const rawNum = { low: 100, high: 0 }
-    const rawPath = getAPath([{ start: 5, end: 10, relationship: 1 }, { start: 10, end: 15, relationship: 2 }])
+    const rawPath = getAPath([
+      { start: 5, end: 10, relationship: 1 },
+      { start: 10, end: 15, relationship: 2 }
+    ])
     const rawRelationship = {
       type: 'TestType',
       properties: [],
@@ -344,15 +371,24 @@ describe('applyGraphTypes', () => {
       end: { low: 10, high: 0 }
     }
 
-    const typedObject = applyGraphTypes({ rawNum, rawNode, rawRelationship, rawPath })
+    const typedObject = applyGraphTypes({
+      rawNum,
+      rawNode,
+      rawRelationship,
+      rawPath
+    })
     expect(typedObject).toBeTruthy()
     expect(typedObject.rawNum).toBeInstanceOf(neo4j.Integer)
     expect(typedObject.rawNode).toBeInstanceOf(neo4j.types.Node)
     expect(typedObject.rawRelationship).toBeInstanceOf(neo4j.types.Relationship)
     expect(typedObject.rawPath).toBeInstanceOf(neo4j.types.Path)
     expect(typedObject.rawPath.segments.length).toEqual(2)
-    expect(typedObject.rawPath.segments[0]).toBeInstanceOf(neo4j.types.PathSegment)
-    expect(typedObject.rawPath.segments[1]).toBeInstanceOf(neo4j.types.PathSegment)
+    expect(typedObject.rawPath.segments[0]).toBeInstanceOf(
+      neo4j.types.PathSegment
+    )
+    expect(typedObject.rawPath.segments[1]).toBeInstanceOf(
+      neo4j.types.PathSegment
+    )
   })
 })
 
@@ -380,7 +416,13 @@ const getAPathSegment = (startId, relId, endId) => {
   return { start: rawStartNode, end: rawEndNode, relationship: rawRelationship }
 }
 
-const getAPath = (segmentList) => {
-  const segments = segmentList.map(segment => getAPathSegment(segment.start, segment.relationship, segment.end))
-  return { start: segments[0].start, end: segments[segments.length - 1].end, segments }
+const getAPath = segmentList => {
+  const segments = segmentList.map(segment =>
+    getAPathSegment(segment.start, segment.relationship, segment.end)
+  )
+  return {
+    start: segments[0].start,
+    end: segments[segments.length - 1].end,
+    segments
+  }
 }

--- a/src/shared/services/bolt/boltMappings.js
+++ b/src/shared/services/bolt/boltMappings.js
@@ -22,7 +22,7 @@ import updateStatsFields from './updateStatisticsFields'
 import { v1 as neo4j } from 'neo4j-driver-alias'
 
 export function toObjects (records, converters) {
-  const recordValues = records.map((record) => {
+  const recordValues = records.map(record => {
     let out = []
     record.forEach((val, key) => out.push(itemIntToString(val, converters)))
     return out
@@ -45,7 +45,7 @@ export function itemIntToString (item, converters) {
 }
 
 export function arrayIntToString (arr, converters) {
-  return arr.map((item) => itemIntToString(item, converters))
+  return arr.map(item => itemIntToString(item, converters))
 }
 
 export function objIntToString (obj, converters) {
@@ -55,7 +55,7 @@ export function objIntToString (obj, converters) {
     newObj = entry.map(item => itemIntToString(item, converters))
   } else if (entry !== null && typeof entry === 'object') {
     newObj = {}
-    Object.keys(entry).forEach((key) => {
+    Object.keys(entry).forEach(key => {
       newObj[key] = itemIntToString(entry[key], converters)
     })
   }
@@ -63,7 +63,10 @@ export function objIntToString (obj, converters) {
 }
 
 export function extractFromNeoObjects (obj, converters) {
-  if (obj instanceof neo4j.types.Node || obj instanceof neo4j.types.Relationship) {
+  if (
+    obj instanceof neo4j.types.Node ||
+    obj instanceof neo4j.types.Relationship
+  ) {
     return obj.properties
   } else if (obj instanceof neo4j.types.Path) {
     return [].concat.apply([], extractPathForRows(obj, converters))
@@ -75,21 +78,21 @@ const extractPathForRows = (path, converters) => {
   let segments = path.segments
   // Zero length path. No relationship, end === start
   if (!Array.isArray(path.segments) || path.segments.length < 1) {
-    segments = [{...path, end: null}]
+    segments = [{ ...path, end: null }]
   }
   return segments.map(function (segment) {
     return [
       objIntToString(segment.start, converters),
       objIntToString(segment.relationship, converters),
       objIntToString(segment.end, converters)
-    ].filter((part) => part !== null)
+    ].filter(part => part !== null)
   })
 }
 
 export function extractPlan (result, calculateTotalDbHits = false) {
   if (result.summary && (result.summary.plan || result.summary.profile)) {
     const rawPlan = result.summary.profile || result.summary.plan
-    const boltPlanToRESTPlanShared = (plan) => {
+    const boltPlanToRESTPlanShared = plan => {
       return {
         operatorType: plan.operatorType,
         LegacyExpression: plan.arguments.LegacyExpression,
@@ -114,7 +117,7 @@ export function extractPlan (result, calculateTotalDbHits = false) {
       obj.totalDbHits = collectHits(obj)
     }
 
-    return {root: obj}
+    return { root: obj }
   }
   return null
 }
@@ -137,21 +140,34 @@ export function extractNodesAndRelationshipsFromRecords (records, types) {
   let keys = records[0].keys
   let rawNodes = []
   let rawRels = []
-  records.forEach((record) => {
-    let graphItems = keys.map((key) => record.get(key))
-    rawNodes = [...rawNodes, ...graphItems.filter((item) => item instanceof types.Node)]
-    rawRels = [...rawRels, ...graphItems.filter((item) => item instanceof types.Relationship)]
-    let paths = graphItems.filter((item) => item instanceof types.Path)
-    paths.forEach((item) => extractNodesAndRelationshipsFromPath(item, rawNodes, rawRels, types))
+  records.forEach(record => {
+    let graphItems = keys.map(key => record.get(key))
+    rawNodes = [
+      ...rawNodes,
+      ...graphItems.filter(item => item instanceof types.Node)
+    ]
+    rawRels = [
+      ...rawRels,
+      ...graphItems.filter(item => item instanceof types.Relationship)
+    ]
+    let paths = graphItems.filter(item => item instanceof types.Path)
+    paths.forEach(item =>
+      extractNodesAndRelationshipsFromPath(item, rawNodes, rawRels, types)
+    )
   })
   return { nodes: rawNodes, relationships: rawRels }
 }
 
-const resultContainsGraphKeys = (keys) => {
-  return (keys.includes('nodes') && keys.includes('relationships'))
+const resultContainsGraphKeys = keys => {
+  return keys.includes('nodes') && keys.includes('relationships')
 }
 
-export function extractNodesAndRelationshipsFromRecordsForOldVis (records, types, filterRels, converters) {
+export function extractNodesAndRelationshipsFromRecordsForOldVis (
+  records,
+  types,
+  filterRels,
+  converters
+) {
   if (records.length === 0) {
     return { nodes: [], relationships: [] }
   }
@@ -162,24 +178,48 @@ export function extractNodesAndRelationshipsFromRecordsForOldVis (records, types
     rawNodes = [...rawNodes, ...records[0].get(keys[0])]
     rawRels = [...rawRels, ...records[0].get(keys[1])]
   } else {
-    records.forEach((record) => {
-      let graphItems = keys.map((key) => record.get(key))
-      graphItems = flattenArray(recursivelyExtractGraphItems(types, graphItems)).filter((item) => item !== false)
-      rawNodes = [...rawNodes, ...graphItems.filter((item) => item instanceof types.Node)]
-      rawRels = [...rawRels, ...graphItems.filter((item) => item instanceof types.Relationship)]
-      let paths = graphItems.filter((item) => item instanceof types.Path)
-      paths.forEach((item) => extractNodesAndRelationshipsFromPath(item, rawNodes, rawRels, types))
+    records.forEach(record => {
+      let graphItems = keys.map(key => record.get(key))
+      graphItems = flattenArray(
+        recursivelyExtractGraphItems(types, graphItems)
+      ).filter(item => item !== false)
+      rawNodes = [
+        ...rawNodes,
+        ...graphItems.filter(item => item instanceof types.Node)
+      ]
+      rawRels = [
+        ...rawRels,
+        ...graphItems.filter(item => item instanceof types.Relationship)
+      ]
+      let paths = graphItems.filter(item => item instanceof types.Path)
+      paths.forEach(item =>
+        extractNodesAndRelationshipsFromPath(item, rawNodes, rawRels, types)
+      )
     })
   }
-  const nodes = rawNodes.map((item) => {
-    return {id: item.identity.toString(), labels: item.labels, properties: itemIntToString(item.properties, converters)}
+  const nodes = rawNodes.map(item => {
+    return {
+      id: item.identity.toString(),
+      labels: item.labels,
+      properties: itemIntToString(item.properties, converters)
+    }
   })
   let relationships = rawRels
   if (filterRels) {
-    relationships = rawRels.filter((item) => nodes.filter((node) => node.id === item.start.toString()).length > 0 && nodes.filter((node) => node.id === item.end.toString()).length > 0)
+    relationships = rawRels.filter(
+      item =>
+        nodes.filter(node => node.id === item.start.toString()).length > 0 &&
+        nodes.filter(node => node.id === item.end.toString()).length > 0
+    )
   }
-  relationships = relationships.map((item) => {
-    return {id: item.identity.toString(), startNodeId: item.start.toString(), endNodeId: item.end.toString(), type: item.type, properties: itemIntToString(item.properties, converters)}
+  relationships = relationships.map(item => {
+    return {
+      id: item.identity.toString(),
+      startNodeId: item.start.toString(),
+      endNodeId: item.end.toString(),
+      type: item.type,
+      properties: itemIntToString(item.properties, converters)
+    }
   })
   return { nodes: nodes, relationships: relationships }
 }
@@ -188,16 +228,20 @@ export const recursivelyExtractGraphItems = (types, item) => {
   if (item instanceof types.Node) return item
   if (item instanceof types.Relationship) return item
   if (item instanceof types.Path) return item
-  if (Array.isArray(item)) return item.map((i) => recursivelyExtractGraphItems(types, i))
+  if (Array.isArray(item)) {
+    return item.map(i => recursivelyExtractGraphItems(types, i))
+  }
   if (['number', 'string', 'boolean'].indexOf(typeof item) !== -1) return false
   if (item === null) return false
   if (typeof item === 'object') {
-    return Object.keys(item).map((key) => recursivelyExtractGraphItems(types, item[key]))
+    return Object.keys(item).map(key =>
+      recursivelyExtractGraphItems(types, item[key])
+    )
   }
   return item
 }
 
-export const flattenArray = (arr) => {
+export const flattenArray = arr => {
   return arr.reduce((all, curr) => {
     if (Array.isArray(curr)) return all.concat(flattenArray(curr))
     return all.concat(curr)
@@ -206,13 +250,13 @@ export const flattenArray = (arr) => {
 
 const extractNodesAndRelationshipsFromPath = (item, rawNodes, rawRels) => {
   let paths = Array.isArray(item) ? item : [item]
-  paths.forEach((path) => {
+  paths.forEach(path => {
     let segments = path.segments
     // Zero length path. No relationship, end === start
     if (!Array.isArray(path.segments) || path.segments.length < 1) {
-      segments = [{...path, end: null}]
+      segments = [{ ...path, end: null }]
     }
-    segments.forEach((segment) => {
+    segments.forEach(segment => {
       if (segment.start) rawNodes.push(segment.start)
       if (segment.end) rawNodes.push(segment.end)
       if (segment.relationship) rawRels.push(segment.relationship)
@@ -220,42 +264,84 @@ const extractNodesAndRelationshipsFromPath = (item, rawNodes, rawRels) => {
   })
 }
 
-export const retrieveFormattedUpdateStatistics = (result) => {
+export const retrieveFormattedUpdateStatistics = result => {
   if (result.summary.counters) {
     const stats = result.summary.counters._stats
-    const statsMessages = updateStatsFields.filter(field => stats[field.field] > 0).map(field => `${field.verb} ${stats[field.field]} ${stats[field.field] === 1 ? field.singular : field.plural}`)
+    const statsMessages = updateStatsFields
+      .filter(field => stats[field.field] > 0)
+      .map(
+        field =>
+          `${field.verb} ${stats[field.field]} ${stats[field.field] === 1
+            ? field.singular
+            : field.plural}`
+      )
     return statsMessages.join(', ')
   } else return null
 }
 
-export const flattenProperties = (rows) => {
-  return rows.map((row) => row.map((entry) => (entry && entry.properties) ? entry.properties : entry))
+export const flattenProperties = rows => {
+  return rows.map(row =>
+    row.map(entry => (entry && entry.properties ? entry.properties : entry))
+  )
 }
 
-export const applyGraphTypes = (item) => {
+export const applyGraphTypes = item => {
   if (item === null || item === undefined) {
     return item
   } else if (Array.isArray(item)) {
     return item.map(applyGraphTypes)
-  } else if (item.hasOwnProperty('labels') && item.hasOwnProperty('properties') && item.hasOwnProperty('identity')) {
-    return new neo4j.types.Node(neo4j.int(item.identity), item.labels, applyGraphTypes(item.properties))
-  } else if (item.hasOwnProperty('segments') && item.hasOwnProperty('start') && item.hasOwnProperty('end')) {
+  } else if (
+    item.hasOwnProperty('labels') &&
+    item.hasOwnProperty('properties') &&
+    item.hasOwnProperty('identity')
+  ) {
+    return new neo4j.types.Node(
+      neo4j.int(item.identity),
+      item.labels,
+      applyGraphTypes(item.properties)
+    )
+  } else if (
+    item.hasOwnProperty('segments') &&
+    item.hasOwnProperty('start') &&
+    item.hasOwnProperty('end')
+  ) {
     const start = applyGraphTypes(item.start)
     const end = applyGraphTypes(item.end)
     const segments = item.segments.map(applyGraphTypes)
     return new neo4j.types.Path(start, end, segments)
-  } else if (item.hasOwnProperty('relationship') && item.hasOwnProperty('start') && item.hasOwnProperty('end')) {
+  } else if (
+    item.hasOwnProperty('relationship') &&
+    item.hasOwnProperty('start') &&
+    item.hasOwnProperty('end')
+  ) {
     const start = applyGraphTypes(item.start)
     const end = applyGraphTypes(item.end)
     const relationship = applyGraphTypes(item.relationship)
     return new neo4j.types.PathSegment(start, relationship, end)
-  } else if (item.hasOwnProperty('start') && item.hasOwnProperty('end') && item.hasOwnProperty('type')) {
-    return new neo4j.types.Relationship(neo4j.int(item.identity), neo4j.int(item.start), neo4j.int(item.end), item.type, applyGraphTypes(item.properties))
-  } else if (item.hasOwnProperty('low') && item.hasOwnProperty('high') && typeof item.low === 'number' && typeof item.high === 'number') {
+  } else if (
+    item.hasOwnProperty('start') &&
+    item.hasOwnProperty('end') &&
+    item.hasOwnProperty('type')
+  ) {
+    return new neo4j.types.Relationship(
+      neo4j.int(item.identity),
+      neo4j.int(item.start),
+      neo4j.int(item.end),
+      item.type,
+      applyGraphTypes(item.properties)
+    )
+  } else if (
+    item.hasOwnProperty('low') &&
+    item.hasOwnProperty('high') &&
+    typeof item.low === 'number' &&
+    typeof item.high === 'number'
+  ) {
     return neo4j.int(item)
   } else if (typeof item === 'object') {
     let typedObject = {}
-    Object.keys(item).forEach((key) => { typedObject[key] = applyGraphTypes(item[key]) })
+    Object.keys(item).forEach(key => {
+      typedObject[key] = applyGraphTypes(item[key])
+    })
     return typedObject
   } else {
     return item

--- a/src/shared/services/bolt/boltMappings.test.js
+++ b/src/shared/services/bolt/boltMappings.test.js
@@ -37,23 +37,43 @@ describe('boltMappings', () => {
     test('should convert matching values with provided function', () => {
       // Given
       const tests = [
-        {val: 'hello', checker: (_) => false, converter: (_) => false, expected: 'hello'},
-        {val: ['hello'], checker: (_) => false, converter: (val) => false, expected: ['hello']},
-        {val: null, checker: (_) => false, converter: (_) => false, expected: null},
         {
-          val: {str: 'hello'},
-          checker: (_) => true,
-          converter: (val) => {
+          val: 'hello',
+          checker: _ => false,
+          converter: _ => false,
+          expected: 'hello'
+        },
+        {
+          val: ['hello'],
+          checker: _ => false,
+          converter: val => false,
+          expected: ['hello']
+        },
+        {
+          val: null,
+          checker: _ => false,
+          converter: _ => false,
+          expected: null
+        },
+        {
+          val: { str: 'hello' },
+          checker: _ => true,
+          converter: val => {
             val.str = val.str.toUpperCase()
             return val
           },
-          expected: {str: 'HELLO'}
+          expected: { str: 'HELLO' }
         }
       ]
 
       // When and Then
-      tests.forEach((test) => {
-        expect(itemIntToString(test.val, {intChecker: test.checker, intConverter: test.converter})).toEqual(test.expected)
+      tests.forEach(test => {
+        expect(
+          itemIntToString(test.val, {
+            intChecker: test.checker,
+            intConverter: test.converter
+          })
+        ).toEqual(test.expected)
       })
     })
   })
@@ -61,14 +81,34 @@ describe('boltMappings', () => {
     test('should convert matching values with provided function', () => {
       // Given
       const tests = [
-        {val: ['hello', 1], checker: (_) => false, converter: (val) => false, expected: ['hello', 1]},
-        {val: ['hello', ['ola', 'hi']], checker: (val) => typeof val === 'string', converter: (val) => val.toUpperCase(), expected: ['HELLO', ['OLA', 'HI']]},
-        {val: ['hello', 1], checker: (val) => typeof val === 'string', converter: (val) => val.toUpperCase(), expected: ['HELLO', 1]}
+        {
+          val: ['hello', 1],
+          checker: _ => false,
+          converter: val => false,
+          expected: ['hello', 1]
+        },
+        {
+          val: ['hello', ['ola', 'hi']],
+          checker: val => typeof val === 'string',
+          converter: val => val.toUpperCase(),
+          expected: ['HELLO', ['OLA', 'HI']]
+        },
+        {
+          val: ['hello', 1],
+          checker: val => typeof val === 'string',
+          converter: val => val.toUpperCase(),
+          expected: ['HELLO', 1]
+        }
       ]
 
       // When and Then
-      tests.forEach((test) => {
-        expect(arrayIntToString(test.val, {intChecker: test.checker, intConverter: test.converter})).toEqual(test.expected)
+      tests.forEach(test => {
+        expect(
+          arrayIntToString(test.val, {
+            intChecker: test.checker,
+            intConverter: test.converter
+          })
+        ).toEqual(test.expected)
       })
     })
   })
@@ -76,16 +116,15 @@ describe('boltMappings', () => {
     test('should convert matching values with provided function', () => {
       // Given
       const tests = [
-        {val: {arr: ['hello']}, checker: (_) => false, converter: (val) => false, expected: {arr: ['hello']}},
+        {
+          val: { arr: ['hello'] },
+          checker: _ => false,
+          converter: val => false,
+          expected: { arr: ['hello'] }
+        },
         {
           val: {
-            arr: [
-              'hello',
-              [
-                'ola',
-                'hi'
-              ]
-            ],
+            arr: ['hello', ['ola', 'hi']],
             str: 'hello',
             num: 2,
             obj: {
@@ -93,16 +132,10 @@ describe('boltMappings', () => {
               str: 'inner hello'
             }
           },
-          checker: (val) => typeof val === 'string',
-          converter: (val) => val.toUpperCase(),
+          checker: val => typeof val === 'string',
+          converter: val => val.toUpperCase(),
           expected: {
-            arr: [
-              'HELLO',
-              [
-                'OLA',
-                'HI'
-              ]
-            ],
+            arr: ['HELLO', ['OLA', 'HI']],
             str: 'HELLO',
             num: 2,
             obj: {
@@ -114,122 +147,204 @@ describe('boltMappings', () => {
       ]
 
       // When and Then
-      tests.forEach((test) => {
-        expect(objIntToString(test.val, {intChecker: test.checker, intConverter: test.converter, objectConverter: (obj) => obj})).toEqual(test.expected)
+      tests.forEach(test => {
+        expect(
+          objIntToString(test.val, {
+            intChecker: test.checker,
+            intConverter: test.converter,
+            objectConverter: obj => obj
+          })
+        ).toEqual(test.expected)
       })
     })
   })
 
   describe('extractNodesAndRelationshipsFromRecords', () => {
-    test.skip('should map bolt records with a path to nodes and relationships', () => {
-      let startNode = new neo4j.v1.types.Node('1', ['Person'], {prop1: 'prop1'})
-      let endNode = new neo4j.v1.types.Node('2', ['Movie'], {prop2: 'prop2'})
-      let relationship = new neo4j.v1.types.Relationship('3', startNode.identity, endNode.identity, 'ACTED_IN', {})
-      let pathSegment = new neo4j.v1.types.PathSegment(startNode, relationship, endNode)
-      let path = new neo4j.v1.types.Path(startNode, endNode, [pathSegment])
-      let boltRecord = {
-        keys: ['p'],
-        get: (key) => path
+    test.skip(
+      'should map bolt records with a path to nodes and relationships',
+      () => {
+        let startNode = new neo4j.v1.types.Node('1', ['Person'], {
+          prop1: 'prop1'
+        })
+        let endNode = new neo4j.v1.types.Node('2', ['Movie'], {
+          prop2: 'prop2'
+        })
+        let relationship = new neo4j.v1.types.Relationship(
+          '3',
+          startNode.identity,
+          endNode.identity,
+          'ACTED_IN',
+          {}
+        )
+        let pathSegment = new neo4j.v1.types.PathSegment(
+          startNode,
+          relationship,
+          endNode
+        )
+        let path = new neo4j.v1.types.Path(startNode, endNode, [pathSegment])
+        let boltRecord = {
+          keys: ['p'],
+          get: key => path
+        }
+
+        let { nodes, relationships } = extractNodesAndRelationshipsFromRecords(
+          [boltRecord],
+          neo4j.v1.types
+        )
+        expect(nodes).to.have.lengthOf(2)
+        let graphNodeStart = nodes.filter(node => node.id === '1')[0]
+        expect(graphNodeStart).toBeDefined()
+        expect(graphNodeStart.labels).toEqual(['Person'])
+        expect(graphNodeStart.properties).toEqual({ prop1: 'prop1' })
+        let graphNodeEnd = nodes.filter(node => node.id === '2')[0]
+        expect(graphNodeEnd).toBeDefined()
+        expect(graphNodeEnd.labels).toEqual(['Movie'])
+        expect(graphNodeEnd.properties).toEqual({ prop2: 'prop2' })
+        expect(relationships).to.have.lengthOf(1)
+        expect(relationships[0].id).toEqual('3')
+        expect(relationships[0].startNodeId).toEqual('1')
+        expect(relationships[0].endNodeId).toEqual('2')
+        expect(relationships[0].type).toEqual('ACTED_IN')
+        expect(relationships[0].properties).toEqual({})
       }
+    )
 
-      let {nodes, relationships} = extractNodesAndRelationshipsFromRecords([boltRecord], neo4j.v1.types)
-      expect(nodes).to.have.lengthOf(2)
-      let graphNodeStart = nodes.filter((node) => node.id === '1')[0]
-      expect(graphNodeStart).toBeDefined()
-      expect(graphNodeStart.labels).toEqual(['Person'])
-      expect(graphNodeStart.properties).toEqual({prop1: 'prop1'})
-      let graphNodeEnd = nodes.filter((node) => node.id === '2')[0]
-      expect(graphNodeEnd).toBeDefined()
-      expect(graphNodeEnd.labels).toEqual(['Movie'])
-      expect(graphNodeEnd.properties).toEqual({prop2: 'prop2'})
-      expect(relationships).to.have.lengthOf(1)
-      expect(relationships[0].id).toEqual('3')
-      expect(relationships[0].startNodeId).toEqual('1')
-      expect(relationships[0].endNodeId).toEqual('2')
-      expect(relationships[0].type).toEqual('ACTED_IN')
-      expect(relationships[0].properties).toEqual({})
-    })
-
-    test.skip('should map bolt nodes and relationships to graph nodes and relationships', () => {
-      let startNode = new neo4j.v1.types.Node('1', ['Person'], {prop1: 'prop1'})
-      let endNode = new neo4j.v1.types.Node('2', ['Movie'], {prop2: 'prop2'})
-      let relationship = new neo4j.v1.types.Relationship('3', startNode.identity, endNode.identity, 'ACTED_IN', {})
-      let boltRecord = {
-        keys: ['r', 'n1', 'n2'],
-        get: (key) => {
-          if (key === 'r') {
-            return relationship
-          }
-          if (key === 'n1') {
-            return startNode
-          }
-          if (key === 'n2') {
-            return endNode
+    test.skip(
+      'should map bolt nodes and relationships to graph nodes and relationships',
+      () => {
+        let startNode = new neo4j.v1.types.Node('1', ['Person'], {
+          prop1: 'prop1'
+        })
+        let endNode = new neo4j.v1.types.Node('2', ['Movie'], {
+          prop2: 'prop2'
+        })
+        let relationship = new neo4j.v1.types.Relationship(
+          '3',
+          startNode.identity,
+          endNode.identity,
+          'ACTED_IN',
+          {}
+        )
+        let boltRecord = {
+          keys: ['r', 'n1', 'n2'],
+          get: key => {
+            if (key === 'r') {
+              return relationship
+            }
+            if (key === 'n1') {
+              return startNode
+            }
+            if (key === 'n2') {
+              return endNode
+            }
           }
         }
-      }
 
-      let {nodes, relationships} = extractNodesAndRelationshipsFromRecords([boltRecord], neo4j.v1.types)
-      expect(nodes).to.have.lengthOf(2)
-      let graphNodeStart = nodes.filter((node) => node.id === '1')[0]
-      expect(graphNodeStart).toBeDefined()
-      expect(graphNodeStart.labels).toEqual(['Person'])
-      expect(graphNodeStart.properties).toEqual({prop1: 'prop1'})
-      let graphNodeEnd = nodes.filter((node) => node.id === '2')[0]
-      expect(graphNodeEnd).toBeDefined()
-      expect(graphNodeEnd.labels).toEqual(['Movie'])
-      expect(graphNodeEnd.properties).toEqual({prop2: 'prop2'})
-      expect(relationships).to.have.lengthOf(1)
-      expect(relationships[0].id).toEqual('3')
-      expect(relationships[0].startNodeId).toEqual('1')
-      expect(relationships[0].endNodeId).toEqual('2')
-      expect(relationships[0].type).toEqual('ACTED_IN')
-      expect(relationships[0].properties).toEqual({})
-    })
-
-    test.skip('should not include relationships where neither start or end node is not in nodes list', () => {
-      let relationship = new neo4j.v1.types.Relationship('3', 1, 2, 'ACTED_IN', {})
-      let boltRecord = {
-        keys: ['r'],
-        get: (key) => relationship
+        let { nodes, relationships } = extractNodesAndRelationshipsFromRecords(
+          [boltRecord],
+          neo4j.v1.types
+        )
+        expect(nodes).to.have.lengthOf(2)
+        let graphNodeStart = nodes.filter(node => node.id === '1')[0]
+        expect(graphNodeStart).toBeDefined()
+        expect(graphNodeStart.labels).toEqual(['Person'])
+        expect(graphNodeStart.properties).toEqual({ prop1: 'prop1' })
+        let graphNodeEnd = nodes.filter(node => node.id === '2')[0]
+        expect(graphNodeEnd).toBeDefined()
+        expect(graphNodeEnd.labels).toEqual(['Movie'])
+        expect(graphNodeEnd.properties).toEqual({ prop2: 'prop2' })
+        expect(relationships).to.have.lengthOf(1)
+        expect(relationships[0].id).toEqual('3')
+        expect(relationships[0].startNodeId).toEqual('1')
+        expect(relationships[0].endNodeId).toEqual('2')
+        expect(relationships[0].type).toEqual('ACTED_IN')
+        expect(relationships[0].properties).toEqual({})
       }
-      let relationships = extractNodesAndRelationshipsFromRecords([boltRecord], neo4j.v1.types).relationships
-      expect(relationships.length).toBe(0)
-    })
-    test.skip('should not include relationships where end node is not in nodes list', () => {
-      let startNode = new neo4j.v1.types.Node('1', ['Person'], {prop1: 'prop1'})
-      let relationship = new neo4j.v1.types.Relationship('3', startNode.identity, 2, 'ACTED_IN', {})
-      let boltRecord = {
-        keys: ['r', 'n1'],
-        get: (key) => {
-          if (key === 'r') {
-            return relationship
-          }
-          if (key === 'n1') {
-            return startNode
+    )
+
+    test.skip(
+      'should not include relationships where neither start or end node is not in nodes list',
+      () => {
+        let relationship = new neo4j.v1.types.Relationship(
+          '3',
+          1,
+          2,
+          'ACTED_IN',
+          {}
+        )
+        let boltRecord = {
+          keys: ['r'],
+          get: key => relationship
+        }
+        let relationships = extractNodesAndRelationshipsFromRecords(
+          [boltRecord],
+          neo4j.v1.types
+        ).relationships
+        expect(relationships.length).toBe(0)
+      }
+    )
+    test.skip(
+      'should not include relationships where end node is not in nodes list',
+      () => {
+        let startNode = new neo4j.v1.types.Node('1', ['Person'], {
+          prop1: 'prop1'
+        })
+        let relationship = new neo4j.v1.types.Relationship(
+          '3',
+          startNode.identity,
+          2,
+          'ACTED_IN',
+          {}
+        )
+        let boltRecord = {
+          keys: ['r', 'n1'],
+          get: key => {
+            if (key === 'r') {
+              return relationship
+            }
+            if (key === 'n1') {
+              return startNode
+            }
           }
         }
+        let relationships = extractNodesAndRelationshipsFromRecords(
+          [boltRecord],
+          neo4j.v1.types
+        ).relationships
+        expect(relationships.length).toBe(0)
       }
-      let relationships = extractNodesAndRelationshipsFromRecords([boltRecord], neo4j.v1.types).relationships
-      expect(relationships.length).toBe(0)
-    })
-    test.skip('should not include relationships where start node is not in nodes list', () => {
-      let endNode = new neo4j.v1.types.Node('2', ['Movie'], {prop2: 'prop2'})
-      let relationship = new neo4j.v1.types.Relationship('3', '1', endNode.identity, 'ACTED_IN', {})
-      let boltRecord = {
-        keys: ['r', 'n1'],
-        get: (key) => {
-          if (key === 'r') {
-            return relationship
-          }
-          if (key === 'n1') {
-            return endNode
+    )
+    test.skip(
+      'should not include relationships where start node is not in nodes list',
+      () => {
+        let endNode = new neo4j.v1.types.Node('2', ['Movie'], {
+          prop2: 'prop2'
+        })
+        let relationship = new neo4j.v1.types.Relationship(
+          '3',
+          '1',
+          endNode.identity,
+          'ACTED_IN',
+          {}
+        )
+        let boltRecord = {
+          keys: ['r', 'n1'],
+          get: key => {
+            if (key === 'r') {
+              return relationship
+            }
+            if (key === 'n1') {
+              return endNode
+            }
           }
         }
+        let relationships = extractNodesAndRelationshipsFromRecords(
+          [boltRecord],
+          neo4j.v1.types
+        ).relationships
+        expect(relationships.length).toBe(0)
       }
-      let relationships = extractNodesAndRelationshipsFromRecords([boltRecord], neo4j.v1.types).relationships
-      expect(relationships.length).toBe(0)
-    })
+    )
   })
   describe('extractPlan', () => {
     const createPlan = () => {
@@ -252,7 +367,7 @@ describe('boltMappings', () => {
       }
     }
 
-    const checkExtractedPlan = (extractedPlan) => {
+    const checkExtractedPlan = extractedPlan => {
       expect(extractedPlan).not.toBeNull()
       expect(extractedPlan.operatorType).toEqual('operatorType')
       expect(extractedPlan.identifiers).toEqual([])
@@ -306,12 +421,8 @@ describe('boltMappings', () => {
   describe('flattenProperties', () => {
     test('should map properties to object when properties exist', () => {
       // Given
-      const result = [
-        [{properties: {foo: 'bar'}}]
-      ]
-      const expectedResult = [
-        [{foo: 'bar'}]
-      ]
+      const result = [[{ properties: { foo: 'bar' } }]]
+      const expectedResult = [[{ foo: 'bar' }]]
 
       // When
       const flattenedProperties = flattenProperties(result)
@@ -321,9 +432,7 @@ describe('boltMappings', () => {
     })
     test('should not map properties to object when properties do not exist', () => {
       // Given
-      const result = [
-        [{x: {foo: 'bar'}}]
-      ]
+      const result = [[{ x: { foo: 'bar' } }]]
 
       // When
       const flattenedProperties = flattenProperties(result)
@@ -335,15 +444,17 @@ describe('boltMappings', () => {
   describe('extractNodesAndRelationshipsFromRecordsForOldVis', () => {
     test('should recursively look for graph items', () => {
       // Given
-      const firstNode = new neo4j.types.Node('1', ['Person'], {prop1: 'prop1'})
+      const firstNode = new neo4j.types.Node('1', ['Person'], {
+        prop1: 'prop1'
+      })
       const nodeCollection = [
-        new neo4j.types.Node('2', ['Person'], {prop1: 'prop1'}),
-        new neo4j.types.Node('3', ['Person'], {prop1: 'prop1'}),
-        new neo4j.types.Node('4', ['Person'], {prop1: 'prop1'})
+        new neo4j.types.Node('2', ['Person'], { prop1: 'prop1' }),
+        new neo4j.types.Node('3', ['Person'], { prop1: 'prop1' }),
+        new neo4j.types.Node('4', ['Person'], { prop1: 'prop1' })
       ]
       const boltRecord = {
         keys: ['n', 'c'],
-        get: (key) => {
+        get: key => {
           if (key === 'n') {
             return firstNode
           }
@@ -361,7 +472,7 @@ describe('boltMappings', () => {
         false,
         {
           intChecker: () => true,
-          intConverter: (a) => a
+          intConverter: a => a
         }
       )
 
@@ -372,14 +483,14 @@ describe('boltMappings', () => {
       // Given
       const converters = {
         intChecker: () => false,
-        intConverter: (a) => a,
+        intConverter: a => a,
         objectConverter: extractFromNeoObjects
       }
-      const start = new neo4j.types.Node(1, ['X'], {x: 1})
-      const rel1 = new neo4j.types.Relationship(3, 1, 2, 'REL', {rel: 1})
-      const end1 = new neo4j.types.Node(2, ['Y'], {y: 1})
-      const rel2 = new neo4j.types.Relationship(6, 4, 5, 'REL2', {rel: 2})
-      const end = new neo4j.types.Node(5, ['Y'], {y: 2})
+      const start = new neo4j.types.Node(1, ['X'], { x: 1 })
+      const rel1 = new neo4j.types.Relationship(3, 1, 2, 'REL', { rel: 1 })
+      const end1 = new neo4j.types.Node(2, ['Y'], { y: 1 })
+      const rel2 = new neo4j.types.Relationship(6, 4, 5, 'REL2', { rel: 2 })
+      const end = new neo4j.types.Node(5, ['Y'], { y: 2 })
       const segments = [
         new neo4j.types.PathSegment(start, rel1, end1),
         new neo4j.types.PathSegment(end1, rel2, end)
@@ -387,7 +498,7 @@ describe('boltMappings', () => {
       const path = new neo4j.types.Path(start, end, segments)
       const boltRecord = {
         keys: ['p'],
-        get: (key) => {
+        get: key => {
           if (key === 'p') return path
         }
       }
@@ -408,16 +519,16 @@ describe('boltMappings', () => {
       // Given
       const converters = {
         intChecker: () => false,
-        intConverter: (a) => a,
+        intConverter: a => a,
         objectConverter: extractFromNeoObjects
       }
-      const start = new neo4j.types.Node(1, ['X'], {x: 2})
+      const start = new neo4j.types.Node(1, ['X'], { x: 2 })
       const end = start
       const segments = []
       const path = new neo4j.types.Path(start, end, segments)
       const boltRecord = {
         keys: ['p'],
-        get: (key) => {
+        get: key => {
           if (key === 'p') return path
         }
       }
@@ -441,10 +552,10 @@ describe('boltMappings', () => {
       // Given
       const converters = {
         intChecker: () => false,
-        intConverter: (a) => a,
+        intConverter: a => a,
         objectConverter: extractFromNeoObjects
       }
-      const start = new neo4j.types.Node(1, ['X'], {x: 1})
+      const start = new neo4j.types.Node(1, ['X'], { x: 1 })
       const end = start
       const segments = []
       const path = new neo4j.types.Path(start, end, segments)
@@ -459,12 +570,12 @@ describe('boltMappings', () => {
       // Given
       const converters = {
         intChecker: () => false,
-        intConverter: (a) => a,
+        intConverter: a => a,
         objectConverter: extractFromNeoObjects
       }
-      const start = new neo4j.types.Node(1, ['X'], {x: 1})
-      const end = new neo4j.types.Node(2, ['Y'], {y: 1})
-      const rel = new neo4j.types.Relationship(3, 1, 2, 'REL', {rel: 1})
+      const start = new neo4j.types.Node(1, ['X'], { x: 1 })
+      const end = new neo4j.types.Node(2, ['Y'], { y: 1 })
+      const rel = new neo4j.types.Relationship(3, 1, 2, 'REL', { rel: 1 })
       const segments = [new neo4j.types.PathSegment(start, rel, end)]
       const path = new neo4j.types.Path(start, end, segments)
 
@@ -481,14 +592,14 @@ describe('boltMappings', () => {
       // Given
       const converters = {
         intChecker: () => false,
-        intConverter: (a) => a,
+        intConverter: a => a,
         objectConverter: extractFromNeoObjects
       }
-      const start = new neo4j.types.Node(1, ['X'], {x: 1})
-      const rel1 = new neo4j.types.Relationship(3, 1, 2, 'REL', {rel: 1})
-      const end1 = new neo4j.types.Node(2, ['Y'], {y: 1})
-      const rel2 = new neo4j.types.Relationship(6, 4, 5, 'REL2', {rel: 2})
-      const end = new neo4j.types.Node(5, ['Y'], {y: 2})
+      const start = new neo4j.types.Node(1, ['X'], { x: 1 })
+      const rel1 = new neo4j.types.Relationship(3, 1, 2, 'REL', { rel: 1 })
+      const end1 = new neo4j.types.Node(2, ['Y'], { y: 1 })
+      const rel2 = new neo4j.types.Relationship(6, 4, 5, 'REL2', { rel: 2 })
+      const end = new neo4j.types.Node(5, ['Y'], { y: 2 })
       const segments = [
         new neo4j.types.PathSegment(start, rel1, end1),
         new neo4j.types.PathSegment(end1, rel2, end)
@@ -528,15 +639,18 @@ describe('boltMappings', () => {
     })
 
     test('should apply node type to array of data', () => {
-      const rawNodes = [{
-        labels: ['Test'],
-        properties: [],
-        identity: { low: 5, high: 0 }
-      }, {
-        labels: ['Test2'],
-        properties: [],
-        identity: { low: 15, high: 0 }
-      }]
+      const rawNodes = [
+        {
+          labels: ['Test'],
+          properties: [],
+          identity: { low: 5, high: 0 }
+        },
+        {
+          labels: ['Test2'],
+          properties: [],
+          identity: { low: 15, high: 0 }
+        }
+      ]
 
       const typedNodes = applyGraphTypes(rawNodes)
       expect(typedNodes.length).toEqual(2)
@@ -556,33 +670,46 @@ describe('boltMappings', () => {
       }
 
       const typedRelationship = applyGraphTypes(rawRelationship)
-      expect(typedRelationship instanceof neo4j.types.Relationship).toEqual(true)
+      expect(typedRelationship instanceof neo4j.types.Relationship).toEqual(
+        true
+      )
       expect(typedRelationship.identity instanceof neo4j.Integer).toEqual(true)
     })
 
     test('should apply relationship type to array of data', () => {
-      const rawRelationships = [{
-        type: 'TestType',
-        properties: [],
-        identity: { low: 1, high: 0 },
-        start: { low: 5, high: 0 },
-        end: { low: 10, high: 0 }
-      }, {
-        type: 'TestType_2',
-        properties: [],
-        identity: { low: 2, high: 0 },
-        start: { low: 15, high: 0 },
-        end: { low: 20, high: 0 }
-      }]
+      const rawRelationships = [
+        {
+          type: 'TestType',
+          properties: [],
+          identity: { low: 1, high: 0 },
+          start: { low: 5, high: 0 },
+          end: { low: 10, high: 0 }
+        },
+        {
+          type: 'TestType_2',
+          properties: [],
+          identity: { low: 2, high: 0 },
+          start: { low: 15, high: 0 },
+          end: { low: 20, high: 0 }
+        }
+      ]
 
       const typedRelationships = applyGraphTypes(rawRelationships)
       expect(typedRelationships.length).toEqual(2)
-      expect(typedRelationships[0] instanceof neo4j.types.Relationship).toEqual(true)
-      expect(typedRelationships[0].identity instanceof neo4j.Integer).toEqual(true)
+      expect(typedRelationships[0] instanceof neo4j.types.Relationship).toEqual(
+        true
+      )
+      expect(typedRelationships[0].identity instanceof neo4j.Integer).toEqual(
+        true
+      )
       expect(typedRelationships[0].start instanceof neo4j.Integer).toEqual(true)
       expect(typedRelationships[0].end instanceof neo4j.Integer).toEqual(true)
-      expect(typedRelationships[1] instanceof neo4j.types.Relationship).toEqual(true)
-      expect(typedRelationships[1].identity instanceof neo4j.Integer).toEqual(true)
+      expect(typedRelationships[1] instanceof neo4j.types.Relationship).toEqual(
+        true
+      )
+      expect(typedRelationships[1].identity instanceof neo4j.Integer).toEqual(
+        true
+      )
       expect(typedRelationships[1].start instanceof neo4j.Integer).toEqual(true)
       expect(typedRelationships[1].end instanceof neo4j.Integer).toEqual(true)
     })
@@ -618,7 +745,10 @@ describe('boltMappings', () => {
         identity: { low: 10, high: 0 }
       }
 
-      const typedObjects = applyGraphTypes([{ num: rawNumber1, node: rawNode1 }, { num: rawNumber2, node: rawNode2 }])
+      const typedObjects = applyGraphTypes([
+        { num: rawNumber1, node: rawNode1 },
+        { num: rawNumber2, node: rawNode2 }
+      ])
       expect(typedObjects.length).toEqual(2)
       expect(typedObjects[0].node instanceof neo4j.types.Node).toEqual(true)
       expect(typedObjects[0].num instanceof neo4j.Integer).toEqual(true)
@@ -632,7 +762,9 @@ describe('boltMappings', () => {
       expect(typedPathSegment instanceof neo4j.types.PathSegment)
       expect(typedPathSegment.start instanceof neo4j.types.Node).toEqual(true)
       expect(typedPathSegment.end instanceof neo4j.types.Node).toEqual(true)
-      expect(typedPathSegment.relationship instanceof neo4j.types.Relationship).toEqual(true)
+      expect(
+        typedPathSegment.relationship instanceof neo4j.types.Relationship
+      ).toEqual(true)
     })
 
     test('should apply to array of PathSegment type', () => {
@@ -642,23 +774,40 @@ describe('boltMappings', () => {
       const typedPathSegments = applyGraphTypes([segment1, segment2])
       expect(typedPathSegments.length).toEqual(2)
 
-      expect(typedPathSegments[0] instanceof neo4j.types.PathSegment).toEqual(true)
-      expect(typedPathSegments[0].start instanceof neo4j.types.Node).toEqual(true)
+      expect(typedPathSegments[0] instanceof neo4j.types.PathSegment).toEqual(
+        true
+      )
+      expect(typedPathSegments[0].start instanceof neo4j.types.Node).toEqual(
+        true
+      )
       expect(typedPathSegments[0].end instanceof neo4j.types.Node).toEqual(true)
-      expect(typedPathSegments[0].relationship instanceof neo4j.types.Relationship).toEqual(true)
+      expect(
+        typedPathSegments[0].relationship instanceof neo4j.types.Relationship
+      ).toEqual(true)
 
-      expect(typedPathSegments[1] instanceof neo4j.types.PathSegment).toEqual(true)
-      expect(typedPathSegments[1].start instanceof neo4j.types.Node).toEqual(true)
+      expect(typedPathSegments[1] instanceof neo4j.types.PathSegment).toEqual(
+        true
+      )
+      expect(typedPathSegments[1].start instanceof neo4j.types.Node).toEqual(
+        true
+      )
       expect(typedPathSegments[1].end instanceof neo4j.types.Node).toEqual(true)
-      expect(typedPathSegments[1].relationship instanceof neo4j.types.Relationship).toEqual(true)
+      expect(
+        typedPathSegments[1].relationship instanceof neo4j.types.Relationship
+      ).toEqual(true)
     })
 
     test('should apply Path type', () => {
-      const typedPath = applyGraphTypes(getAPath([{ start: 5, end: 10, relationship: 1 }, {
-        start: 10,
-        end: 15,
-        relationship: 2
-      }]))
+      const typedPath = applyGraphTypes(
+        getAPath([
+          { start: 5, end: 10, relationship: 1 },
+          {
+            start: 10,
+            end: 15,
+            relationship: 2
+          }
+        ])
+      )
       expect(typedPath).toBeTruthy()
       expect(typedPath instanceof neo4j.types.Path)
       expect(typedPath.start instanceof neo4j.types.Node).toEqual(true)
@@ -676,7 +825,10 @@ describe('boltMappings', () => {
         identity: { low: 5, high: 0 }
       }
       const rawNum = { low: 100, high: 0 }
-      const rawPath = getAPath([{ start: 5, end: 10, relationship: 1 }, { start: 10, end: 15, relationship: 2 }])
+      const rawPath = getAPath([
+        { start: 5, end: 10, relationship: 1 },
+        { start: 10, end: 15, relationship: 2 }
+      ])
       const rawRelationship = {
         type: 'TestType',
         properties: [],
@@ -685,11 +837,18 @@ describe('boltMappings', () => {
         end: { low: 10, high: 0 }
       }
 
-      const typedObject = applyGraphTypes({ rawNum, rawNode, rawRelationship, rawPath })
+      const typedObject = applyGraphTypes({
+        rawNum,
+        rawNode,
+        rawRelationship,
+        rawPath
+      })
       expect(typedObject).toBeTruthy()
       expect(typedObject.rawNum instanceof neo4j.Integer)
       expect(typedObject.rawNode instanceof neo4j.types.Node).toEqual(true)
-      expect(typedObject.rawRelationship instanceof neo4j.types.Relationship).toEqual(true)
+      expect(
+        typedObject.rawRelationship instanceof neo4j.types.Relationship
+      ).toEqual(true)
       expect(typedObject.rawPath instanceof neo4j.types.Path).toEqual(true)
       expect(typedObject.rawPath.segments.length).toEqual(2)
       expect(typedObject.rawPath.segments[0] instanceof neo4j.types.PathSegment)
@@ -722,7 +881,13 @@ const getAPathSegment = (startId, relId, endId) => {
   return { start: rawStartNode, end: rawEndNode, relationship: rawRelationship }
 }
 
-const getAPath = (segmentList) => {
-  const segments = segmentList.map(segment => getAPathSegment(segment.start, segment.relationship, segment.end))
-  return { start: segments[0].start, end: segments[segments.length - 1].end, segments }
+const getAPath = segmentList => {
+  const segments = segmentList.map(segment =>
+    getAPathSegment(segment.start, segment.relationship, segment.end)
+  )
+  return {
+    start: segments[0].start,
+    end: segments[segments.length - 1].end,
+    segments
+  }
 }

--- a/src/shared/services/bolt/boltWorkerMessages.js
+++ b/src/shared/services/bolt/boltWorkerMessages.js
@@ -24,7 +24,13 @@ export const CYPHER_ERROR_MESSAGE = 'CYPHER_ERROR_MESSAGE'
 export const CYPHER_RESPONSE_MESSAGE = 'CYPHER_RESPONSE_MESSAGE'
 export const POST_CANCEL_TRANSACTION_MESSAGE = 'POST_CANCEL_TRANSACTION_MESSAGE'
 
-export const runCypherMessage = (input, parameters, requestId = null, cancelable = false, connectionProperties) => {
+export const runCypherMessage = (
+  input,
+  parameters,
+  requestId = null,
+  cancelable = false,
+  connectionProperties
+) => {
   return {
     type: RUN_CYPHER_MESSAGE,
     input,
@@ -35,21 +41,21 @@ export const runCypherMessage = (input, parameters, requestId = null, cancelable
   }
 }
 
-export const cancelTransactionMessage = (id) => {
+export const cancelTransactionMessage = id => {
   return {
     type: CANCEL_TRANSACTION_MESSAGE,
     id
   }
 }
 
-export const cypherResponseMessage = (result) => {
+export const cypherResponseMessage = result => {
   return {
     type: CYPHER_RESPONSE_MESSAGE,
     result
   }
 }
 
-export const cypherErrorMessage = (error) => {
+export const cypherErrorMessage = error => {
   return {
     type: CYPHER_ERROR_MESSAGE,
     error

--- a/src/shared/services/bolt/updateStatisticsFields.js
+++ b/src/shared/services/bolt/updateStatisticsFields.js
@@ -1,14 +1,59 @@
 export default [
-  { plural: 'constraints', singular: 'constraint', verb: 'added', field: 'constraintsAdded' },
-  { plural: 'constraints', singular: 'constraint', verb: 'removed', field: 'constraintsRemoved' },
-  { plural: 'indexes', singular: 'index', verb: 'added', field: 'indexesAdded' },
-  { plural: 'indexes', singular: 'index', verb: 'removed', field: 'indexesRemoved' },
+  {
+    plural: 'constraints',
+    singular: 'constraint',
+    verb: 'added',
+    field: 'constraintsAdded'
+  },
+  {
+    plural: 'constraints',
+    singular: 'constraint',
+    verb: 'removed',
+    field: 'constraintsRemoved'
+  },
+  {
+    plural: 'indexes',
+    singular: 'index',
+    verb: 'added',
+    field: 'indexesAdded'
+  },
+  {
+    plural: 'indexes',
+    singular: 'index',
+    verb: 'removed',
+    field: 'indexesRemoved'
+  },
   { plural: 'labels', singular: 'label', verb: 'added', field: 'labelsAdded' },
-  { plural: 'labels', singular: 'label', verb: 'removed', field: 'labelsRemoved' },
+  {
+    plural: 'labels',
+    singular: 'label',
+    verb: 'removed',
+    field: 'labelsRemoved'
+  },
   { plural: 'nodes', singular: 'node', verb: 'created', field: 'nodesCreated' },
   { plural: 'nodes', singular: 'node', verb: 'deleted', field: 'nodesDeleted' },
-  { plural: 'properties', singular: 'property', verb: 'set', field: 'propertiesSet' },
-  { plural: 'relationships', singular: 'relationship', verb: 'deleted', field: 'relationshipDeleted' },
-  { plural: 'relationships', singular: 'relationship', verb: 'deleted', field: 'relationshipsDeleted' },
-  { plural: 'relationships', singular: 'relationship', verb: 'created', field: 'relationshipsCreated' }
+  {
+    plural: 'properties',
+    singular: 'property',
+    verb: 'set',
+    field: 'propertiesSet'
+  },
+  {
+    plural: 'relationships',
+    singular: 'relationship',
+    verb: 'deleted',
+    field: 'relationshipDeleted'
+  },
+  {
+    plural: 'relationships',
+    singular: 'relationship',
+    verb: 'deleted',
+    field: 'relationshipsDeleted'
+  },
+  {
+    plural: 'relationships',
+    singular: 'relationship',
+    verb: 'created',
+    field: 'relationshipsCreated'
+  }
 ]

--- a/src/shared/services/browserSyncService.js
+++ b/src/shared/services/browserSyncService.js
@@ -20,11 +20,11 @@
 
 import * as firebase from 'firebase'
 
-export const authenticate = (dataToken) => {
+export const authenticate = dataToken => {
   return firebase.auth().signInWithCustomToken(dataToken)
 }
 
-export const initialize = (config) => {
+export const initialize = config => {
   if (firebase.apps.length && firebase.apps.length > 0) {
     return
   }
@@ -36,7 +36,7 @@ export const status = () => {
   return firebase.database().ref('.info/connected')
 }
 
-export const getResourceFor = (userId) => {
+export const getResourceFor = userId => {
   return firebase.database().ref('users/' + userId)
 }
 

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -24,224 +24,315 @@ import { getHistory } from 'shared/modules/history/historyDuck'
 import { update as updateQueryResult } from 'shared/modules/requests/requestsDuck'
 import { getActiveConnectionData } from 'shared/modules/connections/connectionsDuck'
 import { getParams } from 'shared/modules/params/paramsDuck'
-import { updateGraphStyleData, getGraphStyleData } from 'shared/modules/grass/grassDuck'
+import {
+  updateGraphStyleData,
+  getGraphStyleData
+} from 'shared/modules/grass/grassDuck'
 import { getRemoteContentHostnameWhitelist } from 'shared/modules/dbMeta/dbMetaDuck'
 import { fetchRemoteGuide } from 'shared/modules/commands/helpers/play'
 import remote from 'services/remote'
 import { isLocalRequest, authHeaderFromCredentials } from 'services/remoteUtils'
 import { handleServerCommand } from 'shared/modules/commands/helpers/server'
 import { handleCypherCommand } from 'shared/modules/commands/helpers/cypher'
-import { unknownCommand, showErrorMessage, cypher, successfulCypher, unsuccessfulCypher } from 'shared/modules/commands/commandsDuck'
+import {
+  unknownCommand,
+  showErrorMessage,
+  cypher,
+  successfulCypher,
+  unsuccessfulCypher
+} from 'shared/modules/commands/commandsDuck'
 import { handleParamsCommand } from 'shared/modules/commands/helpers/params'
-import { handleGetConfigCommand, handleUpdateConfigCommand } from 'shared/modules/commands/helpers/config'
-import { CouldNotFetchRemoteGuideError, FetchURLError } from 'services/exceptions'
-import { parseHttpVerbCommand, isValidURL } from 'shared/modules/commands/helpers/http'
-import { fetchRemoteGrass, parseGrass } from 'shared/modules/commands/helpers/grass'
+import {
+  handleGetConfigCommand,
+  handleUpdateConfigCommand
+} from 'shared/modules/commands/helpers/config'
+import {
+  CouldNotFetchRemoteGuideError,
+  FetchURLError
+} from 'services/exceptions'
+import {
+  parseHttpVerbCommand,
+  isValidURL
+} from 'shared/modules/commands/helpers/http'
+import {
+  fetchRemoteGrass,
+  parseGrass
+} from 'shared/modules/commands/helpers/grass'
 import { shouldUseCypherThread } from 'shared/modules/settings/settingsDuck'
 
-const availableCommands = [{
-  name: 'clear',
-  match: (cmd) => cmd === 'clear',
-  exec: function (action, cmdchar, put) {
-    put(frames.clear())
-  }
-}, {
-  name: 'config',
-  match: (cmd) => /^config(\s|$)/.test(cmd),
-  exec: function (action, cmdchar, put, store) {
-    handleUpdateConfigCommand(action, cmdchar, put, store)
-      .then((res) => {
-        put(frames.add({...action, ...handleGetConfigCommand(action, cmdchar, store)}))
-      })
-      .catch((e) => {
-        put(showErrorMessage(e.message))
-      })
-  }
-}, {
-  name: 'set-params',
-  match: (cmd) => /^params?\s/.test(cmd),
-  exec: function (action, cmdchar, put, store) {
-    handleParamsCommand(action, cmdchar, put)
-      .then((res) => {
-        const params = res.type === 'param' ? res.result : getParams(store.getState())
-        put(frames.add({...action, type: res.type, success: true, params}))
-      })
-      .catch((e) => {
-        put(showErrorMessage(e.message))
-      })
-  }
-}, {
-  name: 'params',
-  match: (cmd) => /^params$/.test(cmd),
-  exec: function (action, cmdchar, put, store) {
-    put(frames.add({...action, type: 'params', params: getParams(store.getState())}))
-  }
-}, {
-  name: 'schema',
-  match: (cmd) => /^schema$/.test(cmd),
-  exec: function (action, cmdchar, put, store) {
-    put(frames.add({...action, type: 'schema'}))
-  }
-}, {
-  name: 'sysinfo',
-  match: (cmd) => /^sysinfo$/.test(cmd),
-  exec: function (action, cmdchar, put, store) {
-    put(frames.add({...action, type: 'sysinfo'}))
-  }
-}, {
-  name: 'cypher',
-  match: (cmd) => /^cypher$/.test(cmd),
-  exec: (action, cmdchar, put, store) => {
-    const state = store.getState()
-    const [id, request] = handleCypherCommand(action, put, getParams(state), shouldUseCypherThread(state))
-    put(cypher(action.cmd))
-    put(frames.add({...action, type: 'cypher', requestId: id}))
-    return request
-      .then((res) => {
-        put(updateQueryResult(id, res, 'success'))
-        put(successfulCypher(action.cmd))
-        return res
-      })
-      .catch(function (e) {
-        put(updateQueryResult(id, e, 'error'))
-        put(unsuccessfulCypher(action.cmd))
-        throw e
-      })
-  }
-}, {
-  name: 'server',
-  match: (cmd) => /^server(\s)/.test(cmd),
-  exec: (action, cmdchar, put, store) => {
-    const response = handleServerCommand(action, cmdchar, put, store)
-    if (response && response.then) {
-      response.then((res) => {
-        if (res) put(frames.add({...action, ...res}))
-      })
-    } else if (response) {
-      put(frames.add({...action, ...response}))
+const availableCommands = [
+  {
+    name: 'clear',
+    match: cmd => cmd === 'clear',
+    exec: function (action, cmdchar, put) {
+      put(frames.clear())
     }
-    return response
-  }
-}, {
-  name: 'play-remote',
-  match: (cmd) => /^play(\s|$)https?/.test(cmd),
-  exec: function (action, cmdchar, put, store) {
-    const url = action.cmd.substr(cmdchar.length + 'play '.length)
-    const whitelist = getRemoteContentHostnameWhitelist(store.getState())
-    fetchRemoteGuide(url, whitelist)
-      .then((r) => {
-        put(frames.add({...action, type: 'play-remote', result: r}))
-      }).catch((e) => {
-        put(frames.add({...action, type: 'play-remote', response: (e.response || null), error: CouldNotFetchRemoteGuideError(e.name + ': ' + e.message)}))
-      })
-  }
-}, {
-  name: 'play',
-  match: (cmd) => /^play(\s|$)/.test(cmd),
-  exec: function (action, cmdchar, put, store) {
-    put(frames.add({...action, type: 'play'}))
-  }
-}, {
-  name: 'history',
-  match: (cmd) => cmd === 'history',
-  exec: function (action, cmdchar, put, store) {
-    const historyState = getHistory(store.getState())
-    const newAction = frames.add({ ...action, result: historyState, type: 'history' })
-    put(newAction)
-    return newAction
-  }
-}, {
-  name: 'queries',
-  match: (cmd) => cmd === 'queries',
-  exec: (action, cmdchar, put, store) => {
-    put(frames.add({ ...action, type: 'queries', result: "{res : 'QUERIES RESULT'}" }))
-  }
-}, {
-  name: 'help',
-  match: (cmd) => /^help(\s|$)/.test(cmd),
-  exec: function (action, cmdchar, put, store) {
-    put(frames.add({...action, type: 'help'}))
-  }
-}, {
-  name: 'http',
-  match: (cmd) => /^(get|post|put|delete|head)/i.test(cmd),
-  exec: (action, cmdchar, put, store) => {
-    return parseHttpVerbCommand(action.cmd)
-      .then((r) => {
-        const hostedUrl = getHostedUrl(store.getState())
-        const isLocal = isLocalRequest(hostedUrl, r.url, { hostnameOnly: false })
-        const connectionData = getActiveConnectionData(store.getState())
-        const isSameHostnameAsConnection = isLocalRequest(connectionData.host, r.url, { hostnameOnly: true })
-        let authHeaders = {}
-        if (isLocal || isSameHostnameAsConnection) {
-          if (connectionData.username) {
-            authHeaders = { 'Authorization': 'Basic ' + authHeaderFromCredentials(connectionData.username, connectionData.password) }
-          }
-        }
-        remote.request(r.method, r.url, r.data, authHeaders)
-          .then((res) => res.text())
-          .then((res) => {
-            put(frames.add({...action, result: res, type: 'pre'}))
-          })
-          .catch((e) => {
-            const error = new FetchURLError(e.message)
-            put(frames.add({...action, error, type: 'error'}))
-          })
-      })
-      .catch((error) => {
-        put(frames.add({...action, error, type: 'error'}))
-      })
-  }
-}, {
-  name: 'style',
-  match: (cmd) => /^style(\s|$)/.test(cmd),
-  exec: function (action, cmdchar, put, store) {
-    const match = action.cmd.match(/:style\s*(\S.*)$/)
-    let param = match && match[1] ? match[1] : ''
-
-    if (param === '') {
-      const grassData = JSON.stringify(getGraphStyleData(store.getState()), null, 2)
-      put(frames.add({...action, type: 'pre', result: grassData}))
-    } else if (param === 'reset') {
-      put(updateGraphStyleData(null))
-    } else if (isValidURL(param)) {
-      if (!param.startsWith('http')) {
-        param = 'http://' + param
+  },
+  {
+    name: 'config',
+    match: cmd => /^config(\s|$)/.test(cmd),
+    exec: function (action, cmdchar, put, store) {
+      handleUpdateConfigCommand(action, cmdchar, put, store)
+        .then(res => {
+          put(
+            frames.add({
+              ...action,
+              ...handleGetConfigCommand(action, cmdchar, store)
+            })
+          )
+        })
+        .catch(e => {
+          put(showErrorMessage(e.message))
+        })
+    }
+  },
+  {
+    name: 'set-params',
+    match: cmd => /^params?\s/.test(cmd),
+    exec: function (action, cmdchar, put, store) {
+      handleParamsCommand(action, cmdchar, put)
+        .then(res => {
+          const params =
+            res.type === 'param' ? res.result : getParams(store.getState())
+          put(frames.add({ ...action, type: res.type, success: true, params }))
+        })
+        .catch(e => {
+          put(showErrorMessage(e.message))
+        })
+    }
+  },
+  {
+    name: 'params',
+    match: cmd => /^params$/.test(cmd),
+    exec: function (action, cmdchar, put, store) {
+      put(
+        frames.add({
+          ...action,
+          type: 'params',
+          params: getParams(store.getState())
+        })
+      )
+    }
+  },
+  {
+    name: 'schema',
+    match: cmd => /^schema$/.test(cmd),
+    exec: function (action, cmdchar, put, store) {
+      put(frames.add({ ...action, type: 'schema' }))
+    }
+  },
+  {
+    name: 'sysinfo',
+    match: cmd => /^sysinfo$/.test(cmd),
+    exec: function (action, cmdchar, put, store) {
+      put(frames.add({ ...action, type: 'sysinfo' }))
+    }
+  },
+  {
+    name: 'cypher',
+    match: cmd => /^cypher$/.test(cmd),
+    exec: (action, cmdchar, put, store) => {
+      const state = store.getState()
+      const [id, request] = handleCypherCommand(
+        action,
+        put,
+        getParams(state),
+        shouldUseCypherThread(state)
+      )
+      put(cypher(action.cmd))
+      put(frames.add({ ...action, type: 'cypher', requestId: id }))
+      return request
+        .then(res => {
+          put(updateQueryResult(id, res, 'success'))
+          put(successfulCypher(action.cmd))
+          return res
+        })
+        .catch(function (e) {
+          put(updateQueryResult(id, e, 'error'))
+          put(unsuccessfulCypher(action.cmd))
+          throw e
+        })
+    }
+  },
+  {
+    name: 'server',
+    match: cmd => /^server(\s)/.test(cmd),
+    exec: (action, cmdchar, put, store) => {
+      const response = handleServerCommand(action, cmdchar, put, store)
+      if (response && response.then) {
+        response.then(res => {
+          if (res) put(frames.add({ ...action, ...res }))
+        })
+      } else if (response) {
+        put(frames.add({ ...action, ...response }))
       }
-
+      return response
+    }
+  },
+  {
+    name: 'play-remote',
+    match: cmd => /^play(\s|$)https?/.test(cmd),
+    exec: function (action, cmdchar, put, store) {
+      const url = action.cmd.substr(cmdchar.length + 'play '.length)
       const whitelist = getRemoteContentHostnameWhitelist(store.getState())
-      fetchRemoteGrass(param, whitelist)
-        .then((response) => {
-          const parsedGrass = parseGrass(response)
-          if (parsedGrass) {
-            put(updateGraphStyleData(parsedGrass))
-          } else {
-            put(showErrorMessage('Could not parse grass file'))
+      fetchRemoteGuide(url, whitelist)
+        .then(r => {
+          put(frames.add({ ...action, type: 'play-remote', result: r }))
+        })
+        .catch(e => {
+          put(
+            frames.add({
+              ...action,
+              type: 'play-remote',
+              response: e.response || null,
+              error: CouldNotFetchRemoteGuideError(e.name + ': ' + e.message)
+            })
+          )
+        })
+    }
+  },
+  {
+    name: 'play',
+    match: cmd => /^play(\s|$)/.test(cmd),
+    exec: function (action, cmdchar, put, store) {
+      put(frames.add({ ...action, type: 'play' }))
+    }
+  },
+  {
+    name: 'history',
+    match: cmd => cmd === 'history',
+    exec: function (action, cmdchar, put, store) {
+      const historyState = getHistory(store.getState())
+      const newAction = frames.add({
+        ...action,
+        result: historyState,
+        type: 'history'
+      })
+      put(newAction)
+      return newAction
+    }
+  },
+  {
+    name: 'queries',
+    match: cmd => cmd === 'queries',
+    exec: (action, cmdchar, put, store) => {
+      put(
+        frames.add({
+          ...action,
+          type: 'queries',
+          result: "{res : 'QUERIES RESULT'}"
+        })
+      )
+    }
+  },
+  {
+    name: 'help',
+    match: cmd => /^help(\s|$)/.test(cmd),
+    exec: function (action, cmdchar, put, store) {
+      put(frames.add({ ...action, type: 'help' }))
+    }
+  },
+  {
+    name: 'http',
+    match: cmd => /^(get|post|put|delete|head)/i.test(cmd),
+    exec: (action, cmdchar, put, store) => {
+      return parseHttpVerbCommand(action.cmd)
+        .then(r => {
+          const hostedUrl = getHostedUrl(store.getState())
+          const isLocal = isLocalRequest(hostedUrl, r.url, {
+            hostnameOnly: false
+          })
+          const connectionData = getActiveConnectionData(store.getState())
+          const isSameHostnameAsConnection = isLocalRequest(
+            connectionData.host,
+            r.url,
+            { hostnameOnly: true }
+          )
+          let authHeaders = {}
+          if (isLocal || isSameHostnameAsConnection) {
+            if (connectionData.username) {
+              authHeaders = {
+                Authorization:
+                  'Basic ' +
+                  authHeaderFromCredentials(
+                    connectionData.username,
+                    connectionData.password
+                  )
+              }
+            }
           }
+          remote
+            .request(r.method, r.url, r.data, authHeaders)
+            .then(res => res.text())
+            .then(res => {
+              put(frames.add({ ...action, result: res, type: 'pre' }))
+            })
+            .catch(e => {
+              const error = new FetchURLError(e.message)
+              put(frames.add({ ...action, error, type: 'error' }))
+            })
         })
-        .catch((e) => {
-          const error = new Error(e)
-          put(frames.add({...action, error, type: 'error'}))
+        .catch(error => {
+          put(frames.add({ ...action, error, type: 'error' }))
         })
-    } else {
-      const parsedGrass = parseGrass(param)
-      if (parsedGrass) {
-        put(updateGraphStyleData(parsedGrass))
+    }
+  },
+  {
+    name: 'style',
+    match: cmd => /^style(\s|$)/.test(cmd),
+    exec: function (action, cmdchar, put, store) {
+      const match = action.cmd.match(/:style\s*(\S.*)$/)
+      let param = match && match[1] ? match[1] : ''
+
+      if (param === '') {
+        const grassData = JSON.stringify(
+          getGraphStyleData(store.getState()),
+          null,
+          2
+        )
+        put(frames.add({ ...action, type: 'pre', result: grassData }))
+      } else if (param === 'reset') {
+        put(updateGraphStyleData(null))
+      } else if (isValidURL(param)) {
+        if (!param.startsWith('http')) {
+          param = 'http://' + param
+        }
+
+        const whitelist = getRemoteContentHostnameWhitelist(store.getState())
+        fetchRemoteGrass(param, whitelist)
+          .then(response => {
+            const parsedGrass = parseGrass(response)
+            if (parsedGrass) {
+              put(updateGraphStyleData(parsedGrass))
+            } else {
+              put(showErrorMessage('Could not parse grass file'))
+            }
+          })
+          .catch(e => {
+            const error = new Error(e)
+            put(frames.add({ ...action, error, type: 'error' }))
+          })
       } else {
-        put(showErrorMessage('Could not parse grass data'))
+        const parsedGrass = parseGrass(param)
+        if (parsedGrass) {
+          put(updateGraphStyleData(parsedGrass))
+        } else {
+          put(showErrorMessage('Could not parse grass data'))
+        }
       }
     }
+  },
+  {
+    name: 'catch-all',
+    match: () => true,
+    exec: (action, cmdchar, put) => {
+      put(unknownCommand(action.cmd))
+    }
   }
-}, {
-  name: 'catch-all',
-  match: () => true,
-  exec: (action, cmdchar, put) => {
-    put(unknownCommand(action.cmd))
-  }
-}]
+]
 
 // First to match wins
-const interpret = (cmd) => {
+const interpret = cmd => {
   return availableCommands.reduce((match, candidate) => {
     if (match) return match
     const isMatch = candidate.match(cmd.toLowerCase())
@@ -251,5 +342,5 @@ const interpret = (cmd) => {
 
 export default {
   interpret,
-  commands: availableCommands.map((command) => command.name)
+  commands: availableCommands.map(command => command.name)
 }

--- a/src/shared/services/commandUtils.js
+++ b/src/shared/services/commandUtils.js
@@ -25,11 +25,8 @@ export function cleanCommand (cmd) {
 }
 
 export function stripEmptyCommandLines (str) {
-  const skipEmptyLines = (e) => !/^\s*$/.test(e)
-  return str
-    .split('\n')
-    .filter(skipEmptyLines)
-    .join('\n')
+  const skipEmptyLines = e => !/^\s*$/.test(e)
+  return str.split('\n').filter(skipEmptyLines).join('\n')
 }
 
 export function stripCommandComments (str) {
@@ -43,7 +40,10 @@ export function splitStringOnFirst (str, delimiter) {
 
 export function splitStringOnLast (str, delimiter) {
   const parts = str.split(delimiter)
-  return [].concat(parts.slice(0, parts.length - 1).join(delimiter), parts[parts.length - 1])
+  return [].concat(
+    parts.slice(0, parts.length - 1).join(delimiter),
+    parts[parts.length - 1]
+  )
 }
 
 export const isCypherCommand = (cmd, cmdchar) => {
@@ -56,35 +56,33 @@ export const getInterpreter = (interpret, cmd, cmdchar) => {
   return interpret(cleanCommand(cmd).substr(cmdchar.length))
 }
 
-export const isNamedInterpreter = (interpreter) => interpreter && interpreter.name !== 'catch-all'
+export const isNamedInterpreter = interpreter =>
+  interpreter && interpreter.name !== 'catch-all'
 
-export const extractPostConnectCommandsFromServerConfig = (str) => {
+export const extractPostConnectCommandsFromServerConfig = str => {
   const substituteStr = '@@semicolon@@'
   const substituteRe = new RegExp(substituteStr, 'g')
-  const replaceFn = (m) => m.replace(/;/g, substituteStr)
-  const qs = [
-    /(`[^`]*?`)/g,
-    /("[^"]*?")/g,
-    /('[^']*?')/g
-  ]
-  qs.forEach((q) => (str = str.replace(q, replaceFn)))
+  const replaceFn = m => m.replace(/;/g, substituteStr)
+  const qs = [/(`[^`]*?`)/g, /("[^"]*?")/g, /('[^']*?')/g]
+  qs.forEach(q => (str = str.replace(q, replaceFn)))
   const splitted = str
     .split(';')
-    .map((item) => item.trim())
-    .map((item) => item.replace(substituteRe, ';'))
-    .filter((item) => item && item.length)
+    .map(item => item.trim())
+    .map(item => item.replace(substituteRe, ';'))
+    .filter(item => item && item.length)
   return splitted && splitted.length ? splitted : undefined
 }
 
-const getHelpTopic = (str) => splitStringOnFirst(str, ' ')[1] || 'help' // Map empty input to :help help
-const lowerCase = (str) => str.toLowerCase()
-const trim = (str) => str.trim()
-const replaceSpaceWithDash = (str) => str.replace(/\s/g, '-')
-const snakeToCamel = (str) => str.replace(/(-\w)/g, (match) => match[1].toUpperCase())
-const prependUnderscore = (str) => '_' + str
+const getHelpTopic = str => splitStringOnFirst(str, ' ')[1] || 'help' // Map empty input to :help help
+const lowerCase = str => str.toLowerCase()
+const trim = str => str.trim()
+const replaceSpaceWithDash = str => str.replace(/\s/g, '-')
+const snakeToCamel = str =>
+  str.replace(/(-\w)/g, match => match[1].toUpperCase())
+const prependUnderscore = str => '_' + str
 
-export const transformCommandToHelpTopic = (inputStr) => {
-  const res = [(inputStr || '')]
+export const transformCommandToHelpTopic = inputStr => {
+  const res = [inputStr || '']
     .map(getHelpTopic)
     .map(lowerCase)
     .map(trim)

--- a/src/shared/services/commandUtils.test.js
+++ b/src/shared/services/commandUtils.test.js
@@ -28,59 +28,76 @@ describe('commandutils', () => {
       '// Another comment\nRETURN 1',
       '// Another comment\nRETURN 1\n//Next comment'
     ]
-    testStrs.forEach((str) => {
+    testStrs.forEach(str => {
       expect(utils.stripCommandComments(str)).toEqual('RETURN 1')
     })
   })
 
   test('stripEmptyCommandLines should remove empty lines ', () => {
-    const testStrs = [
-      '\n\n     \nRETURN 1',
-      '   \n\nRETURN 1\n  \n\n'
-    ]
-    testStrs.forEach((str) => {
+    const testStrs = ['\n\n     \nRETURN 1', '   \n\nRETURN 1\n  \n\n']
+    testStrs.forEach(str => {
       expect(utils.stripEmptyCommandLines(str)).toEqual('RETURN 1')
     })
   })
 
   test('stripEmptyCommandLines should preserve usual newlines ', () => {
-    const testStrs = [
-      'MATCH (n)\nRETURN n'
-    ]
-    testStrs.forEach((str) => {
+    const testStrs = ['MATCH (n)\nRETURN n']
+    testStrs.forEach(str => {
       expect(utils.stripEmptyCommandLines(str)).toEqual('MATCH (n)\nRETURN n')
     })
   })
 
   test('splitStringOnFirst should split strings on first occurance of delimiter ', () => {
     const testStrs = [
-      {str: ':config test:"hello :space"', delimiter: ' ', expect: [':config', 'test:"hello :space"']},
-      {str: 'test:"hello :space"', delimiter: ':', expect: ['test', '"hello :space"']}
+      {
+        str: ':config test:"hello :space"',
+        delimiter: ' ',
+        expect: [':config', 'test:"hello :space"']
+      },
+      {
+        str: 'test:"hello :space"',
+        delimiter: ':',
+        expect: ['test', '"hello :space"']
+      }
     ]
-    testStrs.forEach((obj) => {
-      expect(utils.splitStringOnFirst(obj.str, obj.delimiter)).toEqual(obj.expect)
+    testStrs.forEach(obj => {
+      expect(utils.splitStringOnFirst(obj.str, obj.delimiter)).toEqual(
+        obj.expect
+      )
     })
   })
 
   test('splitStringOnLast should split strings on last occurance of delimiter ', () => {
     const testStrs = [
-      {str: ':config test:"hello :space"', delimiter: ' ', expect: [':config test:"hello', ':space"']},
-      {str: 'test:"hello :space"', delimiter: ':', expect: ['test:"hello ', 'space"']}
+      {
+        str: ':config test:"hello :space"',
+        delimiter: ' ',
+        expect: [':config test:"hello', ':space"']
+      },
+      {
+        str: 'test:"hello :space"',
+        delimiter: ':',
+        expect: ['test:"hello ', 'space"']
+      }
     ]
-    testStrs.forEach((obj) => {
-      expect(utils.splitStringOnLast(obj.str, obj.delimiter)).toEqual(obj.expect)
+    testStrs.forEach(obj => {
+      expect(utils.splitStringOnLast(obj.str, obj.delimiter)).toEqual(
+        obj.expect
+      )
     })
   })
 
   test('isCypherCommand should treat everything not starting with : as cypher', () => {
     const testStrs = [
-      {str: ':config {test: 10}', expect: false},
-      {str: 'return 1', expect: true},
-      {str: '//:hello\nRETURN 1', expect: true},
-      {str: '   RETURN 1', expect: true}
+      { str: ':config {test: 10}', expect: false },
+      { str: 'return 1', expect: true },
+      { str: '//:hello\nRETURN 1', expect: true },
+      { str: '   RETURN 1', expect: true }
     ]
-    testStrs.forEach((obj) => {
-      expect(obj.str + ': ' + utils.isCypherCommand(obj.str, ':')).toEqual(obj.str + ': ' + obj.expect)
+    testStrs.forEach(obj => {
+      expect(obj.str + ': ' + utils.isCypherCommand(obj.str, ':')).toEqual(
+        obj.str + ': ' + obj.expect
+      )
     })
   })
   test('extractPostConnectCommandsFromServerConfig should split and return an array of commands', () => {
@@ -93,18 +110,41 @@ describe('commandutils', () => {
       { str: ':play cypher;', expect: [':play cypher'] },
       { str: ':play cypher ;', expect: [':play cypher'] },
       { str: ';:play cypher;', expect: [':play cypher'] },
-      { str: ':play cypher; :param x: 1', expect: [':play cypher', ':param x: 1'] },
-      { str: 'RETURN 1; RETURN 3; :play start', expect: ['RETURN 1', 'RETURN 3', ':play start'] },
-      { str: 'MATCH (n: {foo: "bar;", bar: "foo;"}) RETURN n', expect: ['MATCH (n: {foo: "bar;", bar: "foo;"}) RETURN n'] },
-      { str: 'MATCH (n: {foo: \'bar;\'}) RETURN n', expect: ['MATCH (n: {foo: \'bar;\'}) RETURN n'] },
-      { str: 'MATCH (n: {foo: `bar;`}) RETURN n', expect: ['MATCH (n: {foo: `bar;`}) RETURN n'] },
-      { str: 'MATCH (n: {foo: `bar;;`}) RETURN n', expect: ['MATCH (n: {foo: `bar;;`}) RETURN n'] },
-      { str: ':play cypher; MATCH (n: {foo: `bar; en;`}) RETURN n', expect: [':play cypher', 'MATCH (n: {foo: `bar; en;`}) RETURN n'] }
+      {
+        str: ':play cypher; :param x: 1',
+        expect: [':play cypher', ':param x: 1']
+      },
+      {
+        str: 'RETURN 1; RETURN 3; :play start',
+        expect: ['RETURN 1', 'RETURN 3', ':play start']
+      },
+      {
+        str: 'MATCH (n: {foo: "bar;", bar: "foo;"}) RETURN n',
+        expect: ['MATCH (n: {foo: "bar;", bar: "foo;"}) RETURN n']
+      },
+      {
+        str: "MATCH (n: {foo: 'bar;'}) RETURN n",
+        expect: ["MATCH (n: {foo: 'bar;'}) RETURN n"]
+      },
+      {
+        str: 'MATCH (n: {foo: `bar;`}) RETURN n',
+        expect: ['MATCH (n: {foo: `bar;`}) RETURN n']
+      },
+      {
+        str: 'MATCH (n: {foo: `bar;;`}) RETURN n',
+        expect: ['MATCH (n: {foo: `bar;;`}) RETURN n']
+      },
+      {
+        str: ':play cypher; MATCH (n: {foo: `bar; en;`}) RETURN n',
+        expect: [':play cypher', 'MATCH (n: {foo: `bar; en;`}) RETURN n']
+      }
     ]
 
     // When & Then
-    testStrs.forEach((item) => {
-      expect(utils.extractPostConnectCommandsFromServerConfig(item.str)).toEqual(item.expect)
+    testStrs.forEach(item => {
+      expect(
+        utils.extractPostConnectCommandsFromServerConfig(item.str)
+      ).toEqual(item.expect)
     })
   })
   test('transformCommandToHelpTopic transforms input to help topics', () => {
@@ -121,7 +161,7 @@ describe('commandutils', () => {
     ]
 
     // When & Then
-    input.forEach((inp) => {
+    input.forEach(inp => {
       expect(utils.transformCommandToHelpTopic(inp.test)).toEqual(inp.expect)
     })
   })

--- a/src/shared/services/cypherErrorsHelper.js
+++ b/src/shared/services/cypherErrorsHelper.js
@@ -1,2 +1,2 @@
-export const isUnknownProcedureError = ({code}) =>
+export const isUnknownProcedureError = ({ code }) =>
   code === 'Neo.ClientError.Procedure.ProcedureNotFound'

--- a/src/shared/services/dom-helpers.js
+++ b/src/shared/services/dom-helpers.js
@@ -20,14 +20,14 @@
 
 /* global HTMLElement */
 const addClass = (node, className) => {
-  if (!((node instanceof HTMLElement) && (typeof className === 'string'))) {
+  if (!(node instanceof HTMLElement && typeof className === 'string')) {
     return
   }
 
   // normalize node class name
   var nodeClassName = ' ' + node.className + ' '
   if (nodeClassName.indexOf(' ' + className + ' ') === -1) {
-    node.className += ((node.className ? ' ' : '') + className)
+    node.className += (node.className ? ' ' : '') + className
   }
 }
 

--- a/src/shared/services/duckUtils.js
+++ b/src/shared/services/duckUtils.js
@@ -20,10 +20,10 @@
 
 export const hydrate = (initialState, state) => {
   if (!state) return state
-  return (state.hydrated) ? state : { ...initialState, ...state, hydrated: true }
+  return state.hydrated ? state : { ...initialState, ...state, hydrated: true }
 }
 
-export const dehydrate = (state) => {
+export const dehydrate = state => {
   if (state) {
     delete state.hydrated
   }

--- a/src/shared/services/exceptionMessages.js
+++ b/src/shared/services/exceptionMessages.js
@@ -18,14 +18,22 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export const AddServerValidationError = 'Wrong format. It should be ":server add name username:password@host:port"'
-export const CreateDataSourceValidationError = 'Wrong format. It should be ":datasource create {"name": "myName", "command": "RETURN rand()", "bookmarkId":"uuid-of-existing-bookmark", "refreshInterval": 10, "parameters": {}}"'
-export const RemoveDataSourceValidationError = 'Wrong format. It should be ":datasource remove uuid-of-existing-datasource"'
-export const BoltConnectionError = 'No connection found, did you connect to Neo4j?'
+export const AddServerValidationError =
+  'Wrong format. It should be ":server add name username:password@host:port"'
+export const CreateDataSourceValidationError =
+  'Wrong format. It should be ":datasource create {"name": "myName", "command": "RETURN rand()", "bookmarkId":"uuid-of-existing-bookmark", "refreshInterval": 10, "parameters": {}}"'
+export const RemoveDataSourceValidationError =
+  'Wrong format. It should be ":datasource remove uuid-of-existing-datasource"'
+export const BoltConnectionError =
+  'No connection found, did you connect to Neo4j?'
 export const BoltError = '#code# - #message#'
 export const Neo4jError = '#message#'
 export const UnknownCommandError = 'Unknown command #cmd#'
-export const BookmarkNotFoundError = 'No connection with the name #name# found. Add a bookmark before trying to connect.'
-export const OpenConnectionNotFoundError = 'No open connection with the name #name# found. You have to connect to a bookmark before you can use it.'
-export const CouldNotFetchRemoteGuideError = 'Can not fetch remote guide: #error#'
-export const FetchURLError = 'Could not fetch URL: "#error#". This could be due to the remote server policy. See your web browsers error console for more information.'
+export const BookmarkNotFoundError =
+  'No connection with the name #name# found. Add a bookmark before trying to connect.'
+export const OpenConnectionNotFoundError =
+  'No open connection with the name #name# found. You have to connect to a bookmark before you can use it.'
+export const CouldNotFetchRemoteGuideError =
+  'Can not fetch remote guide: #error#'
+export const FetchURLError =
+  'Could not fetch URL: "#error#". This could be due to the remote server policy. See your web browsers error console for more information.'

--- a/src/shared/services/exceptions.js
+++ b/src/shared/services/exceptions.js
@@ -24,7 +24,7 @@ export function getErrorMessage (errorObject) {
   let str = messages[errorObject.type]
   if (!str) return
   const keys = Object.keys(errorObject)
-  keys.forEach((prop) => {
+  keys.forEach(prop => {
     const re = new RegExp('(#' + prop + '#)', 'g')
     str = str.replace(re, errorObject[prop])
   })
@@ -46,10 +46,14 @@ export function UserException (message) {
 }
 
 export function ConnectionException (message, code = 'Connection Error') {
-  return {fields: [{
-    code,
-    message
-  }]}
+  return {
+    fields: [
+      {
+        code,
+        message
+      }
+    ]
+  }
 }
 
 export function AddServerValidationError () {

--- a/src/shared/services/exceptions.test.js
+++ b/src/shared/services/exceptions.test.js
@@ -18,7 +18,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 /* global describe, test, expect, jest */
-import { createErrorObject, getErrorMessage, BoltConnectionError } from './exceptions'
+import {
+  createErrorObject,
+  getErrorMessage,
+  BoltConnectionError
+} from './exceptions'
 import * as messages from './exceptionMessages'
 
 describe('getErrorMessage', () => {

--- a/src/shared/services/exporting/pngUtils.js
+++ b/src/shared/services/exporting/pngUtils.js
@@ -51,7 +51,11 @@ const downloadWithDataURI = (filename, dataURI) => {
   }
   mimeString = dataURI.split(',')[0].split(':')[1].split(';')[0]
   ia = new Uint8Array(byteString.length)
-  for (i = j = 0, ref = byteString.length; ref >= 0 ? j <= ref : j >= ref; i = ref >= 0 ? ++j : --j) {
+  for (
+    i = j = 0, ref = byteString.length;
+    ref >= 0 ? j <= ref : j >= ref;
+    i = ref >= 0 ? ++j : --j
+  ) {
     ia[i] = byteString.charCodeAt(i)
   }
   return download(filename, mimeString, ia)

--- a/src/shared/services/exporting/svgUtils.js
+++ b/src/shared/services/exporting/svgUtils.js
@@ -20,12 +20,14 @@
 
 export const prepareForExport = (svgElement, graphElement) => {
   const dimensions = getSvgDimensions(graphElement)
-  let svg = window.d3.select(document.createElementNS('http://www.w3.org/2000/svg', 'svg'))
+  let svg = window.d3.select(
+    document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+  )
 
   svg.append('title').text('Neo4j Graph Visualization')
   svg.append('desc').text('Created using Neo4j (http://www.neo4j.com/)')
 
-  window.d3.select(svgElement).selectAll('g.layer').each((node) => {
+  window.d3.select(svgElement).selectAll('g.layer').each(node => {
     svg.node().appendChild(window.d3.select('.' + node).node().cloneNode(true))
   })
   svg.selectAll('.overlay, .ring').remove()
@@ -39,13 +41,18 @@ export const prepareForExport = (svgElement, graphElement) => {
   return svg
 }
 
-export const getSvgDimensions = (view) => {
+export const getSvgDimensions = view => {
   let boundingBox, dimensions
   boundingBox = view.boundingBox()
   dimensions = {
     width: boundingBox.width,
     height: boundingBox.height,
-    viewBox: [boundingBox.x, boundingBox.y, boundingBox.width, boundingBox.height].join(' ')
+    viewBox: [
+      boundingBox.x,
+      boundingBox.y,
+      boundingBox.width,
+      boundingBox.height
+    ].join(' ')
   }
   return dimensions
 }

--- a/src/shared/services/localstorage.js
+++ b/src/shared/services/localstorage.js
@@ -47,7 +47,7 @@ export function setItem (key, val) {
 
 export function getAll () {
   let out = {}
-  keys.forEach((key) => {
+  keys.forEach(key => {
     let current = getItem(key)
     if (current !== undefined) {
       out[key] = current
@@ -59,16 +59,16 @@ export function getAll () {
 export const clear = () => storage.clear()
 
 export function createReduxMiddleware () {
-  return (store) => (next) => (action) => {
+  return store => next => action => {
     const result = next(action)
     const state = store.getState()
-    keys.forEach((key) => setItem(key, dehydrate(state[key])))
+    keys.forEach(key => setItem(key, dehydrate(state[key])))
     return result
   }
 }
 
 export function applyKeys () {
-  Array.from(arguments).forEach((arg) => (keys.push(arg)))
+  Array.from(arguments).forEach(arg => keys.push(arg))
 }
-export const setPrefix = (p) => (keyPrefix = p)
-export const setStorage = (s) => (storage = s)
+export const setPrefix = p => (keyPrefix = p)
+export const setStorage = s => (storage = s)

--- a/src/shared/services/localstorage.test.js
+++ b/src/shared/services/localstorage.test.js
@@ -27,7 +27,7 @@ describe('localstorage', () => {
     const givenKey = 'myKey'
     const givenVal = 'myVal'
     const storage = {
-      getItem: (key) => {
+      getItem: key => {
         expect(key).toEqual(ls.keyPrefix + givenKey)
         return JSON.stringify(givenVal)
       }
@@ -68,7 +68,7 @@ describe('localstorage', () => {
       key2: [1, 2, 3]
     }
     const storage = {
-      getItem: (key) => {
+      getItem: key => {
         return JSON.stringify(vals[key.substring(ls.keyPrefix.length)])
       }
     }

--- a/src/shared/services/remote.js
+++ b/src/shared/services/remote.js
@@ -32,18 +32,17 @@ function request (method, url, data = null, extraHeaders = {}) {
     method,
     headers: headers,
     body: data
-  })
-  .then(checkStatus)
+  }).then(checkStatus)
 }
 
 function get (url) {
   return fetch(url, {
     method: 'get'
   })
-  .then(checkStatus)
-  .then(function (response) {
-    return response.text()
-  })
+    .then(checkStatus)
+    .then(function (response) {
+      return response.text()
+    })
 }
 
 export function getJSON (url) {
@@ -52,11 +51,13 @@ export function getJSON (url) {
     headers: {
       'Content-Type': 'application/json'
     }
-  }).then((response) => {
-    return response.json()
-  }).catch((e) => {
-    throw new Error(e)
   })
+    .then(response => {
+      return response.json()
+    })
+    .catch(e => {
+      throw new Error(e)
+    })
 }
 
 function checkStatus (response) {

--- a/src/shared/services/remoteUtils.js
+++ b/src/shared/services/remoteUtils.js
@@ -23,8 +23,14 @@ import { getUrlInfo } from 'services/utils'
 
 export function cleanHtml (string) {
   if (typeof string !== 'string') return string
-  string = string.replace(/(\s+(on[^\s=]+)[^\s=]*\s*=\s*("[^"]*"|'[^']*'|[\w\-.:]+\s*))/ig, '')
-  return string.replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*(<\/script>)?/gi, '')
+  string = string.replace(
+    /(\s+(on[^\s=]+)[^\s=]*\s*=\s*("[^"]*"|'[^']*'|[\w\-.:]+\s*))/gi,
+    ''
+  )
+  return string.replace(
+    /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*(<\/script>)?/gi,
+    ''
+  )
 }
 
 export const authHeaderFromCredentials = (username, password) => {
@@ -32,7 +38,11 @@ export const authHeaderFromCredentials = (username, password) => {
   return btoa(`${username}:${password}`)
 }
 
-export const isLocalRequest = (localUrl, requestUrl, opts = { hostnameOnly: false }) => {
+export const isLocalRequest = (
+  localUrl,
+  requestUrl,
+  opts = { hostnameOnly: false }
+) => {
   if (!localUrl) return false
 
   if (opts.hostnameOnly === true) {
@@ -42,8 +52,14 @@ export const isLocalRequest = (localUrl, requestUrl, opts = { hostnameOnly: fals
   const localUrlInfo = getUrlInfo(localUrl)
   const requestUrlInfo = getUrlInfo(requestUrl)
   if (!requestUrlInfo.host) return true // GET /path
-  if (opts.hostnameOnly === true) return requestUrlInfo.hostname === localUrlInfo.hostname // GET localhost:8080 from localhost:9000
-  if (requestUrlInfo.host === localUrlInfo.host && requestUrlInfo.protocol === localUrlInfo.protocol) { // Same host and protocol
+  if (opts.hostnameOnly === true) {
+    return requestUrlInfo.hostname === localUrlInfo.hostname
+  } // GET localhost:8080 from localhost:9000
+  if (
+    requestUrlInfo.host === localUrlInfo.host &&
+    requestUrlInfo.protocol === localUrlInfo.protocol
+  ) {
+    // Same host and protocol
     return true
   }
   return false

--- a/src/shared/services/remoteUtils.test.js
+++ b/src/shared/services/remoteUtils.test.js
@@ -32,7 +32,11 @@ describe('remoteUtils', () => {
       { local: undefined, request: '/yo', expect: false },
       { local: 'http://hej.com', request: '/yo', expect: true },
       { local: 'http://hej.com', request: 'http://hej.com/yo', expect: true },
-      { local: 'http://hej.com:8080', request: 'http://hej.com:9000/mine', expect: false },
+      {
+        local: 'http://hej.com:8080',
+        request: 'http://hej.com:9000/mine',
+        expect: false
+      },
       { local: 'http://hej.com', request: 'https://hej.com', expect: false },
       { local: 'http://hej.com', request: 'http://bye.com', expect: false }
     ]
@@ -40,18 +44,28 @@ describe('remoteUtils', () => {
       { local: undefined, request: '/yo', expect: false },
       { local: 'http://hej.com', request: '/yo', expect: true },
       { local: 'http://hej.com', request: 'http://hej.com/yo', expect: true },
-      { local: 'http://hej.com:8080', request: 'http://hej.com:9000/mine', expect: true },
+      {
+        local: 'http://hej.com:8080',
+        request: 'http://hej.com:9000/mine',
+        expect: true
+      },
       { local: 'http://hej.com', request: 'https://hej.com', expect: true },
       { local: 'http://hej.com', request: 'http://bye.com', expect: false },
-      { local: 'bolt://hej.com:7687', request: 'http://hej.com:7474', expect: true }
+      {
+        local: 'bolt://hej.com:7687',
+        request: 'http://hej.com:7474',
+        expect: true
+      }
     ]
 
     // When && Then
-    itemsStrict.forEach((item) => {
+    itemsStrict.forEach(item => {
       expect(utils.isLocalRequest(item.local, item.request)).toBe(item.expect)
     })
-    itemsHostnameOnly.forEach((item) => {
-      expect(utils.isLocalRequest(item.local, item.request, { hostnameOnly: true })).toBe(item.expect)
+    itemsHostnameOnly.forEach(item => {
+      expect(
+        utils.isLocalRequest(item.local, item.request, { hostnameOnly: true })
+      ).toBe(item.expect)
     })
   })
 })

--- a/src/shared/services/serializer.js
+++ b/src/shared/services/serializer.js
@@ -21,42 +21,46 @@
 const csvDelimiter = ','
 const csvNewline = '\n'
 
-const csvEscape = (str) => {
+const csvEscape = str => {
   if (!isString(str)) return str
   if (isEmptyString(str)) return '""'
-  if (hasQuotes(str) || hasDelimiterChars(str)) return '"' + str.replace(/"/g, '""') + '"'
+  if (hasQuotes(str) || hasDelimiterChars(str)) {
+    return '"' + str.replace(/"/g, '""') + '"'
+  }
   return str
 }
-const serializeObject = (input) => isObject(input) ? JSON.stringify(input) : input
+const serializeObject = input =>
+  isObject(input) ? JSON.stringify(input) : input
 
-const hasDelimiterChars = (str) => str && str.indexOf(csvDelimiter) > -1
-const hasQuotes = (str) => str && str.indexOf('"') > -1
-const isString = (str) => typeof str === 'string'
-const isObject = (str) => typeof str === 'object' && str !== null
-const isEmpty = (str) => typeof str === 'undefined' || str === null
-const isEmptyString = (str) => str === ''
+const hasDelimiterChars = str => str && str.indexOf(csvDelimiter) > -1
+const hasQuotes = str => str && str.indexOf('"') > -1
+const isString = str => typeof str === 'string'
+const isObject = str => typeof str === 'object' && str !== null
+const isEmpty = str => typeof str === 'undefined' || str === null
+const isEmptyString = str => str === ''
 
-const csvChain = (input) => (Array.isArray(input) ? input : [])
-  .map(serializeObject)
-  .map(csvEscape)
-  .join(csvDelimiter)
+const csvChain = input =>
+  (Array.isArray(input) ? input : [])
+    .map(serializeObject)
+    .map(csvEscape)
+    .join(csvDelimiter)
 
-export const CSVSerializer = (cols) => {
+export const CSVSerializer = cols => {
   const _cols = cols
   let _data = []
-  const append = (row) => {
+  const append = row => {
     const emptyRowInOneCol = isEmpty(row) && _cols.length === 1
     if (emptyRowInOneCol) return _data.push(row)
-    if (!row || row.length !== _cols.length) throw new Error('Column number mismatch')
+    if (!row || row.length !== _cols.length) {
+      throw new Error('Column number mismatch')
+    }
     _data.push(row)
   }
   return {
     append,
-    appendRows: (rows) => rows.forEach(append),
+    appendRows: rows => rows.forEach(append),
     output: () =>
       csvChain(_cols) +
-      (
-        !_data.length ? '' : csvNewline + _data.map(csvChain).join(csvNewline)
-      )
+      (!_data.length ? '' : csvNewline + _data.map(csvChain).join(csvNewline))
   }
 }

--- a/src/shared/services/serializer.test.js
+++ b/src/shared/services/serializer.test.js
@@ -33,7 +33,7 @@ describe('resultTransform', () => {
       const s = CSVSerializer(cols)
       expect(s.output()).toEqual('col1,"""col2"""')
     })
-    test('should throw exception when row doesn\'t match columns', () => {
+    test("should throw exception when row doesn't match columns", () => {
       const cols = ['col1', '"col2"']
       const s = CSVSerializer(cols)
       expect(() => s.append(['x'])).toThrowError('Column number mismatch')
@@ -93,7 +93,7 @@ describe('resultTransform', () => {
       expect(s.output()).toEqual('true,false')
     })
     test('should represent Object values as JSON', () => {
-      const cols = [{name: 'John'}]
+      const cols = [{ name: 'John' }]
       const s = CSVSerializer(cols)
       expect(s.output()).toEqual('"{""name"":""John""}"')
     })

--- a/src/shared/services/testUtils.js
+++ b/src/shared/services/testUtils.js
@@ -20,12 +20,10 @@
 
 import { mount as enyzmeMount } from 'enzyme'
 
-export const mount = (Component) => {
-  const wrapper = enyzmeMount(
-    <Component />
-  )
+export const mount = Component => {
+  const wrapper = enyzmeMount(<Component />)
   return {
-    withProps: (props) => {
+    withProps: props => {
       wrapper.setProps(props)
       wrapper.update()
       return Promise.resolve(wrapper)

--- a/src/shared/services/utils.js
+++ b/src/shared/services/utils.js
@@ -21,9 +21,9 @@
 export const deepEquals = (x, y) => {
   if (x && y && typeof x === 'object' && typeof y === 'object') {
     if (Object.keys(x).length !== Object.keys(y).length) return false
-    return Object.keys(x).every((key) => deepEquals(x[key], y[key]))
+    return Object.keys(x).every(key => deepEquals(x[key], y[key]))
   }
-  return (x === y)
+  return x === y
 }
 
 export const shallowEquals = (a, b) => {
@@ -32,7 +32,8 @@ export const shallowEquals = (a, b) => {
   return true
 }
 
-export const flatten = arr => arr.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), [])
+export const flatten = arr =>
+  arr.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), [])
 
 export const moveInArray = (fromIndex, toIndex, arr) => {
   if (!Array.isArray(arr)) return false
@@ -49,7 +50,10 @@ export const debounce = (fn, time, context = null) => {
   let pending
   return (...args) => {
     if (pending) clearTimeout(pending)
-    pending = setTimeout(() => typeof fn === 'function' && fn.apply(context, args), parseInt(time))
+    pending = setTimeout(
+      () => typeof fn === 'function' && fn.apply(context, args),
+      parseInt(time)
+    )
   }
 }
 
@@ -65,20 +69,23 @@ export const throttle = (fn, time, context = null) => {
 
 export const firstSuccessPromise = (list, fn) => {
   return list.reduce((promise, item) => {
-    return promise
-      .catch(() => fn(item))
-      .then((r) => Promise.resolve(r))
+    return promise.catch(() => fn(item)).then(r => Promise.resolve(r))
   }, Promise.reject(new Error()))
 }
 
-export const isRoutingHost = (host) => {
+export const isRoutingHost = host => {
   return /^bolt\+routing:\/\//.test(host)
 }
 
-export const toBoltHost = (host) => {
-  return 'bolt://' + (host || '') // prepend with bolt://
-    .split('bolt://').join('') // remove bolt://
-    .split('bolt+routing://').join('') // remove bolt+routing://
+export const toBoltHost = host => {
+  return (
+    'bolt://' +
+    (host || '') // prepend with bolt://
+      .split('bolt://')
+      .join('') // remove bolt://
+      .split('bolt+routing://')
+      .join('')
+  ) // remove bolt+routing://
 }
 
 export const hostIsAllowed = (uri, whitelist = null) => {
@@ -86,13 +93,20 @@ export const hostIsAllowed = (uri, whitelist = null) => {
   const urlInfo = getUrlInfo(uri)
   const hostname = urlInfo.hostname
   const hostnamePlusProtocol = urlInfo.protocol + '//' + hostname
-  const whitelistedHosts = whitelist && whitelist !== '' ? extractWhitelistFromConfigString(whitelist) : []
-  return whitelistedHosts.indexOf(hostname) > -1 || whitelistedHosts.indexOf(hostnamePlusProtocol) > -1
+  const whitelistedHosts =
+    whitelist && whitelist !== ''
+      ? extractWhitelistFromConfigString(whitelist)
+      : []
+  return (
+    whitelistedHosts.indexOf(hostname) > -1 ||
+    whitelistedHosts.indexOf(hostnamePlusProtocol) > -1
+  )
 }
 
-export const extractWhitelistFromConfigString = (str) => str.split(',').map((s) => s.trim().replace(/\/$/, ''))
+export const extractWhitelistFromConfigString = str =>
+  str.split(',').map(s => s.trim().replace(/\/$/, ''))
 
-export const addProtocolsToUrlList = (list) => {
+export const addProtocolsToUrlList = list => {
   return list.reduce((all, uri) => {
     if (!uri || uri === '*') return all
     const urlInfo = getUrlInfo(uri)
@@ -101,24 +115,28 @@ export const addProtocolsToUrlList = (list) => {
   }, [])
 }
 
-export const getUrlInfo = (url) => {
-  const reURLInformation = new RegExp([
-    '^(?:(https?:)//)?', // protocol
-    '(([^:/?#]*)(?::([0-9]+))?)', // host (hostname and port)
-    '(/{0,1}[^?#]*)', // pathname
-    '(\\?[^#]*|)', // search
-    '(#.*|)$' // hash
-  ].join(''))
+export const getUrlInfo = url => {
+  const reURLInformation = new RegExp(
+    [
+      '^(?:(https?:)//)?', // protocol
+      '(([^:/?#]*)(?::([0-9]+))?)', // host (hostname and port)
+      '(/{0,1}[^?#]*)', // pathname
+      '(\\?[^#]*|)', // search
+      '(#.*|)$' // hash
+    ].join('')
+  )
   const match = url.match(reURLInformation)
-  return match && {
-    protocol: match[1],
-    host: match[2],
-    hostname: match[3],
-    port: match[4],
-    pathname: match[5],
-    search: match[6],
-    hash: match[7]
-  }
+  return (
+    match && {
+      protocol: match[1],
+      host: match[2],
+      hostname: match[3],
+      port: match[4],
+      pathname: match[5],
+      search: match[6],
+      hash: match[7]
+    }
+  )
 }
 
 export const getUrlParamValue = (name, url) => {
@@ -133,9 +151,11 @@ export const getUrlParamValue = (name, url) => {
   return out
 }
 
-export const toHumanReadableBytes = (input) => {
+export const toHumanReadableBytes = input => {
   let number = +input
-  if (!isFinite(number)) { return '-' }
+  if (!isFinite(number)) {
+    return '-'
+  }
 
   if (number < 1024) {
     return `${number} B`
@@ -145,7 +165,9 @@ export const toHumanReadableBytes = (input) => {
   let units = ['KiB', 'MiB', 'GiB', 'TiB']
 
   for (let unit of Array.from(units)) {
-    if (number < 1024) { return `${number.toFixed(2)} ${unit}` }
+    if (number < 1024) {
+      return `${number.toFixed(2)} ${unit}`
+    }
     number /= 1024
   }
 
@@ -175,22 +197,30 @@ export const getBrowserName = function () {
 }
 
 export const removeComments = (string = '') => {
-  return string.split(/\r?\n/).filter((line) => !line.startsWith('//')).join('\r\n')
+  return string
+    .split(/\r?\n/)
+    .filter(line => !line.startsWith('//'))
+    .join('\r\n')
 }
 
-export const canUseDOM = () => !!(
-  (typeof window !== 'undefined' &&
-  window.document && window.document.createElement)
-)
+export const canUseDOM = () =>
+  !!(
+    typeof window !== 'undefined' &&
+    window.document &&
+    window.document.createElement
+  )
 
-export const ecsapeCypherMetaItem = (str) => /^[A-Za-z][A-Za-z0-9_]*$/.test(str) ? str : '`' + str.replace(/`/g, '``') + '`'
+export const ecsapeCypherMetaItem = str =>
+  /^[A-Za-z][A-Za-z0-9_]*$/.test(str)
+    ? str
+    : '`' + str.replace(/`/g, '``') + '`'
 
-export const parseTimeMillis = (timeWithOrWithoutUnit) => {
+export const parseTimeMillis = timeWithOrWithoutUnit => {
   timeWithOrWithoutUnit += '' // cast to string
   const readUnit = timeWithOrWithoutUnit.match(/\D+/)
   const value = parseInt(timeWithOrWithoutUnit)
 
-  const unit = (readUnit === undefined || readUnit === null) ? 's' : readUnit[0] // Assume seconds
+  const unit = readUnit === undefined || readUnit === null ? 's' : readUnit[0] // Assume seconds
 
   switch (unit) {
     case 'ms':
@@ -204,24 +234,50 @@ export const parseTimeMillis = (timeWithOrWithoutUnit) => {
   }
 }
 
-export const stringifyMod = (value, modFn = null, prettyLevel = false, skipOpeningIndentation = false) => {
-  prettyLevel = !prettyLevel ? false : (prettyLevel === true ? 1 : parseInt(prettyLevel))
+export const stringifyMod = (
+  value,
+  modFn = null,
+  prettyLevel = false,
+  skipOpeningIndentation = false
+) => {
+  prettyLevel = !prettyLevel
+    ? false
+    : prettyLevel === true ? 1 : parseInt(prettyLevel)
   const nextPrettyLevel = prettyLevel ? prettyLevel + 1 : false
   const newLine = prettyLevel ? '\n' : ''
-  const indentation = prettyLevel && !skipOpeningIndentation ? Array(prettyLevel).join('  ') : ''
+  const indentation =
+    prettyLevel && !skipOpeningIndentation ? Array(prettyLevel).join('  ') : ''
   const endIndentation = prettyLevel ? Array(prettyLevel).join('  ') : ''
   const propSpacing = prettyLevel ? ' ' : ''
   const toString = Object.prototype.toString
-  const isArray = Array.isArray || function (a) { return toString.call(a) === '[object Array]' }
-  const escMap = {'"': '\\"', '\\': '\\\\', '\b': '\\b', '\f': '\\f', '\n': '\\n', '\r': '\\r', '\t': '\\t'}
-  const escFunc = function (m) { return escMap[m] || '\\u' + (m.charCodeAt(0) + 0x10000).toString(16).substr(1) }
+  const isArray =
+    Array.isArray ||
+    function (a) {
+      return toString.call(a) === '[object Array]'
+    }
+  const escMap = {
+    '"': '\\"',
+    '\\': '\\\\',
+    '\b': '\\b',
+    '\f': '\\f',
+    '\n': '\\n',
+    '\r': '\\r',
+    '\t': '\\t'
+  }
+  const escFunc = function (m) {
+    return (
+      escMap[m] || '\\u' + (m.charCodeAt(0) + 0x10000).toString(16).substr(1)
+    )
+  }
   const escRE = /[\\"\u0000-\u001F\u2028\u2029]/g
   if (modFn) {
     const modVal = modFn && modFn(value)
     if (typeof modVal !== 'undefined') return indentation + modVal
   }
   if (value == null) return indentation + 'null'
-  if (typeof value === 'number') return indentation + (isFinite(value) ? value.toString() : 'null')
+  if (typeof value === 'number') {
+    return indentation + (isFinite(value) ? value.toString() : 'null')
+  }
   if (typeof value === 'boolean') return indentation + value.toString()
   if (typeof value === 'object') {
     if (typeof value.toJSON === 'function') {
@@ -231,19 +287,43 @@ export const stringifyMod = (value, modFn = null, prettyLevel = false, skipOpeni
       let res = ''
       for (let i = 0; i < value.length; i++) {
         hasValues = true
-        res += (i ? ',' : '') + newLine + stringifyMod(value[i], modFn, nextPrettyLevel)
+        res +=
+          (i ? ',' : '') +
+          newLine +
+          stringifyMod(value[i], modFn, nextPrettyLevel)
       }
-      return indentation + '[' + res + (hasValues ? newLine + endIndentation : '') + ']'
+      return (
+        indentation +
+        '[' +
+        res +
+        (hasValues ? newLine + endIndentation : '') +
+        ']'
+      )
     } else if (toString.call(value) === '[object Object]') {
       let tmp = []
       for (const k in value) {
-        if (value.hasOwnProperty(k)) tmp.push(stringifyMod(k, modFn, nextPrettyLevel) + ':' + propSpacing + stringifyMod(value[k], modFn, nextPrettyLevel, true))
+        if (value.hasOwnProperty(k)) {
+          tmp.push(
+            stringifyMod(k, modFn, nextPrettyLevel) +
+              ':' +
+              propSpacing +
+              stringifyMod(value[k], modFn, nextPrettyLevel, true)
+          )
+        }
       }
-      return indentation + '{' + newLine + tmp.join(',' + newLine) + newLine + endIndentation + '}'
+      return (
+        indentation +
+        '{' +
+        newLine +
+        tmp.join(',' + newLine) +
+        newLine +
+        endIndentation +
+        '}'
+      )
     }
   }
   return indentation + '"' + value.toString().replace(escRE, escFunc) + '"'
 }
 
 // Epic helpers
-export const put = (dispatch) => (action) => dispatch(action)
+export const put = dispatch => action => dispatch(action)

--- a/src/shared/services/utils.test.js
+++ b/src/shared/services/utils.test.js
@@ -24,9 +24,9 @@ import * as utils from './utils'
 describe('utils', () => {
   test('can deeply compare objects', () => {
     // Given
-    const o1 = {a: 'a', b: 'b', c: {c: 'c'}}
-    const o2 = {...o1}
-    const o3 = {...o1, c: {c: 'd'}}
+    const o1 = { a: 'a', b: 'b', c: { c: 'c' } }
+    const o2 = { ...o1 }
+    const o3 = { ...o1, c: { c: 'd' } }
     const o4 = { ...o1, d: { e: { f: 'g' } } }
     const o5 = { ...o1, d: { e: { f: 'g' } } }
 
@@ -37,9 +37,9 @@ describe('utils', () => {
   })
   test('can shallowEquals compare objects', () => {
     // Given
-    const o1 = {a: 1, b: 2, c: 'hello'}
-    const o2 = {...o1}
-    const o3 = {...o1, c: {c: 'd'}}
+    const o1 = { a: 1, b: 2, c: 'hello' }
+    const o2 = { ...o1 }
+    const o3 = { ...o1, c: { c: 'd' } }
     const o4 = { ...o1, d: { e: { f: 'g' } } }
     const o5 = { ...o4, d: { e: { f: 'g' } } }
 
@@ -61,7 +61,7 @@ describe('utils', () => {
     ]
 
     // When && Then
-    tests.forEach((t) => {
+    tests.forEach(t => {
       expect(utils.moveInArray(t.from, t.to, t.test)).toEqual(t.expect)
     })
   })
@@ -268,23 +268,39 @@ describe('utils', () => {
       expect(utils.hostIsAllowed('anything', whitelist)).toEqual(true)
     })
     test('can parse url params correctly', () => {
-    // Given
+      // Given
       const urls = [
-        {location: 'http://neo4j.com/?param=1', paramName: 'param', expect: ['1']},
-        {location: 'http://neo4j.com/?param=1&param=2', paramName: 'param', expect: ['1', '2']},
-        {location: 'http://neo4j.com/?param2=2&param=1', paramName: 'param', expect: ['1']},
-        {location: 'http://neo4j.com/?param=', paramName: 'param', expect: undefined},
-        {location: 'http://neo4j.com/', paramName: 'param', expect: undefined}
+        {
+          location: 'http://neo4j.com/?param=1',
+          paramName: 'param',
+          expect: ['1']
+        },
+        {
+          location: 'http://neo4j.com/?param=1&param=2',
+          paramName: 'param',
+          expect: ['1', '2']
+        },
+        {
+          location: 'http://neo4j.com/?param2=2&param=1',
+          paramName: 'param',
+          expect: ['1']
+        },
+        {
+          location: 'http://neo4j.com/?param=',
+          paramName: 'param',
+          expect: undefined
+        },
+        { location: 'http://neo4j.com/', paramName: 'param', expect: undefined }
       ]
 
       // When & Then
-      urls.forEach((tCase) => {
+      urls.forEach(tCase => {
         const res = utils.getUrlParamValue(tCase.paramName, tCase.location)
         expect(res).toEqual(tCase.expect)
       })
     })
     test('can remove commented lines from a string', () => {
-    // Given
+      // Given
       const stringWithComments = '//Hello is is a comment\nSome string'
 
       // When & Then
@@ -294,7 +310,7 @@ describe('utils', () => {
   test('stringifyMod works just as JSON.stringify with no modFn', () => {
     // Given
     const tests = [
-      {x: 1, y: ['yy', true, undefined, null]},
+      { x: 1, y: ['yy', true, undefined, null] },
       null,
       false,
       [[], [0]],
@@ -302,24 +318,17 @@ describe('utils', () => {
     ]
 
     // When & Then
-    tests.forEach((t) => {
+    tests.forEach(t => {
       expect(utils.stringifyMod(t)).toEqual(JSON.stringify(t))
     })
   })
 
   test('stringifyMod works just as JSON.stringify with modFn', () => {
     // Given
-    const modFn = (val) => {
+    const modFn = val => {
       if (Number.isInteger(val)) return val.toString()
     }
-    const tests = [
-      null,
-      false,
-      [[], [0]],
-      '4',
-      4,
-      ['string']
-    ]
+    const tests = [null, false, [[], [0]], '4', 4, ['string']]
     const expects = [
       'null',
       'false',
@@ -342,7 +351,12 @@ describe('utils', () => {
       {
         prop1: 1,
         prop2: [
-          {innerProp: 'innerVal', innerProp2: [{innerInner: 'innerVal2', innerInner2: 'innerInnerVal2'}]}
+          {
+            innerProp: 'innerVal',
+            innerProp2: [
+              { innerInner: 'innerVal2', innerInner2: 'innerInnerVal2' }
+            ]
+          }
         ]
       },
       ['string']
@@ -350,12 +364,21 @@ describe('utils', () => {
     const expects = [
       'false',
       JSON.stringify([[], [0]], null, 2),
-      JSON.stringify({
-        prop1: 1,
-        prop2: [
-          {innerProp: 'innerVal', innerProp2: [{innerInner: 'innerVal2', innerInner2: 'innerInnerVal2'}]}
-        ]
-      }, null, 2),
+      JSON.stringify(
+        {
+          prop1: 1,
+          prop2: [
+            {
+              innerProp: 'innerVal',
+              innerProp2: [
+                { innerInner: 'innerVal2', innerInner2: 'innerInnerVal2' }
+              ]
+            }
+          ]
+        },
+        null,
+        2
+      ),
       JSON.stringify(['string'], null, 2)
     ]
 
@@ -377,7 +400,7 @@ describe('utils', () => {
     ]
 
     // When & Then
-    times.forEach((time) => {
+    times.forEach(time => {
       expect(utils.parseTimeMillis(time.test)).toEqual(time.expect)
     })
   })
@@ -392,7 +415,7 @@ describe('utils', () => {
     ]
 
     // When && Then
-    items.forEach((item) => {
+    items.forEach(item => {
       expect(utils.ecsapeCypherMetaItem(item.test)).toEqual(item.expect)
     })
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,6 +104,12 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
+ansi-align@^1.1.0:
+  version "1.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/ansi-align/-/ansi-align-1.1.0.tgz#2f0c1658829739add5ebb15e6b0c6e3423f016ba"
+  dependencies:
+    string-width "^1.0.1"
+
 ansi-escapes@^1.0.0, ansi-escapes@^1.1.0, ansi-escapes@^1.4.0:
   version "1.4.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
@@ -335,6 +341,27 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
+babel-cli@^6.16.0:
+  version "6.24.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-cli/-/babel-cli-6.24.1.tgz#207cd705bba61489b2ea41b5312341cf6aca2283"
+  dependencies:
+    babel-core "^6.24.1"
+    babel-polyfill "^6.23.0"
+    babel-register "^6.24.1"
+    babel-runtime "^6.22.0"
+    commander "^2.8.1"
+    convert-source-map "^1.1.0"
+    fs-readdir-recursive "^1.0.0"
+    glob "^7.0.0"
+    lodash "^4.2.0"
+    output-file-sync "^1.1.0"
+    path-is-absolute "^1.0.0"
+    slash "^1.0.0"
+    source-map "^0.5.0"
+    v8flags "^2.0.10"
+  optionalDependencies:
+    chokidar "^1.6.1"
+
 babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
@@ -343,7 +370,7 @@ babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-babel-core@^6.0.0, babel-core@^6.24.1, babel-core@^6.7.7:
+babel-core@^6.0.0, babel-core@^6.17.0, babel-core@^6.24.1, babel-core@^6.7.7:
   version "6.25.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-core/-/babel-core-6.25.0.tgz#7dd42b0463c742e9d5296deb3ec67a9322dad729"
   dependencies:
@@ -511,6 +538,13 @@ babel-plugin-istanbul@^4.0.0:
 babel-plugin-jest-hoist@^20.0.3:
   version "20.0.3"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz#afedc853bd3f8dc3548ea671fbe69d03cc2c1767"
+
+babel-plugin-jsx-remove-data-test-id@^1.0.8:
+  version "1.0.8"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-jsx-remove-data-test-id/-/babel-plugin-jsx-remove-data-test-id-1.0.8.tgz#be6445185b5068780bca64dbaf238e91ca99707f"
+  dependencies:
+    babel-cli "^6.16.0"
+    babel-core "^6.17.0"
 
 babel-plugin-module-resolver@^2.4.0:
   version "2.7.1"
@@ -765,7 +799,7 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-polyfill@^6.8.0:
+babel-polyfill@^6.23.0, babel-polyfill@^6.8.0:
   version "6.23.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-polyfill/-/babel-polyfill-6.23.0.tgz#8364ca62df8eafb830499f699177466c3b03499d"
   dependencies:
@@ -962,6 +996,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+bluebird@3.3.4:
+  version "3.3.4"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/bluebird/-/bluebird-3.3.4.tgz#f780fe43e1a7a6510f67abd7d0d79533a40ddde6"
+
 bluebird@^2.10.2:
   version "2.11.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
@@ -994,6 +1032,20 @@ boom@2.x.x:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
   dependencies:
     hoek "2.x.x"
+
+boxen@^0.6.0:
+  version "0.6.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/boxen/-/boxen-0.6.0.tgz#8364d4248ac34ff0ef1b2f2bf49a6c60ce0d81b6"
+  dependencies:
+    ansi-align "^1.1.0"
+    camelcase "^2.1.0"
+    chalk "^1.1.1"
+    cli-boxes "^1.0.0"
+    filled-array "^1.0.0"
+    object-assign "^4.0.1"
+    repeating "^2.0.0"
+    string-width "^1.0.1"
+    widest-line "^1.0.0"
 
 brace-expansion@^1.1.7:
   version "1.1.8"
@@ -1097,6 +1149,10 @@ bser@^2.0.0:
   dependencies:
     node-int64 "^0.4.0"
 
+buffer-crc32@~0.2.3:
+  version "0.2.13"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
+
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
@@ -1176,7 +1232,7 @@ camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
 
-camelcase@^2.0.0:
+camelcase@^2.0.0, camelcase@^2.1.0:
   version "2.1.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
 
@@ -1213,6 +1269,10 @@ caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000697, caniuse-lite@^1.0.30000704:
   version "1.0.30000709"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/caniuse-lite/-/caniuse-lite-1.0.30000709.tgz#e027c7a0dfd5ada58f931a1080fc71965375559b"
+
+capture-stack-trace@^1.0.0:
+  version "1.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz#4a6fa07399c26bba47f0b2496b4d0fb408c5550d"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1287,7 +1347,7 @@ cheerio@^0.22.0:
     lodash.reject "^4.4.0"
     lodash.some "^4.4.0"
 
-chokidar@^1.6.0, chokidar@^1.7.0:
+chokidar@^1.6.0, chokidar@^1.6.1, chokidar@^1.7.0:
   version "1.7.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
   dependencies:
@@ -1331,6 +1391,10 @@ clean-css@4.1.x:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/clean-css/-/clean-css-4.1.4.tgz#eec8811db27457e0078d8ca921fa81b72fa82bf4"
   dependencies:
     source-map "0.5.x"
+
+cli-boxes@^1.0.0:
+  version "1.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
 
 cli-cursor@^1.0.1, cli-cursor@^1.0.2:
   version "1.0.2"
@@ -1403,7 +1467,7 @@ coffee-loader@^0.7.3:
   dependencies:
     loader-utils "^1.0.2"
 
-coffee-script@^1.12.7:
+coffee-script@^1.12.7, coffee-script@^1.9.3:
   version "1.12.7"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/coffee-script/-/coffee-script-1.12.7.tgz#c05dae0cb79591d05b3070a8433a98c9a89ccc53"
 
@@ -1469,6 +1533,10 @@ commander@2.9.x, commander@^2.9.0, commander@~2.9.0:
   dependencies:
     graceful-readlink ">= 1.0.0"
 
+commander@^2.8.1:
+  version "2.11.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+
 common-tags@^1.4.0:
   version "1.4.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/common-tags/-/common-tags-1.4.0.tgz#1187be4f3d4cf0c0427d43f74eef1f73501614c0"
@@ -1516,6 +1584,14 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
 
+concat-stream@1.5.0:
+  version "1.5.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/concat-stream/-/concat-stream-1.5.0.tgz#53f7d43c51c5e43f81c8fdd03321c631be68d611"
+  dependencies:
+    inherits "~2.0.1"
+    readable-stream "~2.0.0"
+    typedarray "~0.0.5"
+
 concat-stream@^1.5.2, concat-stream@^1.6.0:
   version "1.6.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/concat-stream/-/concat-stream-1.6.0.tgz#0aac662fd52be78964d5532f694784e70110acf7"
@@ -1523,6 +1599,20 @@ concat-stream@^1.5.2, concat-stream@^1.6.0:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
+
+configstore@^2.0.0:
+  version "2.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/configstore/-/configstore-2.1.0.tgz#737a3a7036e9886102aa6099e47bb33ab1aba1a1"
+  dependencies:
+    dot-prop "^3.0.0"
+    graceful-fs "^4.1.2"
+    mkdirp "^0.5.0"
+    object-assign "^4.0.1"
+    os-tmpdir "^1.0.0"
+    osenv "^0.1.0"
+    uuid "^2.0.1"
+    write-file-atomic "^1.1.2"
+    xdg-basedir "^2.0.0"
 
 connect-history-api-fallback@^1.3.0:
   version "1.3.0"
@@ -1626,6 +1716,12 @@ create-ecdh@^4.0.0:
   dependencies:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
+
+create-error-class@^3.0.1:
+  version "3.0.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
+  dependencies:
+    capture-stack-trace "^1.0.0"
 
 create-hash@^1.1.0, create-hash@^1.1.1, create-hash@^1.1.2:
   version "1.1.3"
@@ -1830,6 +1926,27 @@ cypher-editor-support@1.0.4:
     fuzzaldrin "2.1.0"
     lodash "4.17.4"
 
+cypress-cli@^0.13.1:
+  version "0.13.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/cypress-cli/-/cypress-cli-0.13.1.tgz#239371ae7bec161eb12ae2b4c999fd685d38e752"
+  dependencies:
+    bluebird "3.3.4"
+    chalk "^1.1.0"
+    coffee-script "^1.9.3"
+    commander "^2.8.1"
+    extract-zip "1.5.0"
+    fs-extra "^0.22.1"
+    home-or-tmp "^2.0.0"
+    human-interval "^0.1.5"
+    lodash "^3.10.0"
+    progress "^1.1.8"
+    request "^2.60.0"
+    request-progress "^0.3.1"
+    through2 "^2.0.0"
+    update-notifier "^1.0.3"
+    xvfb cypress-io/node-xvfb
+    yauzl "^2.4.1"
+
 d@1:
   version "1.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
@@ -1854,6 +1971,10 @@ debug-log@^1.0.0:
   version "1.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
 
+debug@0.7.4, debug@~0.7.4:
+  version "0.7.4"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/debug/-/debug-0.7.4.tgz#06e1ea8082c2cb14e39806e22e2f6f757f92af39"
+
 debug@2.2.0, debug@~2.2.0:
   version "2.2.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
@@ -1877,10 +1998,6 @@ debug@2.6.8, debug@^2.1.1, debug@^2.2.0, debug@^2.6.3, debug@^2.6.6, debug@^2.6.
   resolved "https://neo.jfrog.io/neo/api/npm/npm/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
     ms "2.0.0"
-
-debug@~0.7.4:
-  version "0.7.4"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/debug/-/debug-0.7.4.tgz#06e1ea8082c2cb14e39806e22e2f6f757f92af39"
 
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
@@ -2107,6 +2224,18 @@ domutils@1.5.1, domutils@^1.5.1:
   dependencies:
     dom-serializer "0"
     domelementtype "1"
+
+dot-prop@^3.0.0:
+  version "3.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/dot-prop/-/dot-prop-3.0.0.tgz#1b708af094a49c9a0e7dbcad790aba539dac1177"
+  dependencies:
+    is-obj "^1.0.0"
+
+duplexer2@^0.1.4:
+  version "0.1.4"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
+  dependencies:
+    readable-stream "^2.0.2"
 
 duplexer@^0.1.1:
   version "0.1.1"
@@ -2754,6 +2883,15 @@ extract-text-webpack-plugin@^3.0.0:
     schema-utils "^0.3.0"
     webpack-sources "^1.0.1"
 
+extract-zip@1.5.0:
+  version "1.5.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/extract-zip/-/extract-zip-1.5.0.tgz#92ccf6d81ef70a9fa4c1747114ccef6d8688a6c4"
+  dependencies:
+    concat-stream "1.5.0"
+    debug "0.7.4"
+    mkdirp "0.5.0"
+    yauzl "2.4.1"
+
 extsprintf@1.0.2:
   version "1.0.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
@@ -2816,6 +2954,12 @@ fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
+fd-slicer@~1.0.1:
+  version "1.0.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
+  dependencies:
+    pend "~1.2.0"
+
 figures@^1.3.5, figures@^1.7.0:
   version "1.7.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
@@ -2870,6 +3014,10 @@ fill-range@^2.1.0:
     randomatic "^1.1.3"
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
+
+filled-array@^1.0.0:
+  version "1.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/filled-array/-/filled-array-1.1.0.tgz#c3c4f6c663b923459a9aa29912d2d031f1507f84"
 
 finalhandler@~1.0.3:
   version "1.0.3"
@@ -2972,6 +3120,14 @@ fresh@0.5.0:
   version "0.5.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/fresh/-/fresh-0.5.0.tgz#f474ca5e6a9246d6fd8e0953cfa9b9c805afa78e"
 
+fs-extra@^0.22.1:
+  version "0.22.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/fs-extra/-/fs-extra-0.22.1.tgz#5fd6f8049dc976ca19eb2355d658173cabcce056"
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^2.1.0"
+    rimraf "^2.2.8"
+
 fs-extra@^0.26.4:
   version "0.26.7"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/fs-extra/-/fs-extra-0.26.7.tgz#9ae1fdd94897798edab76d0918cf42d0c3184fa9"
@@ -2981,6 +3137,10 @@ fs-extra@^0.26.4:
     klaw "^1.0.0"
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
+
+fs-readdir-recursive@^1.0.0:
+  version "1.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz#8cd1745c8b4f8a29c8caec392476921ba195f560"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -3149,7 +3309,27 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+got@^5.0.0:
+  version "5.7.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/got/-/got-5.7.1.tgz#5f81635a61e4a6589f180569ea4e381680a51f35"
+  dependencies:
+    create-error-class "^3.0.1"
+    duplexer2 "^0.1.4"
+    is-redirect "^1.0.0"
+    is-retry-allowed "^1.0.0"
+    is-stream "^1.0.0"
+    lowercase-keys "^1.0.0"
+    node-status-codes "^1.0.0"
+    object-assign "^4.0.1"
+    parse-json "^2.1.0"
+    pinkie-promise "^2.0.0"
+    read-all-stream "^3.0.0"
+    readable-stream "^2.0.5"
+    timed-out "^3.0.0"
+    unzip-response "^1.0.2"
+    url-parse-lax "^1.0.0"
+
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -3400,6 +3580,10 @@ http-signature@~1.1.0:
 https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
+
+human-interval@^0.1.5:
+  version "0.1.6"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/human-interval/-/human-interval-0.1.6.tgz#0057973454764c3abcbeb2aed612fc9644e68488"
 
 husky@^0.14.3:
   version "0.14.3"
@@ -3656,6 +3840,10 @@ is-my-json-valid@^2.10.0:
     jsonpointer "^4.0.0"
     xtend "^4.0.0"
 
+is-npm@^1.0.0:
+  version "1.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
+
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -3667,6 +3855,10 @@ is-number@^3.0.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
   dependencies:
     kind-of "^3.0.2"
+
+is-obj@^1.0.0:
+  version "1.0.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
 is-path-cwd@^1.0.0:
   version "1.0.0"
@@ -3710,6 +3902,10 @@ is-property@^1.0.0:
   version "1.0.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
 
+is-redirect@^1.0.0:
+  version "1.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
+
 is-regex@^1.0.3:
   version "1.0.4"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
@@ -3722,7 +3918,11 @@ is-resolvable@^1.0.0:
   dependencies:
     tryit "^1.0.1"
 
-is-stream@^1.0.1, is-stream@^1.1.0:
+is-retry-allowed@^1.0.0:
+  version "1.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
+
+is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -4251,9 +4451,19 @@ klaw@^1.0.0:
   optionalDependencies:
     graceful-fs "^4.1.9"
 
+latest-version@^2.0.0:
+  version "2.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/latest-version/-/latest-version-2.0.0.tgz#56f8d6139620847b8017f8f1f4d78e211324168b"
+  dependencies:
+    package-json "^2.0.0"
+
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
+
+lazy-req@^1.1.0:
+  version "1.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/lazy-req/-/lazy-req-1.1.0.tgz#bdaebead30f8d824039ce0ce149d4daa07ba1fac"
 
 lcid@^1.0.0:
   version "1.0.0"
@@ -4499,6 +4709,10 @@ lodash@4.17.4, lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lo
   version "4.17.4"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
+lodash@^3.10.0:
+  version "3.10.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+
 log-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
@@ -4543,6 +4757,10 @@ loud-rejection@^1.0.0:
 lower-case@^1.1.1:
   version "1.1.4"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
+
+lowercase-keys@^1.0.0:
+  version "1.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
 
 lru-cache@^4.0.1:
   version "4.1.1"
@@ -4712,6 +4930,12 @@ minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
+mkdirp@0.5.0:
+  version "0.5.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/mkdirp/-/mkdirp-0.5.0.tgz#1d73076a6df986cd9344e15e71fcc05a4c9abf12"
+  dependencies:
+    minimist "0.0.8"
+
 mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
@@ -4872,6 +5096,10 @@ node-pre-gyp@^0.6.36:
     semver "^5.3.0"
     tar "^2.2.1"
     tar-pack "^3.4.0"
+
+node-status-codes@^1.0.0:
+  version "1.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/node-status-codes/-/node-status-codes-1.0.0.tgz#5ae5541d024645d32a58fcddc9ceecea7ae3ac2f"
 
 nopt@^4.0.1:
   version "4.0.1"
@@ -5130,12 +5358,20 @@ os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1:
   version "1.0.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
-osenv@^0.1.4:
+osenv@^0.1.0, osenv@^0.1.4:
   version "0.1.4"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/osenv/-/osenv-0.1.4.tgz#42fe6d5953df06c8064be6f176c3d05aaaa34644"
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
+
+output-file-sync@^1.1.0:
+  version "1.1.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/output-file-sync/-/output-file-sync-1.1.2.tgz#d0a33eefe61a205facb90092e826598d5245ce76"
+  dependencies:
+    graceful-fs "^4.1.4"
+    mkdirp "^0.5.1"
+    object-assign "^4.1.0"
 
 p-finally@^1.0.0:
   version "1.0.0"
@@ -5154,6 +5390,15 @@ p-locate@^2.0.0:
 p-map@^1.1.1:
   version "1.1.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/p-map/-/p-map-1.1.1.tgz#05f5e4ae97a068371bc2a5cc86bfbdbc19c4ae7a"
+
+package-json@^2.0.0:
+  version "2.4.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/package-json/-/package-json-2.4.0.tgz#0d15bd67d1cbbddbb2ca222ff2edb86bcb31a8bb"
+  dependencies:
+    got "^5.0.0"
+    registry-auth-token "^3.0.1"
+    registry-url "^3.0.3"
+    semver "^5.1.0"
 
 pako@~0.2.0:
   version "0.2.9"
@@ -5184,7 +5429,7 @@ parse-glob@^3.0.4:
     is-extglob "^1.0.0"
     is-glob "^2.0.0"
 
-parse-json@^2.2.0:
+parse-json@^2.1.0, parse-json@^2.2.0:
   version "2.2.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
   dependencies:
@@ -5281,6 +5526,10 @@ pbkdf2@^3.0.3:
     ripemd160 "^2.0.1"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
+
+pend@~1.2.0:
+  version "1.2.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
 
 performance-now@^0.2.0:
   version "0.2.0"
@@ -6034,7 +6283,7 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
 
-prepend-http@^1.0.0:
+prepend-http@^1.0.0, prepend-http@^1.0.1:
   version "1.0.4"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
 
@@ -6231,7 +6480,7 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
-rc@^1.1.7:
+rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
   version "1.2.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"
   dependencies:
@@ -6330,6 +6579,13 @@ react-timeago@^3.4.3:
   version "3.4.3"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/react-timeago/-/react-timeago-3.4.3.tgz#eb9061eefb044e4a2b09ce8c99d34645b2dbfa25"
 
+read-all-stream@^3.0.0:
+  version "3.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/read-all-stream/-/read-all-stream-3.1.0.tgz#35c3e177f2078ef789ee4bfafa4373074eaef4fa"
+  dependencies:
+    pinkie-promise "^2.0.0"
+    readable-stream "^2.0.0"
+
 read-cache@^1.0.0:
   version "1.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/read-cache/-/read-cache-1.0.0.tgz#e664ef31161166c9751cdbe8dbcf86b5fb58f774"
@@ -6375,6 +6631,18 @@ readable-stream@1.0:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
+readable-stream@^2.0.0, readable-stream@^2.1.5:
+  version "2.3.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~1.0.6"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.0.3"
+    util-deprecate "~1.0.1"
+
 readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2, readable-stream@^2.2.6, readable-stream@^2.2.9:
   version "2.3.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/readable-stream/-/readable-stream-2.3.0.tgz#640f5dcda88c91a8dc60787145629170813a1ed2"
@@ -6385,6 +6653,17 @@ readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable
     process-nextick-args "~1.0.6"
     safe-buffer "~5.1.0"
     string_decoder "~1.0.0"
+    util-deprecate "~1.0.1"
+
+readable-stream@~2.0.0:
+  version "2.0.6"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "~1.0.0"
+    process-nextick-args "~1.0.6"
+    string_decoder "~0.10.x"
     util-deprecate "~1.0.1"
 
 readdirp@^2.0.0:
@@ -6553,6 +6832,19 @@ regexpu-core@^2.0.0:
     regjsgen "^0.2.0"
     regjsparser "^0.1.4"
 
+registry-auth-token@^3.0.1:
+  version "3.3.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/registry-auth-token/-/registry-auth-token-3.3.1.tgz#fb0d3289ee0d9ada2cbb52af5dfe66cb070d3006"
+  dependencies:
+    rc "^1.1.6"
+    safe-buffer "^5.0.1"
+
+registry-url@^3.0.3:
+  version "3.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
+  dependencies:
+    rc "^1.0.1"
+
 regjsgen@^0.2.0:
   version "0.2.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/regjsgen/-/regjsgen-0.2.0.tgz#6c016adeac554f75823fe37ac05b92d5a4edb1f7"
@@ -6595,7 +6887,13 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request@^2.79.0, request@^2.81.0:
+request-progress@^0.3.1:
+  version "0.3.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/request-progress/-/request-progress-0.3.1.tgz#0721c105d8a96ac6b2ce8b2c89ae2d5ecfcf6b3a"
+  dependencies:
+    throttleit "~0.0.2"
+
+request@^2.60.0, request@^2.79.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -6758,6 +7056,10 @@ safe-buffer@^5.1.0, safe-buffer@~5.1.0:
   version "5.1.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/safe-buffer/-/safe-buffer-5.1.0.tgz#fe4c8460397f9eaaaa58e73be46273408a45e223"
 
+safe-buffer@~5.1.1:
+  version "5.1.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
+
 sane@~1.6.0:
   version "1.6.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/sane/-/sane-1.6.0.tgz#9610c452307a135d29c1fdfe2547034180c46775"
@@ -6796,9 +7098,19 @@ selfsigned@^1.9.1:
   dependencies:
     node-forge "0.6.33"
 
+semver-diff@^2.0.0:
+  version "2.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
+  dependencies:
+    semver "^5.0.3"
+
 "semver@2 || 3 || 4 || 5", semver@5.3.0, semver@^5.3.0:
   version "5.3.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
+
+semver@^5.0.3, semver@^5.1.0:
+  version "5.4.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
 send@0.15.3:
   version "0.15.3"
@@ -6906,6 +7218,10 @@ slash@^1.0.0:
 slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
+
+slide@^1.1.5:
+  version "1.1.6"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -7164,6 +7480,12 @@ string_decoder@~1.0.0:
   dependencies:
     safe-buffer "~5.0.1"
 
+string_decoder@~1.0.3:
+  version "1.0.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
+  dependencies:
+    safe-buffer "~5.1.0"
+
 stringstream@~0.0.4:
   version "0.0.5"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
@@ -7362,6 +7684,17 @@ throat@^3.0.0:
   version "3.2.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/throat/-/throat-3.2.0.tgz#50cb0670edbc40237b9e347d7e1f88e4620af836"
 
+throttleit@~0.0.2:
+  version "0.0.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/throttleit/-/throttleit-0.0.2.tgz#cfedf88e60c00dd9697b61fdd2a8343a9b680eaf"
+
+through2@^2.0.0:
+  version "2.0.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
+  dependencies:
+    readable-stream "^2.1.5"
+    xtend "~4.0.1"
+
 through@^2.3.6, through@~2.3.6:
   version "2.3.8"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -7373,6 +7706,10 @@ thunky@^0.1.0:
 time-stamp@^2.0.0:
   version "2.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/time-stamp/-/time-stamp-2.0.0.tgz#95c6a44530e15ba8d6f4a3ecb8c3a3fac46da357"
+
+timed-out@^3.0.0:
+  version "3.1.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/timed-out/-/timed-out-3.1.3.tgz#95860bfcc5c76c277f8f8326fd0f5b2e20eba217"
 
 timers-browserify@^2.0.2:
   version "2.0.2"
@@ -7477,7 +7814,7 @@ type-is@~1.6.15:
     media-typer "0.3.0"
     mime-types "~2.1.15"
 
-typedarray@^0.0.6:
+typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
@@ -7550,6 +7887,23 @@ unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
 
+unzip-response@^1.0.2:
+  version "1.0.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/unzip-response/-/unzip-response-1.0.2.tgz#b984f0877fc0a89c2c773cc1ef7b5b232b5b06fe"
+
+update-notifier@^1.0.3:
+  version "1.0.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/update-notifier/-/update-notifier-1.0.3.tgz#8f92c515482bd6831b7c93013e70f87552c7cf5a"
+  dependencies:
+    boxen "^0.6.0"
+    chalk "^1.0.0"
+    configstore "^2.0.0"
+    is-npm "^1.0.0"
+    latest-version "^2.0.0"
+    lazy-req "^1.1.0"
+    semver-diff "^2.0.0"
+    xdg-basedir "^2.0.0"
+
 upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
@@ -7560,6 +7914,12 @@ url-loader@^0.5.8:
   dependencies:
     loader-utils "^1.0.2"
     mime "1.3.x"
+
+url-parse-lax@^1.0.0:
+  version "1.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
+  dependencies:
+    prepend-http "^1.0.1"
 
 url-parse@1.0.x:
   version "1.0.5"
@@ -7581,6 +7941,10 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
+
+user-home@^1.1.1:
+  version "1.1.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
 
 user-home@^2.0.0:
   version "2.0.0"
@@ -7610,13 +7974,19 @@ utils-merge@1.0.0:
   version "1.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
 
-uuid@^2.0.2:
+uuid@^2.0.1, uuid@^2.0.2:
   version "2.0.3"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
 uuid@^3.0.0, uuid@^3.0.1:
   version "3.1.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+
+v8flags@^2.0.10:
+  version "2.1.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/v8flags/-/v8flags-2.1.1.tgz#aab1a1fa30d45f88dd321148875ac02c0b55e5b4"
+  dependencies:
+    user-home "^1.1.1"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"
@@ -7836,6 +8206,12 @@ wide-align@^1.1.0:
   dependencies:
     string-width "^1.0.2"
 
+widest-line@^1.0.0:
+  version "1.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/widest-line/-/widest-line-1.0.0.tgz#0c09c85c2a94683d0d7eaf8ee097d564bf0e105c"
+  dependencies:
+    string-width "^1.0.1"
+
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
@@ -7855,6 +8231,13 @@ worker-farm@^1.3.1:
     errno ">=0.1.1 <0.2.0-0"
     xtend ">=4.0.0 <4.1.0-0"
 
+worker-loader@^0.8.0:
+  version "0.8.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/worker-loader/-/worker-loader-0.8.1.tgz#e8e995331ea34df5bf68296824bfb7f0ad578d43"
+  dependencies:
+    loader-utils "^1.0.2"
+    schema-utils "^0.3.0"
+
 wrap-ansi@^2.0.0:
   version "2.1.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/wrap-ansi/-/wrap-ansi-2.1.0.tgz#d8fc3d284dd05794fe84973caecdd1cf824fdd85"
@@ -7865,6 +8248,14 @@ wrap-ansi@^2.0.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+write-file-atomic@^1.1.2:
+  version "1.3.4"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/write-file-atomic/-/write-file-atomic-1.3.4.tgz#f807a4f0b1d9e913ae7a48112e6cc3af1991b45f"
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    slide "^1.1.5"
 
 write@^0.2.1:
   version "0.2.1"
@@ -7897,6 +8288,12 @@ wtf-8@1.0.0:
   version "1.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/wtf-8/-/wtf-8-1.0.0.tgz#392d8ba2d0f1c34d1ee2d630f15d0efb68e1048a"
 
+xdg-basedir@^2.0.0:
+  version "2.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/xdg-basedir/-/xdg-basedir-2.0.0.tgz#edbc903cc385fc04523d966a335504b5504d1bd2"
+  dependencies:
+    os-homedir "^1.0.0"
+
 xml-char-classes@^1.0.0:
   version "1.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/xml-char-classes/-/xml-char-classes-1.0.0.tgz#64657848a20ffc5df583a42ad8a277b4512bbc4d"
@@ -7926,9 +8323,13 @@ xmlhttprequest@^1.8.0:
   version "1.8.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
 
-"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1:
+"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
+
+"xvfb@github:cypress-io/node-xvfb":
+  version "0.3.0"
+  resolved "https://codeload.github.com/cypress-io/node-xvfb/tar.gz/22e3783c31d81ebe64d8c0df491ea00cdc74726a"
 
 y18n@^3.2.1:
   version "3.2.1"
@@ -8018,6 +8419,19 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yauzl@2.4.1:
+  version "2.4.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
+  dependencies:
+    fd-slicer "~1.0.1"
+
+yauzl@^2.4.1:
+  version "2.8.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/yauzl/-/yauzl-2.8.0.tgz#79450aff22b2a9c5a41ef54e02db907ccfbf9ee2"
+  dependencies:
+    buffer-crc32 "~0.2.3"
+    fd-slicer "~1.0.1"
 
 yeast@0.1.2:
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8327,7 +8327,7 @@ xmlhttprequest@^1.8.0:
   version "4.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 
-"xvfb@github:cypress-io/node-xvfb":
+xvfb@cypress-io/node-xvfb:
   version "0.3.0"
   resolved "https://codeload.github.com/cypress-io/node-xvfb/tar.gz/22e3783c31d81ebe64d8c0df491ea00cdc74726a"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -43,7 +43,11 @@ acorn@^4.0.3, acorn@^4.0.4:
   version "4.0.13"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
-acorn@^5.0.0, acorn@^5.1.1:
+acorn@^5.0.0, acorn@^5.0.1:
+  version "5.0.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/acorn/-/acorn-5.0.3.tgz#c460df08491463f028ccb82eab3730bf01087b3d"
+
+acorn@^5.1.1:
   version "5.1.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/acorn/-/acorn-5.1.1.tgz#53fe161111f912ab999ee887a90a0bc52822fd75"
 
@@ -66,7 +70,16 @@ ajv@^4.7.0, ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.0.0, ajv@^5.1.5, ajv@^5.2.0:
+ajv@^5.0.0, ajv@^5.1.5:
+  version "5.2.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/ajv/-/ajv-5.2.0.tgz#c1735024c5da2ef75cc190713073d44f098bf486"
+  dependencies:
+    co "^4.6.0"
+    fast-deep-equal "^0.1.0"
+    json-schema-traverse "^0.3.0"
+    json-stable-stringify "^1.0.1"
+
+ajv@^5.2.0:
   version "5.2.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/ajv/-/ajv-5.2.2.tgz#47c68d69e86f5d953103b0074a9430dc63da5e39"
   dependencies:
@@ -91,13 +104,7 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-ansi-align@^1.1.0:
-  version "1.1.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/ansi-align/-/ansi-align-1.1.0.tgz#2f0c1658829739add5ebb15e6b0c6e3423f016ba"
-  dependencies:
-    string-width "^1.0.1"
-
-ansi-escapes@^1.1.0, ansi-escapes@^1.4.0:
+ansi-escapes@^1.0.0, ansi-escapes@^1.1.0, ansi-escapes@^1.4.0:
   version "1.4.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/ansi-escapes/-/ansi-escapes-1.4.0.tgz#d3a8a83b319aa67793662b13e761c7911422306e"
 
@@ -121,7 +128,13 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.0.0, ansi-styles@^3.1.0:
+ansi-styles@^3.0.0:
+  version "3.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/ansi-styles/-/ansi-styles-3.1.0.tgz#09c202d5c917ec23188caa5c9cb9179cd9547750"
+  dependencies:
+    color-convert "^1.0.0"
+
+ansi-styles@^3.1.0:
   version "3.2.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
@@ -132,11 +145,15 @@ antlr4@4.6.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/antlr4/-/antlr4-4.6.0.tgz#0d7e8b4b4692ebf1d9470ae59cf627428bcc6dec"
 
 anymatch@^1.3.0:
-  version "1.3.2"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/anymatch/-/anymatch-1.3.2.tgz#553dcb8f91e3c889845dfdba34c77721b90b9d7a"
+  version "1.3.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/anymatch/-/anymatch-1.3.0.tgz#a3e52fa39168c825ff57b0248126ce5a8ff95507"
   dependencies:
+    arrify "^1.0.0"
     micromatch "^2.1.5"
-    normalize-path "^2.0.0"
+
+app-root-path@^2.0.0:
+  version "2.0.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/app-root-path/-/app-root-path-2.0.1.tgz#cd62dcf8e4fd5a417efc664d2e5b10653c651b46"
 
 append-transform@^0.4.0:
   version "0.4.0"
@@ -168,8 +185,8 @@ arr-diff@^2.0.0:
     arr-flatten "^1.0.1"
 
 arr-flatten@^1.0.1:
-  version "1.1.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/arr-flatten/-/arr-flatten-1.1.0.tgz#36048bbff4e7b47e136644316c99669ea5ae91f1"
+  version "1.0.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/arr-flatten/-/arr-flatten-1.0.3.tgz#a274ed85ac08849b6bd7847c4580745dc51adfb1"
 
 array-equal@^1.0.0:
   version "1.0.0"
@@ -217,8 +234,8 @@ arrify@^1.0.0, arrify@^1.0.1:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
 
 asap@^2.0.3, asap@~2.0.3:
-  version "2.0.6"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+  version "2.0.5"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/asap/-/asap-2.0.5.tgz#522765b50c3510490e52d7dcfe085ef9ba96958f"
 
 ascii-data-table@^2.1.1:
   version "2.1.1"
@@ -268,7 +285,13 @@ async@^1.4.0, async@^1.5.2:
   version "1.5.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
 
-async@^2.1.2, async@^2.1.4, async@^2.4.1:
+async@^2.1.2, async@^2.1.4:
+  version "2.4.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/async/-/async-2.4.1.tgz#62a56b279c98a11d0987096a01cc3eeb8eb7bbd7"
+  dependencies:
+    lodash "^4.14.0"
+
+async@^2.4.1:
   version "2.5.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/async/-/async-2.5.0.tgz#843190fd6b7357a0b9e1c956edddd5ec8462b54d"
   dependencies:
@@ -312,27 +335,6 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
-babel-cli@^6.16.0:
-  version "6.24.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-cli/-/babel-cli-6.24.1.tgz#207cd705bba61489b2ea41b5312341cf6aca2283"
-  dependencies:
-    babel-core "^6.24.1"
-    babel-polyfill "^6.23.0"
-    babel-register "^6.24.1"
-    babel-runtime "^6.22.0"
-    commander "^2.8.1"
-    convert-source-map "^1.1.0"
-    fs-readdir-recursive "^1.0.0"
-    glob "^7.0.0"
-    lodash "^4.2.0"
-    output-file-sync "^1.1.0"
-    path-is-absolute "^1.0.0"
-    slash "^1.0.0"
-    source-map "^0.5.0"
-    v8flags "^2.0.10"
-  optionalDependencies:
-    chokidar "^1.6.1"
-
 babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
   version "6.22.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-code-frame/-/babel-code-frame-6.22.0.tgz#027620bee567a88c32561574e7fd0801d33118e4"
@@ -341,7 +343,7 @@ babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.22.0:
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-babel-core@^6.0.0, babel-core@^6.17.0, babel-core@^6.24.1, babel-core@^6.7.7:
+babel-core@^6.0.0, babel-core@^6.24.1, babel-core@^6.7.7:
   version "6.25.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-core/-/babel-core-6.25.0.tgz#7dd42b0463c742e9d5296deb3ec67a9322dad729"
   dependencies:
@@ -364,6 +366,15 @@ babel-core@^6.0.0, babel-core@^6.17.0, babel-core@^6.24.1, babel-core@^6.7.7:
     private "^0.1.6"
     slash "^1.0.0"
     source-map "^0.5.0"
+
+babel-eslint@>=7.2.3:
+  version "7.2.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-eslint/-/babel-eslint-7.2.3.tgz#b2fe2d80126470f5c19442dc757253a897710827"
+  dependencies:
+    babel-code-frame "^6.22.0"
+    babel-traverse "^6.23.1"
+    babel-types "^6.23.0"
+    babylon "^6.17.0"
 
 babel-generator@^6.18.0, babel-generator@^6.25.0:
   version "6.25.0"
@@ -500,13 +511,6 @@ babel-plugin-istanbul@^4.0.0:
 babel-plugin-jest-hoist@^20.0.3:
   version "20.0.3"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-20.0.3.tgz#afedc853bd3f8dc3548ea671fbe69d03cc2c1767"
-
-babel-plugin-jsx-remove-data-test-id@^1.0.8:
-  version "1.0.8"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-jsx-remove-data-test-id/-/babel-plugin-jsx-remove-data-test-id-1.0.8.tgz#be6445185b5068780bca64dbaf238e91ca99707f"
-  dependencies:
-    babel-cli "^6.16.0"
-    babel-core "^6.17.0"
 
 babel-plugin-module-resolver@^2.4.0:
   version "2.7.1"
@@ -761,7 +765,7 @@ babel-plugin-transform-strict-mode@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
 
-babel-polyfill@^6.23.0, babel-polyfill@^6.8.0:
+babel-polyfill@^6.8.0:
   version "6.23.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-polyfill/-/babel-polyfill-6.23.0.tgz#8364ca62df8eafb830499f699177466c3b03499d"
   dependencies:
@@ -833,7 +837,14 @@ babel-register@^6.24.1:
     mkdirp "^0.5.1"
     source-map-support "^0.4.2"
 
-babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.25.0, babel-runtime@^6.6.1:
+babel-runtime@^6.18.0, babel-runtime@^6.2.0, babel-runtime@^6.22.0, babel-runtime@^6.6.1:
+  version "6.23.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-runtime/-/babel-runtime-6.23.0.tgz#0a9489f144de70efb3ce4300accdb329e2fc543b"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.10.0"
+
+babel-runtime@^6.23.0, babel-runtime@^6.25.0:
   version "6.25.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-runtime/-/babel-runtime-6.25.0.tgz#33b98eaa5d482bb01a8d1aa6b437ad2b01aec41c"
   dependencies:
@@ -850,7 +861,7 @@ babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.25.0:
     babylon "^6.17.2"
     lodash "^4.2.0"
 
-babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.25.0:
+babel-traverse@^6.18.0, babel-traverse@^6.23.1, babel-traverse@^6.24.1, babel-traverse@^6.25.0:
   version "6.25.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-traverse/-/babel-traverse-6.25.0.tgz#2257497e2fcd19b89edc13c4c91381f9512496f1"
   dependencies:
@@ -864,7 +875,7 @@ babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.25.0:
     invariant "^2.2.0"
     lodash "^4.2.0"
 
-babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.25.0:
+babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24.1, babel-types@^6.25.0:
   version "6.25.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-types/-/babel-types-6.25.0.tgz#70afb248d5660e5d18f811d91c8303b54134a18e"
   dependencies:
@@ -873,7 +884,7 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.25
     lodash "^4.2.0"
     to-fast-properties "^1.0.1"
 
-babylon@^6.17.2, babylon@^6.17.4:
+babylon@^6.13.0, babylon@^6.17.0, babylon@^6.17.2:
   version "6.17.4"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/babylon/-/babylon-6.17.4.tgz#3e8b7402b88d22c3423e137a1577883b15ff869a"
 
@@ -902,8 +913,8 @@ base64-arraybuffer@0.1.5:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz#73926771923b5a19747ad666aa5cd4bf9c6e9ce8"
 
 base64-js@^1.0.2:
-  version "1.2.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/base64-js/-/base64-js-1.2.1.tgz#a91947da1f4a516ea38e5b4ec0ec3773675e0886"
+  version "1.2.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/base64-js/-/base64-js-1.2.0.tgz#a39992d723584811982be5e290bb6a53d86700f1"
 
 base64id@1.0.0:
   version "1.0.0"
@@ -934,8 +945,8 @@ big.js@^3.1.3:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/big.js/-/big.js-3.1.3.tgz#4cada2193652eb3ca9ec8e55c9015669c9806978"
 
 binary-extensions@^1.0.0:
-  version "1.9.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/binary-extensions/-/binary-extensions-1.9.0.tgz#66506c16ce6f4d6928a5b3cd6a33ca41e941e37b"
+  version "1.8.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/binary-extensions/-/binary-extensions-1.8.0.tgz#48ec8d16df4377eae5fa5884682480af4d95c774"
 
 blessed@^0.1.81:
   version "0.1.81"
@@ -951,10 +962,6 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@3.3.4:
-  version "3.3.4"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/bluebird/-/bluebird-3.3.4.tgz#f780fe43e1a7a6510f67abd7d0d79533a40ddde6"
-
 bluebird@^2.10.2:
   version "2.11.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
@@ -964,8 +971,8 @@ bluebird@^3.4.7:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
-  version "4.11.7"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/bn.js/-/bn.js-4.11.7.tgz#ddb048e50d9482790094c13eb3fcfc833ce7ab46"
+  version "4.11.6"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/bn.js/-/bn.js-4.11.6.tgz#53344adb14617a13f6e8dd2ce28905d1c0ba3215"
 
 bonjour@^3.5.0:
   version "3.5.0"
@@ -987,20 +994,6 @@ boom@2.x.x:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
   dependencies:
     hoek "2.x.x"
-
-boxen@^0.6.0:
-  version "0.6.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/boxen/-/boxen-0.6.0.tgz#8364d4248ac34ff0ef1b2f2bf49a6c60ce0d81b6"
-  dependencies:
-    ansi-align "^1.1.0"
-    camelcase "^2.1.0"
-    chalk "^1.1.1"
-    cli-boxes "^1.0.0"
-    filled-array "^1.0.0"
-    object-assign "^4.0.1"
-    repeating "^2.0.0"
-    string-width "^1.0.1"
-    widest-line "^1.0.0"
 
 brace-expansion@^1.1.7:
   version "1.1.8"
@@ -1086,11 +1079,11 @@ browserslist@^1.3.6, browserslist@^1.5.2, browserslist@^1.7.6:
     electron-to-chromium "^1.2.7"
 
 browserslist@^2.0.0, browserslist@^2.1.5:
-  version "2.3.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/browserslist/-/browserslist-2.3.0.tgz#b2aa76415c71643fe2368f6243b43bbbb4211752"
+  version "2.2.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/browserslist/-/browserslist-2.2.2.tgz#e9b4618b8a01c193f9786beea09f6fd10dbe31c3"
   dependencies:
-    caniuse-lite "^1.0.30000710"
-    electron-to-chromium "^1.3.17"
+    caniuse-lite "^1.0.30000704"
+    electron-to-chromium "^1.3.16"
 
 bser@1.0.2:
   version "1.0.2"
@@ -1103,10 +1096,6 @@ bser@^2.0.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
   dependencies:
     node-int64 "^0.4.0"
-
-buffer-crc32@~0.2.3:
-  version "0.2.13"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
 
 buffer-equal-constant-time@1.0.1:
   version "1.0.1"
@@ -1129,8 +1118,8 @@ buffer@^4.3.0:
     isarray "^1.0.0"
 
 buffer@^5.0.3:
-  version "5.0.7"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/buffer/-/buffer-5.0.7.tgz#570a290b625cf2603290c1149223d27ccf04db97"
+  version "5.0.6"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/buffer/-/buffer-5.0.6.tgz#2ea669f7eec0b6eda05b08f8b5ff661b28573588"
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -1143,9 +1132,9 @@ builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
 
-bytes@2.5.0:
-  version "2.5.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/bytes/-/bytes-2.5.0.tgz#4c9423ea2d252c270c41b2bdefeff9bb6b62c06a"
+bytes@2.3.0:
+  version "2.3.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/bytes/-/bytes-2.3.0.tgz#d5b680a165b6201739acb611542aabc2d8ceb070"
 
 caller-path@^0.1.0:
   version "0.1.0"
@@ -1187,7 +1176,7 @@ camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
 
-camelcase@^2.0.0, camelcase@^2.1.0:
+camelcase@^2.0.0:
   version "2.1.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/camelcase/-/camelcase-2.1.1.tgz#7c1d16d679a1bbe59ca02cacecfb011e201f5a1f"
 
@@ -1218,16 +1207,12 @@ caniuse-api@^2.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-db@^1.0.30000529, caniuse-db@^1.0.30000634, caniuse-db@^1.0.30000639:
-  version "1.0.30000712"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/caniuse-db/-/caniuse-db-1.0.30000712.tgz#89748396f9d7419d5fa27df3b48872dadbf8318a"
+  version "1.0.30000692"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/caniuse-db/-/caniuse-db-1.0.30000692.tgz#3da9a99353adbcea1e142b99f60ecc6216df47a5"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000697, caniuse-lite@^1.0.30000710:
-  version "1.0.30000712"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/caniuse-lite/-/caniuse-lite-1.0.30000712.tgz#b4732def2459224f3f78c6a9ba103abfcc705670"
-
-capture-stack-trace@^1.0.0:
-  version "1.0.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz#4a6fa07399c26bba47f0b2496b4d0fb408c5550d"
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000697, caniuse-lite@^1.0.30000704:
+  version "1.0.30000709"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/caniuse-lite/-/caniuse-lite-1.0.30000709.tgz#e027c7a0dfd5ada58f931a1080fc71965375559b"
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -1241,8 +1226,8 @@ center-align@^0.1.1:
     lazy-cache "^1.0.3"
 
 chai@*:
-  version "4.1.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/chai/-/chai-4.1.1.tgz#66e21279e6f3c6415ff8231878227900e2171b39"
+  version "4.0.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/chai/-/chai-4.0.2.tgz#2f7327c4de6f385dd7787999e2ab02697a32b83b"
   dependencies:
     assertion-error "^1.0.1"
     check-error "^1.0.1"
@@ -1270,8 +1255,8 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     supports-color "^2.0.0"
 
 chalk@^2.0.0, chalk@^2.0.1:
-  version "2.1.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
+  version "2.0.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/chalk/-/chalk-2.0.1.tgz#dbec49436d2ae15f536114e76d14656cdbc0f44d"
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
@@ -1302,7 +1287,7 @@ cheerio@^0.22.0:
     lodash.reject "^4.4.0"
     lodash.some "^4.4.0"
 
-chokidar@^1.6.0, chokidar@^1.6.1, chokidar@^1.7.0:
+chokidar@^1.6.0, chokidar@^1.7.0:
   version "1.7.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
   dependencies:
@@ -1322,15 +1307,14 @@ ci-info@^1.0.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/ci-info/-/ci-info-1.0.0.tgz#dc5285f2b4e251821683681c381c3388f46ec534"
 
 cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
-  version "1.0.4"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/cipher-base/-/cipher-base-1.0.4.tgz#8760e4ecc272f4c363532f926d874aae2c1397de"
+  version "1.0.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/cipher-base/-/cipher-base-1.0.3.tgz#eeabf194419ce900da3018c207d212f2a6df0a07"
   dependencies:
     inherits "^2.0.1"
-    safe-buffer "^5.0.1"
 
 circular-json@^0.3.1:
-  version "0.3.3"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/circular-json/-/circular-json-0.3.3.tgz#815c99ea84f6809529d2f45791bdf82711352d66"
+  version "0.3.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/circular-json/-/circular-json-0.3.1.tgz#be8b36aefccde8b3ca7aa2d6afc07a37242c0d2d"
 
 clap@^1.0.9:
   version "1.2.0"
@@ -1343,16 +1327,12 @@ classnames@^2.2.5:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/classnames/-/classnames-2.2.5.tgz#fb3801d453467649ef3603c7d61a02bd129bde6d"
 
 clean-css@4.1.x:
-  version "4.1.7"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/clean-css/-/clean-css-4.1.7.tgz#b9aea4f85679889cf3eae8b40349ec4ebdfdd032"
+  version "4.1.4"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/clean-css/-/clean-css-4.1.4.tgz#eec8811db27457e0078d8ca921fa81b72fa82bf4"
   dependencies:
     source-map "0.5.x"
 
-cli-boxes@^1.0.0:
-  version "1.0.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/cli-boxes/-/cli-boxes-1.0.0.tgz#4fa917c3e59c94a004cd61f8ee509da651687143"
-
-cli-cursor@^1.0.1:
+cli-cursor@^1.0.1, cli-cursor@^1.0.2:
   version "1.0.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/cli-cursor/-/cli-cursor-1.0.2.tgz#64da3f7d56a54412e59794bd62dc35295e8f2987"
   dependencies:
@@ -1363,6 +1343,17 @@ cli-cursor@^2.1.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
   dependencies:
     restore-cursor "^2.0.0"
+
+cli-spinners@^0.1.2:
+  version "0.1.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/cli-spinners/-/cli-spinners-0.1.2.tgz#bb764d88e185fb9e1e6a2a1f19772318f605e31c"
+
+cli-truncate@^0.2.1:
+  version "0.2.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/cli-truncate/-/cli-truncate-0.2.1.tgz#9f15cfbb0705005369216c626ac7d05ab90dd574"
+  dependencies:
+    slice-ansi "0.0.4"
+    string-width "^1.0.1"
 
 cli-width@^2.0.0:
   version "2.1.0"
@@ -1393,8 +1384,8 @@ co@^4.6.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
 
 coa@~1.0.1:
-  version "1.0.4"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/coa/-/coa-1.0.4.tgz#a9ef153660d6a86a8bdec0289a5c684d217432fd"
+  version "1.0.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/coa/-/coa-1.0.3.tgz#1b54a5e1dcf77c990455d4deea98c564416dc893"
   dependencies:
     q "^1.1.2"
 
@@ -1412,19 +1403,19 @@ coffee-loader@^0.7.3:
   dependencies:
     loader-utils "^1.0.2"
 
-coffee-script@^1.12.7, coffee-script@^1.9.3:
+coffee-script@^1.12.7:
   version "1.12.7"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/coffee-script/-/coffee-script-1.12.7.tgz#c05dae0cb79591d05b3070a8433a98c9a89ccc53"
 
-color-convert@^1.3.0, color-convert@^1.8.2, color-convert@^1.9.0:
+color-convert@^1.0.0, color-convert@^1.3.0, color-convert@^1.8.2, color-convert@^1.9.0:
   version "1.9.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/color-convert/-/color-convert-1.9.0.tgz#1accf97dd739b983bf994d56fec8f95853641b7a"
   dependencies:
     color-name "^1.1.1"
 
 color-name@^1.0.0, color-name@^1.1.1:
-  version "1.1.3"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
+  version "1.1.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/color-name/-/color-name-1.1.2.tgz#5c8ab72b64bd2215d617ae9559ebb148475cf98d"
 
 color-string@^0.3.0:
   version "0.3.0"
@@ -1472,9 +1463,17 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@2.11.x, commander@^2.8.1, commander@^2.9.0, commander@~2.11.0:
-  version "2.11.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
+commander@2.9.x, commander@^2.9.0, commander@~2.9.0:
+  version "2.9.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
+  dependencies:
+    graceful-readlink ">= 1.0.0"
+
+common-tags@^1.4.0:
+  version "1.4.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/common-tags/-/common-tags-1.4.0.tgz#1187be4f3d4cf0c0427d43f74eef1f73501614c0"
+  dependencies:
+    babel-runtime "^6.18.0"
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -1496,35 +1495,26 @@ component-inherit@0.0.3:
   version "0.0.3"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/component-inherit/-/component-inherit-0.0.3.tgz#645fc4adf58b72b649d5cae65135619db26ff143"
 
-compressible@~2.0.10:
-  version "2.0.11"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/compressible/-/compressible-2.0.11.tgz#16718a75de283ed8e604041625a2064586797d8a"
+compressible@~2.0.8:
+  version "2.0.10"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/compressible/-/compressible-2.0.10.tgz#feda1c7f7617912732b29bf8cf26252a20b9eecd"
   dependencies:
-    mime-db ">= 1.29.0 < 2"
+    mime-db ">= 1.27.0 < 2"
 
 compression@^1.5.2:
-  version "1.7.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/compression/-/compression-1.7.0.tgz#030c9f198f1643a057d776a738e922da4373012d"
+  version "1.6.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/compression/-/compression-1.6.2.tgz#cceb121ecc9d09c52d7ad0c3350ea93ddd402bc3"
   dependencies:
     accepts "~1.3.3"
-    bytes "2.5.0"
-    compressible "~2.0.10"
-    debug "2.6.8"
+    bytes "2.3.0"
+    compressible "~2.0.8"
+    debug "~2.2.0"
     on-headers "~1.0.1"
-    safe-buffer "5.1.1"
-    vary "~1.1.1"
+    vary "~1.1.0"
 
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-
-concat-stream@1.5.0:
-  version "1.5.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/concat-stream/-/concat-stream-1.5.0.tgz#53f7d43c51c5e43f81c8fdd03321c631be68d611"
-  dependencies:
-    inherits "~2.0.1"
-    readable-stream "~2.0.0"
-    typedarray "~0.0.5"
 
 concat-stream@^1.5.2, concat-stream@^1.6.0:
   version "1.6.0"
@@ -1533,20 +1523,6 @@ concat-stream@^1.5.2, concat-stream@^1.6.0:
     inherits "^2.0.3"
     readable-stream "^2.2.2"
     typedarray "^0.0.6"
-
-configstore@^2.0.0:
-  version "2.1.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/configstore/-/configstore-2.1.0.tgz#737a3a7036e9886102aa6099e47bb33ab1aba1a1"
-  dependencies:
-    dot-prop "^3.0.0"
-    graceful-fs "^4.1.2"
-    mkdirp "^0.5.0"
-    object-assign "^4.0.1"
-    os-tmpdir "^1.0.0"
-    osenv "^0.1.0"
-    uuid "^2.0.1"
-    write-file-atomic "^1.1.2"
-    xdg-basedir "^2.0.0"
 
 connect-history-api-fallback@^1.3.0:
   version "1.3.0"
@@ -1612,16 +1588,29 @@ core-js@^1.0.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
 
 core-js@^2.4.0, core-js@^2.4.1:
-  version "2.5.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/core-js/-/core-js-2.5.0.tgz#569c050918be6486b3837552028ae0466b717086"
+  version "2.4.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/core-js/-/core-js-2.4.1.tgz#4de911e667b0eae9124e34254b53aea6fc618d3e"
 
-core-util-is@1.0.2, core-util-is@~1.0.0:
+core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
+cosmiconfig@^1.1.0:
+  version "1.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/cosmiconfig/-/cosmiconfig-1.1.0.tgz#0dea0f9804efdfb929fbb1b188e25553ea053d37"
+  dependencies:
+    graceful-fs "^4.1.2"
+    js-yaml "^3.4.3"
+    minimist "^1.2.0"
+    object-assign "^4.0.1"
+    os-homedir "^1.0.1"
+    parse-json "^2.2.0"
+    pinkie-promise "^2.0.0"
+    require-from-string "^1.1.0"
+
 cosmiconfig@^2.1.0, cosmiconfig@^2.1.1:
-  version "2.2.2"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/cosmiconfig/-/cosmiconfig-2.2.2.tgz#6173cebd56fac042c1f4390edf7af6c07c7cb892"
+  version "2.1.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/cosmiconfig/-/cosmiconfig-2.1.3.tgz#952771eb0dddc1cb3fa2f6fbe51a522e93b3ee0a"
   dependencies:
     is-directory "^0.3.1"
     js-yaml "^3.4.3"
@@ -1637,12 +1626,6 @@ create-ecdh@^4.0.0:
   dependencies:
     bn.js "^4.1.0"
     elliptic "^6.0.0"
-
-create-error-class@^3.0.1:
-  version "3.0.2"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/create-error-class/-/create-error-class-3.0.2.tgz#06be7abef947a3f14a30fd610671d401bca8b7b6"
-  dependencies:
-    capture-stack-trace "^1.0.0"
 
 create-hash@^1.1.0, create-hash@^1.1.1, create-hash@^1.1.2:
   version "1.1.3"
@@ -1686,8 +1669,8 @@ cryptiles@2.x.x:
     boom "2.x.x"
 
 crypto-browserify@^3.11.0:
-  version "3.11.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/crypto-browserify/-/crypto-browserify-3.11.1.tgz#948945efc6757a400d6e5e5af47194d10064279f"
+  version "3.11.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/crypto-browserify/-/crypto-browserify-3.11.0.tgz#3652a0906ab9b2a7e0c3ce66a408e957a2485522"
   dependencies:
     browserify-cipher "^1.0.0"
     browserify-sign "^4.0.0"
@@ -1847,27 +1830,6 @@ cypher-editor-support@1.0.4:
     fuzzaldrin "2.1.0"
     lodash "4.17.4"
 
-cypress-cli@^0.13.1:
-  version "0.13.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/cypress-cli/-/cypress-cli-0.13.1.tgz#239371ae7bec161eb12ae2b4c999fd685d38e752"
-  dependencies:
-    bluebird "3.3.4"
-    chalk "^1.1.0"
-    coffee-script "^1.9.3"
-    commander "^2.8.1"
-    extract-zip "1.5.0"
-    fs-extra "^0.22.1"
-    home-or-tmp "^2.0.0"
-    human-interval "^0.1.5"
-    lodash "^3.10.0"
-    progress "^1.1.8"
-    request "^2.60.0"
-    request-progress "^0.3.1"
-    through2 "^2.0.0"
-    update-notifier "^1.0.3"
-    xvfb cypress-io/node-xvfb
-    yauzl "^2.4.1"
-
 d@1:
   version "1.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/d/-/d-1.0.0.tgz#754bb5bfe55451da69a58b94d45f4c5b0462d58f"
@@ -1880,6 +1842,10 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+date-fns@^1.27.2:
+  version "1.28.5"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/date-fns/-/date-fns-1.28.5.tgz#257cfc45d322df45ef5658665967ee841cd73faf"
+
 date-now@^0.1.4:
   version "0.1.4"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
@@ -1888,11 +1854,7 @@ debug-log@^1.0.0:
   version "1.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
 
-debug@0.7.4, debug@~0.7.4:
-  version "0.7.4"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/debug/-/debug-0.7.4.tgz#06e1ea8082c2cb14e39806e22e2f6f757f92af39"
-
-debug@2.2.0:
+debug@2.2.0, debug@~2.2.0:
   version "2.2.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
@@ -1904,11 +1866,21 @@ debug@2.3.3:
   dependencies:
     ms "0.7.2"
 
+debug@2.6.7:
+  version "2.6.7"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/debug/-/debug-2.6.7.tgz#92bad1f6d05bbb6bba22cca88bcd0ec894c2861e"
+  dependencies:
+    ms "2.0.0"
+
 debug@2.6.8, debug@^2.1.1, debug@^2.2.0, debug@^2.6.3, debug@^2.6.6, debug@^2.6.8:
   version "2.6.8"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
     ms "2.0.0"
+
+debug@~0.7.4:
+  version "0.7.4"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/debug/-/debug-0.7.4.tgz#06e1ea8082c2cb14e39806e22e2f6f757f92af39"
 
 decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
@@ -1997,9 +1969,9 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
 
-depd@1.1.1, depd@~1.1.1:
-  version "1.1.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/depd/-/depd-1.1.1.tgz#5783b4e1c459f06fa5ca27f991f3d06e7a310359"
+depd@1.1.0, depd@~1.1.0:
+  version "1.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/depd/-/depd-1.1.0.tgz#e1bd82c6aab6ced965b97b88b17ed3e528ca18c3"
 
 des.js@^1.0.0:
   version "1.0.0"
@@ -2023,8 +1995,8 @@ detect-node@^2.0.3:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/detect-node/-/detect-node-2.0.3.tgz#a2033c09cc8e158d37748fbde7507832bd6ce127"
 
 diff@^3.2.0:
-  version "3.3.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/diff/-/diff-3.3.0.tgz#056695150d7aa93237ca7e378ac3b1682b7963b9"
+  version "3.2.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
 diffie-hellman@^5.0.0:
   version "5.0.2"
@@ -2037,6 +2009,10 @@ diffie-hellman@^5.0.0:
 disposables@^1.0.1:
   version "1.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/disposables/-/disposables-1.0.1.tgz#064727a25b54f502bd82b89aa2dfb8df9f1b39e3"
+
+dlv@^1.1.0:
+  version "1.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/dlv/-/dlv-1.1.0.tgz#fee1a7c43f63be75f3f679e85262da5f102764a7"
 
 dnd-core@^2.2.4, dnd-core@^2.4.0:
   version "2.4.0"
@@ -2095,10 +2071,6 @@ dom-storage@^2.0.2:
   version "2.0.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/dom-storage/-/dom-storage-2.0.2.tgz#ed17cbf68abd10e0aef8182713e297c5e4b500b0"
 
-dom-walk@^0.1.0:
-  version "0.1.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
-
 domain-browser@^1.1.1:
   version "1.1.7"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/domain-browser/-/domain-browser-1.1.7.tgz#867aa4b093faa05f1de08c06f4d7b21fdf8698bc"
@@ -2136,18 +2108,6 @@ domutils@1.5.1, domutils@^1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
-dot-prop@^3.0.0:
-  version "3.0.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/dot-prop/-/dot-prop-3.0.0.tgz#1b708af094a49c9a0e7dbcad790aba539dac1177"
-  dependencies:
-    is-obj "^1.0.0"
-
-duplexer2@^0.1.4:
-  version "0.1.4"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/duplexer2/-/duplexer2-0.1.4.tgz#8b12dab878c0d69e3e7891051662a32fc6bddcc1"
-  dependencies:
-    readable-stream "^2.0.2"
-
 duplexer@^0.1.1:
   version "0.1.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/duplexer/-/duplexer-0.1.1.tgz#ace6ff808c1ce66b57d1ebf97977acb02334cfc1"
@@ -2170,12 +2130,20 @@ ee-first@1.1.1:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/ee-first/-/ee-first-1.1.1.tgz#590c61156b0ae2f4f0255732a158b266bc56b21d"
 
 ejs@^2.5.6:
-  version "2.5.7"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/ejs/-/ejs-2.5.7.tgz#cc872c168880ae3c7189762fd5ffc00896c9518a"
+  version "2.5.6"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/ejs/-/ejs-2.5.6.tgz#479636bfa3fe3b1debd52087f0acb204b4f19c88"
 
-electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.17:
-  version "1.3.17"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/electron-to-chromium/-/electron-to-chromium-1.3.17.tgz#41c13457cc7166c5c15e767ae61d86a8cacdee5d"
+electron-to-chromium@^1.2.7:
+  version "1.3.14"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/electron-to-chromium/-/electron-to-chromium-1.3.14.tgz#64af0f9efd3c3c6acd57d71f83b49ca7ee9c4b43"
+
+electron-to-chromium@^1.3.16:
+  version "1.3.16"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/electron-to-chromium/-/electron-to-chromium-1.3.16.tgz#d0e026735754770901ae301a21664cba45d92f7d"
+
+elegant-spinner@^1.0.1:
+  version "1.0.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/elegant-spinner/-/elegant-spinner-1.0.1.tgz#db043521c95d7e303fd8f345bedc3349cfb0729e"
 
 elliptic@^6.0.0:
   version "6.4.0"
@@ -2270,7 +2238,7 @@ enzyme@^2.9.1:
     prop-types "^15.5.10"
     uuid "^3.0.1"
 
-errno@^0.1.3, errno@^0.1.4:
+"errno@>=0.1.1 <0.2.0-0", errno@^0.1.3:
   version "0.1.4"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/errno/-/errno-0.1.4.tgz#b896e23a9e5e8ba33871fc996abd3635fc9a1c7d"
   dependencies:
@@ -2283,14 +2251,13 @@ error-ex@^1.2.0:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.6.1, es-abstract@^1.7.0:
-  version "1.8.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/es-abstract/-/es-abstract-1.8.0.tgz#3b00385e85729932beffa9163bbea1234e932914"
+  version "1.7.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/es-abstract/-/es-abstract-1.7.0.tgz#dfade774e01bfcd97f96180298c449c8623fb94c"
   dependencies:
     es-to-primitive "^1.1.1"
     function-bind "^1.1.0"
-    has "^1.0.1"
     is-callable "^1.1.3"
-    is-regex "^1.0.4"
+    is-regex "^1.0.3"
 
 es-to-primitive@^1.1.1:
   version "1.1.1"
@@ -2301,8 +2268,8 @@ es-to-primitive@^1.1.1:
     is-symbol "^1.0.1"
 
 es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
-  version "0.10.26"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/es5-ext/-/es5-ext-0.10.26.tgz#51b2128a531b70c4f6764093a73cbebb82186372"
+  version "0.10.23"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/es5-ext/-/es5-ext-0.10.23.tgz#7578b51be974207a5487821b56538c224e4e7b38"
   dependencies:
     es6-iterator "2"
     es6-symbol "~3.1"
@@ -2410,7 +2377,14 @@ eslint-import-resolver-node@^0.3.1:
     debug "^2.6.8"
     resolve "^1.2.0"
 
-eslint-module-utils@^2.0.0, eslint-module-utils@^2.1.1:
+eslint-module-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/eslint-module-utils/-/eslint-module-utils-2.0.0.tgz#a6f8c21d901358759cdc35dbac1982ae1ee58bce"
+  dependencies:
+    debug "2.2.0"
+    pkg-dir "^1.0.0"
+
+eslint-module-utils@^2.1.1:
   version "2.1.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz#abaec824177613b8a95b299639e1b6facf473449"
   dependencies:
@@ -2465,8 +2439,8 @@ eslint-plugin-node@^5.1.1:
     semver "5.3.0"
 
 eslint-plugin-node@~4.2.2:
-  version "4.2.3"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/eslint-plugin-node/-/eslint-plugin-node-4.2.3.tgz#c04390ab8dbcbb6887174023d6f3a72769e63b97"
+  version "4.2.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/eslint-plugin-node/-/eslint-plugin-node-4.2.2.tgz#82959ca9aed79fcbd28bb1b188d05cac04fb3363"
   dependencies:
     ignore "^3.0.11"
     minimatch "^3.0.2"
@@ -2511,6 +2485,46 @@ eslint-scope@^3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint@^3.19.0, eslint@~3.19.0:
+  version "3.19.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
+  dependencies:
+    babel-code-frame "^6.16.0"
+    chalk "^1.1.3"
+    concat-stream "^1.5.2"
+    debug "^2.1.1"
+    doctrine "^2.0.0"
+    escope "^3.6.0"
+    espree "^3.4.0"
+    esquery "^1.0.0"
+    estraverse "^4.2.0"
+    esutils "^2.0.2"
+    file-entry-cache "^2.0.0"
+    glob "^7.0.3"
+    globals "^9.14.0"
+    ignore "^3.2.0"
+    imurmurhash "^0.1.4"
+    inquirer "^0.12.0"
+    is-my-json-valid "^2.10.0"
+    is-resolvable "^1.0.0"
+    js-yaml "^3.5.1"
+    json-stable-stringify "^1.0.0"
+    levn "^0.3.0"
+    lodash "^4.0.0"
+    mkdirp "^0.5.0"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.1"
+    pluralize "^1.2.1"
+    progress "^1.1.8"
+    require-uncached "^1.0.2"
+    shelljs "^0.7.5"
+    strip-bom "^3.0.0"
+    strip-json-comments "~2.0.1"
+    table "^3.7.8"
+    text-table "~0.2.0"
+    user-home "^2.0.0"
+
 eslint@^4.4.0:
   version "4.4.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/eslint/-/eslint-4.4.0.tgz#a3e153e704b64f78290ef03592494eaba228d3bc"
@@ -2552,47 +2566,14 @@ eslint@^4.4.0:
     table "^4.0.1"
     text-table "~0.2.0"
 
-eslint@~3.19.0:
-  version "3.19.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
+espree@^3.4.0:
+  version "3.4.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/espree/-/espree-3.4.3.tgz#2910b5ccd49ce893c2ffffaab4fd8b3a31b82374"
   dependencies:
-    babel-code-frame "^6.16.0"
-    chalk "^1.1.3"
-    concat-stream "^1.5.2"
-    debug "^2.1.1"
-    doctrine "^2.0.0"
-    escope "^3.6.0"
-    espree "^3.4.0"
-    esquery "^1.0.0"
-    estraverse "^4.2.0"
-    esutils "^2.0.2"
-    file-entry-cache "^2.0.0"
-    glob "^7.0.3"
-    globals "^9.14.0"
-    ignore "^3.2.0"
-    imurmurhash "^0.1.4"
-    inquirer "^0.12.0"
-    is-my-json-valid "^2.10.0"
-    is-resolvable "^1.0.0"
-    js-yaml "^3.5.1"
-    json-stable-stringify "^1.0.0"
-    levn "^0.3.0"
-    lodash "^4.0.0"
-    mkdirp "^0.5.0"
-    natural-compare "^1.4.0"
-    optionator "^0.8.2"
-    path-is-inside "^1.0.1"
-    pluralize "^1.2.1"
-    progress "^1.1.8"
-    require-uncached "^1.0.2"
-    shelljs "^0.7.5"
-    strip-bom "^3.0.0"
-    strip-json-comments "~2.0.1"
-    table "^3.7.8"
-    text-table "~0.2.0"
-    user-home "^2.0.0"
+    acorn "^5.0.1"
+    acorn-jsx "^3.0.0"
 
-espree@^3.4.0, espree@^3.5.0:
+espree@^3.5.0:
   version "3.5.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/espree/-/espree-3.5.0.tgz#98358625bdd055861ea27e2867ea729faf463d8d"
   dependencies:
@@ -2603,13 +2584,13 @@ esprima@^2.6.0, esprima@^2.7.1:
   version "2.7.3"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/esprima/-/esprima-2.7.3.tgz#96e3b70d5779f6ad49cd032673d1c312767ba581"
 
+esprima@^3.1.1, esprima@~3.1.0:
+  version "3.1.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
+
 esprima@^4.0.0:
   version "4.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
-
-esprima@~3.1.0:
-  version "3.1.3"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
 esquery@^1.0.0:
   version "1.0.0"
@@ -2685,6 +2666,18 @@ execa@^0.7.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+execa@^0.8.0:
+  version "0.8.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/execa/-/execa-0.8.0.tgz#d8d76bbc1b55217ed190fd6dd49d3c774ecfc8da"
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
+
 exit-hook@^1.0.0:
   version "1.1.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/exit-hook/-/exit-hook-1.1.1.tgz#f05ca233b48c05d54fff07765df8507e95c02ff8"
@@ -2702,8 +2695,8 @@ expand-range@^1.8.1:
     fill-range "^2.1.0"
 
 express@^4.13.3, express@^4.15.2:
-  version "4.15.4"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/express/-/express-4.15.4.tgz#032e2253489cf8fce02666beca3d11ed7a2daed1"
+  version "4.15.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/express/-/express-4.15.3.tgz#bab65d0f03aa80c358408972fc700f916944b662"
   dependencies:
     accepts "~1.3.3"
     array-flatten "1.1.1"
@@ -2711,23 +2704,23 @@ express@^4.13.3, express@^4.15.2:
     content-type "~1.0.2"
     cookie "0.3.1"
     cookie-signature "1.0.6"
-    debug "2.6.8"
-    depd "~1.1.1"
+    debug "2.6.7"
+    depd "~1.1.0"
     encodeurl "~1.0.1"
     escape-html "~1.0.3"
     etag "~1.8.0"
-    finalhandler "~1.0.4"
+    finalhandler "~1.0.3"
     fresh "0.5.0"
     merge-descriptors "1.0.1"
     methods "~1.1.2"
     on-finished "~2.3.0"
     parseurl "~1.3.1"
     path-to-regexp "0.1.7"
-    proxy-addr "~1.1.5"
-    qs "6.5.0"
+    proxy-addr "~1.1.4"
+    qs "6.4.0"
     range-parser "~1.2.0"
-    send "0.15.4"
-    serve-static "1.12.4"
+    send "0.15.3"
+    serve-static "1.12.3"
     setprototypeof "1.0.3"
     statuses "~1.3.1"
     type-is "~1.6.15"
@@ -2761,18 +2754,13 @@ extract-text-webpack-plugin@^3.0.0:
     schema-utils "^0.3.0"
     webpack-sources "^1.0.1"
 
-extract-zip@1.5.0:
-  version "1.5.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/extract-zip/-/extract-zip-1.5.0.tgz#92ccf6d81ef70a9fa4c1747114ccef6d8688a6c4"
-  dependencies:
-    concat-stream "1.5.0"
-    debug "0.7.4"
-    mkdirp "0.5.0"
-    yauzl "2.4.1"
+extsprintf@1.0.2:
+  version "1.0.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/extsprintf/-/extsprintf-1.0.2.tgz#e1080e0658e300b06294990cc70e1502235fd550"
 
-extsprintf@1.3.0, extsprintf@^1.2.0:
-  version "1.3.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
+fast-deep-equal@^0.1.0:
+  version "0.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/fast-deep-equal/-/fast-deep-equal-0.1.0.tgz#5c6f4599aba6b333ee3342e2ed978672f1001f8d"
 
 fast-deep-equal@^1.0.0:
   version "1.0.0"
@@ -2817,8 +2805,8 @@ fb-watchman@^2.0.0:
     bser "^2.0.0"
 
 fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.9:
-  version "0.8.14"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/fbjs/-/fbjs-0.8.14.tgz#d1dbe2be254c35a91e09f31f9cd50a40b2a0ed1c"
+  version "0.8.12"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -2828,13 +2816,7 @@ fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-fd-slicer@~1.0.1:
-  version "1.0.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/fd-slicer/-/fd-slicer-1.0.1.tgz#8b5bcbd9ec327c5041bf9ab023fd6750f1177e65"
-  dependencies:
-    pend "~1.2.0"
-
-figures@^1.3.5:
+figures@^1.3.5, figures@^1.7.0:
   version "1.7.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/figures/-/figures-1.7.0.tgz#cbe1e3affcf1cd44b80cadfed28dc793a9701d2e"
   dependencies:
@@ -2889,15 +2871,11 @@ fill-range@^2.1.0:
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
 
-filled-array@^1.0.0:
-  version "1.1.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/filled-array/-/filled-array-1.1.0.tgz#c3c4f6c663b923459a9aa29912d2d031f1507f84"
-
-finalhandler@~1.0.4:
-  version "1.0.4"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/finalhandler/-/finalhandler-1.0.4.tgz#18574f2e7c4b98b8ae3b230c21f201f31bdb3fb7"
+finalhandler@~1.0.3:
+  version "1.0.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/finalhandler/-/finalhandler-1.0.3.tgz#ef47e77950e999780e86022a560e3217e0d0cc89"
   dependencies:
-    debug "2.6.8"
+    debug "2.6.7"
     encodeurl "~1.0.1"
     escape-html "~1.0.3"
     on-finished "~2.3.0"
@@ -2921,8 +2899,8 @@ find-cache-dir@^1.0.0:
     pkg-dir "^2.0.0"
 
 find-root@^1.0.0:
-  version "1.1.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  version "1.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/find-root/-/find-root-1.0.0.tgz#962ff211aab25c6520feeeb8d6287f8f6e95807a"
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -2994,14 +2972,6 @@ fresh@0.5.0:
   version "0.5.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/fresh/-/fresh-0.5.0.tgz#f474ca5e6a9246d6fd8e0953cfa9b9c805afa78e"
 
-fs-extra@^0.22.1:
-  version "0.22.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/fs-extra/-/fs-extra-0.22.1.tgz#5fd6f8049dc976ca19eb2355d658173cabcce056"
-  dependencies:
-    graceful-fs "^4.1.2"
-    jsonfile "^2.1.0"
-    rimraf "^2.2.8"
-
 fs-extra@^0.26.4:
   version "0.26.7"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/fs-extra/-/fs-extra-0.26.7.tgz#9ae1fdd94897798edab76d0918cf42d0c3184fa9"
@@ -3011,10 +2981,6 @@ fs-extra@^0.26.4:
     klaw "^1.0.0"
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
-
-fs-readdir-recursive@^1.0.0:
-  version "1.0.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz#8cd1745c8b4f8a29c8caec392476921ba195f560"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -3049,12 +3015,12 @@ function-bind@^1.0.2, function-bind@^1.1.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/function-bind/-/function-bind-1.1.0.tgz#16176714c801798e4e8f2cf7f7529467bb4a5771"
 
 function.prototype.name@^1.0.0:
-  version "1.0.3"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/function.prototype.name/-/function.prototype.name-1.0.3.tgz#0099ae5572e9dd6f03c97d023fd92bcc5e639eac"
+  version "1.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/function.prototype.name/-/function.prototype.name-1.0.0.tgz#5f523ca64e491a5f95aba80cc1e391080a14482e"
   dependencies:
     define-properties "^1.1.2"
     function-bind "^1.1.0"
-    is-callable "^1.1.3"
+    is-callable "^1.1.2"
 
 functional-red-black-tree@^1.0.1:
   version "1.0.1"
@@ -3147,12 +3113,16 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-global@^4.3.2:
-  version "4.3.2"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/global/-/global-4.3.2.tgz#e76989268a6c74c38908b1305b10fc0e394e9d0f"
+glob@~7.0.6:
+  version "7.0.6"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/glob/-/glob-7.0.6.tgz#211bafaf49e525b8cd93260d14ab136152b3f57a"
   dependencies:
-    min-document "^2.19.0"
-    process "~0.5.1"
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.0.2"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
 
 globals@^9.0.0, globals@^9.14.0, globals@^9.17.0:
   version "9.18.0"
@@ -3179,29 +3149,13 @@ globby@^6.1.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
-got@^5.0.0:
-  version "5.7.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/got/-/got-5.7.1.tgz#5f81635a61e4a6589f180569ea4e381680a51f35"
-  dependencies:
-    create-error-class "^3.0.1"
-    duplexer2 "^0.1.4"
-    is-redirect "^1.0.0"
-    is-retry-allowed "^1.0.0"
-    is-stream "^1.0.0"
-    lowercase-keys "^1.0.0"
-    node-status-codes "^1.0.0"
-    object-assign "^4.0.1"
-    parse-json "^2.1.0"
-    pinkie-promise "^2.0.0"
-    read-all-stream "^3.0.0"
-    readable-stream "^2.0.5"
-    timed-out "^3.0.0"
-    unzip-response "^1.0.2"
-    url-parse-lax "^1.0.0"
-
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
+graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
+"graceful-readlink@>= 1.0.0":
+  version "1.0.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -3279,8 +3233,8 @@ hash-base@^2.0.0:
     inherits "^2.0.1"
 
 hash.js@^1.0.0, hash.js@^1.0.3:
-  version "1.1.3"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/hash.js/-/hash.js-1.1.3.tgz#340dedbe6290187151c1ea1d777a3448935df846"
+  version "1.1.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/hash.js/-/hash.js-1.1.1.tgz#5cb2e796499224e69fd0b00ed01d2d4a16e7a323"
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.0"
@@ -3322,8 +3276,8 @@ home-or-tmp@^2.0.0:
     os-tmpdir "^1.0.1"
 
 hosted-git-info@^2.1.4:
-  version "2.5.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
+  version "2.4.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/hosted-git-info/-/hosted-git-info-2.4.2.tgz#0076b9f46a270506ddbaaea56496897460612a67"
 
 hpack.js@^2.1.6:
   version "2.1.6"
@@ -3359,12 +3313,12 @@ html-loader@^0.5.0:
     object-assign "^4.1.0"
 
 html-minifier@^3.0.1, html-minifier@^3.2.3:
-  version "3.5.3"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/html-minifier/-/html-minifier-3.5.3.tgz#4a275e3b1a16639abb79b4c11191ff0d0fcf1ab9"
+  version "3.5.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/html-minifier/-/html-minifier-3.5.2.tgz#d73bc3ff448942408818ce609bf3fb0ea7ef4eb7"
   dependencies:
     camel-case "3.0.x"
     clean-css "4.1.x"
-    commander "2.11.x"
+    commander "2.9.x"
     he "1.1.x"
     ncname "1.0.x"
     param-case "2.1.x"
@@ -3410,11 +3364,11 @@ http-deceiver@^1.2.7:
   version "1.2.7"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/http-deceiver/-/http-deceiver-1.2.7.tgz#fa7168944ab9a519d337cb0bec7284dc3e723d87"
 
-http-errors@~1.6.1, http-errors@~1.6.2:
-  version "1.6.2"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/http-errors/-/http-errors-1.6.2.tgz#0a002cc85707192a7e7946ceedc11155f60ec736"
+http-errors@~1.6.1:
+  version "1.6.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/http-errors/-/http-errors-1.6.1.tgz#5f8b8ed98aca545656bf572997387f904a722257"
   dependencies:
-    depd "1.1.1"
+    depd "1.1.0"
     inherits "2.0.3"
     setprototypeof "1.0.3"
     statuses ">= 1.3.1 < 2"
@@ -3447,9 +3401,13 @@ https-browserify@0.0.1:
   version "0.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/https-browserify/-/https-browserify-0.0.1.tgz#3f91365cabe60b77ed0ebba24b454e3e09d95a82"
 
-human-interval@^0.1.5:
-  version "0.1.6"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/human-interval/-/human-interval-0.1.6.tgz#0057973454764c3abcbeb2aed612fc9644e68488"
+husky@^0.14.3:
+  version "0.14.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+  dependencies:
+    is-ci "^1.0.10"
+    normalize-path "^1.0.0"
+    strip-indent "^2.0.0"
 
 iconv-lite@0.4.13:
   version "0.4.13"
@@ -3478,8 +3436,8 @@ ignore@^3.0.11, ignore@^3.0.9, ignore@^3.2.0, ignore@^3.3.3:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/ignore/-/ignore-3.3.3.tgz#432352e57accd87ab3110e82d3fea0e47812156d"
 
 immutability-helper@^2.1.2:
-  version "2.3.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/immutability-helper/-/immutability-helper-2.3.0.tgz#e897741c1da29541a861ea16bdbf909265e2eb55"
+  version "2.2.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/immutability-helper/-/immutability-helper-2.2.2.tgz#e7e9da728b3de2fad34a216f4157b326dbccc892"
   dependencies:
     invariant "^2.2.0"
 
@@ -3492,6 +3450,10 @@ indent-string@^2.1.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/indent-string/-/indent-string-2.1.0.tgz#8e2d48348742121b4a8218b7a137e9a52049dc80"
   dependencies:
     repeating "^2.0.0"
+
+indent-string@^3.0.0, indent-string@^3.1.0:
+  version "3.2.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
 
 indexes-of@^1.0.1:
   version "1.0.1"
@@ -3581,9 +3543,9 @@ ip@^1.1.0:
   version "1.1.5"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
 
-ipaddr.js@1.4.0:
-  version "1.4.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/ipaddr.js/-/ipaddr.js-1.4.0.tgz#296aca878a821816e5b85d0a285a99bcff4582f0"
+ipaddr.js@1.3.0:
+  version "1.3.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/ipaddr.js/-/ipaddr.js-1.3.0.tgz#1e03a52fdad83a8bbb2b25cbf4998b4cffcd3dec"
 
 is-absolute-url@^2.0.0:
   version "2.1.0"
@@ -3613,7 +3575,7 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
-is-callable@^1.1.1, is-callable@^1.1.3:
+is-callable@^1.1.1, is-callable@^1.1.2, is-callable@^1.1.3:
   version "1.1.3"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
 
@@ -3694,10 +3656,6 @@ is-my-json-valid@^2.10.0:
     jsonpointer "^4.0.0"
     xtend "^4.0.0"
 
-is-npm@^1.0.0:
-  version "1.0.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/is-npm/-/is-npm-1.0.0.tgz#f2fb63a65e4905b406c86072765a1a4dc793b9f4"
-
 is-number@^2.1.0:
   version "2.1.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/is-number/-/is-number-2.1.0.tgz#01fcbbb393463a548f2f466cce16dece49db908f"
@@ -3709,10 +3667,6 @@ is-number@^3.0.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
   dependencies:
     kind-of "^3.0.2"
-
-is-obj@^1.0.0:
-  version "1.0.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
 
 is-path-cwd@^1.0.0:
   version "1.0.0"
@@ -3735,10 +3689,10 @@ is-plain-obj@^1.0.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
 
 is-plain-object@^2.0.1:
-  version "2.0.4"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/is-plain-object/-/is-plain-object-2.0.4.tgz#2c163b3fafb1b606d9d17928f05c2a1c38e07677"
+  version "2.0.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/is-plain-object/-/is-plain-object-2.0.3.tgz#c15bf3e4b66b62d72efaf2925848663ecbc619b6"
   dependencies:
-    isobject "^3.0.1"
+    isobject "^3.0.0"
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
@@ -3756,11 +3710,7 @@ is-property@^1.0.0:
   version "1.0.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/is-property/-/is-property-1.0.2.tgz#57fe1c4e48474edd65b09911f26b1cd4095dda84"
 
-is-redirect@^1.0.0:
-  version "1.0.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/is-redirect/-/is-redirect-1.0.0.tgz#1d03dded53bd8db0f30c26e4f95d36fc7c87dc24"
-
-is-regex@^1.0.4:
+is-regex@^1.0.3:
   version "1.0.4"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
   dependencies:
@@ -3772,11 +3722,7 @@ is-resolvable@^1.0.0:
   dependencies:
     tryit "^1.0.1"
 
-is-retry-allowed@^1.0.0:
-  version "1.1.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz#11a060568b67339444033d0125a61a20d564fb34"
-
-is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
@@ -3828,9 +3774,9 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
-isobject@^3.0.1:
-  version "3.0.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
+isobject@^3.0.0:
+  version "3.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/isobject/-/isobject-3.0.0.tgz#39565217f3661789e8a0a0c080d5f7e6bc46e1a0"
 
 isomorphic-fetch@^2.1.1, isomorphic-fetch@^2.2.1:
   version "2.2.1"
@@ -3844,14 +3790,14 @@ isstream@~0.1.2:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
 istanbul-api@^1.1.1:
-  version "1.1.11"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/istanbul-api/-/istanbul-api-1.1.11.tgz#fcc0b461e2b3bda71e305155138238768257d9de"
+  version "1.1.9"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/istanbul-api/-/istanbul-api-1.1.9.tgz#2827920d380d4286d857d57a2968a841db8a7ec8"
   dependencies:
     async "^2.1.4"
     fileset "^2.0.2"
     istanbul-lib-coverage "^1.1.1"
     istanbul-lib-hook "^1.0.7"
-    istanbul-lib-instrument "^1.7.4"
+    istanbul-lib-instrument "^1.7.2"
     istanbul-lib-report "^1.1.1"
     istanbul-lib-source-maps "^1.2.1"
     istanbul-reports "^1.1.1"
@@ -3869,15 +3815,15 @@ istanbul-lib-hook@^1.0.7:
   dependencies:
     append-transform "^0.4.0"
 
-istanbul-lib-instrument@^1.4.2, istanbul-lib-instrument@^1.7.2, istanbul-lib-instrument@^1.7.4:
-  version "1.7.4"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.4.tgz#e9fd920e4767f3d19edc765e2d6b3f5ccbd0eea8"
+istanbul-lib-instrument@^1.4.2, istanbul-lib-instrument@^1.7.2:
+  version "1.7.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.2.tgz#6014b03d3470fb77638d5802508c255c06312e56"
   dependencies:
     babel-generator "^6.18.0"
     babel-template "^6.16.0"
     babel-traverse "^6.18.0"
     babel-types "^6.18.0"
-    babylon "^6.17.4"
+    babylon "^6.13.0"
     istanbul-lib-coverage "^1.1.1"
     semver "^5.3.0"
 
@@ -3989,8 +3935,8 @@ jest-environment-node@^20.0.3:
     jest-util "^20.0.3"
 
 jest-haste-map@^20.0.4:
-  version "20.0.5"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/jest-haste-map/-/jest-haste-map-20.0.5.tgz#abad74efb1a005974a7b6517e11010709cab9112"
+  version "20.0.4"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/jest-haste-map/-/jest-haste-map-20.0.4.tgz#653eb55c889ce3c021f7b94693f20a4159badf03"
   dependencies:
     fb-watchman "^2.0.0"
     graceful-fs "^4.1.11"
@@ -4131,10 +4077,17 @@ js-base64@^2.1.9:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/js-base64/-/js-base64-2.1.9.tgz#f0e80ae039a4bd654b5f281fc93f04a914a7fcce"
 
 js-tokens@^3.0.0:
-  version "3.0.2"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+  version "3.0.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
-js-yaml@^3.4.3, js-yaml@^3.5.1, js-yaml@^3.7.0, js-yaml@^3.9.1:
+js-yaml@^3.4.3, js-yaml@^3.5.1, js-yaml@^3.7.0:
+  version "3.8.4"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/js-yaml/-/js-yaml-3.8.4.tgz#520b4564f86573ba96662af85a8cafa7b4b5a6f6"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^3.1.1"
+
+js-yaml@^3.9.1:
   version "3.9.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/js-yaml/-/js-yaml-3.9.1.tgz#08775cebdfdd359209f0d2acd383c8f86a6904a0"
   dependencies:
@@ -4153,8 +4106,8 @@ jsbn@~0.1.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
 
 jschardet@^1.4.2:
-  version "1.5.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/jschardet/-/jschardet-1.5.1.tgz#c519f629f86b3a5bedba58a88d311309eec097f9"
+  version "1.5.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/jschardet/-/jschardet-1.5.0.tgz#a61f310306a5a71188e1b1acd08add3cfbb08b1e"
 
 jsdom@^9.12.0:
   version "9.12.0"
@@ -4188,13 +4141,17 @@ jsesc@~0.5.0:
   version "0.5.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/jsesc/-/jsesc-0.5.0.tgz#e7dee66e35d6fc16f710fe91d5cf69f70f08911d"
 
-json-loader@^0.5.4, json-loader@^0.5.7:
+json-loader@^0.5.4:
+  version "0.5.4"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/json-loader/-/json-loader-0.5.4.tgz#8baa1365a632f58a3c46d20175fc6002c96e37de"
+
+json-loader@^0.5.7:
   version "0.5.7"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/json-loader/-/json-loader-0.5.7.tgz#dca14a70235ff82f0ac9a3abeb60d337a365185d"
 
 json-schema-traverse@^0.3.0:
-  version "0.3.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz#349a6d44c53a51de89b40805c5d5e59b417d3340"
+  version "0.3.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/json-schema-traverse/-/json-schema-traverse-0.3.0.tgz#0016c0b1ca1efe46d44d37541bcdfc19dcfae0db"
 
 json-schema@0.2.3:
   version "0.2.3"
@@ -4237,8 +4194,8 @@ jsonpointer@^4.0.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
 
 jsonwebtoken@^7.3.0:
-  version "7.4.2"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/jsonwebtoken/-/jsonwebtoken-7.4.2.tgz#571b903c07e875c0fc59203d1ac78667d80e09cd"
+  version "7.4.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/jsonwebtoken/-/jsonwebtoken-7.4.1.tgz#7ca324f5215f8be039cd35a6c45bb8cb74a448fb"
   dependencies:
     joi "^6.10.1"
     jws "^3.1.4"
@@ -4247,13 +4204,13 @@ jsonwebtoken@^7.3.0:
     xtend "^4.0.1"
 
 jsprim@^1.2.2:
-  version "1.4.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
+  version "1.4.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/jsprim/-/jsprim-1.4.0.tgz#a3b87e40298d8c380552d8cc7628a0bb95a22918"
   dependencies:
     assert-plus "1.0.0"
-    extsprintf "1.3.0"
+    extsprintf "1.0.2"
     json-schema "0.2.3"
-    verror "1.10.0"
+    verror "1.3.6"
 
 jsx-ast-utils@^1.3.4, jsx-ast-utils@^1.4.1:
   version "1.4.1"
@@ -4294,19 +4251,9 @@ klaw@^1.0.0:
   optionalDependencies:
     graceful-fs "^4.1.9"
 
-latest-version@^2.0.0:
-  version "2.0.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/latest-version/-/latest-version-2.0.0.tgz#56f8d6139620847b8017f8f1f4d78e211324168b"
-  dependencies:
-    package-json "^2.0.0"
-
 lazy-cache@^1.0.3:
   version "1.0.4"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/lazy-cache/-/lazy-cache-1.0.4.tgz#a1d78fc3a50474cb80845d3b3b6e1da49a446e8e"
-
-lazy-req@^1.1.0:
-  version "1.1.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/lazy-req/-/lazy-req-1.1.0.tgz#bdaebead30f8d824039ce0ce149d4daa07ba1fac"
 
 lcid@^1.0.0:
   version "1.0.0"
@@ -4324,6 +4271,67 @@ levn@^0.3.0, levn@~0.3.0:
   dependencies:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
+
+lint-staged@^4.0.3:
+  version "4.0.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/lint-staged/-/lint-staged-4.0.3.tgz#1ce55591bc2c83a781a90b69a0a0c8aa0fc6370b"
+  dependencies:
+    app-root-path "^2.0.0"
+    cosmiconfig "^1.1.0"
+    execa "^0.8.0"
+    listr "^0.12.0"
+    lodash.chunk "^4.2.0"
+    minimatch "^3.0.0"
+    npm-which "^3.0.1"
+    p-map "^1.1.1"
+    staged-git-files "0.0.4"
+
+listr-silent-renderer@^1.1.1:
+  version "1.1.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz#924b5a3757153770bf1a8e3fbf74b8bbf3f9242e"
+
+listr-update-renderer@^0.2.0:
+  version "0.2.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/listr-update-renderer/-/listr-update-renderer-0.2.0.tgz#ca80e1779b4e70266807e8eed1ad6abe398550f9"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    elegant-spinner "^1.0.1"
+    figures "^1.7.0"
+    indent-string "^3.0.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    strip-ansi "^3.0.1"
+
+listr-verbose-renderer@^0.4.0:
+  version "0.4.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/listr-verbose-renderer/-/listr-verbose-renderer-0.4.0.tgz#44dc01bb0c34a03c572154d4d08cde9b1dc5620f"
+  dependencies:
+    chalk "^1.1.3"
+    cli-cursor "^1.0.2"
+    date-fns "^1.27.2"
+    figures "^1.7.0"
+
+listr@^0.12.0:
+  version "0.12.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/listr/-/listr-0.12.0.tgz#6bce2c0f5603fa49580ea17cd6a00cc0e5fa451a"
+  dependencies:
+    chalk "^1.1.3"
+    cli-truncate "^0.2.1"
+    figures "^1.7.0"
+    indent-string "^2.1.0"
+    is-promise "^2.1.0"
+    is-stream "^1.1.0"
+    listr-silent-renderer "^1.1.1"
+    listr-update-renderer "^0.2.0"
+    listr-verbose-renderer "^0.4.0"
+    log-symbols "^1.0.2"
+    log-update "^1.0.2"
+    ora "^0.2.3"
+    p-map "^1.1.1"
+    rxjs "^5.0.0-beta.11"
+    stream-to-observable "^0.1.0"
+    strip-ansi "^3.0.1"
 
 load-json-file@^1.0.0:
   version "1.1.0"
@@ -4396,6 +4404,10 @@ lodash.camelcase@^4.3.0:
   version "4.3.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
 
+lodash.chunk@^4.2.0:
+  version "4.2.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/lodash.chunk/-/lodash.chunk-4.2.0.tgz#66e5ce1f76ed27b4303d8c6512e8d1216e8106bc"
+
 lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
@@ -4442,7 +4454,7 @@ lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
 
-lodash.merge@^4.4.0:
+lodash.merge@^4.4.0, lodash.merge@^4.6.0:
   version "4.6.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
@@ -4487,9 +4499,25 @@ lodash@4.17.4, lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lo
   version "4.17.4"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
-lodash@^3.10.0:
-  version "3.10.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+log-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  dependencies:
+    chalk "^1.0.0"
+
+log-update@^1.0.2:
+  version "1.0.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/log-update/-/log-update-1.0.2.tgz#19929f64c4093d2d2e7075a1dad8af59c296b8d1"
+  dependencies:
+    ansi-escapes "^1.0.0"
+    cli-cursor "^1.0.2"
+
+loglevel-colored-level-prefix@^1.0.0:
+  version "1.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/loglevel-colored-level-prefix/-/loglevel-colored-level-prefix-1.0.0.tgz#6a40218fdc7ae15fc76c3d0f3e676c465388603e"
+  dependencies:
+    chalk "^1.1.3"
+    loglevel "^1.4.1"
 
 loglevel@^1.4.1:
   version "1.4.1"
@@ -4516,10 +4544,6 @@ lower-case@^1.1.1:
   version "1.1.4"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
 
-lowercase-keys@^1.0.0:
-  version "1.0.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/lowercase-keys/-/lowercase-keys-1.0.0.tgz#4e3366b39e7f5457e35f1324bdf6f88d0bfc7306"
-
 lru-cache@^4.0.1:
   version "4.1.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/lru-cache/-/lru-cache-4.1.1.tgz#622e32e82488b49279114a4f9ecf45e7cd6bba55"
@@ -4536,6 +4560,12 @@ make-dir@^1.0.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/make-dir/-/make-dir-1.0.0.tgz#97a011751e91dd87cfadef58832ebb04936de978"
   dependencies:
     pify "^2.3.0"
+
+make-plural@~3.0.6:
+  version "3.0.6"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/make-plural/-/make-plural-3.0.6.tgz#2033a03bac290b8f3bb91258f65b9df7e8b01ca7"
+  optionalDependencies:
+    minimist "^1.2.0"
 
 makeerror@1.0.x:
   version "1.0.11"
@@ -4568,7 +4598,7 @@ memory-fs@^0.4.0, memory-fs@~0.4.1:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
-meow@^3.3.0:
+meow@3.7.0, meow@^3.3.0:
   version "3.7.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
   dependencies:
@@ -4590,6 +4620,20 @@ merge-descriptors@1.0.1:
 merge@^1.1.3:
   version "1.2.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
+
+messageformat-parser@^1.0.0:
+  version "1.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/messageformat-parser/-/messageformat-parser-1.1.0.tgz#13ba2250a76bbde8e0fca0dbb3475f95c594a90a"
+
+messageformat@^1.0.2:
+  version "1.0.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/messageformat/-/messageformat-1.0.2.tgz#908f4691f29ff28dae35c45436a24cff93402388"
+  dependencies:
+    glob "~7.0.6"
+    make-plural "~3.0.6"
+    messageformat-parser "^1.0.0"
+    nopt "~3.0.6"
+    reserved-words "^0.1.1"
 
 methods@~1.1.2:
   version "1.1.2"
@@ -4620,15 +4664,19 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-"mime-db@>= 1.29.0 < 2", mime-db@~1.29.0:
-  version "1.29.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/mime-db/-/mime-db-1.29.0.tgz#48d26d235589651704ac5916ca06001914266878"
+"mime-db@>= 1.27.0 < 2":
+  version "1.28.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/mime-db/-/mime-db-1.28.0.tgz#fedd349be06d2865b7fc57d837c6de4f17d7ac3c"
+
+mime-db@~1.27.0:
+  version "1.27.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/mime-db/-/mime-db-1.27.0.tgz#820f572296bbd20ec25ed55e5b5de869e5436eb1"
 
 mime-types@^2.1.12, mime-types@~2.1.11, mime-types@~2.1.15, mime-types@~2.1.7:
-  version "2.1.16"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/mime-types/-/mime-types-2.1.16.tgz#2b858a52e5ecd516db897ac2be87487830698e23"
+  version "2.1.15"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/mime-types/-/mime-types-2.1.15.tgz#a4ebf5064094569237b8cf70046776d09fc92aed"
   dependencies:
-    mime-db "~1.29.0"
+    mime-db "~1.27.0"
 
 mime@1.3.4:
   version "1.3.4"
@@ -4641,12 +4689,6 @@ mime@1.3.x, mime@^1.3.4:
 mimic-fn@^1.0.0:
   version "1.1.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
-
-min-document@^2.19.0:
-  version "2.19.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/min-document/-/min-document-2.19.0.tgz#7bd282e3f5842ed295bb748cdd9f1ffa2c824685"
-  dependencies:
-    dom-walk "^0.1.0"
 
 minimalistic-assert@^1.0.0:
   version "1.0.0"
@@ -4669,12 +4711,6 @@ minimist@0.0.8, minimist@~0.0.1:
 minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
-
-mkdirp@0.5.0:
-  version "0.5.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/mkdirp/-/mkdirp-0.5.0.tgz#1d73076a6df986cd9344e15e71fcc05a4c9abf12"
-  dependencies:
-    minimist "0.0.8"
 
 mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
@@ -4837,10 +4873,6 @@ node-pre-gyp@^0.6.36:
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
-node-status-codes@^1.0.0:
-  version "1.0.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/node-status-codes/-/node-status-codes-1.0.0.tgz#5ae5541d024645d32a58fcddc9ceecea7ae3ac2f"
-
 nopt@^4.0.1:
   version "4.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/nopt/-/nopt-4.0.1.tgz#d0d4685afd5415193c8c7505602d0d17cd64474d"
@@ -4848,16 +4880,26 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
+nopt@~3.0.6:
+  version "3.0.6"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/nopt/-/nopt-3.0.6.tgz#c6465dbf08abcd4db359317f79ac68a646b28ff9"
+  dependencies:
+    abbrev "1"
+
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
-  version "2.4.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
+  version "2.3.8"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/normalize-package-data/-/normalize-package-data-2.3.8.tgz#d819eda2a9dedbd1ffa563ea4071d936782295bb"
   dependencies:
     hosted-git-info "^2.1.4"
     is-builtin-module "^1.0.0"
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-normalize-path@^2.0.0, normalize-path@^2.0.1:
+normalize-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
+
+normalize-path@^2.0.1:
   version "2.1.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
   dependencies:
@@ -4876,15 +4918,29 @@ normalize-url@^1.4.0:
     query-string "^4.1.0"
     sort-keys "^1.0.0"
 
+npm-path@^2.0.2:
+  version "2.0.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/npm-path/-/npm-path-2.0.3.tgz#15cff4e1c89a38da77f56f6055b24f975dfb2bbe"
+  dependencies:
+    which "^1.2.10"
+
 npm-run-path@^2.0.0:
   version "2.0.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/npm-run-path/-/npm-run-path-2.0.2.tgz#35a9232dfa35d7067b4cb2ddf2357b1871536c5f"
   dependencies:
     path-key "^2.0.0"
 
+npm-which@^3.0.1:
+  version "3.0.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/npm-which/-/npm-which-3.0.1.tgz#9225f26ec3a285c209cae67c3b11a6b4ab7140aa"
+  dependencies:
+    commander "^2.9.0"
+    npm-path "^2.0.2"
+    which "^1.2.10"
+
 npmlog@^4.0.2:
-  version "4.1.2"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/npmlog/-/npmlog-4.1.2.tgz#08a7f2a8bf734604779a9efa4ad5cc717abb954b"
+  version "4.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/npmlog/-/npmlog-4.1.0.tgz#dc59bee85f64f00ed424efb2af0783df25d1c0b5"
   dependencies:
     are-we-there-yet "~1.1.2"
     console-control-strings "~1.1.0"
@@ -5033,6 +5089,15 @@ options@>=0.0.5:
   version "0.0.6"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/options/-/options-0.0.6.tgz#ec22d312806bb53e731773e7cdaefcf1c643128f"
 
+ora@^0.2.3:
+  version "0.2.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/ora/-/ora-0.2.3.tgz#37527d220adcd53c39b73571d754156d5db657a4"
+  dependencies:
+    chalk "^1.1.1"
+    cli-cursor "^1.0.2"
+    cli-spinners "^0.1.2"
+    object-assign "^4.0.1"
+
 original@>=0.0.5:
   version "1.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/original/-/original-1.0.0.tgz#9147f93fa1696d04be61e01bd50baeaca656bd3b"
@@ -5065,20 +5130,12 @@ os-tmpdir@^1.0.0, os-tmpdir@^1.0.1, os-tmpdir@~1.0.1:
   version "1.0.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
 
-osenv@^0.1.0, osenv@^0.1.4:
+osenv@^0.1.4:
   version "0.1.4"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/osenv/-/osenv-0.1.4.tgz#42fe6d5953df06c8064be6f176c3d05aaaa34644"
   dependencies:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.0"
-
-output-file-sync@^1.1.0:
-  version "1.1.2"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/output-file-sync/-/output-file-sync-1.1.2.tgz#d0a33eefe61a205facb90092e826598d5245ce76"
-  dependencies:
-    graceful-fs "^4.1.4"
-    mkdirp "^0.5.1"
-    object-assign "^4.1.0"
 
 p-finally@^1.0.0:
   version "1.0.0"
@@ -5097,15 +5154,6 @@ p-locate@^2.0.0:
 p-map@^1.1.1:
   version "1.1.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/p-map/-/p-map-1.1.1.tgz#05f5e4ae97a068371bc2a5cc86bfbdbc19c4ae7a"
-
-package-json@^2.0.0:
-  version "2.4.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/package-json/-/package-json-2.4.0.tgz#0d15bd67d1cbbddbb2ca222ff2edb86bcb31a8bb"
-  dependencies:
-    got "^5.0.0"
-    registry-auth-token "^3.0.1"
-    registry-url "^3.0.3"
-    semver "^5.1.0"
 
 pako@~0.2.0:
   version "0.2.9"
@@ -5136,7 +5184,7 @@ parse-glob@^3.0.4:
     is-extglob "^1.0.0"
     is-glob "^2.0.0"
 
-parse-json@^2.1.0, parse-json@^2.2.0:
+parse-json@^2.2.0:
   version "2.2.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/parse-json/-/parse-json-2.2.0.tgz#f480f40434ef80741f8469099f8dea18f55a4dc9"
   dependencies:
@@ -5225,18 +5273,14 @@ pathval@^1.0.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
 
 pbkdf2@^3.0.3:
-  version "3.0.13"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/pbkdf2/-/pbkdf2-3.0.13.tgz#c37d295531e786b1da3e3eadc840426accb0ae25"
+  version "3.0.12"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/pbkdf2/-/pbkdf2-3.0.12.tgz#be36785c5067ea48d806ff923288c5f750b6b8a2"
   dependencies:
     create-hash "^1.1.2"
     create-hmac "^1.1.4"
     ripemd160 "^2.0.1"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
-
-pend@~1.2.0:
-  version "1.2.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
 
 performance-now@^0.2.0:
   version "0.2.0"
@@ -5889,13 +5933,21 @@ postcss@^5.0.10, postcss@^5.0.11, postcss@^5.0.12, postcss@^5.0.13, postcss@^5.0
     source-map "^0.5.6"
     supports-color "^3.2.3"
 
-postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.2, postcss@^6.0.3, postcss@^6.0.5, postcss@^6.0.6, postcss@^6.0.8:
+postcss@^6.0.0, postcss@^6.0.3, postcss@^6.0.5, postcss@^6.0.6, postcss@^6.0.8:
   version "6.0.8"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/postcss/-/postcss-6.0.8.tgz#89067a9ce8b11f8a84cbc5117efc30419a0857b3"
   dependencies:
     chalk "^2.0.1"
     source-map "^0.5.6"
     supports-color "^4.2.0"
+
+postcss@^6.0.1, postcss@^6.0.2:
+  version "6.0.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/postcss/-/postcss-6.0.3.tgz#b7f565b3d956fbb8565ca7c1e239d0506e427d8b"
+  dependencies:
+    chalk "^1.1.3"
+    source-map "^0.5.6"
+    supports-color "^4.0.0"
 
 preact-compat-enzyme@^0.2.5:
   version "0.2.5"
@@ -5904,7 +5956,17 @@ preact-compat-enzyme@^0.2.5:
     preact "8.x"
     preact-compat "3.x"
 
-preact-compat@3.x, preact-compat@^3.11.0, preact-compat@^3.17.0:
+preact-compat@3.x, preact-compat@^3.11.0:
+  version "3.16.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/preact-compat/-/preact-compat-3.16.0.tgz#cf2bc1b2f8fca14900d68094f9e10b8b329cc41e"
+  dependencies:
+    immutability-helper "^2.1.2"
+    preact-render-to-string "^3.6.0"
+    preact-transition-group "^1.1.0"
+    prop-types "^15.5.8"
+    standalone-react-addons-pure-render-mixin "^0.1.1"
+
+preact-compat@^3.17.0:
   version "3.17.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/preact-compat/-/preact-compat-3.17.0.tgz#528cfdfc301190c1a0f47567336be1f4be0266b3"
   dependencies:
@@ -5939,7 +6001,11 @@ preact-transition-group@^1.1.0:
   version "1.1.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/preact-transition-group/-/preact-transition-group-1.1.1.tgz#f0a49327ea515ece34ea2be864c4a7d29e5d6e10"
 
-preact@8.x, preact@^8.2.1:
+preact@8.x:
+  version "8.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/preact/-/preact-8.1.0.tgz#f035b808eebb74e46d56246b02ca0f190b6d6574"
+
+preact@^8.2.1:
   version "8.2.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/preact/-/preact-8.2.1.tgz#674243df0c847884d019834044aa2fcd311e72ed"
 
@@ -5968,13 +6034,52 @@ prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
 
-prepend-http@^1.0.0, prepend-http@^1.0.1:
+prepend-http@^1.0.0:
   version "1.0.4"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
 
 preserve@^0.2.0:
   version "0.2.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
+
+prettier-eslint@^6.3.0:
+  version "6.4.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/prettier-eslint/-/prettier-eslint-6.4.2.tgz#9bafd9549e0827396c75848e8dbeb65525b9096e"
+  dependencies:
+    common-tags "^1.4.0"
+    dlv "^1.1.0"
+    eslint "^3.19.0"
+    indent-string "^3.1.0"
+    lodash.merge "^4.6.0"
+    loglevel-colored-level-prefix "^1.0.0"
+    prettier "^1.5.0"
+    pretty-format "^20.0.3"
+    require-relative "^0.8.7"
+
+prettier-standard@^6.0.0:
+  version "6.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/prettier-standard/-/prettier-standard-6.0.0.tgz#4c55db1401b9a5c09f0547009ea2ed1494a3346c"
+  dependencies:
+    babel-eslint ">=7.2.3"
+    babel-runtime "^6.23.0"
+    chalk "^1.1.3"
+    eslint "^3.19.0"
+    find-up "^2.1.0"
+    get-stdin "^5.0.1"
+    glob "^7.1.2"
+    ignore "^3.3.3"
+    indent-string "^3.1.0"
+    lodash.memoize "^4.1.2"
+    loglevel-colored-level-prefix "^1.0.0"
+    meow "3.7.0"
+    messageformat "^1.0.2"
+    prettier "^1.4.4"
+    prettier-eslint "^6.3.0"
+    rxjs "^5.4.0"
+
+prettier@^1.4.4, prettier@^1.5.0:
+  version "1.5.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/prettier/-/prettier-1.5.3.tgz#59dadc683345ec6b88f88b94ed4ae7e1da394bfe"
 
 pretty-error@^2.0.2:
   version "2.1.1"
@@ -6005,10 +6110,6 @@ process-nextick-args@~1.0.6:
 process@^0.11.0:
   version "0.11.10"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
-
-process@~0.5.1:
-  version "0.5.2"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/process/-/process-0.5.2.tgz#1638d8a8e34c2f440a91db95ab9aeb677fc185cf"
 
 progress@^1.1.8:
   version "1.1.8"
@@ -6045,12 +6146,12 @@ propagate@0.4.0:
   version "0.4.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/propagate/-/propagate-0.4.0.tgz#f3fcca0a6fe06736a7ba572966069617c130b481"
 
-proxy-addr@~1.1.5:
-  version "1.1.5"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/proxy-addr/-/proxy-addr-1.1.5.tgz#71c0ee3b102de3f202f3b64f608d173fcba1a918"
+proxy-addr@~1.1.4:
+  version "1.1.4"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/proxy-addr/-/proxy-addr-1.1.4.tgz#27e545f6960a44a627d9b44467e35c1b6b4ce2f3"
   dependencies:
     forwarded "~0.1.0"
-    ipaddr.js "1.4.0"
+    ipaddr.js "1.3.0"
 
 prr@~0.0.0:
   version "0.0.0"
@@ -6079,18 +6180,14 @@ punycode@^1.2.4, punycode@^1.4.1:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
 pure-color@^1.2.0:
-  version "1.3.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/pure-color/-/pure-color-1.3.0.tgz#1fe064fb0ac851f0de61320a8bf796836422f33e"
+  version "1.2.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/pure-color/-/pure-color-1.2.0.tgz#702d2f2819dd545b1fde5116fca5f0c2dad2d18d"
 
 q@^1.1.2:
   version "1.5.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/q/-/q-1.5.0.tgz#dd01bac9d06d30e6f219aecb8253ee9ebdc308f1"
 
-qs@6.5.0, qs@^6.0.2:
-  version "6.5.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/qs/-/qs-6.5.0.tgz#8d04954d364def3efc55b5a0793e1e2c8b1e6e49"
-
-qs@~6.4.0:
+qs@6.4.0, qs@^6.0.2, qs@~6.4.0:
   version "6.4.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
@@ -6134,7 +6231,7 @@ range-parser@^1.0.3, range-parser@~1.2.0:
   version "1.2.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
 
-rc@^1.0.1, rc@^1.1.6, rc@^1.1.7:
+rc@^1.1.7:
   version "1.2.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/rc/-/rc-1.2.1.tgz#2e03e8e42ee450b8cb3dce65be1bf8974e1dfd95"
   dependencies:
@@ -6233,13 +6330,6 @@ react-timeago@^3.4.3:
   version "3.4.3"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/react-timeago/-/react-timeago-3.4.3.tgz#eb9061eefb044e4a2b09ce8c99d34645b2dbfa25"
 
-read-all-stream@^3.0.0:
-  version "3.1.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/read-all-stream/-/read-all-stream-3.1.0.tgz#35c3e177f2078ef789ee4bfafa4373074eaef4fa"
-  dependencies:
-    pinkie-promise "^2.0.0"
-    readable-stream "^2.0.0"
-
 read-cache@^1.0.0:
   version "1.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/read-cache/-/read-cache-1.0.0.tgz#e664ef31161166c9751cdbe8dbcf86b5fb58f774"
@@ -6285,27 +6375,16 @@ readable-stream@1.0:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.2.6, readable-stream@^2.2.9:
-  version "2.3.3"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/readable-stream/-/readable-stream-2.3.3.tgz#368f2512d79f9d46fdfc71349ae7878bbc1eb95c"
+readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2, readable-stream@^2.2.6, readable-stream@^2.2.9:
+  version "2.3.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/readable-stream/-/readable-stream-2.3.0.tgz#640f5dcda88c91a8dc60787145629170813a1ed2"
   dependencies:
     core-util-is "~1.0.0"
     inherits "~2.0.3"
     isarray "~1.0.0"
     process-nextick-args "~1.0.6"
-    safe-buffer "~5.1.1"
-    string_decoder "~1.0.3"
-    util-deprecate "~1.0.1"
-
-readable-stream@~2.0.0:
-  version "2.0.6"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/readable-stream/-/readable-stream-2.0.6.tgz#8f90341e68a53ccc928788dacfcd11b36eb9b78e"
-  dependencies:
-    core-util-is "~1.0.0"
-    inherits "~2.0.1"
-    isarray "~1.0.0"
-    process-nextick-args "~1.0.6"
-    string_decoder "~0.10.x"
+    safe-buffer "~5.1.0"
+    string_decoder "~1.0.0"
     util-deprecate "~1.0.1"
 
 readdirp@^2.0.0:
@@ -6417,7 +6496,16 @@ redux-observable@^0.14.1:
   version "0.14.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/redux-observable/-/redux-observable-0.14.1.tgz#9f3d870c69388fdc427ded6770a3e326f3b69693"
 
-redux@^3.2.0, redux@^3.7.2:
+redux@^3.2.0:
+  version "3.7.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/redux/-/redux-3.7.1.tgz#bfc535c757d3849562ead0af18ac52122cd7268e"
+  dependencies:
+    lodash "^4.2.1"
+    lodash-es "^4.2.1"
+    loose-envify "^1.1.0"
+    symbol-observable "^1.0.3"
+
+redux@^3.7.2:
   version "3.7.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
   dependencies:
@@ -6465,19 +6553,6 @@ regexpu-core@^2.0.0:
     regjsgen "^0.2.0"
     regjsparser "^0.1.4"
 
-registry-auth-token@^3.0.1:
-  version "3.3.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/registry-auth-token/-/registry-auth-token-3.3.1.tgz#fb0d3289ee0d9ada2cbb52af5dfe66cb070d3006"
-  dependencies:
-    rc "^1.1.6"
-    safe-buffer "^5.0.1"
-
-registry-url@^3.0.3:
-  version "3.1.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/registry-url/-/registry-url-3.1.0.tgz#3d4ef870f73dde1d77f0cf9a381432444e174942"
-  dependencies:
-    rc "^1.0.1"
-
 regjsgen@^0.2.0:
   version "0.2.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/regjsgen/-/regjsgen-0.2.0.tgz#6c016adeac554f75823fe37ac05b92d5a4edb1f7"
@@ -6520,13 +6595,7 @@ repeating@^2.0.0:
   dependencies:
     is-finite "^1.0.0"
 
-request-progress@^0.3.1:
-  version "0.3.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/request-progress/-/request-progress-0.3.1.tgz#0721c105d8a96ac6b2ce8b2c89ae2d5ecfcf6b3a"
-  dependencies:
-    throttleit "~0.0.2"
-
-request@^2.60.0, request@^2.79.0, request@^2.81.0:
+request@^2.79.0, request@^2.81.0:
   version "2.81.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/request/-/request-2.81.0.tgz#c6928946a0e06c5f8d6f8a9333469ffda46298a0"
   dependencies:
@@ -6565,6 +6634,10 @@ require-main-filename@^1.0.1:
   version "1.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
 
+require-relative@^0.8.7:
+  version "0.8.7"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/require-relative/-/require-relative-0.8.7.tgz#7999539fc9e047a37928fa196f8e1563dabd36de"
+
 require-uncached@^1.0.2, require-uncached@^1.0.3:
   version "1.0.3"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
@@ -6576,6 +6649,10 @@ requires-port@1.0.x, requires-port@1.x.x:
   version "1.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
+reserved-words@^0.1.1:
+  version "0.1.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/reserved-words/-/reserved-words-0.1.1.tgz#6f7c15e5e5614c50da961630da46addc87c0cef2"
+
 resolve-from@^1.0.0:
   version "1.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
@@ -6584,7 +6661,13 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
-resolve@^1.1.6, resolve@^1.1.7, resolve@^1.2.0, resolve@^1.3.2, resolve@^1.3.3:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.2.0, resolve@^1.3.2:
+  version "1.3.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/resolve/-/resolve-1.3.3.tgz#655907c3469a8680dc2de3a275a8fdd69691f0e5"
+  dependencies:
+    path-parse "^1.0.5"
+
+resolve@^1.3.3:
   version "1.4.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
   dependencies:
@@ -6661,19 +6744,19 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
-rxjs@^5.4.2:
+rxjs@^5.0.0-beta.11, rxjs@^5.4.0, rxjs@^5.4.2:
   version "5.4.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/rxjs/-/rxjs-5.4.2.tgz#2a3236fcbf03df57bae06fd6972fd99e5c08fcf7"
   dependencies:
     symbol-observable "^1.0.1"
 
-safe-buffer@5.1.1, safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
-  version "5.1.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/safe-buffer/-/safe-buffer-5.1.1.tgz#893312af69b2123def71f57889001671eeb2c853"
-
-safe-buffer@~5.0.1:
+safe-buffer@^5.0.1, safe-buffer@~5.0.1:
   version "5.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/safe-buffer/-/safe-buffer-5.0.1.tgz#d263ca54696cd8a306b5ca6551e92de57918fbe7"
+
+safe-buffer@^5.1.0, safe-buffer@~5.1.0:
+  version "5.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/safe-buffer/-/safe-buffer-5.1.0.tgz#fe4c8460397f9eaaaa58e73be46273408a45e223"
 
 sane@~1.6.0:
   version "1.6.0"
@@ -6694,8 +6777,8 @@ save-as@^0.1.7:
     chai "*"
 
 sax@>=0.6.0, sax@^1.2.1, sax@~1.2.1:
-  version "1.2.4"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
+  version "1.2.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
 
 schema-utils@^0.3.0:
   version "0.3.0"
@@ -6713,32 +6796,22 @@ selfsigned@^1.9.1:
   dependencies:
     node-forge "0.6.33"
 
-semver-diff@^2.0.0:
-  version "2.1.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/semver-diff/-/semver-diff-2.1.0.tgz#4bbb8437c8d37e4b0cf1a68fd726ec6d645d6d36"
-  dependencies:
-    semver "^5.0.3"
-
-"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.1.0, semver@^5.3.0:
-  version "5.4.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
-
-semver@5.3.0:
+"semver@2 || 3 || 4 || 5", semver@5.3.0, semver@^5.3.0:
   version "5.3.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
-send@0.15.4:
-  version "0.15.4"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/send/-/send-0.15.4.tgz#985faa3e284b0273c793364a35c6737bd93905b9"
+send@0.15.3:
+  version "0.15.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/send/-/send-0.15.3.tgz#5013f9f99023df50d1bd9892c19e3defd1d53309"
   dependencies:
-    debug "2.6.8"
-    depd "~1.1.1"
+    debug "2.6.7"
+    depd "~1.1.0"
     destroy "~1.0.4"
     encodeurl "~1.0.1"
     escape-html "~1.0.3"
     etag "~1.8.0"
     fresh "0.5.0"
-    http-errors "~1.6.2"
+    http-errors "~1.6.1"
     mime "1.3.4"
     ms "2.0.0"
     on-finished "~2.3.0"
@@ -6757,14 +6830,14 @@ serve-index@^1.7.2:
     mime-types "~2.1.15"
     parseurl "~1.3.1"
 
-serve-static@1.12.4:
-  version "1.12.4"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/serve-static/-/serve-static-1.12.4.tgz#9b6aa98eeb7253c4eedc4c1f6fdbca609901a961"
+serve-static@1.12.3:
+  version "1.12.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/serve-static/-/serve-static-1.12.3.tgz#9f4ba19e2f3030c547f8af99107838ec38d5b1e2"
   dependencies:
     encodeurl "~1.0.1"
     escape-html "~1.0.3"
     parseurl "~1.3.1"
-    send "0.15.4"
+    send "0.15.3"
 
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
@@ -6833,10 +6906,6 @@ slash@^1.0.0:
 slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
-
-slide@^1.1.5:
-  version "1.1.6"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
 
 sntp@1.x.x:
   version "1.0.9"
@@ -6997,6 +7066,10 @@ sshpk@^1.7.0:
     jsbn "~0.1.0"
     tweetnacl "~0.14.0"
 
+staged-git-files@0.0.4:
+  version "0.0.4"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/staged-git-files/-/staged-git-files-0.0.4.tgz#d797e1b551ca7a639dec0237dc6eb4bb9be17d35"
+
 standalone-react-addons-pure-render-mixin@^0.1.1:
   version "0.1.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/standalone-react-addons-pure-render-mixin/-/standalone-react-addons-pure-render-mixin-0.1.1.tgz#3c7409f4c79c40de9ac72c616cf679a994f37551"
@@ -7045,6 +7118,10 @@ stream-http@^2.3.1:
     to-arraybuffer "^1.0.0"
     xtend "^4.0.0"
 
+stream-to-observable@^0.1.0:
+  version "0.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/stream-to-observable/-/stream-to-observable-0.1.0.tgz#45bf1d9f2d7dc09bed81f1c307c430e68b84cffe"
+
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
@@ -7063,7 +7140,14 @@ string-width@^1.0.1, string-width@^1.0.2:
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
 
-string-width@^2.0.0, string-width@^2.1.0:
+string-width@^2.0.0:
+  version "2.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/string-width/-/string-width-2.0.0.tgz#635c5436cc72a6e0c387ceca278d4e2eec52687e"
+  dependencies:
+    is-fullwidth-code-point "^2.0.0"
+    strip-ansi "^3.0.0"
+
+string-width@^2.1.0:
   version "2.1.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
   dependencies:
@@ -7074,11 +7158,11 @@ string_decoder@^0.10.25, string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
 
-string_decoder@~1.0.3:
-  version "1.0.3"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/string_decoder/-/string_decoder-1.0.3.tgz#0fc67d7c141825de94282dd536bec6b9bce860ab"
+string_decoder@~1.0.0:
+  version "1.0.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/string_decoder/-/string_decoder-1.0.2.tgz#b29e1f4e1125fa97a10382b8a533737b7491e179"
   dependencies:
-    safe-buffer "~5.1.0"
+    safe-buffer "~5.0.1"
 
 stringstream@~0.0.4:
   version "0.0.5"
@@ -7115,6 +7199,10 @@ strip-indent@^1.0.1:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
   dependencies:
     get-stdin "^4.0.1"
+
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -7165,7 +7253,13 @@ supports-color@^3.1.1, supports-color@^3.1.2, supports-color@^3.2.3:
   dependencies:
     has-flag "^1.0.0"
 
-supports-color@^4.0.0, supports-color@^4.2.0, supports-color@^4.2.1:
+supports-color@^4.0.0:
+  version "4.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/supports-color/-/supports-color-4.0.0.tgz#33a7c680aa512c9d03ef929cacbb974d203d2790"
+  dependencies:
+    has-flag "^2.0.0"
+
+supports-color@^4.2.0, supports-color@^4.2.1:
   version "4.2.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/supports-color/-/supports-color-4.2.1.tgz#65a4bb2631e90e02420dba5554c375a4754bb836"
   dependencies:
@@ -7222,8 +7316,8 @@ table@^4.0.1:
     string-width "^2.0.0"
 
 tapable@^0.2.7:
-  version "0.2.8"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/tapable/-/tapable-0.2.8.tgz#99372a5c999bf2df160afc0d74bed4f47948cd22"
+  version "0.2.7"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/tapable/-/tapable-0.2.7.tgz#e46c0daacbb2b8a98b9b0cea0f4052105817ed5c"
 
 tar-pack@^3.4.0:
   version "3.4.0"
@@ -7268,17 +7362,6 @@ throat@^3.0.0:
   version "3.2.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/throat/-/throat-3.2.0.tgz#50cb0670edbc40237b9e347d7e1f88e4620af836"
 
-throttleit@~0.0.2:
-  version "0.0.2"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/throttleit/-/throttleit-0.0.2.tgz#cfedf88e60c00dd9697b61fdd2a8343a9b680eaf"
-
-through2@^2.0.0:
-  version "2.0.3"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/through2/-/through2-2.0.3.tgz#0004569b37c7c74ba39c43f3ced78d1ad94140be"
-  dependencies:
-    readable-stream "^2.1.5"
-    xtend "~4.0.1"
-
 through@^2.3.6, through@~2.3.6:
   version "2.3.8"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
@@ -7291,15 +7374,10 @@ time-stamp@^2.0.0:
   version "2.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/time-stamp/-/time-stamp-2.0.0.tgz#95c6a44530e15ba8d6f4a3ecb8c3a3fac46da357"
 
-timed-out@^3.0.0:
-  version "3.1.3"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/timed-out/-/timed-out-3.1.3.tgz#95860bfcc5c76c277f8f8326fd0f5b2e20eba217"
-
 timers-browserify@^2.0.2:
-  version "2.0.3"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/timers-browserify/-/timers-browserify-2.0.3.tgz#41fd0bdc926a5feedc33a17a8e1f7d491925f7fc"
+  version "2.0.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/timers-browserify/-/timers-browserify-2.0.2.tgz#ab4883cf597dcd50af211349a00fbca56ac86b86"
   dependencies:
-    global "^4.3.2"
     setimmediate "^1.0.4"
 
 tmp@^0.0.31:
@@ -7399,19 +7477,19 @@ type-is@~1.6.15:
     media-typer "0.3.0"
     mime-types "~2.1.15"
 
-typedarray@^0.0.6, typedarray@~0.0.5:
+typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
 ua-parser-js@^0.7.9:
-  version "0.7.14"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/ua-parser-js/-/ua-parser-js-0.7.14.tgz#110d53fa4c3f326c121292bbeac904d2e03387ca"
+  version "0.7.12"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/ua-parser-js/-/ua-parser-js-0.7.12.tgz#04c81a99bdd5dc52263ea29d24c6bf8d4818a4bb"
 
 uglify-js@3.0.x:
-  version "3.0.27"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/uglify-js/-/uglify-js-3.0.27.tgz#a97db8c8ba6b9dba4e2f88d86aa9548fa6320034"
+  version "3.0.18"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/uglify-js/-/uglify-js-3.0.18.tgz#d67a3e5a0a08356b787fb1c9bddf3a807630902e"
   dependencies:
-    commander "~2.11.0"
+    commander "~2.9.0"
     source-map "~0.5.1"
 
 uglify-js@^2.6, uglify-js@^2.8.29:
@@ -7472,23 +7550,6 @@ unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
 
-unzip-response@^1.0.2:
-  version "1.0.2"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/unzip-response/-/unzip-response-1.0.2.tgz#b984f0877fc0a89c2c773cc1ef7b5b232b5b06fe"
-
-update-notifier@^1.0.3:
-  version "1.0.3"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/update-notifier/-/update-notifier-1.0.3.tgz#8f92c515482bd6831b7c93013e70f87552c7cf5a"
-  dependencies:
-    boxen "^0.6.0"
-    chalk "^1.0.0"
-    configstore "^2.0.0"
-    is-npm "^1.0.0"
-    latest-version "^2.0.0"
-    lazy-req "^1.1.0"
-    semver-diff "^2.0.0"
-    xdg-basedir "^2.0.0"
-
 upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
@@ -7499,12 +7560,6 @@ url-loader@^0.5.8:
   dependencies:
     loader-utils "^1.0.2"
     mime "1.3.x"
-
-url-parse-lax@^1.0.0:
-  version "1.0.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/url-parse-lax/-/url-parse-lax-1.0.0.tgz#7af8f303645e9bd79a272e7a14ac68bc0609da73"
-  dependencies:
-    prepend-http "^1.0.1"
 
 url-parse@1.0.x:
   version "1.0.5"
@@ -7526,10 +7581,6 @@ url@^0.11.0:
   dependencies:
     punycode "1.3.2"
     querystring "0.2.0"
-
-user-home@^1.1.1:
-  version "1.1.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
 
 user-home@^2.0.0:
   version "2.0.0"
@@ -7559,19 +7610,13 @@ utils-merge@1.0.0:
   version "1.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/utils-merge/-/utils-merge-1.0.0.tgz#0294fb922bb9375153541c4f7096231f287c8af8"
 
-uuid@^2.0.1, uuid@^2.0.2:
+uuid@^2.0.2:
   version "2.0.3"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/uuid/-/uuid-2.0.3.tgz#67e2e863797215530dff318e5bf9dcebfd47b21a"
 
 uuid@^3.0.0, uuid@^3.0.1:
   version "3.1.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
-
-v8flags@^2.0.10:
-  version "2.1.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/v8flags/-/v8flags-2.1.1.tgz#aab1a1fa30d45f88dd321148875ac02c0b55e5b4"
-  dependencies:
-    user-home "^1.1.1"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"
@@ -7580,7 +7625,7 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "~1.0.0"
     spdx-expression-parse "~1.0.0"
 
-vary@~1.1.1:
+vary@~1.1.0, vary@~1.1.1:
   version "1.1.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/vary/-/vary-1.1.1.tgz#67535ebb694c1d52257457984665323f587e8d37"
 
@@ -7588,13 +7633,11 @@ vendors@^1.0.0:
   version "1.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/vendors/-/vendors-1.0.1.tgz#37ad73c8ee417fb3d580e785312307d274847f22"
 
-verror@1.10.0:
-  version "1.10.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
+verror@1.3.6:
+  version "1.3.6"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/verror/-/verror-1.3.6.tgz#cff5df12946d297d2baaefaa2689e25be01c005c"
   dependencies:
-    assert-plus "^1.0.0"
-    core-util-is "1.0.2"
-    extsprintf "^1.2.0"
+    extsprintf "1.0.2"
 
 viewport-dimensions@^0.2.0:
   version "0.2.0"
@@ -7775,9 +7818,15 @@ which-module@^2.0.0:
   version "2.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
 
-which@^1.2.12, which@^1.2.9:
+which@^1.2.10:
   version "1.3.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/which/-/which-1.3.0.tgz#ff04bdfc010ee547d780bec38e1ac1c2777d253a"
+  dependencies:
+    isexe "^2.0.0"
+
+which@^1.2.12, which@^1.2.9:
+  version "1.2.14"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/which/-/which-1.2.14.tgz#9a87c4378f03e827cecaf1acdf56c736c01c14e5"
   dependencies:
     isexe "^2.0.0"
 
@@ -7786,12 +7835,6 @@ wide-align@^1.1.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/wide-align/-/wide-align-1.1.2.tgz#571e0f1b0604636ebc0dfc21b0339bbe31341710"
   dependencies:
     string-width "^1.0.2"
-
-widest-line@^1.0.0:
-  version "1.0.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/widest-line/-/widest-line-1.0.0.tgz#0c09c85c2a94683d0d7eaf8ee097d564bf0e105c"
-  dependencies:
-    string-width "^1.0.1"
 
 window-size@0.1.0:
   version "0.1.0"
@@ -7806,17 +7849,11 @@ wordwrap@~1.0.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
 
 worker-farm@^1.3.1:
-  version "1.4.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/worker-farm/-/worker-farm-1.4.1.tgz#a438bc993a7a7d133bcb6547c95eca7cff4897d8"
+  version "1.3.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/worker-farm/-/worker-farm-1.3.1.tgz#4333112bb49b17aa050b87895ca6b2cacf40e5ff"
   dependencies:
-    errno "^0.1.4"
-    xtend "^4.0.1"
-
-worker-loader@^0.8.0:
-  version "0.8.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/worker-loader/-/worker-loader-0.8.0.tgz#13582960dcd7d700dc829d3fd252a7561696167e"
-  dependencies:
-    loader-utils "^1.0.2"
+    errno ">=0.1.1 <0.2.0-0"
+    xtend ">=4.0.0 <4.1.0-0"
 
 wrap-ansi@^2.0.0:
   version "2.1.0"
@@ -7828,14 +7865,6 @@ wrap-ansi@^2.0.0:
 wrappy@1:
   version "1.0.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
-
-write-file-atomic@^1.1.2:
-  version "1.3.4"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/write-file-atomic/-/write-file-atomic-1.3.4.tgz#f807a4f0b1d9e913ae7a48112e6cc3af1991b45f"
-  dependencies:
-    graceful-fs "^4.1.11"
-    imurmurhash "^0.1.4"
-    slide "^1.1.5"
 
 write@^0.2.1:
   version "0.2.1"
@@ -7868,12 +7897,6 @@ wtf-8@1.0.0:
   version "1.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/wtf-8/-/wtf-8-1.0.0.tgz#392d8ba2d0f1c34d1ee2d630f15d0efb68e1048a"
 
-xdg-basedir@^2.0.0:
-  version "2.0.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/xdg-basedir/-/xdg-basedir-2.0.0.tgz#edbc903cc385fc04523d966a335504b5504d1bd2"
-  dependencies:
-    os-homedir "^1.0.0"
-
 xml-char-classes@^1.0.0:
   version "1.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/xml-char-classes/-/xml-char-classes-1.0.0.tgz#64657848a20ffc5df583a42ad8a277b4512bbc4d"
@@ -7903,13 +7926,9 @@ xmlhttprequest@^1.8.0:
   version "1.8.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz#67fe075c5c24fef39f9d65f5f7b7fe75171968fc"
 
-xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
+"xtend@>=4.0.0 <4.1.0-0", xtend@^4.0.0, xtend@^4.0.1:
   version "4.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
-
-xvfb@cypress-io/node-xvfb:
-  version "0.3.0"
-  resolved "https://codeload.github.com/cypress-io/node-xvfb/tar.gz/22e3783c31d81ebe64d8c0df491ea00cdc74726a"
 
 y18n@^3.2.1:
   version "3.2.1"
@@ -7999,19 +8018,6 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
-
-yauzl@2.4.1:
-  version "2.4.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/yauzl/-/yauzl-2.4.1.tgz#9528f442dab1b2284e58b4379bb194e22e0c4005"
-  dependencies:
-    fd-slicer "~1.0.1"
-
-yauzl@^2.4.1:
-  version "2.8.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/yauzl/-/yauzl-2.8.0.tgz#79450aff22b2a9c5a41ef54e02db907ccfbf9ee2"
-  dependencies:
-    buffer-crc32 "~0.2.3"
-    fd-slicer "~1.0.1"
 
 yeast@0.1.2:
   version "0.1.2"


### PR DESCRIPTION
Run code through [prettier-standard](https://github.com/sheerun/prettier-standard) to have prettier formatting the code and then standard doing `--fix` to change things to align with the linter rules (double quotes on jsx is one of those things that prettier adds but isn't allowed in standard).

I'd suggest that all developers download prettier plugins for their editors / IDE:s to have auto format on save.

A precommit hook is added to `package.json` to prettify code before a commit is performed.

The point is that we shouldn't have to think about the code format, it's automatically fixed for us to have maximun readability.

Do we like this, or not?