### PR TITLE
Pass encryption mode when force changing password

### DIFF
--- a/src/shared/modules/cypher/cypherDuck.js
+++ b/src/shared/modules/cypher/cypherDuck.js
@@ -23,6 +23,7 @@ import Rx from 'rxjs'
 import bolt from 'services/bolt/bolt'
 import { getActiveConnectionData } from 'shared/modules/connections/connectionsDuck'
 import { getCausalClusterAddresses } from './queriesProcedureHelper'
+import { getEncryptionMode } from 'services/bolt/boltHelpers'
 import { flatten } from 'services/utils'
 
 const NAME = 'cypher'
@@ -144,7 +145,12 @@ export const handleForcePasswordChangeEpic = (some$, store) =>
     if (!action.$$responseChannel) return Rx.Observable.of(null)
     return new Promise((resolve, reject) => {
       bolt
-        .directConnect(action, undefined, undefined, false) // Ignore validation errors
+        .directConnect(
+          action,
+          { encrypted: getEncryptionMode() },
+          undefined,
+          false // Ignore validation errors
+        )
         .then(driver => {
           adHocSession(driver, resolve, action)
         })


### PR DESCRIPTION
This fixes an issue when using officially signed certificates on a newly installed Neo4j when setting up initial password.
For some reason browsers are ok with opening an unsecure websocket on a "secure" website if it's a manually trusted self signed certificate. But I won't open an unsecure websocket from a website on a officially signed cert.
That made this quite hard to find, but https://github.com/neo4j/neo4j-browser/issues/522#issuecomment-332502755 pointed me in the right direction.

This can be verified (that an unsecure websocket is opened) by looking in the network tab in chrome on a newly installed neo4j when setting the initial password.
With these changes, all opened websockets are secure.

Changelog: Fix setting initial password over officially trusted TLS certificates