### PR TITLE
Update neo4j-driver to 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "jsonic": "^0.3.0",
     "lint-staged": "^4.0.4",
     "lodash.debounce": "^4.0.8",
-    "neo4j-driver": "~1.2.0",
+    "neo4j-driver": "^1.4.0",
     "node-noop": "^1.0.0",
     "preact": "^8.2.5",
     "preact-compat": "^3.17.0",

--- a/src/shared/services/bolt/boltConnection.js
+++ b/src/shared/services/bolt/boltConnection.js
@@ -118,7 +118,6 @@ export function openConnection (props, opts = {}, onLostConnection) {
     driver.onError = e => {
       onLostConnection(e)
       _drivers = null
-      driversObj.close()
       reject(e)
     }
     const myResolve = driver => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5148,9 +5148,9 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
-neo4j-driver@~1.2.0:
-  version "1.2.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/neo4j-driver/-/neo4j-driver-1.2.0.tgz#e81ab4e8781d3839cb3b7c9bbde9b2d63a162356"
+neo4j-driver@^1.4.0:
+  version "1.4.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/neo4j-driver/-/neo4j-driver-1.4.0.tgz#fcdce19c0c766df197c5ee5e5bb982beb4d151e3"
   dependencies:
     babel-runtime "^6.18.0"
 


### PR DESCRIPTION
No need to close an errored driver (this removes a js error message).