### PR TITLE
Correct query to select movies from the nineties

### DIFF
--- a/src/browser/modules/Guides/html/movie-graph.html
+++ b/src/browser/modules/Guides/html/movie-graph.html
@@ -580,7 +580,7 @@ MATCH (a)-[:ACTED_IN]-&gt;(m)&lt;-[:DIRECTED]-(d) RETURN a,m,d LIMIT 10
         </figure>
         <p class="lead">Find movies released in the 1990s...</p>
         <figure>
-          <pre class="pre-scrollable code runnable">MATCH (nineties:Movie) WHERE nineties.released &gt; 1990 AND nineties.released &lt; 2000 RETURN nineties.title
+          <pre class="pre-scrollable code runnable">MATCH (nineties:Movie) WHERE nineties.released &gt;= 1990 AND nineties.released &lt; 2000 RETURN nineties.title
 </pre>
         </figure>
       </div>


### PR DESCRIPTION
The example query to select movies from the nineties excludes any movies release in 1990, causing it to miss `Joe Versus the Volcano` in the results.