### PR TITLE
Add button to download vis as svg

### DIFF
--- a/src/browser/modules/Stream/FrameTitlebar.jsx
+++ b/src/browser/modules/Stream/FrameTitlebar.jsx
@@ -49,7 +49,10 @@ import {
   DropdownButton,
   DropdownItem
 } from './styled'
-import { downloadPNGFromSVG } from 'shared/services/exporting/pngUtils'
+import {
+  downloadPNGFromSVG,
+  downloadSVG
+} from 'shared/services/exporting/imageUtils'
 
 const getCsvData = exportData => {
   if (exportData && exportData.length > 0) {
@@ -83,6 +86,11 @@ class FrameTitlebar extends Component {
     downloadPNGFromSVG(svgElement, graphElement, type)
   }
 
+  exportSVG () {
+    const { svgElement, graphElement, type } = this.props.visElement
+    downloadSVG(svgElement, graphElement, type)
+  }
+
   render () {
     let props = this.props
     const { frame = {} } = props
@@ -110,9 +118,14 @@ class FrameTitlebar extends Component {
               <DropdownList>
                 <DropdownContent>
                   <Render if={props.visElement}>
-                    <DropdownItem onClick={() => this.exportPNG()}>
-                      Export PNG
-                    </DropdownItem>
+                    <span>
+                      <DropdownItem onClick={() => this.exportPNG()}>
+                        Export PNG
+                      </DropdownItem>
+                      <DropdownItem onClick={() => this.exportSVG()}>
+                        Export SVG
+                      </DropdownItem>
+                    </span>
                   </Render>
                   <Render if={props.exportData}>
                     <DropdownItem

--- a/src/shared/services/exporting/imageUtils.js
+++ b/src/shared/services/exporting/imageUtils.js
@@ -37,10 +37,18 @@ export const downloadPNGFromSVG = (svg, graph, type) => {
   return downloadWithDataURI(filename + '.png', canvas.toDataURL('image/png'))
 }
 
+export const downloadSVG = (svg, graph, type) => {
+  const svgObj = prepareForExport(svg, graph, type).node()
+  svgObj.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
+  return download(
+    type + '.svg',
+    'image/svg+xml;charset=utf-8',
+    svgObj.outerHTML
+  )
+}
+
 const download = (filename, mime, data) => {
-  const blob = new Blob([data], {
-    type: mime
-  })
+  const blob = new Blob([data], { type: mime })
   return FileSaver.saveAs(blob, filename)
 }
 

--- a/src/shared/services/exporting/imageUtils.js
+++ b/src/shared/services/exporting/imageUtils.js
@@ -23,10 +23,7 @@ import FileSaver from 'file-saver'
 
 export const downloadPNGFromSVG = (svg, graph, type) => {
   const svgObj = prepareForExport(svg, graph, type)
-  const filename = type
-  const svgData = new window.XMLSerializer()
-    .serializeToString(svgObj.node())
-    .replace(/&nbsp;/g, '&#160;')
+  const svgData = htmlCharacterRefToNumericalRef(svgObj.node())
 
   let canvas
   canvas = document.createElement('canvas')
@@ -34,18 +31,20 @@ export const downloadPNGFromSVG = (svg, graph, type) => {
   canvas.height = svgObj.attr('height')
 
   window.canvg(canvas, svgData)
-  return downloadWithDataURI(filename + '.png', canvas.toDataURL('image/png'))
+  return downloadWithDataURI(type + '.png', canvas.toDataURL('image/png'))
 }
 
 export const downloadSVG = (svg, graph, type) => {
-  const svgObj = prepareForExport(svg, graph, type).node()
-  svgObj.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
-  return download(
-    type + '.svg',
-    'image/svg+xml;charset=utf-8',
-    svgObj.outerHTML
-  )
+  const svgObj = prepareForExport(svg, graph, type)
+  const svgData = htmlCharacterRefToNumericalRef(svgObj.node())
+
+  return download(type + '.svg', 'image/svg+xml;charset=utf-8', svgData)
 }
+
+const htmlCharacterRefToNumericalRef = node =>
+  new window.XMLSerializer()
+    .serializeToString(node)
+    .replace(/&nbsp;/g, '&#160;')
 
 const download = (filename, mime, data) => {
   const blob = new Blob([data], { type: mime })

--- a/src/shared/services/exporting/svgUtils.js
+++ b/src/shared/services/exporting/svgUtils.js
@@ -48,7 +48,7 @@ export const prepareForExport = (svgElement, graphElement, type) => {
   return svg
 }
 
-export const getSvgDimensions = view => {
+const getSvgDimensions = view => {
   let boundingBox, dimensions
   boundingBox = view.boundingBox()
   dimensions = {


### PR DESCRIPTION
The download button is visible in cypher results frame titlebar when the visualization tab is selected

![scg-export](https://user-images.githubusercontent.com/849508/31515317-a9c28912-af8c-11e7-904d-52e1059274e5.gif)
