### PR TITLE
Sort keys when inspecting nodes

### DIFF
--- a/src/browser/modules/D3Visualization/components/Inspector.jsx
+++ b/src/browser/modules/D3Visualization/components/Inspector.jsx
@@ -38,9 +38,16 @@ import {
 import { GrassEditor } from './GrassEditor'
 import { RowExpandToggleComponent } from './RowExpandToggle'
 
-const mapItemProperties = itemProperties => {
-  return itemProperties.map((prop, i) => {
-    return (
+const mapItemProperties = itemProperties => (
+  itemProperties
+    .sort(({ key: keyA }, { key: keyB }) => (
+      keyA < keyB
+        ? -1
+        : keyA === keyB
+          ? 0
+          : 1
+    ))
+    .map((prop, i) => (
       <StyledInspectorFooterRowListPair className='pair' key={'prop' + i}>
         <StyledInspectorFooterRowListKey className='key'>
           {prop.key + ': '}
@@ -49,9 +56,8 @@ const mapItemProperties = itemProperties => {
           {prop.value.toString()}
         </StyledInspectorFooterRowListValue>
       </StyledInspectorFooterRowListPair>
-    )
-  })
-}
+    ))
+)
 
 const mapLabels = (graphStyle, itemLabels) => {
   return itemLabels.map((label, i) => {


### PR DESCRIPTION
I have to hunt down where my properties are in the inspector a lot. I assume others do, too. Cmd-F isn't the most friendly tool in this view, so this should help improve that experience. :-)

Since there are usually very few properties shown in the inspector (a few dozen?) the performance impact should be negligible.