### PR TITLE
Remove standard and bring in eslint

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,17 +1,17 @@
 {
-  "presets": ["es2015", "react"],
+  "presets": ["es2015", "stage-2", "react"],
   "plugins": [
-    "transform-object-rest-spread",
     "preact-require",
-    ["transform-react-jsx", {
-      "pragma": "h"
-    }]
+    [
+      "transform-react-jsx",
+      {
+        "pragma": "h"
+      }
+    ]
   ],
   "env": {
     "production": {
-      "plugins": [
-        "babel-plugin-jsx-remove-data-test-id"
-      ]
+      "plugins": ["babel-plugin-jsx-remove-data-test-id"]
     }
   }
 }

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+node_modules
+build
+dist
+src/browser/external

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,19 @@
 {
-  "extends": ["standard", "standard-jsx"]
+  "parser": "babel-eslint",
+  "extends": ["standard", "standard-jsx"],
+  "parserOptions": {
+    "sourceType": "module"
+  },
+  "globals": {
+    "it": true,
+    "describe": true,
+    "test": true,
+    "expect": true,
+    "beforeEach": true,
+    "afterEach": true,
+    "neo": true,
+    "FileReader": true,
+    "Blob": true,
+    "fetch": true
+  }
 }

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "start": "webpack-dashboard -t 'Neo4j Browser' -- webpack-dev-server --colors --no-info",
     "starts": "webpack-dashboard -t 'Neo4j Browser' -- webpack-dev-server --https --colors --no-info",
     "precommit": "lint-staged",
-    "format": "prettier-standard 'src/**/!(*.min).js' 'src/**/*.jsx'",
-    "lint": "standard --fix",
+    "format": "prettier-eslint 'src/**/!(*.min).js' 'src/**/*.jsx' --write",
+    "lint": "eslint --fix --ext .js --ext .jsx ./",
     "test": "npm run lint && jest",
     "e2e": "cypress run --config fixturesFolder=e2e_tests/fixtures,integrationFolder=e2e_tests/integration,screenshotsFolder=e2e_tests/screenshots,supportFile=e2e_tests/support,videosFolder=e2e_tests/videos",
     "dev": "jest --watch",
@@ -20,7 +20,7 @@
   "lint-staged": {
     "linters": {
       "*.{js,jsx}": [
-        "prettier-standard",
+        "prettier-eslint --write",
         "git add"
       ]
     }
@@ -48,26 +48,6 @@
       "<rootDir>/src/shared"
     ]
   },
-  "standard": {
-    "ignore": [
-      "node_modules",
-      "build",
-      "dist",
-      "src/browser/external"
-    ],
-    "globals": [
-      "it",
-      "describe",
-      "test",
-      "expect",
-      "beforeEach",
-      "afterEach",
-      "neo",
-      "FileReader",
-      "Blob",
-      "fetch"
-    ]
-  },
   "repository": {},
   "keywords": [],
   "author": "",
@@ -76,17 +56,18 @@
   "devDependencies": {
     "autoprefixer": "^7.1.2",
     "babel-core": "^6.7.7",
+    "babel-eslint": "^7.2.3",
     "babel-jest": "^20.0.0",
     "babel-loader": "^7.1.1",
     "babel-plugin-jsx-remove-data-test-id": "^1.0.8",
     "babel-plugin-module-resolver": "^2.4.0",
     "babel-plugin-preact-require": "^1.0.0",
     "babel-plugin-styled-components": "^1.1.7",
-    "babel-plugin-transform-object-rest-spread": "^6.23.0",
     "babel-plugin-transform-react-jsx": "^6.23.0",
     "babel-polyfill": "^6.8.0",
     "babel-preset-es2015": "^6.6.0",
     "babel-preset-react": "^6.5.0",
+    "babel-preset-stage-2": "^6.24.1",
     "babel-runtime": "^6.25.0",
     "coffee-loader": "^0.7.3",
     "coffee-script": "^1.12.7",
@@ -94,7 +75,7 @@
     "css-loader": "^0.28.0",
     "cypress-cli": "^0.13.1",
     "enzyme": "^2.9.1",
-    "eslint": "^4.4.0",
+    "eslint": "^4.4.1",
     "eslint-config-standard": "^10.2.1",
     "eslint-config-standard-jsx": "^4.0.1",
     "eslint-plugin-import": "^2.7.0",
@@ -118,14 +99,14 @@
     "preact-render-to-string": "^3.6.3",
     "preact-test-utils": "^0.1.3",
     "precss": "^2.0.0",
-    "prettier-standard": "^6.0.0",
+    "prettier-eslint": "^6.4.2",
+    "prettier-eslint-cli": "^4.2.0",
     "react-addons-test-utils": "^15.0.2",
     "react-hot-loader": "^1.3.0",
     "redux-devtools": "^3.2.0",
     "redux-devtools-dock-monitor": "^1.1.1",
     "redux-devtools-log-monitor": "^1.0.11",
     "redux-mock-store": "^1.2.3",
-    "standard": "^10.0.3",
     "style-loader": "^0.18.1",
     "url-loader": "^0.5.8",
     "webpack": "^3.4.1",

--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -53,19 +53,19 @@ import Render from 'browser-components/Render'
 
 class App extends Component {
   componentDidMount () {
-    document.addEventListener('keyup', this.focusEditorOnSlash.bind(this))
-    document.addEventListener('keyup', this.expandEditorOnEsc.bind(this))
+    document.addEventListener('keyup', this.focusEditorOnSlash)
+    document.addEventListener('keyup', this.expandEditorOnEsc)
   }
   componentWillUnmount () {
-    document.removeEventListener('keyup', this.focusEditorOnSlash.bind(this))
-    document.removeEventListener('keyup', this.expandEditorOnEsc.bind(this))
+    document.removeEventListener('keyup', this.focusEditorOnSlash)
+    document.removeEventListener('keyup', this.expandEditorOnEsc)
   }
-  focusEditorOnSlash (e) {
+  focusEditorOnSlash = e => {
     if (['INPUT', 'TEXTAREA'].indexOf(e.target.tagName) > -1) return
     if (e.key !== '/') return
     this.props.bus && this.props.bus.send(FOCUS)
   }
-  expandEditorOnEsc (e) {
+  expandEditorOnEsc = e => {
     if (e.keyCode !== 27) return
     this.props.bus && this.props.bus.send(EXPAND)
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -25,7 +25,8 @@ const DashboardPlugin = require('webpack-dashboard/plugin')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer')
+  .BundleAnalyzerPlugin
 
 const nodeEnv = process.env.NODE_ENV || 'development'
 const isProduction = nodeEnv === 'production'
@@ -82,20 +83,24 @@ const rules = [
   {
     test: /\.(js|jsx)$/,
     exclude: /(node_modules)|(cypher-codemirror)/,
-    use: [{
-      loader: 'babel-loader',
-      options: {
-        presets: [['es2015', {modules: false}], 'react'],
-        plugins: [
-          'styled-components',
-          'transform-object-rest-spread',
-          'preact-require',
-          ['transform-react-jsx', {
-            'pragma': 'h'
-          }]
-        ]
+    use: [
+      {
+        loader: 'babel-loader',
+        options: {
+          presets: [['es2015', { modules: false }], 'stage-2', 'react'],
+          plugins: [
+            'styled-components',
+            'preact-require',
+            [
+              'transform-react-jsx',
+              {
+                pragma: 'h'
+              }
+            ]
+          ]
+        }
       }
-    }]
+    ]
   },
   {
     test: /\.json$/,
@@ -121,7 +126,10 @@ const rules = [
   {
     test: /\.css$/,
     include: path.resolve('./src'), // css modules for component css files
-    exclude: [path.resolve('./src/browser/styles'), path.resolve('./src/browser/modules/Guides')],
+    exclude: [
+      path.resolve('./src/browser/styles'),
+      path.resolve('./src/browser/modules/Guides')
+    ],
     use: [
       'style-loader',
       {
@@ -138,7 +146,10 @@ const rules = [
   },
   {
     test: /\.css$/, // global css files that don't need any processing
-    exclude: [path.resolve('./src/browser/components'), path.resolve('./src/browser/modules')],
+    exclude: [
+      path.resolve('./src/browser/components'),
+      path.resolve('./src/browser/modules')
+    ],
     use: ['style-loader', 'css-loader']
   },
   {
@@ -155,11 +166,31 @@ const rules = [
     test: /\.html?$/,
     use: ['html-loader']
   },
-  { test: /\.svg$/, use: 'file-loader?limit=65000&mimetype=image/svg+xml&name=assets/fonts/[name].[ext]' },
-  { test: /\.woff$/, use: 'file-loader?limit=65000&mimetype=application/font-woff&name=assets/fonts/[name].[ext]' },
-  { test: /\.woff2$/, use: 'file-loader?limit=65000&mimetype=application/font-woff2&name=assets/fonts/[name].[ext]' },
-  { test: /\.[ot]tf$/, use: 'file-loader?limit=65000&mimetype=application/octet-stream&name=assets/fonts/[name].[ext]' },
-  { test: /\.eot$/, use: 'file-loader?limit=65000&mimetype=application/vnd.ms-fontobject&name=assets/fonts/[name].[ext]' }
+  {
+    test: /\.svg$/,
+    use:
+      'file-loader?limit=65000&mimetype=image/svg+xml&name=assets/fonts/[name].[ext]'
+  },
+  {
+    test: /\.woff$/,
+    use:
+      'file-loader?limit=65000&mimetype=application/font-woff&name=assets/fonts/[name].[ext]'
+  },
+  {
+    test: /\.woff2$/,
+    use:
+      'file-loader?limit=65000&mimetype=application/font-woff2&name=assets/fonts/[name].[ext]'
+  },
+  {
+    test: /\.[ot]tf$/,
+    use:
+      'file-loader?limit=65000&mimetype=application/octet-stream&name=assets/fonts/[name].[ext]'
+  },
+  {
+    test: /\.eot$/,
+    use:
+      'file-loader?limit=65000&mimetype=application/vnd.ms-fontobject&name=assets/fonts/[name].[ext]'
+  }
 ]
 
 if (isProduction) {
@@ -205,9 +236,7 @@ module.exports = {
   devtool: isProduction ? 'eval' : 'source-map',
   context: jsSourcePath,
   entry: {
-    js: [
-      'index.jsx'
-    ],
+    js: ['index.jsx'],
     vendor: [
       'cypher-codemirror',
       'firebase',
@@ -237,22 +266,27 @@ module.exports = {
     rules
   },
   resolve: {
-    extensions: ['.webpack-loader.js', '.web-loader.js', '.loader.js', '.js', '.jsx', '.css', '.coffee'],
-    modules: [
-      path.resolve(__dirname, 'node_modules'),
-      jsSourcePath
+    extensions: [
+      '.webpack-loader.js',
+      '.web-loader.js',
+      '.loader.js',
+      '.js',
+      '.jsx',
+      '.css',
+      '.coffee'
     ],
+    modules: [path.resolve(__dirname, 'node_modules'), jsSourcePath],
     alias: {
       'neo4j-driver-alias': 'neo4j-driver/lib/browser/neo4j-web.min.js',
       'src-root': path.resolve(__dirname, 'src'),
       'project-root': path.resolve(__dirname),
-      'services': path.resolve(__dirname, 'src/shared/services'),
+      services: path.resolve(__dirname, 'src/shared/services'),
       'browser-services': path.resolve(__dirname, 'src/browser/services'),
-      'shared': path.resolve(__dirname, 'src/shared'),
-      'react': 'preact-compat/dist/preact-compat',
+      shared: path.resolve(__dirname, 'src/shared'),
+      react: 'preact-compat/dist/preact-compat',
       'react-dom': 'preact-compat/dist/preact-compat',
       'browser-components': path.resolve(__dirname, 'src/browser/components'),
-      'browser': path.resolve(__dirname, 'src/browser'),
+      browser: path.resolve(__dirname, 'src/browser'),
       'browser-styles': path.resolve(__dirname, 'src/browser/styles')
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -224,13 +224,6 @@ array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"
 
-array.prototype.find@^2.0.1:
-  version "2.0.4"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/array.prototype.find/-/array.prototype.find-2.0.4.tgz#556a5c5362c08648323ddaeb9de9d14bc1864c90"
-  dependencies:
-    define-properties "^1.1.2"
-    es-abstract "^1.7.0"
-
 arraybuffer.slice@0.0.6:
   version "0.0.6"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz#f33b2159f0532a3f3107a272c0ccfbd1ad2979ca"
@@ -394,7 +387,7 @@ babel-core@^6.0.0, babel-core@^6.17.0, babel-core@^6.24.1, babel-core@^6.7.7:
     slash "^1.0.0"
     source-map "^0.5.0"
 
-babel-eslint@>=7.2.3:
+babel-eslint@^7.2.3:
   version "7.2.3"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-eslint/-/babel-eslint-7.2.3.tgz#b2fe2d80126470f5c19442dc757253a897710827"
   dependencies:
@@ -415,6 +408,22 @@ babel-generator@^6.18.0, babel-generator@^6.25.0:
     lodash "^4.2.0"
     source-map "^0.5.0"
     trim-right "^1.0.1"
+
+babel-helper-bindify-decorators@^6.24.1:
+  version "6.24.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz#14c19e5f142d7b47f19a52431e52b1ccbc40a330"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-builder-binary-assignment-operator-visitor@^6.24.1:
+  version "6.24.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz#cce4517ada356f4220bcae8a02c2b346f9a56664"
+  dependencies:
+    babel-helper-explode-assignable-expression "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-types "^6.24.1"
 
 babel-helper-builder-react-jsx@^6.24.1:
   version "6.24.1"
@@ -441,6 +450,23 @@ babel-helper-define-map@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
     lodash "^4.2.0"
+
+babel-helper-explode-assignable-expression@^6.24.1:
+  version "6.24.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz#f25b82cf7dc10433c55f70592d5746400ac22caa"
+  dependencies:
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
+
+babel-helper-explode-class@^6.24.1:
+  version "6.24.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz#7dc2a3910dee007056e1e31d640ced3d54eaa9eb"
+  dependencies:
+    babel-helper-bindify-decorators "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
 
 babel-helper-function-name@^6.24.1:
   version "6.24.1"
@@ -480,6 +506,16 @@ babel-helper-regex@^6.24.1:
     babel-runtime "^6.22.0"
     babel-types "^6.24.1"
     lodash "^4.2.0"
+
+babel-helper-remap-async-to-generator@^6.24.1:
+  version "6.24.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz#5ec581827ad723fecdd381f1c928390676e4551b"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-traverse "^6.24.1"
+    babel-types "^6.24.1"
 
 babel-helper-replace-supers@^6.24.1:
   version "6.24.1"
@@ -564,6 +600,30 @@ babel-plugin-styled-components@^1.1.7:
   dependencies:
     stylis "^3.2.1"
 
+babel-plugin-syntax-async-functions@^6.8.0:
+  version "6.13.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
+
+babel-plugin-syntax-async-generators@^6.5.0:
+  version "6.13.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz#6bc963ebb16eccbae6b92b596eb7f35c342a8b9a"
+
+babel-plugin-syntax-class-properties@^6.8.0:
+  version "6.13.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
+
+babel-plugin-syntax-decorators@^6.13.0:
+  version "6.13.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz#312563b4dbde3cc806cee3e416cceeaddd11ac0b"
+
+babel-plugin-syntax-dynamic-import@^6.18.0:
+  version "6.18.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
+
+babel-plugin-syntax-exponentiation-operator@^6.8.0:
+  version "6.13.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz#9ee7e8337290da95288201a6a57f4170317830de"
+
 babel-plugin-syntax-flow@^6.18.0:
   version "6.18.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
@@ -575,6 +635,45 @@ babel-plugin-syntax-jsx@^6.3.13, babel-plugin-syntax-jsx@^6.8.0:
 babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
+
+babel-plugin-syntax-trailing-function-commas@^6.22.0:
+  version "6.22.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz#ba0360937f8d06e40180a43fe0d5616fff532cf3"
+
+babel-plugin-transform-async-generator-functions@^6.24.1:
+  version "6.24.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz#f058900145fd3e9907a6ddf28da59f215258a5db"
+  dependencies:
+    babel-helper-remap-async-to-generator "^6.24.1"
+    babel-plugin-syntax-async-generators "^6.5.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-async-to-generator@^6.24.1:
+  version "6.24.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz#6536e378aff6cb1d5517ac0e40eb3e9fc8d08761"
+  dependencies:
+    babel-helper-remap-async-to-generator "^6.24.1"
+    babel-plugin-syntax-async-functions "^6.8.0"
+    babel-runtime "^6.22.0"
+
+babel-plugin-transform-class-properties@^6.24.1:
+  version "6.24.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz#6a79763ea61d33d36f37b611aa9def81a81b46ac"
+  dependencies:
+    babel-helper-function-name "^6.24.1"
+    babel-plugin-syntax-class-properties "^6.8.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+
+babel-plugin-transform-decorators@^6.24.1:
+  version "6.24.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz#788013d8f8c6b5222bdf7b344390dfd77569e24d"
+  dependencies:
+    babel-helper-explode-class "^6.24.1"
+    babel-plugin-syntax-decorators "^6.13.0"
+    babel-runtime "^6.22.0"
+    babel-template "^6.24.1"
+    babel-types "^6.24.1"
 
 babel-plugin-transform-es2015-arrow-functions@^6.22.0:
   version "6.22.0"
@@ -744,6 +843,14 @@ babel-plugin-transform-es2015-unicode-regex@^6.24.1:
     babel-runtime "^6.22.0"
     regexpu-core "^2.0.0"
 
+babel-plugin-transform-exponentiation-operator@^6.24.1:
+  version "6.24.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz#2ab0c9c7f3098fa48907772bb813fe41e8de3a0e"
+  dependencies:
+    babel-helper-builder-binary-assignment-operator-visitor "^6.24.1"
+    babel-plugin-syntax-exponentiation-operator "^6.8.0"
+    babel-runtime "^6.22.0"
+
 babel-plugin-transform-flow-strip-types@^6.22.0:
   version "6.22.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz#84cb672935d43714fdc32bce84568d87441cf7cf"
@@ -751,12 +858,12 @@ babel-plugin-transform-flow-strip-types@^6.22.0:
     babel-plugin-syntax-flow "^6.18.0"
     babel-runtime "^6.22.0"
 
-babel-plugin-transform-object-rest-spread@^6.23.0:
-  version "6.23.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz#875d6bc9be761c58a2ae3feee5dc4895d8c7f921"
+babel-plugin-transform-object-rest-spread@^6.22.0:
+  version "6.26.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.26.0.tgz#0f36692d50fef6b7e2d4b3ac1478137a963b7b06"
   dependencies:
     babel-plugin-syntax-object-rest-spread "^6.8.0"
-    babel-runtime "^6.22.0"
+    babel-runtime "^6.26.0"
 
 babel-plugin-transform-react-display-name@^6.23.0:
   version "6.25.0"
@@ -859,6 +966,25 @@ babel-preset-react@^6.5.0:
     babel-plugin-transform-react-jsx-source "^6.22.0"
     babel-preset-flow "^6.23.0"
 
+babel-preset-stage-2@^6.24.1:
+  version "6.24.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz#d9e2960fb3d71187f0e64eec62bc07767219bdc1"
+  dependencies:
+    babel-plugin-syntax-dynamic-import "^6.18.0"
+    babel-plugin-transform-class-properties "^6.24.1"
+    babel-plugin-transform-decorators "^6.24.1"
+    babel-preset-stage-3 "^6.24.1"
+
+babel-preset-stage-3@^6.24.1:
+  version "6.24.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz#836ada0a9e7a7fa37cb138fb9326f87934a48395"
+  dependencies:
+    babel-plugin-syntax-trailing-function-commas "^6.22.0"
+    babel-plugin-transform-async-generator-functions "^6.24.1"
+    babel-plugin-transform-async-to-generator "^6.24.1"
+    babel-plugin-transform-exponentiation-operator "^6.24.1"
+    babel-plugin-transform-object-rest-spread "^6.22.0"
+
 babel-register@^6.24.1:
   version "6.24.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-register/-/babel-register-6.24.1.tgz#7e10e13a2f71065bdfad5a1787ba45bca6ded75f"
@@ -884,6 +1010,13 @@ babel-runtime@^6.23.0, babel-runtime@^6.25.0:
   dependencies:
     core-js "^2.4.0"
     regenerator-runtime "^0.10.0"
+
+babel-runtime@^6.26.0:
+  version "6.26.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
+  dependencies:
+    core-js "^2.4.0"
+    regenerator-runtime "^0.11.0"
 
 babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.25.0:
   version "6.25.0"
@@ -1026,6 +1159,10 @@ bonjour@^3.5.0:
 boolbase@~1.0.0:
   version "1.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+
+boolify@^1.0.0:
+  version "1.0.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/boolify/-/boolify-1.0.1.tgz#b5c09e17cacd113d11b7bb3ed384cc012994d86b"
 
 boom@2.x.x:
   version "2.10.1"
@@ -1227,6 +1364,14 @@ camelcase-keys@^2.0.0:
   dependencies:
     camelcase "^2.0.0"
     map-obj "^1.0.0"
+
+camelcase-keys@^4.1.0:
+  version "4.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/camelcase-keys/-/camelcase-keys-4.1.0.tgz#214d348cc5457f39316a2c31cc3e37246325e73f"
+  dependencies:
+    camelcase "^4.1.0"
+    map-obj "^2.0.0"
+    quick-lru "^1.0.0"
 
 camelcase@^1.0.2:
   version "1.2.1"
@@ -1967,10 +2112,6 @@ date-now@^0.1.4:
   version "0.1.4"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/date-now/-/date-now-0.1.4.tgz#eaf439fd4d4848ad74e5cc7dbef200672b9e345b"
 
-debug-log@^1.0.0:
-  version "1.0.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/debug-log/-/debug-log-1.0.1.tgz#2307632d4c04382b8df8a32f70b895046d52745f"
-
 debug@0.7.4, debug@~0.7.4:
   version "0.7.4"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/debug/-/debug-0.7.4.tgz#06e1ea8082c2cb14e39806e22e2f6f757f92af39"
@@ -2043,17 +2184,6 @@ define-properties@^1.1.2:
 defined@^1.0.0:
   version "1.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
-
-deglob@^2.1.0:
-  version "2.1.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/deglob/-/deglob-2.1.0.tgz#4d44abe16ef32c779b4972bd141a80325029a14a"
-  dependencies:
-    find-root "^1.0.0"
-    glob "^7.0.5"
-    ignore "^3.0.9"
-    pkg-config "^1.1.0"
-    run-parallel "^1.1.2"
-    uniq "^1.0.1"
 
 del@^2.0.2:
   version "2.2.2"
@@ -2157,7 +2287,7 @@ dns-txt@^2.0.2:
   dependencies:
     buffer-indexof "^1.0.0"
 
-doctrine@1.5.0, doctrine@^1.2.2:
+doctrine@1.5.0:
   version "1.5.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
   dependencies:
@@ -2379,7 +2509,7 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.6.1, es-abstract@^1.7.0:
+es-abstract@^1.6.1:
   version "1.7.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/es-abstract/-/es-abstract-1.7.0.tgz#dfade774e01bfcd97f96180298c449c8623fb94c"
   dependencies:
@@ -2483,21 +2613,13 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-config-standard-jsx@4.0.2, eslint-config-standard-jsx@^4.0.1:
+eslint-config-standard-jsx@^4.0.1:
   version "4.0.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/eslint-config-standard-jsx/-/eslint-config-standard-jsx-4.0.2.tgz#009e53c4ddb1e9ee70b4650ffe63a7f39f8836e1"
 
-eslint-config-standard@10.2.1, eslint-config-standard@^10.2.1:
+eslint-config-standard@^10.2.1:
   version "10.2.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz#c061e4d066f379dc17cd562c64e819b4dd454591"
-
-eslint-import-resolver-node@^0.2.0:
-  version "0.2.3"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/eslint-import-resolver-node/-/eslint-import-resolver-node-0.2.3.tgz#5add8106e8c928db2cba232bcd9efa846e3da16c"
-  dependencies:
-    debug "^2.2.0"
-    object-assign "^4.0.1"
-    resolve "^1.1.6"
 
 eslint-import-resolver-node@^0.3.1:
   version "0.3.1"
@@ -2505,13 +2627,6 @@ eslint-import-resolver-node@^0.3.1:
   dependencies:
     debug "^2.6.8"
     resolve "^1.2.0"
-
-eslint-module-utils@^2.0.0:
-  version "2.0.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/eslint-module-utils/-/eslint-module-utils-2.0.0.tgz#a6f8c21d901358759cdc35dbac1982ae1ee58bce"
-  dependencies:
-    debug "2.2.0"
-    pkg-dir "^1.0.0"
 
 eslint-module-utils@^2.1.1:
   version "2.1.1"
@@ -2535,21 +2650,6 @@ eslint-plugin-import@^2.7.0:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
-eslint-plugin-import@~2.2.0:
-  version "2.2.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/eslint-plugin-import/-/eslint-plugin-import-2.2.0.tgz#72ba306fad305d67c4816348a4699a4229ac8b4e"
-  dependencies:
-    builtin-modules "^1.1.1"
-    contains-path "^0.1.0"
-    debug "^2.2.0"
-    doctrine "1.5.0"
-    eslint-import-resolver-node "^0.2.0"
-    eslint-module-utils "^2.0.0"
-    has "^1.0.1"
-    lodash.cond "^4.3.0"
-    minimatch "^3.0.3"
-    pkg-up "^1.0.0"
-
 eslint-plugin-jsx@^0.0.2:
   version "0.0.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/eslint-plugin-jsx/-/eslint-plugin-jsx-0.0.2.tgz#64b6621d70dc7098dd14a189b1427c70e34cb230"
@@ -2567,17 +2667,7 @@ eslint-plugin-node@^5.1.1:
     resolve "^1.3.3"
     semver "5.3.0"
 
-eslint-plugin-node@~4.2.2:
-  version "4.2.2"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/eslint-plugin-node/-/eslint-plugin-node-4.2.2.tgz#82959ca9aed79fcbd28bb1b188d05cac04fb3363"
-  dependencies:
-    ignore "^3.0.11"
-    minimatch "^3.0.2"
-    object-assign "^4.0.1"
-    resolve "^1.1.7"
-    semver "5.3.0"
-
-eslint-plugin-promise@^3.4.0, eslint-plugin-promise@~3.5.0:
+eslint-plugin-promise@^3.4.0:
   version "3.5.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/eslint-plugin-promise/-/eslint-plugin-promise-3.5.0.tgz#78fbb6ffe047201627569e85a6c5373af2a68fca"
 
@@ -2593,17 +2683,7 @@ eslint-plugin-react@^7.0.1:
     has "^1.0.1"
     jsx-ast-utils "^1.4.1"
 
-eslint-plugin-react@~6.10.0:
-  version "6.10.3"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz#c5435beb06774e12c7db2f6abaddcbf900cd3f78"
-  dependencies:
-    array.prototype.find "^2.0.1"
-    doctrine "^1.2.2"
-    has "^1.0.1"
-    jsx-ast-utils "^1.3.4"
-    object.assign "^4.0.4"
-
-eslint-plugin-standard@^3.0.1, eslint-plugin-standard@~3.0.1:
+eslint-plugin-standard@^3.0.1:
   version "3.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz#34d0c915b45edc6f010393c7eef3823b08565cf2"
 
@@ -2614,7 +2694,7 @@ eslint-scope@^3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint@^3.19.0, eslint@~3.19.0:
+eslint@^3.19.0:
   version "3.19.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/eslint/-/eslint-3.19.0.tgz#c8fc6201c7f40dd08941b87c085767386a679acc"
   dependencies:
@@ -2654,9 +2734,9 @@ eslint@^3.19.0, eslint@~3.19.0:
     text-table "~0.2.0"
     user-home "^2.0.0"
 
-eslint@^4.4.0:
-  version "4.4.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/eslint/-/eslint-4.4.0.tgz#a3e153e704b64f78290ef03592494eaba228d3bc"
+eslint@^4.4.1:
+  version "4.4.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/eslint/-/eslint-4.4.1.tgz#99cd7eafcffca2ff99a5c8f5f2a474d6364b4bd3"
   dependencies:
     ajv "^5.2.0"
     babel-code-frame "^6.22.0"
@@ -3045,10 +3125,6 @@ find-cache-dir@^1.0.0:
     commondir "^1.0.1"
     make-dir "^1.0.0"
     pkg-dir "^2.0.0"
-
-find-root@^1.0.0:
-  version "1.0.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/find-root/-/find-root-1.0.0.tgz#962ff211aab25c6520feeeb8d6287f8f6e95807a"
 
 find-up@^1.0.0:
   version "1.1.2"
@@ -3615,7 +3691,7 @@ ieee754@^1.1.4:
   version "1.1.8"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/ieee754/-/ieee754-1.1.8.tgz#be33d40ac10ef1926701f6f08a2d86fbfd1ad3e4"
 
-ignore@^3.0.11, ignore@^3.0.9, ignore@^3.2.0, ignore@^3.3.3:
+ignore@^3.2.0, ignore@^3.2.7, ignore@^3.3.3:
   version "3.3.3"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/ignore/-/ignore-3.3.3.tgz#432352e57accd87ab3110e82d3fea0e47812156d"
 
@@ -4412,7 +4488,7 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
-jsx-ast-utils@^1.3.4, jsx-ast-utils@^1.4.1:
+jsx-ast-utils@^1.4.1:
   version "1.4.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz#3867213e8dd79bf1e8f2300c0cfc1efb182c0df1"
 
@@ -4795,6 +4871,10 @@ map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
 
+map-obj@^2.0.0:
+  version "2.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/map-obj/-/map-obj-2.0.0.tgz#a65cd29087a92598b8791257a523e021222ac1f9"
+
 math-expression-evaluator@^1.2.14:
   version "1.2.17"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz#de819fdbcd84dccd8fae59c6aeb79615b9d266ac"
@@ -4816,7 +4896,7 @@ memory-fs@^0.4.0, memory-fs@~0.4.1:
     errno "^0.1.3"
     readable-stream "^2.0.1"
 
-meow@3.7.0, meow@^3.3.0:
+meow@^3.3.0:
   version "3.7.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/meow/-/meow-3.7.0.tgz#72cb668b425228290abbfa856892587308a801fb"
   dependencies:
@@ -4926,7 +5006,7 @@ minimist@0.0.8, minimist@~0.0.1:
   version "0.0.8"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -5561,21 +5641,6 @@ pixrem@^4.0.0:
     postcss "^6.0.0"
     reduce-css-calc "^1.2.7"
 
-pkg-conf@^2.0.0:
-  version "2.0.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/pkg-conf/-/pkg-conf-2.0.0.tgz#071c87650403bccfb9c627f58751bfe47c067279"
-  dependencies:
-    find-up "^2.0.0"
-    load-json-file "^2.0.0"
-
-pkg-config@^1.1.0:
-  version "1.1.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/pkg-config/-/pkg-config-1.1.1.tgz#557ef22d73da3c8837107766c52eadabde298fe4"
-  dependencies:
-    debug-log "^1.0.0"
-    find-root "^1.0.0"
-    xtend "^4.0.1"
-
 pkg-dir@^1.0.0:
   version "1.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
@@ -5587,12 +5652,6 @@ pkg-dir@^2.0.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
   dependencies:
     find-up "^2.1.0"
-
-pkg-up@^1.0.0:
-  version "1.0.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/pkg-up/-/pkg-up-1.0.0.tgz#3e08fb461525c4421624a33b9f7e6d0af5b05a26"
-  dependencies:
-    find-up "^1.0.0"
 
 pleeease-filters@^4.0.0:
   version "4.0.0"
@@ -6291,7 +6350,30 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier-eslint@^6.3.0:
+prettier-eslint-cli@^4.2.0:
+  version "4.2.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/prettier-eslint-cli/-/prettier-eslint-cli-4.2.0.tgz#733e19efac70432c2ef989665c0e458985c62fd3"
+  dependencies:
+    arrify "^1.0.1"
+    babel-runtime "^6.23.0"
+    boolify "^1.0.0"
+    camelcase-keys "^4.1.0"
+    chalk "^1.1.3"
+    common-tags "^1.4.0"
+    eslint "^3.19.0"
+    find-up "^2.1.0"
+    get-stdin "^5.0.1"
+    glob "^7.1.1"
+    ignore "^3.2.7"
+    indent-string "^3.1.0"
+    lodash.memoize "^4.1.2"
+    loglevel-colored-level-prefix "^1.0.0"
+    messageformat "^1.0.2"
+    prettier-eslint "^6.0.0"
+    rxjs "^5.3.0"
+    yargs "^7.1.0"
+
+prettier-eslint@^6.0.0, prettier-eslint@^6.4.2:
   version "6.4.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/prettier-eslint/-/prettier-eslint-6.4.2.tgz#9bafd9549e0827396c75848e8dbeb65525b9096e"
   dependencies:
@@ -6305,28 +6387,7 @@ prettier-eslint@^6.3.0:
     pretty-format "^20.0.3"
     require-relative "^0.8.7"
 
-prettier-standard@^6.0.0:
-  version "6.0.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/prettier-standard/-/prettier-standard-6.0.0.tgz#4c55db1401b9a5c09f0547009ea2ed1494a3346c"
-  dependencies:
-    babel-eslint ">=7.2.3"
-    babel-runtime "^6.23.0"
-    chalk "^1.1.3"
-    eslint "^3.19.0"
-    find-up "^2.1.0"
-    get-stdin "^5.0.1"
-    glob "^7.1.2"
-    ignore "^3.3.3"
-    indent-string "^3.1.0"
-    lodash.memoize "^4.1.2"
-    loglevel-colored-level-prefix "^1.0.0"
-    meow "3.7.0"
-    messageformat "^1.0.2"
-    prettier "^1.4.4"
-    prettier-eslint "^6.3.0"
-    rxjs "^5.4.0"
-
-prettier@^1.4.4, prettier@^1.5.0:
+prettier@^1.5.0:
   version "1.5.3"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/prettier/-/prettier-1.5.3.tgz#59dadc683345ec6b88f88b94ed4ae7e1da394bfe"
 
@@ -6462,6 +6523,10 @@ querystringify@0.0.x:
 querystringify@~1.0.0:
   version "1.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
+
+quick-lru@^1.0.0:
+  version "1.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
 
 randomatic@^1.1.3:
   version "1.1.7"
@@ -6801,6 +6866,10 @@ regenerator-runtime@^0.10.0:
   version "0.10.5"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz#336c3efc1220adcedda2c9fab67b5a7955a33658"
 
+regenerator-runtime@^0.11.0:
+  version "0.11.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz#7e54fe5b5ccd5d6624ea6255c3473be090b802e1"
+
 regenerator-transform@0.9.11:
   version "0.9.11"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/regenerator-transform/-/regenerator-transform-0.9.11.tgz#3a7d067520cb7b7176769eb5ff868691befe1283"
@@ -6948,8 +7017,8 @@ requires-port@1.0.x, requires-port@1.x.x:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
 reserved-words@^0.1.1:
-  version "0.1.1"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/reserved-words/-/reserved-words-0.1.1.tgz#6f7c15e5e5614c50da961630da46addc87c0cef2"
+  version "0.1.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/reserved-words/-/reserved-words-0.1.2.tgz#00a0940f98cd501aeaaac316411d9adc52b31ab1"
 
 resolve-from@^1.0.0:
   version "1.0.1"
@@ -7024,10 +7093,6 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
-run-parallel@^1.1.2:
-  version "1.1.6"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/run-parallel/-/run-parallel-1.1.6.tgz#29003c9a2163e01e2d2dfc90575f2c6c1d61a039"
-
 rx-lite-aggregates@^4.0.8:
   version "4.0.8"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
@@ -7042,9 +7107,15 @@ rx-lite@^3.1.2:
   version "3.1.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/rx-lite/-/rx-lite-3.1.2.tgz#19ce502ca572665f3b647b10939f97fd1615f102"
 
-rxjs@^5.0.0-beta.11, rxjs@^5.4.0, rxjs@^5.4.2:
+rxjs@^5.0.0-beta.11, rxjs@^5.4.2:
   version "5.4.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/rxjs/-/rxjs-5.4.2.tgz#2a3236fcbf03df57bae06fd6972fd99e5c08fcf7"
+  dependencies:
+    symbol-observable "^1.0.1"
+
+rxjs@^5.3.0:
+  version "5.4.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/rxjs/-/rxjs-5.4.3.tgz#0758cddee6033d68e0fd53676f0f3596ce3d483f"
   dependencies:
     symbol-observable "^1.0.1"
 
@@ -7389,29 +7460,6 @@ staged-git-files@0.0.4:
 standalone-react-addons-pure-render-mixin@^0.1.1:
   version "0.1.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/standalone-react-addons-pure-render-mixin/-/standalone-react-addons-pure-render-mixin-0.1.1.tgz#3c7409f4c79c40de9ac72c616cf679a994f37551"
-
-standard-engine@~7.0.0:
-  version "7.0.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/standard-engine/-/standard-engine-7.0.0.tgz#ebb77b9c8fc2c8165ffa353bd91ba0dff41af690"
-  dependencies:
-    deglob "^2.1.0"
-    get-stdin "^5.0.1"
-    minimist "^1.1.0"
-    pkg-conf "^2.0.0"
-
-standard@^10.0.3:
-  version "10.0.3"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/standard/-/standard-10.0.3.tgz#7869bcbf422bdeeaab689a1ffb1fea9677dd50ea"
-  dependencies:
-    eslint "~3.19.0"
-    eslint-config-standard "10.2.1"
-    eslint-config-standard-jsx "4.0.2"
-    eslint-plugin-import "~2.2.0"
-    eslint-plugin-node "~4.2.2"
-    eslint-plugin-promise "~3.5.0"
-    eslint-plugin-react "~6.10.0"
-    eslint-plugin-standard "~3.0.1"
-    standard-engine "~7.0.0"
 
 "statuses@>= 1.3.1 < 2", statuses@~1.3.1:
   version "1.3.1"
@@ -8375,7 +8423,7 @@ yargs@^6.0.0:
     y18n "^3.2.1"
     yargs-parser "^4.2.0"
 
-yargs@^7.0.2:
+yargs@^7.0.2, yargs@^7.1.0:
   version "7.1.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/yargs/-/yargs-7.1.0.tgz#6ba318eb16961727f5d284f8ea003e8d6154d0c8"
   dependencies:


### PR DESCRIPTION
## Wait, what!?
We keep the standard config. 
Nothing will change style wise, we just use `eslint` directly rather than going through `standard`.

Move to `prettier-eslint` as well.

The point of this is to being able to configure the linting rules and plugins in a simpler way.
With this commit we also bring in babel support for `stage-2` proposals so we don’t explicitly need to bring in `"transform-object-rest-spread"` and `”babel-plugin-transform-class-properties”` which is why I started this in the first place.
It's very common in the React community to use class properties and I like the patter so I think we should start using it (no need to change what we already have though, but for anything new).

When (if) this goes in, you probably need to configure your IDE:s to use eslint instead go standard.

## Why babel-plugin-transform-class-properties ?
More info on it here: https://babeljs.io/docs/plugins/transform-class-properties/

One direct benefit:  
With the pattern of setting class properties we don't need to use the `.bind(this)` everywhere when passing methods as props to children. But standard have problems accepting these (I tried using `babel-eslint` as the parser for `standard` without any luck).

Before:
<img width="628" alt="oskarhane-mbpt 2017-08-18 at 20 09 16" src="https://user-images.githubusercontent.com/570998/29471713-46ccea34-8451-11e7-8149-eab74bab19bd.png">

After:
<img width="534" alt="oskarhane-mbpt 2017-08-18 at 20 08 35" src="https://user-images.githubusercontent.com/570998/29471717-4d55182c-8451-11e7-9671-baa7675e355e.png">