### PR TITLE
Set editor to update mode after adding a new favorite

### DIFF
--- a/src/browser/modules/Editor/Editor.jsx
+++ b/src/browser/modules/Editor/Editor.jsx
@@ -22,6 +22,7 @@
 import { Component } from 'preact'
 import { connect } from 'preact-redux'
 import { withBus } from 'preact-suber'
+import uuid from 'uuid'
 import {
   executeCommand,
   executeSystemCommand
@@ -31,7 +32,8 @@ import {
   SET_CONTENT,
   EDIT_CONTENT,
   FOCUS,
-  EXPAND
+  EXPAND,
+  editContent
 } from 'shared/modules/editor/editorDuck'
 import { getHistory } from 'shared/modules/history/historyDuck'
 import {
@@ -385,7 +387,9 @@ export class Editor extends Component {
           </Render>
           <Render if={!this.state.contentId}>
             <EditorButton
-              onClick={() => this.props.onFavoriteClick(this.getEditorValue())}
+              onClick={() => {
+                this.props.onFavoriteClick(this.getEditorValue())
+              }}
               disabled={this.getEditorValue().length < 1}
               title='Update favorite'
               hoverIcon='&quot;\58&quot;'
@@ -417,8 +421,13 @@ export class Editor extends Component {
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
     onFavoriteClick: cmd => {
-      const action = favorites.addFavorite(cmd)
-      ownProps.bus.send(action.type, action)
+      const id = uuid.v4()
+
+      const addAction = favorites.addFavorite(cmd, id)
+      ownProps.bus.send(addAction.type, addAction)
+
+      const updateAction = editContent(id, cmd)
+      ownProps.bus.send(updateAction.type, updateAction)
     },
     onFavoriteUpdateClick: (id, cmd) => {
       const action = favorites.updateFavorite(id, cmd)

--- a/src/shared/modules/favorites/favoritesDuck.js
+++ b/src/shared/modules/favorites/favoritesDuck.js
@@ -49,7 +49,7 @@ export default function reducer (state = initialState, action) {
     case REMOVE_FAVORITE:
       return removeFavoriteById(state, action.id)
     case ADD_FAVORITE:
-      return state.concat([{ id: uuid.v4(), content: action.cmd }])
+      return state.concat([{ id: action.id || uuid.v4(), content: action.cmd }])
     case UPDATE_FAVORITE:
       const mergedFavorite = Object.assign({}, getFavorite(state, action.id), {
         content: action.cmd
@@ -76,10 +76,11 @@ export function removeFavorite (id) {
     id
   }
 }
-export function addFavorite (cmd) {
+export function addFavorite (cmd, id) {
   return {
     type: ADD_FAVORITE,
-    cmd
+    cmd,
+    id
   }
 }
 export function loadFavorites (favorites) {

--- a/src/shared/modules/favorites/favoritesDuck.test.js
+++ b/src/shared/modules/favorites/favoritesDuck.test.js
@@ -23,6 +23,31 @@ import uuid from 'uuid'
 import reducer, * as favorites from './favoritesDuck'
 
 describe('favorites reducer', () => {
+  test('should allow id to be injected when adding a favorite', () => {
+    const action = {
+      type: favorites.ADD_FAVORITE,
+      id: 'foo',
+      cmd: 'bar'
+    }
+    const nextState = reducer([], action)
+    expect(nextState.length).toBe(1)
+
+    const actual = nextState[0]
+    expect(actual.id).toEqual('foo')
+    expect(actual.content).toEqual('bar')
+  })
+  test('should generate an id when adding a favorite and only passing cmd value', () => {
+    const action = {
+      type: favorites.ADD_FAVORITE,
+      cmd: 'bar'
+    }
+    const nextState = reducer([], action)
+    expect(nextState.length).toBe(1)
+
+    const actual = nextState[0]
+    expect(actual.id).not.toBeFalsy()
+    expect(actual.content).toEqual('bar')
+  })
   test('should update state for favorites when favorite is removed and only one item is in the list', () => {
     const favoriteScript = {
       name: 'Test1',


### PR DESCRIPTION
This pr puts the editor in 'update favorite' mode. Subsequent changes will reference the favorite that has been created. Clicking on the 'pen' icon will update the newly added favorite.  

In action: ![add-fav-feedback](https://user-images.githubusercontent.com/849508/31545532-be60be62-b017-11e7-8f26-5b75a95c1fdc.gif)
