### PR TITLE
Remap query plan arguments to the root object

### DIFF
--- a/src/shared/services/bolt/boltMappings.js
+++ b/src/shared/services/bolt/boltMappings.js
@@ -95,24 +95,16 @@ export function extractPlan (result, calculateTotalDbHits = false) {
     const boltPlanToRESTPlanShared = plan => {
       return {
         operatorType: plan.operatorType,
-        LegacyExpression: plan.arguments.LegacyExpression,
-        ExpandExpression: plan.arguments.ExpandExpression,
         DbHits: plan.dbHits,
         Rows: plan.rows,
-        EstimatedRows: plan.arguments.EstimatedRows,
         identifiers: plan.identifiers,
-        Index: plan.arguments.Index,
-        children: plan.children.map(boltPlanToRESTPlanShared)
+        children: plan.children.map(_ => ({
+          ..._.arguments,
+          ...boltPlanToRESTPlanShared(_)
+        }))
       }
     }
-    let obj = boltPlanToRESTPlanShared(rawPlan)
-    obj['runtime-impl'] = rawPlan.arguments['runtime-impl']
-    obj['planner-impl'] = rawPlan.arguments['planner-impl']
-    obj['version'] = rawPlan.arguments['version']
-    obj['KeyNames'] = rawPlan.arguments['KeyNames']
-    obj['planner'] = rawPlan.arguments['planner']
-    obj['runtime'] = rawPlan.arguments['runtime']
-    obj['Signature'] = rawPlan.arguments['Signature']
+    let obj = { ...rawPlan.arguments, ...boltPlanToRESTPlanShared(rawPlan) }
 
     if (calculateTotalDbHits === true) {
       obj.totalDbHits = collectHits(obj)

--- a/src/shared/services/bolt/boltMappings.test.js
+++ b/src/shared/services/bolt/boltMappings.test.js
@@ -371,7 +371,7 @@ describe('boltMappings', () => {
       expect(extractedPlan.Signature).toEqual('Signature')
     }
 
-    test.skip('should extract plan from result summary', () => {
+    test('should extract plan from result summary', () => {
       // Given
       const result = {
         summary: {
@@ -382,7 +382,7 @@ describe('boltMappings', () => {
       checkExtractedPlan(extractedPlan)
     })
 
-    test.skip('should extract profile from result summary', () => {
+    test('should extract profile from result summary', () => {
       // Given
       const profile = createPlan()
       profile.dbHits = 20


### PR DESCRIPTION
- Re-enable skipped boltMapping tests

Before:
![all-node-scan-old](https://user-images.githubusercontent.com/849508/31249162-354bd8dc-aa0e-11e7-9812-cc6725de2681.png)

After:
![all-nodes-scan-new](https://user-images.githubusercontent.com/849508/31249165-38d49566-aa0e-11e7-9414-55cfb48b7bd5.png)
