### PR TITLE
Add ability to download a query plan as png

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/PlanView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/PlanView.jsx
@@ -59,10 +59,9 @@ export class PlanView extends Component {
         })
     }
     this.ensureToggleExpand(props)
+    props.assignVisElement && props.assignVisElement(this.el, this.plan)
   }
   shouldComponentUpdate (props, state) {
-    this.props.assignVisElement && this.props.assignVisElement(this.el, this.plan)
-
     if (this.props.result === undefined) return true
     return (
       !deepEquals(props.result.summary, this.props.result.summary) ||

--- a/src/browser/modules/Stream/CypherFrame/PlanView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/PlanView.jsx
@@ -61,6 +61,8 @@ export class PlanView extends Component {
     this.ensureToggleExpand(props)
   }
   shouldComponentUpdate (props, state) {
+    this.props.assignVisElement && this.props.assignVisElement(this.el, this.plan)
+
     if (this.props.result === undefined) return true
     return (
       !deepEquals(props.result.summary, this.props.result.summary) ||
@@ -79,8 +81,14 @@ export class PlanView extends Component {
   planInit (el) {
     if (el != null && !this.plan) {
       const NeoConstructor = neo.queryPlan
-      this.plan = new NeoConstructor(el)
+      this.el = el
+      this.plan = new NeoConstructor(this.el)
       this.plan.display(this.state.extractedPlan)
+      this.plan.boundingBox = () => {
+        return this.el.getBBox()
+      }
+
+      this.props.assignVisElement && this.props.assignVisElement(this.el, this.plan)
     }
   }
   ensureToggleExpand (props) {

--- a/src/browser/modules/Stream/CypherFrame/PlanView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/PlanView.jsx
@@ -87,7 +87,8 @@ export class PlanView extends Component {
         return this.el.getBBox()
       }
 
-      this.props.assignVisElement && this.props.assignVisElement(this.el, this.plan)
+      this.props.assignVisElement &&
+        this.props.assignVisElement(this.el, this.plan)
     }
   }
   ensureToggleExpand (props) {

--- a/src/browser/modules/Stream/CypherFrame/index.jsx
+++ b/src/browser/modules/Stream/CypherFrame/index.jsx
@@ -276,11 +276,15 @@ export class CypherFrame extends Component {
           />
         </Display>
         <Display if={this.state.openView === viewTypes.PLAN} lazy>
-          <PlanView {...this.state} result={result} setParentState={this.setState.bind(this)}
+          <PlanView
+            {...this.state}
+            result={result}
+            setParentState={this.setState.bind(this)}
             assignVisElement={(svgElement, graphElement) => {
-              this.visElement = {svgElement, graphElement, type: 'plan'}
-              this.setState({hasVis: true})
-            }} />
+              this.visElement = { svgElement, graphElement, type: 'plan' }
+              this.setState({ hasVis: true })
+            }}
+          />
         </Display>
         <Display if={this.state.openView === viewTypes.VISUALIZATION} lazy>
           <VisualizationConnectedBus
@@ -289,8 +293,8 @@ export class CypherFrame extends Component {
             setParentState={this.setState.bind(this)}
             frameHeight={this.state.frameHeight}
             assignVisElement={(svgElement, graphElement) => {
-              this.visElement = {svgElement, graphElement, type: 'graph'}
-              this.setState({hasVis: true})
+              this.visElement = { svgElement, graphElement, type: 'graph' }
+              this.setState({ hasVis: true })
             }}
             initialNodeDisplay={this.props.initialNodeDisplay}
             autoComplete={this.props.autoComplete}
@@ -371,13 +375,16 @@ export class CypherFrame extends Component {
         contents={frameContents}
         statusbar={statusBar}
         exportData={
-        exportData={(this.state.openView !== viewTypes.VISUALIZATION && this.state.openView !== viewTypes.PLAN) ? this.state.exportData : null}
+          this.state.openView !== viewTypes.VISUALIZATION &&
+          this.state.openView !== viewTypes.PLAN
             ? this.state.exportData
             : null
         }
         onResize={this.onResize.bind(this)}
         visElement={
-        visElement={(this.state.hasVis && (this.state.openView === viewTypes.VISUALIZATION || this.state.openView === viewTypes.PLAN)) ? this.visElement : null}
+          this.state.hasVis &&
+          (this.state.openView === viewTypes.VISUALIZATION ||
+            this.state.openView === viewTypes.PLAN)
             ? this.visElement
             : null
         }

--- a/src/browser/modules/Stream/CypherFrame/index.jsx
+++ b/src/browser/modules/Stream/CypherFrame/index.jsx
@@ -276,11 +276,11 @@ export class CypherFrame extends Component {
           />
         </Display>
         <Display if={this.state.openView === viewTypes.PLAN} lazy>
-          <PlanView
-            {...this.state}
-            result={result}
-            setParentState={this.setState.bind(this)}
-          />
+          <PlanView {...this.state} result={result} setParentState={this.setState.bind(this)}
+            assignVisElement={(svgElement, graphElement) => {
+              this.visElement = {svgElement, graphElement, type: 'plan'}
+              this.setState({hasVis: true})
+            }} />
         </Display>
         <Display if={this.state.openView === viewTypes.VISUALIZATION} lazy>
           <VisualizationConnectedBus
@@ -289,8 +289,8 @@ export class CypherFrame extends Component {
             setParentState={this.setState.bind(this)}
             frameHeight={this.state.frameHeight}
             assignVisElement={(svgElement, graphElement) => {
-              this.visElement = { svgElement, graphElement }
-              this.setState({ hasVis: true })
+              this.visElement = {svgElement, graphElement, type: 'graph'}
+              this.setState({hasVis: true})
             }}
             initialNodeDisplay={this.props.initialNodeDisplay}
             autoComplete={this.props.autoComplete}
@@ -371,13 +371,13 @@ export class CypherFrame extends Component {
         contents={frameContents}
         statusbar={statusBar}
         exportData={
-          this.state.openView !== viewTypes.VISUALIZATION
+        exportData={(this.state.openView !== viewTypes.VISUALIZATION && this.state.openView !== viewTypes.PLAN) ? this.state.exportData : null}
             ? this.state.exportData
             : null
         }
         onResize={this.onResize.bind(this)}
         visElement={
-          this.state.hasVis && this.state.openView === viewTypes.VISUALIZATION
+        visElement={(this.state.hasVis && (this.state.openView === viewTypes.VISUALIZATION || this.state.openView === viewTypes.PLAN)) ? this.visElement : null}
             ? this.visElement
             : null
         }

--- a/src/browser/modules/Stream/FrameTitlebar.jsx
+++ b/src/browser/modules/Stream/FrameTitlebar.jsx
@@ -79,9 +79,8 @@ class FrameTitlebar extends Component {
   }
 
   exportPNG () {
-    const { svgElement, graphElement } = this.props.visElement
-    const fileName = 'graph'
-    downloadPNGFromSVG(svgElement, graphElement, fileName)
+    const {svgElement, graphElement, type} = this.props.visElement
+    downloadPNGFromSVG(svgElement, graphElement, type)
   }
 
   render () {

--- a/src/browser/modules/Stream/FrameTitlebar.jsx
+++ b/src/browser/modules/Stream/FrameTitlebar.jsx
@@ -79,7 +79,7 @@ class FrameTitlebar extends Component {
   }
 
   exportPNG () {
-    const {svgElement, graphElement, type} = this.props.visElement
+    const { svgElement, graphElement, type } = this.props.visElement
     downloadPNGFromSVG(svgElement, graphElement, type)
   }
 

--- a/src/shared/services/exporting/pngUtils.js
+++ b/src/shared/services/exporting/pngUtils.js
@@ -21,17 +21,18 @@
 import { prepareForExport } from './svgUtils'
 import FileSaver from 'file-saver'
 
-export const downloadPNGFromSVG = (svg, graph, filename) => {
-  let canvas, png, svgData
-  const svgObj = prepareForExport(svg, graph)
-  svgData = new window.XMLSerializer().serializeToString(svgObj.node())
-  svgData = svgData.replace(/&nbsp;/g, '&#160;')
+export const downloadPNGFromSVG = (svg, graph, type) => {
+  const svgObj = prepareForExport(svg, graph, type)
+  const filename = type
+  const svgData = new window.XMLSerializer().serializeToString(svgObj.node()).replace(/&nbsp;/g, '&#160;')
+
+  let canvas
   canvas = document.createElement('canvas')
   canvas.width = svgObj.attr('width')
   canvas.height = svgObj.attr('height')
+
   window.canvg(canvas, svgData)
-  png = canvas.toDataURL('image/png')
-  return downloadWithDataURI(filename + '.png', png)
+  return downloadWithDataURI(filename + '.png', canvas.toDataURL('image/png'))
 }
 
 const download = (filename, mime, data) => {

--- a/src/shared/services/exporting/pngUtils.js
+++ b/src/shared/services/exporting/pngUtils.js
@@ -24,7 +24,9 @@ import FileSaver from 'file-saver'
 export const downloadPNGFromSVG = (svg, graph, type) => {
   const svgObj = prepareForExport(svg, graph, type)
   const filename = type
-  const svgData = new window.XMLSerializer().serializeToString(svgObj.node()).replace(/&nbsp;/g, '&#160;')
+  const svgData = new window.XMLSerializer()
+    .serializeToString(svgObj.node())
+    .replace(/&nbsp;/g, '&#160;')
 
   let canvas
   canvas = document.createElement('canvas')

--- a/src/shared/services/exporting/svgUtils.js
+++ b/src/shared/services/exporting/svgUtils.js
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export const prepareForExport = (svgElement, graphElement) => {
+export const prepareForExport = (svgElement, graphElement, type) => {
   const dimensions = getSvgDimensions(graphElement)
   let svg = window.d3.select(
     document.createElementNS('http://www.w3.org/2000/svg', 'svg')
@@ -27,9 +27,16 @@ export const prepareForExport = (svgElement, graphElement) => {
   svg.append('title').text('Neo4j Graph Visualization')
   svg.append('desc').text('Created using Neo4j (http://www.neo4j.com/)')
 
-  window.d3.select(svgElement).selectAll('g.layer').each(node => {
-    svg.node().appendChild(window.d3.select('.' + node).node().cloneNode(true))
-  })
+  switch (type) {
+    case 'plan': {
+      svg = appendPlanLayers(svgElement, svg)
+      break
+    }
+    case 'graph':
+    default:
+      svg = appendGraphLayers(svgElement, svg)
+  }
+
   svg.selectAll('.overlay, .ring').remove()
   svg.selectAll('.context-menu-item').remove()
   svg.selectAll('text').attr('font-family', 'sans-serif')
@@ -55,4 +62,18 @@ export const getSvgDimensions = view => {
     ].join(' ')
   }
   return dimensions
+}
+
+const appendGraphLayers = (svgElement, svg) => {
+  window.d3.select(svgElement).selectAll('g.layer').each((node) => {
+    svg.node().appendChild(window.d3.select('.' + node).node().cloneNode(true))
+  })
+  return svg
+}
+const appendPlanLayers = (svgElement, svg) => {
+  window.d3.select(svgElement).selectAll('g.layer').each((node) => {
+    svg.node().appendChild(window.d3.select('.links').node().cloneNode(true))
+    svg.node().appendChild(window.d3.select('.operators').node().cloneNode(true))
+  })
+  return svg
 }

--- a/src/shared/services/exporting/svgUtils.js
+++ b/src/shared/services/exporting/svgUtils.js
@@ -65,15 +65,14 @@ export const getSvgDimensions = view => {
 }
 
 const appendGraphLayers = (svgElement, svg) => {
-  window.d3.select(svgElement).selectAll('g.layer').each((node) => {
-    svg.node().appendChild(window.d3.select('.' + node).node().cloneNode(true))
+  window.d3.select(svgElement).selectAll('g.layer').each(function (node) {
+    svg.node().appendChild(window.d3.select(this).node().cloneNode(true))
   })
   return svg
 }
 const appendPlanLayers = (svgElement, svg) => {
-  window.d3.select(svgElement).selectAll('g.layer').each((node) => {
-    svg.node().appendChild(window.d3.select('.links').node().cloneNode(true))
-    svg.node().appendChild(window.d3.select('.operators').node().cloneNode(true))
+  window.d3.select(svgElement).selectAll('g.layer').each(function (node) {
+    svg.node().appendChild(window.d3.select(this).node().cloneNode(true))
   })
   return svg
 }


### PR DESCRIPTION
In the cypher result frame for `EXPLAN||PROFILE` query we display the `plan` view that has an interactive query plan element. 

This PR adds a button in the titlebar to download the query plan as a png file.