### PR TITLE
Fix x overflow in frames with %-width in IE 11

### DIFF
--- a/src/browser/modules/Stream/styled.jsx
+++ b/src/browser/modules/Stream/styled.jsx
@@ -76,6 +76,7 @@ export const StyledFrameMainSection = styled.div`
   height: inherit;
   display: flex;
   flex-direction: column;
+  width: 100%;
 `
 
 export const StyledFrameContents = styled.div`


### PR DESCRIPTION
Before:

<img width="1028" alt="oskarhane-mbpt 2017-08-10 at 22 22 26" src="https://user-images.githubusercontent.com/570998/29190458-8542d5b8-7e1a-11e7-8c0e-10d96c65a297.png">

After:

<img width="1021" alt="oskarhane-mbpt 2017-08-10 at 22 21 53" src="https://user-images.githubusercontent.com/570998/29190460-87039afe-7e1a-11e7-8598-63ff383a493f.png">