### PR TITLE
Rename references to Neo4j Technology -> Neo4j, Inc

### DIFF
--- a/__mocks__/fileMock.js
+++ b/__mocks__/fileMock.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/__mocks__/neo4j.js
+++ b/__mocks__/neo4j.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.
@@ -63,11 +63,21 @@ var out = {
   }
 }
 
-out.v1.types.Node.prototype.toString = function () { return 'node' }
-out.v1.types.Relationship.prototype.toString = function () { return 'rel' }
-out.v1.types.Path.prototype.toString = function () { return 'path' }
-out.v1.types.PathSegment.prototype.toString = function () { return 'pathsegment' }
-out.v1.Integer.prototype.toInt = function () { return this.low }
-out.v1.int = (val) => new out.v1.Integer(val)
+out.v1.types.Node.prototype.toString = function () {
+  return 'node'
+}
+out.v1.types.Relationship.prototype.toString = function () {
+  return 'rel'
+}
+out.v1.types.Path.prototype.toString = function () {
+  return 'path'
+}
+out.v1.types.PathSegment.prototype.toString = function () {
+  return 'pathsegment'
+}
+out.v1.Integer.prototype.toInt = function () {
+  return this.low
+}
+out.v1.int = val => new out.v1.Integer(val)
 
 module.exports = out

--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/__mocks__/workerLoaderMock.js
+++ b/__mocks__/workerLoaderMock.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/e2e_tests/integration/index.spec.js
+++ b/e2e_tests/integration/index.spec.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
       <id>neo4j</id>
       <name>The Neo4j Team</name>
       <url>http://neo4j.org/</url>
-      <organization>Neo Technology</organization>
+      <organization>Neo4j, Inc</organization>
       <organizationUrl>http://www.neotechnology.com/</organizationUrl>
     </developer>
   </developers>
@@ -34,13 +34,13 @@
       <name>GNU General Public License, Version 3</name>
       <url>http://www.gnu.org/licenses/gpl-3.0-standalone.html</url>
       <comments>The software ("Software") developed and owned by Network Engine for
-        Objects in Lund AB (referred to in this notice as "Neo Technology") is
+        Objects in Lund AB (referred to in this notice as "Neo4j, Inc") is
         licensed under the GNU GENERAL PUBLIC LICENSE Version 3 to all third
         parties and that license is included below.
 
         However, if you have executed an End User Software License and Services
         Agreement or an OEM Software License and Support Services Agreement, or
-        another commercial license agreement with Neo Technology or one of its
+        another commercial license agreement with Neo4j, Inc or one of its
         affiliates (each, a "Commercial Agreement"), the terms of the license in
         such Commercial Agreement will supersede the GNU GENERAL PUBLIC LICENSE
         Version 3 and you may use the Software solely pursuant to the terms of

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.
@@ -20,12 +20,9 @@
 
 module.exports = {
   plugins: {
-    'precss': {},
-    'autoprefixer': {
-      browsers: [
-        'last 3 version',
-        'ie >= 10'
-      ]
+    precss: {},
+    autoprefixer: {
+      browsers: ['last 3 version', 'ie >= 10']
     }
   }
 }

--- a/scripts/prepare-mvn-package.js
+++ b/scripts/prepare-mvn-package.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/scripts/set-pom-version.js
+++ b/scripts/set-pom-version.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.
@@ -53,13 +53,16 @@ function main (args) {
 
 function parseArgv (argv) {
   let out = {}
-  for (let i = 0; i < argv.length; i += 2) { // Pairs
+  for (let i = 0; i < argv.length; i += 2) {
+    // Pairs
     out[argv[i]] = argv[i + 1]
   }
   return out
 }
 
 function failExit () {
-  console.log('Error. Usage: "node set-pom-version.js -f filepath/from/project/root/pom.xml -v new-version-semver"')
+  console.log(
+    'Error. Usage: "node set-pom-version.js -f filepath/from/project/root/pom.xml -v new-version-semver"'
+  )
   process.exit(1)
 }

--- a/src/browser/components/Centered.jsx
+++ b/src/browser/components/Centered.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/DataTables.jsx
+++ b/src/browser/components/DataTables.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/Directives.jsx
+++ b/src/browser/components/Directives.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/Directives.test.js
+++ b/src/browser/components/Directives.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/Display.jsx
+++ b/src/browser/components/Display.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/Display.test.js
+++ b/src/browser/components/Display.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/EditionView.jsx
+++ b/src/browser/components/EditionView.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/Ellipsis.jsx
+++ b/src/browser/components/Ellipsis.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/FileImporter/FileDrop.jsx
+++ b/src/browser/components/FileImporter/FileDrop.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/FileImporter/FileDrop.test.jsx
+++ b/src/browser/components/FileImporter/FileDrop.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/FileImporter/FileDropBar.jsx
+++ b/src/browser/components/FileImporter/FileDropBar.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/FileImporter/dndGlobalContext.js
+++ b/src/browser/components/FileImporter/dndGlobalContext.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/Form.jsx
+++ b/src/browser/components/Form.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/Render/index.jsx
+++ b/src/browser/components/Render/index.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/Render/index.test.js
+++ b/src/browser/components/Render/index.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/TabNavigation/Navigation.jsx
+++ b/src/browser/components/TabNavigation/Navigation.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/TabNavigation/Navigation.test.jsx
+++ b/src/browser/components/TabNavigation/Navigation.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/TabNavigation/styled.jsx
+++ b/src/browser/components/TabNavigation/styled.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/Tables.jsx
+++ b/src/browser/components/Tables.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/Text.jsx
+++ b/src/browser/components/Text.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/badge/index.jsx
+++ b/src/browser/components/badge/index.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/buttons/ConfirmationButton.jsx
+++ b/src/browser/components/buttons/ConfirmationButton.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/buttons/index.jsx
+++ b/src/browser/components/buttons/index.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/drawer/Drawer.jsx
+++ b/src/browser/components/drawer/Drawer.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/drawer/index.js
+++ b/src/browser/components/drawer/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/form/formKeyHandler.js
+++ b/src/browser/components/form/formKeyHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/form/formKeyHandler.test.js
+++ b/src/browser/components/form/formKeyHandler.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/headers/Headers.jsx
+++ b/src/browser/components/headers/Headers.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/headers/index.js
+++ b/src/browser/components/headers/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/components/icons/Icons.jsx
+++ b/src/browser/components/icons/Icons.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/external/d3.min.js
+++ b/src/browser/external/d3.min.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/external/neoPlanner.js
+++ b/src/browser/external/neoPlanner.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/init.js
+++ b/src/browser/init.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/App/styled.jsx
+++ b/src/browser/modules/App/styled.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/ClickToCode/index.jsx
+++ b/src/browser/modules/ClickToCode/index.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/ClickToCode/index.test.js
+++ b/src/browser/modules/ClickToCode/index.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/ClickToCode/styled.jsx
+++ b/src/browser/modules/ClickToCode/styled.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/ConnectionsDropdown/ConnectionsDropdown.jsx
+++ b/src/browser/modules/ConnectionsDropdown/ConnectionsDropdown.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/GraphEventHandler.js
+++ b/src/browser/modules/D3Visualization/GraphEventHandler.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/components/Explorer.jsx
+++ b/src/browser/modules/D3Visualization/components/Explorer.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/components/Graph.jsx
+++ b/src/browser/modules/D3Visualization/components/Graph.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/components/GrassEditor.jsx
+++ b/src/browser/modules/D3Visualization/components/GrassEditor.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/components/Inspector.jsx
+++ b/src/browser/modules/D3Visualization/components/Inspector.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.
@@ -205,11 +205,9 @@ export class InspectorComponent extends Component {
         <StyledStatus className='status'>
           <StyledInspectorFooter
             className={
-              this.state.contracted ? (
-                'contracted inspector-footer'
-              ) : (
-                'inspector-footer'
-              )
+              this.state.contracted
+                ? 'contracted inspector-footer'
+                : 'inspector-footer'
             }
           >
             <StyledInspectorFooterRow

--- a/src/browser/modules/D3Visualization/components/Legend.jsx
+++ b/src/browser/modules/D3Visualization/components/Legend.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/components/RowExpandToggle.jsx
+++ b/src/browser/modules/D3Visualization/components/RowExpandToggle.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/components/index.js
+++ b/src/browser/modules/D3Visualization/components/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/components/styled.jsx
+++ b/src/browser/modules/D3Visualization/components/styled.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/graphStyle.js
+++ b/src/browser/modules/D3Visualization/graphStyle.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.
@@ -300,7 +300,8 @@ export default function neoGraphStyle () {
         } else {
           return leading
         }
-      }, '')
+      },
+      '')
       defaultCaption || (defaultCaption = '<id>')
       return {
         caption: defaultCaption

--- a/src/browser/modules/D3Visualization/index.js
+++ b/src/browser/modules/D3Visualization/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/components/collision.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/collision.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/components/graph.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/graph.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/components/graphGeometry.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/graphGeometry.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/components/graphView.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/graphView.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/components/layout.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/layout.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/components/node.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/node.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/components/queryPlan.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/queryPlan.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/components/relationship.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/relationship.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/components/renderer.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/renderer.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/components/style.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/style.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/components/visualization.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/visualization.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/index.js
+++ b/src/browser/modules/D3Visualization/lib/visualization/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/neod3.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/neod3.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/renders/init.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/renders/init.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2015 "Neo Technology,"
+Copyright (c) 2002-2015 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/renders/menu.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/renders/menu.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2015 "Neo Technology,"
+Copyright (c) 2002-2015 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/utils/adjacentAngles.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/utils/adjacentAngles.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/utils/angleList.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/utils/angleList.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/utils/arcArrow.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/utils/arcArrow.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/utils/arrays.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/utils/arrays.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/utils/circularLayout.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/utils/circularLayout.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/utils/circumferentialDistribution.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/utils/circumferentialDistribution.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/utils/circumferentialRelationshipRouting.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/utils/circumferentialRelationshipRouting.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/utils/clickHandler.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/utils/clickHandler.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/utils/loopArrow.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/utils/loopArrow.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/utils/pairwiseArcsRelationshipRouting.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/utils/pairwiseArcsRelationshipRouting.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/utils/straightArrow.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/utils/straightArrow.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/lib/visualization/utils/textMeasurement.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/utils/textMeasurement.coffee
@@ -1,5 +1,5 @@
 ###!
-Copyright (c) 2002-2017 "Neo Technology,"
+Copyright (c) 2002-2017 "Neo4j, Inc,"
 Network Engine for Objects in Lund AB [http://neotechnology.com]
 
 This file is part of Neo4j.

--- a/src/browser/modules/D3Visualization/mapper.js
+++ b/src/browser/modules/D3Visualization/mapper.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/DatabaseInfo/DatabaseInfo.jsx
+++ b/src/browser/modules/DatabaseInfo/DatabaseInfo.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/DatabaseInfo/DatabaseInfo.test.jsx
+++ b/src/browser/modules/DatabaseInfo/DatabaseInfo.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/DatabaseInfo/DatabaseKernelInfo.jsx
+++ b/src/browser/modules/DatabaseInfo/DatabaseKernelInfo.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/DatabaseInfo/DatabaseKernelInfo.test.jsx
+++ b/src/browser/modules/DatabaseInfo/DatabaseKernelInfo.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/DatabaseInfo/MetaItems.jsx
+++ b/src/browser/modules/DatabaseInfo/MetaItems.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/DatabaseInfo/MetaItems.test.js
+++ b/src/browser/modules/DatabaseInfo/MetaItems.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/DatabaseInfo/UserDetails.jsx
+++ b/src/browser/modules/DatabaseInfo/UserDetails.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/DatabaseInfo/UserDetails.test.jsx
+++ b/src/browser/modules/DatabaseInfo/UserDetails.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/DatabaseInfo/styled.jsx
+++ b/src/browser/modules/DatabaseInfo/styled.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/DocTitle/index.jsx
+++ b/src/browser/modules/DocTitle/index.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/DocTitle/index.test.js
+++ b/src/browser/modules/DocTitle/index.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/DocTitle/titleStringBuilder.js
+++ b/src/browser/modules/DocTitle/titleStringBuilder.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/DocTitle/titleStringBuilder.test.js
+++ b/src/browser/modules/DocTitle/titleStringBuilder.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Editor/Codemirror.jsx
+++ b/src/browser/modules/Editor/Codemirror.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Editor/Editor.jsx
+++ b/src/browser/modules/Editor/Editor.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Editor/Editor.test.jsx
+++ b/src/browser/modules/Editor/Editor.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.
@@ -32,27 +32,24 @@ describe('Editor', () => {
     onExecute = jest.fn()
   })
 
-  test.skip(
-    'should render Codemirror component with correct properties',
-    () => {
-      const content = 'content-' + Math.random()
-      const wrapper = mount(
-        <EditorComponent
-          bus={createBus()}
-          onExecute={onExecute}
-          content={content}
-          history=''
-        />
-      )
-      const codeMirror = wrapper.find(Codemirror)
-      expect(codeMirror.props().value).toEqual(content)
-      codeMirror
-        .get(0)
-        .getCodeMirrorInstance()
-        .keyMap['default']['Cmd-Enter'](codeMirror.get(0).getCodeMirror())
-      expect(onExecute).toHaveBeenCalled()
-    }
-  )
+  test.skip('should render Codemirror component with correct properties', () => {
+    const content = 'content-' + Math.random()
+    const wrapper = mount(
+      <EditorComponent
+        bus={createBus()}
+        onExecute={onExecute}
+        content={content}
+        history=''
+      />
+    )
+    const codeMirror = wrapper.find(Codemirror)
+    expect(codeMirror.props().value).toEqual(content)
+    codeMirror
+      .get(0)
+      .getCodeMirrorInstance()
+      .keyMap['default']['Cmd-Enter'](codeMirror.get(0).getCodeMirror())
+    expect(onExecute).toHaveBeenCalled()
+  })
 
   test.skip('should execute current command on Cmd-Enter', () => {
     const content = 'content-' + Math.random()
@@ -102,72 +99,69 @@ describe('Editor', () => {
     ).toEqual('')
   })
 
-  test.skip(
-    'should replace content as with history as user arrows up and down',
-    () => {
-      const content = 'content-' + Math.random()
-      const history = [{ cmd: 'latest' }, { cmd: 'middle' }, { cmd: 'oldest' }]
-      const wrapper = mount(
-        <EditorComponent
-          bus={createBus()}
-          onExecute={onExecute}
-          content={content}
-          history={history}
-        />
-      )
-      const codeMirror = wrapper.find(Codemirror)
+  test.skip('should replace content as with history as user arrows up and down', () => {
+    const content = 'content-' + Math.random()
+    const history = [{ cmd: 'latest' }, { cmd: 'middle' }, { cmd: 'oldest' }]
+    const wrapper = mount(
+      <EditorComponent
+        bus={createBus()}
+        onExecute={onExecute}
+        content={content}
+        history={history}
+      />
+    )
+    const codeMirror = wrapper.find(Codemirror)
+    codeMirror
+      .get(0)
+      .getCodeMirrorInstance()
+      .keyMap['default']['Cmd-Up'](codeMirror.get(0).getCodeMirror())
+    expect(
       codeMirror
         .get(0)
-        .getCodeMirrorInstance()
-        .keyMap['default']['Cmd-Up'](codeMirror.get(0).getCodeMirror())
-      expect(
-        codeMirror
-          .get(0)
-          .getCodeMirror()
-          .getValue()
-      ).toEqual('latest')
+        .getCodeMirror()
+        .getValue()
+    ).toEqual('latest')
+    codeMirror
+      .get(0)
+      .getCodeMirrorInstance()
+      .keyMap['default']['Ctrl-Up'](codeMirror.get(0).getCodeMirror())
+    expect(
       codeMirror
         .get(0)
-        .getCodeMirrorInstance()
-        .keyMap['default']['Ctrl-Up'](codeMirror.get(0).getCodeMirror())
-      expect(
-        codeMirror
-          .get(0)
-          .getCodeMirror()
-          .getValue()
-      ).toEqual('middle')
+        .getCodeMirror()
+        .getValue()
+    ).toEqual('middle')
+    codeMirror
+      .get(0)
+      .getCodeMirrorInstance()
+      .keyMap['default']['Ctrl-Up'](codeMirror.get(0).getCodeMirror())
+    expect(
       codeMirror
         .get(0)
-        .getCodeMirrorInstance()
-        .keyMap['default']['Ctrl-Up'](codeMirror.get(0).getCodeMirror())
-      expect(
-        codeMirror
-          .get(0)
-          .getCodeMirror()
-          .getValue()
-      ).toEqual('oldest')
+        .getCodeMirror()
+        .getValue()
+    ).toEqual('oldest')
+    codeMirror
+      .get(0)
+      .getCodeMirrorInstance()
+      .keyMap['default']['Cmd-Down'](codeMirror.get(0).getCodeMirror())
+    expect(
       codeMirror
         .get(0)
-        .getCodeMirrorInstance()
-        .keyMap['default']['Cmd-Down'](codeMirror.get(0).getCodeMirror())
-      expect(
-        codeMirror
-          .get(0)
-          .getCodeMirror()
-          .getValue()
-      ).toEqual('middle')
+        .getCodeMirror()
+        .getValue()
+    ).toEqual('middle')
+    codeMirror
+      .get(0)
+      .getCodeMirrorInstance()
+      .keyMap['default']['Ctrl-Down'](codeMirror.get(0).getCodeMirror())
+    expect(
       codeMirror
         .get(0)
-        .getCodeMirrorInstance()
-        .keyMap['default']['Ctrl-Down'](codeMirror.get(0).getCodeMirror())
-      expect(
-        codeMirror
-          .get(0)
-          .getCodeMirror()
-          .getValue()
-      ).toEqual('latest')
-    }
-  )
+        .getCodeMirror()
+        .getValue()
+    ).toEqual('latest')
+  })
 
   test.skip('should resest history after execution', () => {
     const history = [{ cmd: 'latest' }, { cmd: 'middle' }, { cmd: 'oldest' }]

--- a/src/browser/modules/Editor/cypher/functions.js
+++ b/src/browser/modules/Editor/cypher/functions.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Editor/editorSchemaConverter.js
+++ b/src/browser/modules/Editor/editorSchemaConverter.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Editor/editorSchemaConverter.test.js
+++ b/src/browser/modules/Editor/editorSchemaConverter.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Editor/styled.jsx
+++ b/src/browser/modules/Editor/styled.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.
@@ -62,7 +62,7 @@ const BaseEditorWrapper = styled.div`
   padding: ${editorPadding}px;
   background-color: ${props => props.theme.editorBarBackground};
   font-family: Monaco, 'Courier New', Terminal, monospace;
-  min-Height: ${props =>
+  min-height: ${props =>
     Math.max(dim.editorbarHeight, props.minHeight + editorPadding * 2)}px;
   .CodeMirror {
     background-color: ${props => props.theme.editorBackground} !important;

--- a/src/browser/modules/Guides/Carousel.jsx
+++ b/src/browser/modules/Guides/Carousel.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Guides/CarouselSlidePicker.jsx
+++ b/src/browser/modules/Guides/CarouselSlidePicker.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Guides/CarouselSlidePicker.test.js
+++ b/src/browser/modules/Guides/CarouselSlidePicker.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Guides/Guides.jsx
+++ b/src/browser/modules/Guides/Guides.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Guides/Guides.test.jsx
+++ b/src/browser/modules/Guides/Guides.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Guides/Slide.jsx
+++ b/src/browser/modules/Guides/Slide.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Guides/Slide.test.jsx
+++ b/src/browser/modules/Guides/Slide.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Guides/html/index.js
+++ b/src/browser/modules/Guides/html/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Guides/html/start.html
+++ b/src/browser/modules/Guides/html/start.html
@@ -51,7 +51,7 @@
       </div>
     </div>
     <footer class="tight">
-      <p class="text-muted">Copyright &copy;<a target="_blank" href="http://neo4j.com/" class="no-icon"> Neo Technology</a>&nbsp;2002–<span>2017</span></p>
+      <p class="text-muted">Copyright &copy;<a target="_blank" href="http://neo4j.com/" class="no-icon"> Neo4j, Inc</a>&nbsp;2002–<span>2017</span></p>
     </footer>
   </div>
 </article>

--- a/src/browser/modules/Guides/styled.jsx
+++ b/src/browser/modules/Guides/styled.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Help/html/index.js
+++ b/src/browser/modules/Help/html/index.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Intercom/index.jsx
+++ b/src/browser/modules/Intercom/index.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Main/Main.jsx
+++ b/src/browser/modules/Main/Main.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Main/SyncReminderBanner.jsx
+++ b/src/browser/modules/Main/SyncReminderBanner.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Main/styled.jsx
+++ b/src/browser/modules/Main/styled.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Sidebar/About.jsx
+++ b/src/browser/modules/Sidebar/About.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.
@@ -38,7 +38,7 @@ const About = () => {
           <DrawerSubHeader>
             Made by{' '}
             <a target='_blank' href='http://neo4j.com/'>
-              Neo Technology
+              Neo4j, Inc
             </a>
           </DrawerSubHeader>
         </DrawerSection>

--- a/src/browser/modules/Sidebar/DocumentItems.jsx
+++ b/src/browser/modules/Sidebar/DocumentItems.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Sidebar/DocumentItems.test.jsx
+++ b/src/browser/modules/Sidebar/DocumentItems.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Sidebar/Documents.jsx
+++ b/src/browser/modules/Sidebar/Documents.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Sidebar/Documents.test.jsx
+++ b/src/browser/modules/Sidebar/Documents.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Sidebar/Favorite.jsx
+++ b/src/browser/modules/Sidebar/Favorite.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Sidebar/Favorite.test.jsx
+++ b/src/browser/modules/Sidebar/Favorite.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Sidebar/Favorites.jsx
+++ b/src/browser/modules/Sidebar/Favorites.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Sidebar/Favorites.test.jsx
+++ b/src/browser/modules/Sidebar/Favorites.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Sidebar/FileDrop.jsx
+++ b/src/browser/modules/Sidebar/FileDrop.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Sidebar/FileDrop.test.jsx
+++ b/src/browser/modules/Sidebar/FileDrop.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Sidebar/Folder.jsx
+++ b/src/browser/modules/Sidebar/Folder.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Sidebar/Settings.jsx
+++ b/src/browser/modules/Sidebar/Settings.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Sidebar/Settings.test.js
+++ b/src/browser/modules/Sidebar/Settings.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Sidebar/Sidebar.jsx
+++ b/src/browser/modules/Sidebar/Sidebar.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Sidebar/Sidebar.test.jsx
+++ b/src/browser/modules/Sidebar/Sidebar.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Sidebar/styled.jsx
+++ b/src/browser/modules/Sidebar/styled.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/Auth/ChangePasswordForm.jsx
+++ b/src/browser/modules/Stream/Auth/ChangePasswordForm.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/Auth/ChangePasswordForm.test.js
+++ b/src/browser/modules/Stream/Auth/ChangePasswordForm.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/Auth/ChangePasswordFrame.jsx
+++ b/src/browser/modules/Stream/Auth/ChangePasswordFrame.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/Auth/ConnectForm.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectForm.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/Auth/ConnectedView.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectedView.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/Auth/ConnectionForm.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectionForm.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/Auth/ConnectionFrame.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectionFrame.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/Auth/DisconnectFrame.jsx
+++ b/src/browser/modules/Stream/Auth/DisconnectFrame.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/Auth/ServerStatusFrame.jsx
+++ b/src/browser/modules/Stream/Auth/ServerStatusFrame.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/Auth/styled.jsx
+++ b/src/browser/modules/Stream/Auth/styled.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/CypherFrame/AsciiView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/AsciiView.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/CypherFrame/AsciiView.test.js
+++ b/src/browser/modules/Stream/CypherFrame/AsciiView.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/CypherFrame/CodeView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/CodeView.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/CypherFrame/CodeView.test.js
+++ b/src/browser/modules/Stream/CypherFrame/CodeView.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/CypherFrame/ErrorsView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/ErrorsView.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/CypherFrame/ErrorsView.test.js
+++ b/src/browser/modules/Stream/CypherFrame/ErrorsView.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/CypherFrame/PlanView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/PlanView.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.
@@ -123,11 +123,9 @@ export class PlanView extends Component {
     return (
       <PlanSVG
         style={
-          this.props.fullscreen ? (
-            { 'padding-bottom': dim.frameStatusbarHeight + 'px' }
-          ) : (
-            {}
-          )
+          this.props.fullscreen
+            ? { 'padding-bottom': dim.frameStatusbarHeight + 'px' }
+            : {}
         }
         innerRef={this.planInit.bind(this)}
       />
@@ -171,14 +169,12 @@ export class PlanStatusbar extends Component {
           <Ellipsis>
             Cypher version: {plan.root.version}, planner: {plan.root.planner},
             runtime: {plan.root.runtime}.
-            {plan.root.totalDbHits ? (
-              ` ${plan.root
+            {plan.root.totalDbHits
+              ? ` ${plan.root
                 .totalDbHits} total db hits in ${result.summary.resultAvailableAfter
                 .add(result.summary.resultConsumedAfter)
                 .toNumber() || 0} ms.`
-            ) : (
-              ``
-            )}
+              : ``}
           </Ellipsis>
         </StyledLeftPartial>
         <StyledRightPartial>

--- a/src/browser/modules/Stream/CypherFrame/PlanView.styled.jsx
+++ b/src/browser/modules/Stream/CypherFrame/PlanView.styled.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/CypherFrame/PlanView.test.js
+++ b/src/browser/modules/Stream/CypherFrame/PlanView.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/CypherFrame/TableView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/TableView.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/CypherFrame/TableView.test.js
+++ b/src/browser/modules/Stream/CypherFrame/TableView.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView.styled.jsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView.styled.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/CypherFrame/WarningsView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/WarningsView.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/CypherFrame/WarningsView.test.js
+++ b/src/browser/modules/Stream/CypherFrame/WarningsView.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/CypherFrame/helpers.js
+++ b/src/browser/modules/Stream/CypherFrame/helpers.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/CypherFrame/helpers.test.js
+++ b/src/browser/modules/Stream/CypherFrame/helpers.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/CypherFrame/index.jsx
+++ b/src/browser/modules/Stream/CypherFrame/index.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.
@@ -376,17 +376,17 @@ export class CypherFrame extends Component {
         statusbar={statusBar}
         exportData={
           this.state.openView !== viewTypes.VISUALIZATION &&
-          this.state.openView !== viewTypes.PLAN ? (
-              this.state.exportData
-            ) : null
+          this.state.openView !== viewTypes.PLAN
+            ? this.state.exportData
+            : null
         }
         onResize={this.onResize.bind(this)}
         visElement={
           this.state.hasVis &&
           (this.state.openView === viewTypes.VISUALIZATION ||
-            this.state.openView === viewTypes.PLAN) ? (
-              this.visElement
-            ) : null
+            this.state.openView === viewTypes.PLAN)
+            ? this.visElement
+            : null
         }
       />
     )

--- a/src/browser/modules/Stream/CypherFrame/index.test.js
+++ b/src/browser/modules/Stream/CypherFrame/index.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/ErrorFrame.jsx
+++ b/src/browser/modules/Stream/ErrorFrame.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/Frame.jsx
+++ b/src/browser/modules/Stream/Frame.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/FrameError.jsx
+++ b/src/browser/modules/Stream/FrameError.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/FrameError.test.js
+++ b/src/browser/modules/Stream/FrameError.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/FrameSidebar.jsx
+++ b/src/browser/modules/Stream/FrameSidebar.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/FrameSuccess.jsx
+++ b/src/browser/modules/Stream/FrameSuccess.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/FrameSuccess.test.js
+++ b/src/browser/modules/Stream/FrameSuccess.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/FrameTemplate.jsx
+++ b/src/browser/modules/Stream/FrameTemplate.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/FrameTitlebar.jsx
+++ b/src/browser/modules/Stream/FrameTitlebar.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/HelpFrame.jsx
+++ b/src/browser/modules/Stream/HelpFrame.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/HistoryFrame.jsx
+++ b/src/browser/modules/Stream/HistoryFrame.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/HistoryRow.jsx
+++ b/src/browser/modules/Stream/HistoryRow.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/HistoryRow.test.js
+++ b/src/browser/modules/Stream/HistoryRow.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/ParamsFrame.jsx
+++ b/src/browser/modules/Stream/ParamsFrame.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/PlayFrame.jsx
+++ b/src/browser/modules/Stream/PlayFrame.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.
@@ -81,8 +81,8 @@ export class PlayFrame extends Component {
       })
     }
     const topicInput = (splitStringOnFirst(this.props.frame.cmd, ' ')[1] ||
-      'start')
-      .trim()
+      'start'
+    ).trim()
     const guideName = topicInput.toLowerCase().replace(/\s|-/g, '')
     if (html[guideName] !== undefined) {
       // Found it locally

--- a/src/browser/modules/Stream/PlayFrame.test.jsx
+++ b/src/browser/modules/Stream/PlayFrame.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.
@@ -43,13 +43,10 @@ describe('PlayFrame', () => {
     const card = shallow(wrapper.find('.playFrame').node)
     expect(card.find('.frame-contents').text()).to.match(/not\sfound/)
   })
-  test.skip(
-    'should render contents when contents is passed to PlayFrame',
-    () => {
-      const wrapper = shallow(<PlayFrame frame={{ result: 'Hello' }} />)
-      expect(wrapper.find('.playFrame').length).toBe(1)
-      const card = shallow(wrapper.find('.playFrame').node)
-      expect(card.find(Guides).props().html).to.eql('Hello')
-    }
-  )
+  test.skip('should render contents when contents is passed to PlayFrame', () => {
+    const wrapper = shallow(<PlayFrame frame={{ result: 'Hello' }} />)
+    expect(wrapper.find('.playFrame').length).toBe(1)
+    const card = shallow(wrapper.find('.playFrame').node)
+    expect(card.find(Guides).props().html).to.eql('Hello')
+  })
 })

--- a/src/browser/modules/Stream/PreFrame.jsx
+++ b/src/browser/modules/Stream/PreFrame.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/Queries/QueriesFrame.jsx
+++ b/src/browser/modules/Stream/Queries/QueriesFrame.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/Queries/styled.jsx
+++ b/src/browser/modules/Stream/Queries/styled.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/SchemaFrame.jsx
+++ b/src/browser/modules/Stream/SchemaFrame.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/Stream.jsx
+++ b/src/browser/modules/Stream/Stream.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/Stream.test.jsx
+++ b/src/browser/modules/Stream/Stream.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/SysInfoFrame/index.jsx
+++ b/src/browser/modules/Stream/SysInfoFrame/index.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/SysInfoFrame/index.test.js
+++ b/src/browser/modules/Stream/SysInfoFrame/index.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/SysInfoFrame/sysinfo.js
+++ b/src/browser/modules/Stream/SysInfoFrame/sysinfo.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/SysInfoFrame/sysinfo.test.js
+++ b/src/browser/modules/Stream/SysInfoFrame/sysinfo.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Stream/styled.jsx
+++ b/src/browser/modules/Stream/styled.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Sync/BrowserSync.jsx
+++ b/src/browser/modules/Sync/BrowserSync.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.
@@ -182,11 +182,9 @@ export class BrowserSync extends Component {
               <DrawerSection>{clearLocalDataContent}</DrawerSection>
               <FormButton
                 label={
-                  this.state.clearLocalRequested ? (
-                    'Sign out + clear'
-                  ) : (
-                    'Clear local data'
-                  )
+                  this.state.clearLocalRequested
+                    ? 'Sign out + clear'
+                    : 'Clear local data'
                 }
                 onClick={() => this.signOutAndClearLocalStorage()}
                 icon={<BinIcon suppressIconStyles='true' />}

--- a/src/browser/modules/Sync/BrowserSyncAuthWindow.jsx
+++ b/src/browser/modules/Sync/BrowserSyncAuthWindow.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/Sync/styled.jsx
+++ b/src/browser/modules/Sync/styled.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/User/RolesSelector.jsx
+++ b/src/browser/modules/User/RolesSelector.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/User/RolesSelector.test.jsx
+++ b/src/browser/modules/User/RolesSelector.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/User/UserAdd.jsx
+++ b/src/browser/modules/User/UserAdd.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/User/UserAdd.test.jsx
+++ b/src/browser/modules/User/UserAdd.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/User/UserInfo.jsx
+++ b/src/browser/modules/User/UserInfo.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/User/UserInfo.test.jsx
+++ b/src/browser/modules/User/UserInfo.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/User/UserInformation.jsx
+++ b/src/browser/modules/User/UserInformation.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/User/UserInformation.test.jsx
+++ b/src/browser/modules/User/UserInformation.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/User/UserList.jsx
+++ b/src/browser/modules/User/UserList.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/User/UserList.test.jsx
+++ b/src/browser/modules/User/UserList.test.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/User/styled.jsx
+++ b/src/browser/modules/User/styled.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/modules/UserInteraction/index.jsx
+++ b/src/browser/modules/UserInteraction/index.jsx
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/services/localstorageMiddleware.js
+++ b/src/browser/services/localstorageMiddleware.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/services/localstorageMiddleware.test.js
+++ b/src/browser/services/localstorageMiddleware.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/styles/constants.js
+++ b/src/browser/styles/constants.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/styles/global-styles.js
+++ b/src/browser/styles/global-styles.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/browser/styles/themes.js
+++ b/src/browser/styles/themes.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/app/appDuck.js
+++ b/src/shared/modules/app/appDuck.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/app/appDuck.test.js
+++ b/src/shared/modules/app/appDuck.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/commands/commandsDuck.js
+++ b/src/shared/modules/commands/commandsDuck.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/commands/commandsDuck.test.js
+++ b/src/shared/modules/commands/commandsDuck.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/commands/helpers/config.js
+++ b/src/shared/modules/commands/helpers/config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/commands/helpers/config.test.js
+++ b/src/shared/modules/commands/helpers/config.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/commands/helpers/cypher.js
+++ b/src/shared/modules/commands/helpers/cypher.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/commands/helpers/grass.js
+++ b/src/shared/modules/commands/helpers/grass.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/commands/helpers/grass.test.js
+++ b/src/shared/modules/commands/helpers/grass.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/commands/helpers/http.js
+++ b/src/shared/modules/commands/helpers/http.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/commands/helpers/http.test.js
+++ b/src/shared/modules/commands/helpers/http.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/commands/helpers/params.js
+++ b/src/shared/modules/commands/helpers/params.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/commands/helpers/params.test.js
+++ b/src/shared/modules/commands/helpers/params.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/commands/helpers/play.js
+++ b/src/shared/modules/commands/helpers/play.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/commands/helpers/server.js
+++ b/src/shared/modules/commands/helpers/server.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/commands/postConnectCmdEpic.test.js
+++ b/src/shared/modules/commands/postConnectCmdEpic.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/connections/connectionsDuck.js
+++ b/src/shared/modules/connections/connectionsDuck.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/connections/connectionsDuck.test.js
+++ b/src/shared/modules/connections/connectionsDuck.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/credentialsPolicy/credentialsPolicyDuck.js
+++ b/src/shared/modules/credentialsPolicy/credentialsPolicyDuck.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/currentUser/currentUserDuck.js
+++ b/src/shared/modules/currentUser/currentUserDuck.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/currentUser/currentUserDuck.test.js
+++ b/src/shared/modules/currentUser/currentUserDuck.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/cypher/boltUserHelper.js
+++ b/src/shared/modules/cypher/boltUserHelper.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/cypher/cypherDuck.js
+++ b/src/shared/modules/cypher/cypherDuck.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/cypher/procedureFactory.js
+++ b/src/shared/modules/cypher/procedureFactory.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/cypher/queriesProcedureHelper.js
+++ b/src/shared/modules/cypher/queriesProcedureHelper.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/dbMeta/dbMetaDuck.js
+++ b/src/shared/modules/dbMeta/dbMetaDuck.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/dbMeta/dbMetaDuck.test.js
+++ b/src/shared/modules/dbMeta/dbMetaDuck.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/discovery/discoveryDuck.js
+++ b/src/shared/modules/discovery/discoveryDuck.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/discovery/discoveryDuck.test.js
+++ b/src/shared/modules/discovery/discoveryDuck.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/editor/editorDuck.js
+++ b/src/shared/modules/editor/editorDuck.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/favorites/favoritesDuck.js
+++ b/src/shared/modules/favorites/favoritesDuck.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/favorites/favoritesDuck.test.js
+++ b/src/shared/modules/favorites/favoritesDuck.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/favorites/foldersDuck.js
+++ b/src/shared/modules/favorites/foldersDuck.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/favorites/staticScripts.js
+++ b/src/shared/modules/favorites/staticScripts.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/features/featuresDuck.js
+++ b/src/shared/modules/features/featuresDuck.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/features/featuresDuck.test.js
+++ b/src/shared/modules/features/featuresDuck.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/grass/grassDuck.js
+++ b/src/shared/modules/grass/grassDuck.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/grass/grassDuck.test.js
+++ b/src/shared/modules/grass/grassDuck.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/history/historyDuck.js
+++ b/src/shared/modules/history/historyDuck.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/history/historyDuck.test.js
+++ b/src/shared/modules/history/historyDuck.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/localstorage/localstorageDuck.js
+++ b/src/shared/modules/localstorage/localstorageDuck.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/params/paramsDuck.js
+++ b/src/shared/modules/params/paramsDuck.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/params/paramsDuck.test.js
+++ b/src/shared/modules/params/paramsDuck.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/requests/requestsDuck.js
+++ b/src/shared/modules/requests/requestsDuck.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/settings/settingsDuck.js
+++ b/src/shared/modules/settings/settingsDuck.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/settings/settingsDuck.test.js
+++ b/src/shared/modules/settings/settingsDuck.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/sidebar/sidebarDuck.js
+++ b/src/shared/modules/sidebar/sidebarDuck.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/sidebar/sidebarDuck.test.js
+++ b/src/shared/modules/sidebar/sidebarDuck.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/stream/epics.test.js
+++ b/src/shared/modules/stream/epics.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/stream/frameViewTypes.js
+++ b/src/shared/modules/stream/frameViewTypes.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/stream/streamDuck.js
+++ b/src/shared/modules/stream/streamDuck.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/stream/streamDuck.test.js
+++ b/src/shared/modules/stream/streamDuck.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/sync/SyncSignInManager.js
+++ b/src/shared/modules/sync/SyncSignInManager.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/sync/syncDuck.js
+++ b/src/shared/modules/sync/syncDuck.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/udc/udcDuck.js
+++ b/src/shared/modules/udc/udcDuck.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/udc/udcDuck.test.js
+++ b/src/shared/modules/udc/udcDuck.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/udc/udcHelpers.js
+++ b/src/shared/modules/udc/udcHelpers.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/udc/udcHelpers.test.js
+++ b/src/shared/modules/udc/udcHelpers.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/modules/userInteraction/userInteractionDuck.js
+++ b/src/shared/modules/userInteraction/userInteractionDuck.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/rootEpic.js
+++ b/src/shared/rootEpic.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/rootReducer.js
+++ b/src/shared/rootReducer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/bolt/applyGraphTypes.test.js
+++ b/src/shared/services/bolt/applyGraphTypes.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/bolt/bolt.js
+++ b/src/shared/services/bolt/bolt.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/bolt/boltConnection.js
+++ b/src/shared/services/bolt/boltConnection.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/bolt/boltHelpers.js
+++ b/src/shared/services/bolt/boltHelpers.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/bolt/boltMappings.js
+++ b/src/shared/services/bolt/boltMappings.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/bolt/boltMappings.test.js
+++ b/src/shared/services/bolt/boltMappings.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.
@@ -160,191 +160,176 @@ describe('boltMappings', () => {
   })
 
   describe('extractNodesAndRelationshipsFromRecords', () => {
-    test.skip(
-      'should map bolt records with a path to nodes and relationships',
-      () => {
-        let startNode = new neo4j.v1.types.Node('1', ['Person'], {
-          prop1: 'prop1'
-        })
-        let endNode = new neo4j.v1.types.Node('2', ['Movie'], {
-          prop2: 'prop2'
-        })
-        let relationship = new neo4j.v1.types.Relationship(
-          '3',
-          startNode.identity,
-          endNode.identity,
-          'ACTED_IN',
-          {}
-        )
-        let pathSegment = new neo4j.v1.types.PathSegment(
-          startNode,
-          relationship,
-          endNode
-        )
-        let path = new neo4j.v1.types.Path(startNode, endNode, [pathSegment])
-        let boltRecord = {
-          keys: ['p'],
-          get: key => path
-        }
-
-        let { nodes, relationships } = extractNodesAndRelationshipsFromRecords(
-          [boltRecord],
-          neo4j.v1.types
-        )
-        expect(nodes).to.have.lengthOf(2)
-        let graphNodeStart = nodes.filter(node => node.id === '1')[0]
-        expect(graphNodeStart).toBeDefined()
-        expect(graphNodeStart.labels).toEqual(['Person'])
-        expect(graphNodeStart.properties).toEqual({ prop1: 'prop1' })
-        let graphNodeEnd = nodes.filter(node => node.id === '2')[0]
-        expect(graphNodeEnd).toBeDefined()
-        expect(graphNodeEnd.labels).toEqual(['Movie'])
-        expect(graphNodeEnd.properties).toEqual({ prop2: 'prop2' })
-        expect(relationships).to.have.lengthOf(1)
-        expect(relationships[0].id).toEqual('3')
-        expect(relationships[0].startNodeId).toEqual('1')
-        expect(relationships[0].endNodeId).toEqual('2')
-        expect(relationships[0].type).toEqual('ACTED_IN')
-        expect(relationships[0].properties).toEqual({})
+    test.skip('should map bolt records with a path to nodes and relationships', () => {
+      let startNode = new neo4j.v1.types.Node('1', ['Person'], {
+        prop1: 'prop1'
+      })
+      let endNode = new neo4j.v1.types.Node('2', ['Movie'], {
+        prop2: 'prop2'
+      })
+      let relationship = new neo4j.v1.types.Relationship(
+        '3',
+        startNode.identity,
+        endNode.identity,
+        'ACTED_IN',
+        {}
+      )
+      let pathSegment = new neo4j.v1.types.PathSegment(
+        startNode,
+        relationship,
+        endNode
+      )
+      let path = new neo4j.v1.types.Path(startNode, endNode, [pathSegment])
+      let boltRecord = {
+        keys: ['p'],
+        get: key => path
       }
-    )
 
-    test.skip(
-      'should map bolt nodes and relationships to graph nodes and relationships',
-      () => {
-        let startNode = new neo4j.v1.types.Node('1', ['Person'], {
-          prop1: 'prop1'
-        })
-        let endNode = new neo4j.v1.types.Node('2', ['Movie'], {
-          prop2: 'prop2'
-        })
-        let relationship = new neo4j.v1.types.Relationship(
-          '3',
-          startNode.identity,
-          endNode.identity,
-          'ACTED_IN',
-          {}
-        )
-        let boltRecord = {
-          keys: ['r', 'n1', 'n2'],
-          get: key => {
-            if (key === 'r') {
-              return relationship
-            }
-            if (key === 'n1') {
-              return startNode
-            }
-            if (key === 'n2') {
-              return endNode
-            }
+      let { nodes, relationships } = extractNodesAndRelationshipsFromRecords(
+        [boltRecord],
+        neo4j.v1.types
+      )
+      expect(nodes).to.have.lengthOf(2)
+      let graphNodeStart = nodes.filter(node => node.id === '1')[0]
+      expect(graphNodeStart).toBeDefined()
+      expect(graphNodeStart.labels).toEqual(['Person'])
+      expect(graphNodeStart.properties).toEqual({ prop1: 'prop1' })
+      let graphNodeEnd = nodes.filter(node => node.id === '2')[0]
+      expect(graphNodeEnd).toBeDefined()
+      expect(graphNodeEnd.labels).toEqual(['Movie'])
+      expect(graphNodeEnd.properties).toEqual({ prop2: 'prop2' })
+      expect(relationships).to.have.lengthOf(1)
+      expect(relationships[0].id).toEqual('3')
+      expect(relationships[0].startNodeId).toEqual('1')
+      expect(relationships[0].endNodeId).toEqual('2')
+      expect(relationships[0].type).toEqual('ACTED_IN')
+      expect(relationships[0].properties).toEqual({})
+    })
+
+    test.skip('should map bolt nodes and relationships to graph nodes and relationships', () => {
+      let startNode = new neo4j.v1.types.Node('1', ['Person'], {
+        prop1: 'prop1'
+      })
+      let endNode = new neo4j.v1.types.Node('2', ['Movie'], {
+        prop2: 'prop2'
+      })
+      let relationship = new neo4j.v1.types.Relationship(
+        '3',
+        startNode.identity,
+        endNode.identity,
+        'ACTED_IN',
+        {}
+      )
+      let boltRecord = {
+        keys: ['r', 'n1', 'n2'],
+        get: key => {
+          if (key === 'r') {
+            return relationship
+          }
+          if (key === 'n1') {
+            return startNode
+          }
+          if (key === 'n2') {
+            return endNode
           }
         }
-
-        let { nodes, relationships } = extractNodesAndRelationshipsFromRecords(
-          [boltRecord],
-          neo4j.v1.types
-        )
-        expect(nodes).to.have.lengthOf(2)
-        let graphNodeStart = nodes.filter(node => node.id === '1')[0]
-        expect(graphNodeStart).toBeDefined()
-        expect(graphNodeStart.labels).toEqual(['Person'])
-        expect(graphNodeStart.properties).toEqual({ prop1: 'prop1' })
-        let graphNodeEnd = nodes.filter(node => node.id === '2')[0]
-        expect(graphNodeEnd).toBeDefined()
-        expect(graphNodeEnd.labels).toEqual(['Movie'])
-        expect(graphNodeEnd.properties).toEqual({ prop2: 'prop2' })
-        expect(relationships).to.have.lengthOf(1)
-        expect(relationships[0].id).toEqual('3')
-        expect(relationships[0].startNodeId).toEqual('1')
-        expect(relationships[0].endNodeId).toEqual('2')
-        expect(relationships[0].type).toEqual('ACTED_IN')
-        expect(relationships[0].properties).toEqual({})
       }
-    )
 
-    test.skip(
-      'should not include relationships where neither start or end node is not in nodes list',
-      () => {
-        let relationship = new neo4j.v1.types.Relationship(
-          '3',
-          1,
-          2,
-          'ACTED_IN',
-          {}
-        )
-        let boltRecord = {
-          keys: ['r'],
-          get: key => relationship
-        }
-        let relationships = extractNodesAndRelationshipsFromRecords(
-          [boltRecord],
-          neo4j.v1.types
-        ).relationships
-        expect(relationships.length).toBe(0)
+      let { nodes, relationships } = extractNodesAndRelationshipsFromRecords(
+        [boltRecord],
+        neo4j.v1.types
+      )
+      expect(nodes).to.have.lengthOf(2)
+      let graphNodeStart = nodes.filter(node => node.id === '1')[0]
+      expect(graphNodeStart).toBeDefined()
+      expect(graphNodeStart.labels).toEqual(['Person'])
+      expect(graphNodeStart.properties).toEqual({ prop1: 'prop1' })
+      let graphNodeEnd = nodes.filter(node => node.id === '2')[0]
+      expect(graphNodeEnd).toBeDefined()
+      expect(graphNodeEnd.labels).toEqual(['Movie'])
+      expect(graphNodeEnd.properties).toEqual({ prop2: 'prop2' })
+      expect(relationships).to.have.lengthOf(1)
+      expect(relationships[0].id).toEqual('3')
+      expect(relationships[0].startNodeId).toEqual('1')
+      expect(relationships[0].endNodeId).toEqual('2')
+      expect(relationships[0].type).toEqual('ACTED_IN')
+      expect(relationships[0].properties).toEqual({})
+    })
+
+    test.skip('should not include relationships where neither start or end node is not in nodes list', () => {
+      let relationship = new neo4j.v1.types.Relationship(
+        '3',
+        1,
+        2,
+        'ACTED_IN',
+        {}
+      )
+      let boltRecord = {
+        keys: ['r'],
+        get: key => relationship
       }
-    )
-    test.skip(
-      'should not include relationships where end node is not in nodes list',
-      () => {
-        let startNode = new neo4j.v1.types.Node('1', ['Person'], {
-          prop1: 'prop1'
-        })
-        let relationship = new neo4j.v1.types.Relationship(
-          '3',
-          startNode.identity,
-          2,
-          'ACTED_IN',
-          {}
-        )
-        let boltRecord = {
-          keys: ['r', 'n1'],
-          get: key => {
-            if (key === 'r') {
-              return relationship
-            }
-            if (key === 'n1') {
-              return startNode
-            }
+      let relationships = extractNodesAndRelationshipsFromRecords(
+        [boltRecord],
+        neo4j.v1.types
+      ).relationships
+      expect(relationships.length).toBe(0)
+    })
+    test.skip('should not include relationships where end node is not in nodes list', () => {
+      let startNode = new neo4j.v1.types.Node('1', ['Person'], {
+        prop1: 'prop1'
+      })
+      let relationship = new neo4j.v1.types.Relationship(
+        '3',
+        startNode.identity,
+        2,
+        'ACTED_IN',
+        {}
+      )
+      let boltRecord = {
+        keys: ['r', 'n1'],
+        get: key => {
+          if (key === 'r') {
+            return relationship
+          }
+          if (key === 'n1') {
+            return startNode
           }
         }
-        let relationships = extractNodesAndRelationshipsFromRecords(
-          [boltRecord],
-          neo4j.v1.types
-        ).relationships
-        expect(relationships.length).toBe(0)
       }
-    )
-    test.skip(
-      'should not include relationships where start node is not in nodes list',
-      () => {
-        let endNode = new neo4j.v1.types.Node('2', ['Movie'], {
-          prop2: 'prop2'
-        })
-        let relationship = new neo4j.v1.types.Relationship(
-          '3',
-          '1',
-          endNode.identity,
-          'ACTED_IN',
-          {}
-        )
-        let boltRecord = {
-          keys: ['r', 'n1'],
-          get: key => {
-            if (key === 'r') {
-              return relationship
-            }
-            if (key === 'n1') {
-              return endNode
-            }
+      let relationships = extractNodesAndRelationshipsFromRecords(
+        [boltRecord],
+        neo4j.v1.types
+      ).relationships
+      expect(relationships.length).toBe(0)
+    })
+    test.skip('should not include relationships where start node is not in nodes list', () => {
+      let endNode = new neo4j.v1.types.Node('2', ['Movie'], {
+        prop2: 'prop2'
+      })
+      let relationship = new neo4j.v1.types.Relationship(
+        '3',
+        '1',
+        endNode.identity,
+        'ACTED_IN',
+        {}
+      )
+      let boltRecord = {
+        keys: ['r', 'n1'],
+        get: key => {
+          if (key === 'r') {
+            return relationship
+          }
+          if (key === 'n1') {
+            return endNode
           }
         }
-        let relationships = extractNodesAndRelationshipsFromRecords(
-          [boltRecord],
-          neo4j.v1.types
-        ).relationships
-        expect(relationships.length).toBe(0)
       }
-    )
+      let relationships = extractNodesAndRelationshipsFromRecords(
+        [boltRecord],
+        neo4j.v1.types
+      ).relationships
+      expect(relationships.length).toBe(0)
+    })
   })
   describe('extractPlan', () => {
     const createPlan = () => {

--- a/src/shared/services/bolt/boltWorker.js
+++ b/src/shared/services/bolt/boltWorker.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/bolt/boltWorkerMessages.js
+++ b/src/shared/services/bolt/boltWorkerMessages.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/browserSyncService.js
+++ b/src/shared/services/browserSyncService.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/commandInterpreterHelper.test.js
+++ b/src/shared/services/commandInterpreterHelper.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/commandUtils.js
+++ b/src/shared/services/commandUtils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/commandUtils.test.js
+++ b/src/shared/services/commandUtils.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/dom-helpers.js
+++ b/src/shared/services/dom-helpers.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/duckUtils.js
+++ b/src/shared/services/duckUtils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/duckUtils.test.js
+++ b/src/shared/services/duckUtils.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/exceptionMessages.js
+++ b/src/shared/services/exceptionMessages.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/exceptions.js
+++ b/src/shared/services/exceptions.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/exceptions.test.js
+++ b/src/shared/services/exceptions.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/exporting/pngUtils.js
+++ b/src/shared/services/exporting/pngUtils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/exporting/svgUtils.js
+++ b/src/shared/services/exporting/svgUtils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/intercom.js
+++ b/src/shared/services/intercom.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/localstorage.js
+++ b/src/shared/services/localstorage.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/localstorage.test.js
+++ b/src/shared/services/localstorage.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/remote.js
+++ b/src/shared/services/remote.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/remoteUtils.js
+++ b/src/shared/services/remoteUtils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/remoteUtils.test.js
+++ b/src/shared/services/remoteUtils.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/serializer.js
+++ b/src/shared/services/serializer.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/serializer.test.js
+++ b/src/shared/services/serializer.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/testUtils.js
+++ b/src/shared/services/testUtils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/utils.js
+++ b/src/shared/services/utils.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/src/shared/services/utils.test.js
+++ b/src/shared/services/utils.test.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2002-2017 "Neo Technology,"
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
  *
  * This file is part of Neo4j.


### PR DESCRIPTION
Mainly licence headers

Reason: https://neo4j.com/blog/hello-world-neo4j-inc/ 