### PR TITLE
Enable webworkers when using a non-tls connection

### DIFF
--- a/src/shared/modules/features/featuresDuck.js
+++ b/src/shared/modules/features/featuresDuck.js
@@ -22,11 +22,15 @@ import bolt from 'services/bolt/bolt'
 import { APP_START } from 'shared/modules/app/appDuck'
 import { CONNECTION_SUCCESS } from 'shared/modules/connections/connectionsDuck'
 
+const TLS_ENABLED = 'TLS_ENABLED'
+
 export const NAME = 'features'
 export const RESET = 'features/RESET'
 export const UPDATE_ALL_FEATURES = 'features/UPDATE_ALL_FEATURES'
+export const UPDATE_FEATURE = 'features/UPDATE_FEATURE'
 
 export const getAvailableProcedures = state => state[NAME].availableProcedures
+export const getIsTlsEnabled = state => state[NAME][TLS_ENABLED]
 export const isACausalCluster = state =>
   getAvailableProcedures(state).includes('dbms.cluster.overview')
 export const canAssignRolesToUser = state =>
@@ -44,6 +48,8 @@ export default function (state = initialState, action) {
   switch (action.type) {
     case UPDATE_ALL_FEATURES:
       return { ...state, availableProcedures: [...action.availableProcedures] }
+    case UPDATE_FEATURE:
+      return { ...state, ...action.feature }
     case RESET:
       return initialState
     default:
@@ -58,7 +64,23 @@ export const updateFeatures = availableProcedures => {
     availableProcedures
   }
 }
+export const updateFeature = (featureKey, value) => {
+  return {
+    type: UPDATE_FEATURE,
+    feature: { [featureKey]: value }
+  }
+}
 
+export const appStartFeaturesDiscoveryEpic = (action$, store) => {
+  return action$
+    .ofType(APP_START)
+    .do(() =>
+      store.dispatch(
+        updateFeature(TLS_ENABLED, window.location.protocol.includes('https'))
+      )
+    )
+    .mapTo({ type: 'NOOP' })
+}
 export const featuresDiscoveryEpic = (action$, store) => {
   return action$
     .ofType(CONNECTION_SUCCESS)

--- a/src/shared/modules/features/featuresDuck.test.js
+++ b/src/shared/modules/features/featuresDuck.test.js
@@ -46,6 +46,11 @@ describe('features reducer', () => {
     const nextState = reducer(initialState, action)
     expect(nextState.availableProcedures).toEqual(['c'])
   })
+  test('handles UPDATE_FEATURE', () => {
+    const action = features.updateFeature('FOO', 'bar')
+    const nextState = reducer(undefined, action)
+    expect(nextState.FOO).toEqual('bar')
+  })
 })
 
 describe('feature getters', () => {
@@ -83,5 +88,10 @@ describe('feature getters', () => {
       { type: '' }
     )
     expect(features.canAssignRolesToUser({ features: nextState })).toBe(true)
+  })
+  test('should be able to getIsTlsEnabled value', () => {
+    const nextState = reducer({ TLS_ENABLED: true }, { type: '' })
+
+    expect(features.getIsTlsEnabled({ features: nextState })).toBe(true)
   })
 })

--- a/src/shared/modules/settings/__snapshots__/settingsDuck.test.js.snap
+++ b/src/shared/modules/settings/__snapshots__/settingsDuck.test.js.snap
@@ -6,7 +6,6 @@ Object {
   "browserSyncDebugServer": null,
   "cmdchar": ":",
   "editorAutocomplete": true,
-  "enableCypherThread": false,
   "initCmd": ":play start",
   "initialNodeDisplay": 300,
   "maxFrames": 30,

--- a/src/shared/modules/settings/settingsDuck.js
+++ b/src/shared/modules/settings/settingsDuck.js
@@ -60,8 +60,7 @@ export const getUseNewVisualization = state => state[NAME].useNewVis
 export const getCmdChar = state => state[NAME].cmdchar || initialState.cmdchar
 export const shouldEditorAutocomplete = state =>
   state[NAME].editorAutocomplete !== false
-export const shouldUseCypherThread = state =>
-  state[NAME].useCypherThread && state[NAME].enableCypherThread
+export const shouldUseCypherThread = state => state[NAME].useCypherThread
 
 const initialState = {
   cmdchar: ':',
@@ -79,8 +78,7 @@ const initialState = {
   scrollToTop: true,
   maxFrames: 30,
   editorAutocomplete: true,
-  useCypherThread: true,
-  enableCypherThread: false
+  useCypherThread: true
 }
 
 export default function settings (state = initialState, action) {

--- a/src/shared/rootEpic.js
+++ b/src/shared/rootEpic.js
@@ -50,7 +50,10 @@ import {
   clusterCypherRequestEpic,
   handleForcePasswordChangeEpic
 } from './modules/cypher/cypherDuck'
-import { featuresDiscoveryEpic } from './modules/features/featuresDuck'
+import {
+  featuresDiscoveryEpic,
+  appStartFeaturesDiscoveryEpic
+} from './modules/features/featuresDuck'
 import {
   syncItemsEpic,
   clearSyncEpic,
@@ -95,6 +98,7 @@ export default combineEpics(
   clearLocalstorageEpic,
   handleForcePasswordChangeEpic,
   featuresDiscoveryEpic,
+  appStartFeaturesDiscoveryEpic,
   syncFavoritesEpic,
   loadFavoritesFromSyncEpic,
   syncItemsEpic,

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -59,6 +59,7 @@ import {
   parseGrass
 } from 'shared/modules/commands/helpers/grass'
 import { shouldUseCypherThread } from 'shared/modules/settings/settingsDuck'
+import { getIsTlsEnabled } from 'shared/modules/features/featuresDuck'
 
 const availableCommands = [
   {
@@ -137,7 +138,7 @@ const availableCommands = [
         action,
         put,
         getParams(state),
-        shouldUseCypherThread(state)
+        shouldUseCypherThread(state) && !getIsTlsEnabled(state)
       )
       put(cypher(action.cmd))
       put(frames.add({ ...action, type: 'cypher', requestId: id }))


### PR DESCRIPTION
- Allows non-blocking rendering when executing a long running cypher query