### PR TITLE
Upgrade cypher-codemirror to 1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "ascii-data-table": "^2.1.1",
     "classnames": "^2.2.5",
     "codemirror": "^5.29.0",
-    "cypher-codemirror": "1.0.4",
+    "cypher-codemirror": "^1.0.5",
     "dnd-core": "^2.5.1",
     "file-saver": "^1.3.3",
     "firebase": "^4.2.0",

--- a/src/browser/modules/Editor/Editor.jsx
+++ b/src/browser/modules/Editor/Editor.jsx
@@ -216,10 +216,7 @@ export class Editor extends Component {
   }
 
   updateCode (newCode, change, cb = () => {}) {
-    const mode =
-      this.props.cmdchar && newCode.trim().indexOf(this.props.cmdchar) === 0
-        ? 'text'
-        : 'cypher'
+    const mode = 'cypher'
     this.clearHints()
     if (
       mode === 'cypher' &&
@@ -442,6 +439,7 @@ const mapStateToProps = state => {
     cmdchar: getCmdChar(state),
     schema: {
       consoleCommands: consoleCommands,
+      parameters: Object.keys(state.params),
       labels: state.meta.labels.map(schemaConvert.toLabel),
       relationshipTypes: state.meta.relationshipTypes.map(
         schemaConvert.toRelationshipType

--- a/yarn.lock
+++ b/yarn.lock
@@ -2201,9 +2201,9 @@ currently-unhandled@^0.4.1:
   dependencies:
     array-find-index "^1.0.1"
 
-cypher-codemirror@1.0.4:
-  version "1.0.4"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/cypher-codemirror/-/cypher-codemirror-1.0.4.tgz#b78643df281b3e9e1dbfa7cb1d299b3cee69d6d6"
+cypher-codemirror@^1.0.5:
+  version "1.0.5"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/cypher-codemirror/-/cypher-codemirror-1.0.5.tgz#9a6e1cb4bee2cfab846d7a1fad65078d8a361e77"
   dependencies:
     cypher-editor-support "1.0.4"
 


### PR DESCRIPTION
Changes:

Errors in console commands are suppressed. Therefore autocompletion & syntax highlight is enabled now for console commands
Add schema-based parameter autocompletion
Fixed various Cypher parser bugs

This replaces https://github.com/neo4j/neo4j-browser/pull/615

changelog: Fix various bugs in editor Cypher parsing