### PR TITLE
Integrate with desktop API

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "homepage": "https://neo4j.com",
   "main": "dist/index.html",
   "neo4jDesktop": {
-    "apiVersion": "1.1.0"
+    "apiVersion": "^1.2.0"
   },
   "scripts": {
     "start":

--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
   "homepage": "https://neo4j.com",
   "main": "dist/index.html",
   "neo4jDesktop": {
-    "apiVersion": "1.0.0"
+    "apiVersion": "1.1.0"
   },
   "scripts": {
-    "start": "webpack-dashboard -t 'Neo4j Browser' -- webpack-dev-server --colors --no-info",
-    "starts": "webpack-dashboard -t 'Neo4j Browser' -- webpack-dev-server --https --colors --no-info",
+    "start":
+      "webpack-dashboard -t 'Neo4j Browser' -- webpack-dev-server --colors --no-info",
+    "starts":
+      "webpack-dashboard -t 'Neo4j Browser' -- webpack-dev-server --https --colors --no-info",
     "precommit": "lint-staged",
     "format": "prettier-eslint 'src/**/!(*.min).js' 'src/**/*.jsx' --write",
     "lint": "eslint --fix --ext .js --ext .jsx ./",
@@ -26,24 +28,20 @@
     "build": "rm -rf ./dist && NODE_ENV=\"production\" webpack",
     "prepare-jar": "node ./scripts/prepare-mvn-package.js",
     "jar": "yarn build && mvn package",
-    "version-pom": "node ./scripts/set-pom-version.js -f ./pom.xml -v $npm_package_version",
+    "version-pom":
+      "node ./scripts/set-pom-version.js -f ./pom.xml -v $npm_package_version",
     "version": "npm run version-pom && git add ./pom.xml"
   },
   "lint-staged": {
     "linters": {
-      "*.{js,jsx}": [
-        "prettier-eslint --write",
-        "git add"
-      ]
+      "*.{js,jsx}": ["prettier-eslint --write", "git add"]
     }
   },
   "jest": {
-    "testPathIgnorePatterns": [
-      ".jsx$",
-      "/e2e_tests/"
-    ],
+    "testPathIgnorePatterns": [".jsx$", "/e2e_tests/"],
     "moduleNameMapper": {
-      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|html)$": "<rootDir>/__mocks__/fileMock.js",
+      "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|html)$":
+        "<rootDir>/__mocks__/fileMock.js",
       "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js",
       "neo4j": "<rootDir>/__mocks__/neo4j.js",
       "^react-dom/server$": "preact-render-to-string",
@@ -55,10 +53,7 @@
       "^browser-components(.*)$": "<rootDir>/src/browser/components$1",
       "worker-loader": "<rootDir>/__mocks__/workerLoaderMock.js"
     },
-    "modulePaths": [
-      "<rootDir>/src",
-      "<rootDir>/src/shared"
-    ]
+    "modulePaths": ["<rootDir>/src", "<rootDir>/src/shared"]
   },
   "devDependencies": {
     "autoprefixer": "^7.1.4",

--- a/src/browser/components/DesktopIntegration/helpers.js
+++ b/src/browser/components/DesktopIntegration/helpers.js
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export const getActiveGraph = (context = {}) => {
+  if (!context) return null
+  const { projects } = context
+  if (!Array.isArray(projects)) return null
+  const activeProject = projects.find(project => {
+    if (!project) return false
+    if (!(project.graphs && Array.isArray(project.graphs))) return false
+    return project.graphs.find(({ status }) => status === 'ACTIVE')
+  })
+  if (!activeProject) return null
+  return activeProject.graphs.find(({ status }) => status === 'ACTIVE')
+}
+
+export const getCredentials = (type, connection) => {
+  if (!connection) return undefined
+  const { configuration = null } = connection
+  if (
+    !(
+      configuration &&
+      configuration.constructor &&
+      configuration.constructor === Object
+    )
+  ) {
+    return undefined
+  }
+  if (
+    !(
+      configuration.protocols &&
+      configuration.protocols.constructor &&
+      configuration.protocols.constructor === Object
+    )
+  ) {
+    return undefined
+  }
+  if (typeof configuration.protocols[type] === 'undefined') {
+    return undefined
+  }
+  return configuration.protocols[type]
+}
+
+// XXX_YYY -> onXxxYyy
+export const eventToHandler = type => {
+  if (typeof type !== 'string') return undefined
+  return (
+    'on' +
+    splitOnUnderscore(type)
+      .filter(notEmpty)
+      .map(toLower)
+      .map(upperFirst)
+      .join('')
+  )
+}
+const notEmpty = str => str.length > 0
+const splitOnUnderscore = str => str.split('_')
+const toLower = str => str.toLowerCase()
+const upperFirst = str => str[0].toUpperCase() + str.substring(1)

--- a/src/browser/components/DesktopIntegration/helpers.js
+++ b/src/browser/components/DesktopIntegration/helpers.js
@@ -32,7 +32,7 @@ export const getActiveGraph = (context = {}) => {
 }
 
 export const getCredentials = (type, connection) => {
-  if (!connection) return undefined
+  if (!connection) return null
   const { configuration = null } = connection
   if (
     !(
@@ -41,7 +41,7 @@ export const getCredentials = (type, connection) => {
       configuration.constructor === Object
     )
   ) {
-    return undefined
+    return null
   }
   if (
     !(
@@ -50,17 +50,17 @@ export const getCredentials = (type, connection) => {
       configuration.protocols.constructor === Object
     )
   ) {
-    return undefined
+    return null
   }
   if (typeof configuration.protocols[type] === 'undefined') {
-    return undefined
+    return null
   }
   return configuration.protocols[type]
 }
 
 // XXX_YYY -> onXxxYyy
 export const eventToHandler = type => {
-  if (typeof type !== 'string') return undefined
+  if (typeof type !== 'string') return null
   return (
     'on' +
     splitOnUnderscore(type)
@@ -74,3 +74,9 @@ const notEmpty = str => str.length > 0
 const splitOnUnderscore = str => str.split('_')
 const toLower = str => str.toLowerCase()
 const upperFirst = str => str[0].toUpperCase() + str.substring(1)
+
+export const didChangeActiveGraph = (oldContext, newContext) => {
+  const oldActive = getActiveGraph(oldContext)
+  const newActive = getActiveGraph(newContext)
+  return !(oldActive && newActive && newActive.id === oldActive.id)
+}

--- a/src/browser/components/DesktopIntegration/helpers.js
+++ b/src/browser/components/DesktopIntegration/helpers.js
@@ -75,8 +75,16 @@ const splitOnUnderscore = str => str.split('_')
 const toLower = str => str.toLowerCase()
 const upperFirst = str => str[0].toUpperCase() + str.substring(1)
 
-export const didChangeActiveGraph = (oldContext, newContext) => {
+export const didChangeActiveGraph = (newContext, oldContext) => {
   const oldActive = getActiveGraph(oldContext)
   const newActive = getActiveGraph(newContext)
+  if (!oldActive && !newActive) return false // If no active before and after = nu change
   return !(oldActive && newActive && newActive.id === oldActive.id)
+}
+
+export const getActiveCredentials = (type, context) => {
+  const activeGraph = getActiveGraph(context)
+  if (!activeGraph || typeof activeGraph.connection === 'undefined') return null
+  const creds = getCredentials('bolt', activeGraph.connection)
+  return creds || null
 }

--- a/src/browser/components/DesktopIntegration/helpers.test.js
+++ b/src/browser/components/DesktopIntegration/helpers.test.js
@@ -1,0 +1,101 @@
+/*
+* Copyright (c) 2002-2017 "Neo4j, Inc,"
+* Network Engine for Objects in Lund AB [http://neotechnology.com]
+*
+* This file is part of Neo4j.
+*
+* Neo4j is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+/* global test, expect */
+import { getCredentials, getActiveGraph, eventToHandler } from './helpers'
+
+test('getActiveGraph handles non objects and non-active projects', () => {
+  // Given
+  const graphs = [
+    null,
+    'string',
+    undefined,
+    [1],
+    { project: null },
+    { projects: { x: 1 } },
+    { projects: [{ x: 1 }] },
+    { projects: [{ graphs: [{ status: 'NOPE' }] }] }
+  ]
+
+  // When && Then
+  graphs.forEach(graph => {
+    expect(getActiveGraph(graph)).toEqual(null)
+  })
+})
+test('getActiveGraph handles expected objects', () => {
+  // Given
+  const graph = {
+    status: 'ACTIVE',
+    connection: {
+      configuration: {
+        host: 'bolt://host',
+        port: '7687',
+        username: 'username',
+        password: 'password',
+        encrypted: true
+      }
+    }
+  }
+  const apiResponse = {
+    projects: [
+      {
+        graphs: [graph]
+      }
+    ]
+  }
+
+  // When
+  const activeGraph = getActiveGraph(apiResponse)
+
+  // Then
+  expect(activeGraph).toEqual(graph)
+})
+
+test('getCredentials handles non objects', () => {
+  // Given
+  const configs = [null, 'string', undefined, [1]]
+
+  // When && Then
+  configs.forEach(config => {
+    expect(getCredentials('xxx', config)).toBeUndefined()
+  })
+})
+
+test('XXX_YYY -> onXxxYyy', () => {
+  // Given
+  const tests = [
+    { type: undefined, expect: undefined },
+    { type: true, expect: undefined },
+    { type: 'XXX', expect: 'onXxx' },
+    { type: '_XXX', expect: 'onXxx' },
+    { type: 'XXX_YYY', expect: 'onXxxYyy' },
+    { type: 'XXX_YYY_ZZZ', expect: 'onXxxYyyZzz' },
+    { type: 'xxx', expect: 'onXxx' },
+    { type: 'xxx_yyy', expect: 'onXxxYyy' },
+    { type: 'XXX_123', expect: 'onXxx123' },
+    { type: '0', expect: 'on0' },
+    { type: '1', expect: 'on1' },
+    { type: 1, expect: undefined }
+  ]
+
+  // When && Then
+  tests.forEach(test => {
+    expect(eventToHandler(test.type)).toEqual(test.expect)
+  })
+})

--- a/src/browser/components/DesktopIntegration/index.jsx
+++ b/src/browser/components/DesktopIntegration/index.jsx
@@ -24,7 +24,6 @@ import { getActiveGraph, getCredentials, eventToHandler } from './helpers'
 export default class DesktopIntegration extends Component {
   setupListener () {
     const { integrationPoint } = this.props
-    // Run on context updates
     if (integrationPoint && integrationPoint.onContextUpdate) {
       integrationPoint.onContextUpdate((event, newContext, oldContext) => {
         const handlerPropName = eventToHandler(event.type)
@@ -34,7 +33,7 @@ export default class DesktopIntegration extends Component {
       })
     }
   }
-  checkContextForActiveConnection () {
+  loadInitialContext () {
     const { integrationPoint, onMount = null } = this.props
     if (integrationPoint && integrationPoint.getContext) {
       integrationPoint
@@ -53,7 +52,7 @@ export default class DesktopIntegration extends Component {
     }
   }
   componentDidMount () {
-    this.checkContextForActiveConnection()
+    this.loadInitialContext()
     this.setupListener()
   }
   render () {

--- a/src/browser/components/DesktopIntegration/index.jsx
+++ b/src/browser/components/DesktopIntegration/index.jsx
@@ -59,11 +59,11 @@ export default class DesktopIntegration extends Component {
         .catch(e => {}) // Catch but don't bother
     }
   }
-  componentDidMount = () => {
+  componentDidMount () {
     this.checkContextForActiveConnection(this.props)
     this.setupListener(this.props)
   }
-  componentWillReceiveProps = props => {
+  componentWillReceiveProps (props) {
     this.setupListener(props)
   }
   render = () => {

--- a/src/browser/components/DesktopIntegration/index.jsx
+++ b/src/browser/components/DesktopIntegration/index.jsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Component } from 'preact'
+import { getActiveGraph, getCredentials, eventToHandler } from './helpers'
+
+export default class DesktopIntegration extends Component {
+  state = {
+    listenerSetup: false,
+    cachedConnectionCredentials: {}
+  }
+  setupListener = props => {
+    if (this.state.listenerSetup) return
+    const { integrationPoint } = props
+    // Run on context updates
+    if (integrationPoint && integrationPoint.onContextUpdate) {
+      const listenerSetup = () =>
+        integrationPoint.onContextUpdate((event, newContext, oldContext) => {
+          const handlerPropName = eventToHandler(event.type)
+          if (!handlerPropName) return
+          if (typeof this.props[handlerPropName] === 'undefined') return
+          this.props[handlerPropName](event, newContext, oldContext)
+        })
+      this.setState({ listenerSetup: true }, listenerSetup)
+    }
+  }
+  checkContextForActiveConnection = props => {
+    const { integrationPoint } = props
+    if (integrationPoint && integrationPoint.getContext) {
+      integrationPoint
+        .getContext()
+        .then(context => {
+          const activeGraph = getActiveGraph(context)
+          if (this.props.onMount) {
+            const connectionCredentials = getCredentials(
+              'bolt',
+              activeGraph.connection
+            )
+            this.props.onMount(activeGraph, connectionCredentials, context)
+          }
+        })
+        .catch(e => {}) // Catch but don't bother
+    }
+  }
+  componentDidMount = () => {
+    this.checkContextForActiveConnection(this.props)
+    this.setupListener(this.props)
+  }
+  componentWillReceiveProps = props => {
+    this.setupListener(props)
+  }
+  render = () => {
+    return null
+  }
+}

--- a/src/browser/components/DesktopIntegration/index.test.js
+++ b/src/browser/components/DesktopIntegration/index.test.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* global test, expect, jest */
+
+import { mount } from 'services/testUtils'
+import DesktopIntegration from './index'
+
+describe('<DesktopIntegration>', () => {
+  test('does not render anything if no integration point', () => {
+    // Given
+    const integrationPoint = null
+
+    // When
+    const result = mount(DesktopIntegration)
+      .withProps({ integrationPoint })
+      // Then
+      .then(wrapper => {
+        expect(wrapper.text()).toEqual('')
+      })
+
+    // Return test result (promise)
+    return result
+  })
+  test('does not render anything if there is an integration point', () => {
+    // Given
+    const integrationPoint = { x: true }
+
+    // When
+    const result = mount(DesktopIntegration)
+      .withProps({ integrationPoint })
+      // Then
+      .then(wrapper => {
+        expect(wrapper.text()).toEqual('')
+      })
+
+    // Return test result (promise)
+    return result
+  })
+  test('calls onMount with data on mounting', () => {
+    // Given
+    const mFn = jest.fn()
+    const context = {
+      projects: [
+        {
+          graphs: [
+            {
+              status: 'ACTIVE',
+              configuration: {
+                protocols: {
+                  bolt: {
+                    username: 'neo4j'
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    }
+    const integrationPoint = { getContext: () => Promise.resolve(context) }
+
+    // When
+    const result = mount(DesktopIntegration)
+      .withProps({ integrationPoint, onMount: mFn })
+      // Then
+      .then(wrapper => {
+        expect(wrapper.text()).toEqual('')
+        expect(mFn).toHaveBeenCalledTimes(1)
+      })
+
+    // Return test result (promise)
+    return result
+  })
+})

--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -33,7 +33,7 @@ import reducers from 'shared/rootReducer'
 import epics from 'shared/rootEpic'
 
 import { createReduxMiddleware, getAll, applyKeys } from 'services/localstorage'
-import { APP_START } from 'shared/modules/app/appDuck'
+import { APP_START, DESKTOP, WEB } from 'shared/modules/app/appDuck'
 
 // Configure localstorage sync
 applyKeys(
@@ -75,8 +75,11 @@ bus.applyMiddleware((_, origin) => (channel, message, source) => {
   store.dispatch({ ...message, type: channel, ...origin })
 })
 
+// Introduce environment to be able to fork funtionality
+const env = window && window.neo4jDesktopApi ? DESKTOP : WEB
+
 // Signal app upstart (for epics)
-store.dispatch({ type: APP_START, url: window.location.href })
+store.dispatch({ type: APP_START, url: window.location.href, env })
 
 const mountElement = document.getElementById('mount')
 let elem
@@ -85,7 +88,11 @@ const renderApp = () => {
   elem = render(
     <Provider store={store}>
       <BusProvider bus={bus}>
-        <App />
+        <App
+          desktopIntegrationPoint={
+            window && window.neo4jDesktopApi ? window.neo4jDesktopApi : null
+          }
+        />
       </BusProvider>
     </Provider>,
     mountElement,

--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -173,6 +173,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     const creds = getActiveCredentials('bolt', newContext)
     if (!creds) return // No conection. Ignore and let browser show connection lost msgs.
     const connectionCreds = {
+      // Use current connections creds until we get new from API
       ...stateProps.connectionData,
       encrypted: creds.tlsLevel === 'REQUIRED',
       host: `bolt://${creds.host}:${creds.port}`

--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -38,10 +38,10 @@ import {
   getActiveConnection,
   getConnectionState,
   getActiveConnectionData,
-  isConnected
+  isConnected,
+  SWITCH_CONNECTION
 } from 'shared/modules/connections/connectionsDuck'
 import { toggle } from 'shared/modules/sidebar/sidebarDuck'
-
 import {
   StyledWrapper,
   StyledApp,
@@ -56,6 +56,7 @@ import asTitleString from '../DocTitle/titleStringBuilder'
 import Intercom from '../Intercom'
 import Render from 'browser-components/Render'
 import BrowserSyncInit from '../Sync/BrowserSyncInit'
+import DesktopIntegration from 'browser-components/DesktopIntegration'
 import { getMetadata, getUserAuthStatus } from 'shared/modules/sync/syncDuck'
 
 class App extends Component {
@@ -98,6 +99,10 @@ class App extends Component {
         <StyledWrapper>
           <DocTitle titleString={this.props.titleString} />
           <UserInteraction />
+          <DesktopIntegration
+            integrationPoint={this.props.desktopIntegrationPoint}
+            onConnectionChange={this.props.changeConnection}
+          />
           <Render if={loadExternalScripts}>
             <Intercom appID='lq70afwx' />
           </Render>
@@ -156,4 +161,20 @@ const mapDispatchToProps = dispatch => {
   }
 }
 
-export default withBus(connect(mapStateToProps, mapDispatchToProps)(App))
+const mergeProps = (stateProps, dispatchProps, ownProps) => {
+  const changeConnection = creds => {
+    console.log('ownProps.activeConnection: ', stateProps)
+    console.log('creds: ', creds)
+    ownProps.bus.send(SWITCH_CONNECTION, creds)
+  }
+  return {
+    ...stateProps,
+    ...ownProps,
+    ...dispatchProps,
+    changeConnection
+  }
+}
+
+export default withBus(
+  connect(mapStateToProps, mapDispatchToProps, mergeProps)(App)
+)

--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -64,7 +64,6 @@ import Render from 'browser-components/Render'
 import BrowserSyncInit from '../Sync/BrowserSyncInit'
 import DesktopIntegration from 'browser-components/DesktopIntegration'
 import {
-  didChangeActiveGraph,
   getActiveCredentials,
   getActiveGraph
 } from 'browser-components/DesktopIntegration/helpers'
@@ -113,8 +112,8 @@ class App extends Component {
           <DesktopIntegration
             integrationPoint={this.props.desktopIntegrationPoint}
             onMount={this.props.setInitialConnectionData}
-            onDatabaseStarted={this.props.changeConnectionMaybe}
-            onDatabaseStopped={this.props.closeConnectionMaybe}
+            onGraphActive={this.props.switchConnection}
+            onGraphInactive={this.props.closeConnectionMaybe}
           />
           <Render if={loadExternalScripts}>
             <Intercom appID='lq70afwx' />
@@ -176,14 +175,13 @@ const mapDispatchToProps = dispatch => {
 }
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
-  const changeConnectionMaybe = (event, newContext, oldContext) => {
-    const didChange = didChangeActiveGraph(newContext, oldContext)
-    if (!didChange) return
+  const switchConnection = (event, newContext, oldContext) => {
     const creds = getActiveCredentials('bolt', newContext)
     if (!creds) return // No conection. Ignore and let browser show connection lost msgs.
     const connectionCreds = {
       // Use current connections creds until we get new from API
       ...stateProps.defaultConnectionData,
+      ...creds,
       encrypted: creds.tlsLevel === 'REQUIRED',
       host: `bolt://${creds.host}:${creds.port}`
     }
@@ -209,7 +207,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     ...stateProps,
     ...ownProps,
     ...dispatchProps,
-    changeConnectionMaybe,
+    switchConnection,
     setInitialConnectionData,
     closeConnectionMaybe
   }

--- a/src/browser/modules/Stream/Auth/ConnectedView.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectedView.jsx
@@ -29,22 +29,34 @@ const ConnectedView = ({
   host,
   username,
   storeCredentials,
+  hideStoreCredentials = false,
+  additionalFooter = null,
   showHost = true
 }) => {
   return (
     <StyledConnectionBody>
-      You are connected as user <StyledCode>{username}</StyledCode>
-      <br />
+      <Render if={username}>
+        <span>
+          You are connected as user <StyledCode>{username}</StyledCode>
+          <br />
+        </span>
+      </Render>
+      <Render if={!username}>You are connected </Render>
       <Render if={showHost}>
         <span>
           to the server <StyledCode>{host}</StyledCode>
           <br />
         </span>
       </Render>
-      <StyledConnectionFooter>
-        Connection credentials are {storeCredentials ? '' : 'not '}stored in
-        your web browser.
-      </StyledConnectionFooter>
+      <Render if={!hideStoreCredentials}>
+        <StyledConnectionFooter>
+          Connection credentials are {storeCredentials ? '' : 'not '}stored in
+          your web browser.
+        </StyledConnectionFooter>
+      </Render>
+      <Render if={additionalFooter}>
+        <StyledConnectionFooter>{additionalFooter}</StyledConnectionFooter>
+      </Render>
     </StyledConnectionBody>
   )
 }

--- a/src/browser/modules/Stream/Auth/ConnectionForm.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectionForm.jsx
@@ -54,7 +54,8 @@ export class ConnectionForm extends Component {
       passwordChangeNeeded: props.passwordChangeNeeded || false,
       forcePasswordChange: props.forcePasswordChange || false,
       successCallback: props.onSuccess || (() => {}),
-      used: isConnected
+      used: isConnected,
+      storeCredentials: this.props.storeCredentials
     }
   }
   connect (doneFn = () => {}) {
@@ -170,9 +171,9 @@ export class ConnectionForm extends Component {
     } else if (this.state.isConnected) {
       view = (
         <ConnectedView
-          host={this.props.activeConnectionData.host}
-          username={this.props.activeConnectionData.username}
-          storeCredentials={this.props.storeCredentials}
+          host={this.state.host}
+          username={this.state.username}
+          storeCredentials={this.state.storeCredentials}
         />
       )
     } else if (!this.state.isConnected && !this.state.passwordChangeNeeded) {

--- a/src/browser/modules/Stream/Auth/ServerSwitchFrame.jsx
+++ b/src/browser/modules/Stream/Auth/ServerSwitchFrame.jsx
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Component } from 'preact'
+import { connect } from 'preact-redux'
+import FrameTemplate from '../FrameTemplate'
+import {
+  StyledConnectionFrame,
+  StyledConnectionAside,
+  StyledConnectionBodyContainer,
+  StyledConnectionBody
+} from './styled'
+import ConnectedView from './ConnectedView'
+import { H3 } from 'browser-components/headers'
+import Render from 'browser-components/Render'
+import ClickToCode from '../../ClickToCode'
+import {
+  getActiveConnectionData,
+  getActiveConnection
+} from 'shared/modules/connections/connectionsDuck'
+import { shouldRetainConnectionCredentials } from 'shared/modules/dbMeta/dbMetaDuck'
+
+class ServerStatusFrame extends Component {
+  render () {
+    const { frame, activeConnectionData, storeCredentials } = this.props
+
+    return (
+      <FrameTemplate
+        header={frame}
+        contents={
+          <StyledConnectionFrame>
+            <StyledConnectionAside>
+              <span>
+                <H3>Connection updated</H3>
+                You have switched connection.
+              </span>
+            </StyledConnectionAside>
+            <StyledConnectionBodyContainer>
+              <Render if={frame.type === 'switch-fail'}>
+                <StyledConnectionBody>
+                  The updated credentials was not correct.
+                  <br />
+                  You are now disconnected.
+                  <br />
+                  Execute <ClickToCode>:server connect</ClickToCode> to manually
+                  enter credentials.
+                </StyledConnectionBody>
+              </Render>
+              <Render
+                if={
+                  frame.type === 'switch-success' &&
+                  activeConnectionData &&
+                  activeConnectionData.authEnabled
+                }
+              >
+                <ConnectedView
+                  host={activeConnectionData && activeConnectionData.host}
+                  username={
+                    activeConnectionData && activeConnectionData.username
+                  }
+                  showHost
+                  storeCredentials={storeCredentials}
+                />
+              </Render>
+              <Render
+                if={
+                  frame.type === 'switch-success' &&
+                  activeConnectionData &&
+                  !activeConnectionData.authEnabled
+                }
+              >
+                <StyledConnectionBody>
+                  You have a working connection with the Neo4j database and
+                  server auth is disabled.
+                </StyledConnectionBody>
+              </Render>
+            </StyledConnectionBodyContainer>
+          </StyledConnectionFrame>
+        }
+      />
+    )
+  }
+}
+
+const mapStateToProps = state => {
+  return {
+    activeConnection: getActiveConnection(state),
+    activeConnectionData: getActiveConnectionData(state),
+    storeCredentials: shouldRetainConnectionCredentials(state)
+  }
+}
+
+export default connect(mapStateToProps, null)(ServerStatusFrame)

--- a/src/browser/modules/Stream/Auth/ServerSwitchFrame.jsx
+++ b/src/browser/modules/Stream/Auth/ServerSwitchFrame.jsx
@@ -33,7 +33,10 @@ import ClickToCode from '../../ClickToCode'
 
 class ServerStatusFrame extends Component {
   render () {
-    const { frame } = this.props
+    const {
+      frame,
+      activeConnectionData: dynamicConnectionData = {}
+    } = this.props
     const { activeConnectionData, storeCredentials } = frame
     return (
       <FrameTemplate
@@ -49,7 +52,8 @@ class ServerStatusFrame extends Component {
             <StyledConnectionBodyContainer>
               <Render if={frame.type === 'switch-fail'}>
                 <StyledConnectionBody>
-                  The updated credentials was not correct.
+                  The connection credentials provided could not be used to
+                  connect.
                   <br />
                   You are now disconnected.
                   <br />
@@ -61,7 +65,8 @@ class ServerStatusFrame extends Component {
                 if={
                   frame.type === 'switch-success' &&
                   activeConnectionData &&
-                  activeConnectionData.authEnabled
+                  dynamicConnectionData &&
+                  dynamicConnectionData.authEnabled
                 }
               >
                 <ConnectedView
@@ -77,13 +82,18 @@ class ServerStatusFrame extends Component {
                 if={
                   frame.type === 'switch-success' &&
                   activeConnectionData &&
-                  !activeConnectionData.authEnabled
+                  dynamicConnectionData &&
+                  !dynamicConnectionData.authEnabled
                 }
               >
-                <StyledConnectionBody>
-                  You have a working connection with the Neo4j database and
-                  server auth is disabled.
-                </StyledConnectionBody>
+                <div>
+                  <ConnectedView
+                    host={activeConnectionData && activeConnectionData.host}
+                    showHost
+                    hideStoreCredentials
+                    additionalFooter='You have a working connection with the Neo4j database and server auth is disabled.'
+                  />
+                </div>
               </Render>
             </StyledConnectionBodyContainer>
           </StyledConnectionFrame>

--- a/src/browser/modules/Stream/Auth/ServerSwitchFrame.jsx
+++ b/src/browser/modules/Stream/Auth/ServerSwitchFrame.jsx
@@ -19,7 +19,6 @@
  */
 
 import { Component } from 'preact'
-import { connect } from 'preact-redux'
 import FrameTemplate from '../FrameTemplate'
 import {
   StyledConnectionFrame,
@@ -31,16 +30,11 @@ import ConnectedView from './ConnectedView'
 import { H3 } from 'browser-components/headers'
 import Render from 'browser-components/Render'
 import ClickToCode from '../../ClickToCode'
-import {
-  getActiveConnectionData,
-  getActiveConnection
-} from 'shared/modules/connections/connectionsDuck'
-import { shouldRetainConnectionCredentials } from 'shared/modules/dbMeta/dbMetaDuck'
 
 class ServerStatusFrame extends Component {
   render () {
-    const { frame, activeConnectionData, storeCredentials } = this.props
-
+    const { frame } = this.props
+    const { activeConnectionData, storeCredentials } = frame
     return (
       <FrameTemplate
         header={frame}
@@ -99,12 +93,4 @@ class ServerStatusFrame extends Component {
   }
 }
 
-const mapStateToProps = state => {
-  return {
-    activeConnection: getActiveConnection(state),
-    activeConnectionData: getActiveConnectionData(state),
-    storeCredentials: shouldRetainConnectionCredentials(state)
-  }
-}
-
-export default connect(mapStateToProps, null)(ServerStatusFrame)
+export default ServerStatusFrame

--- a/src/browser/modules/Stream/Stream.jsx
+++ b/src/browser/modules/Stream/Stream.jsx
@@ -35,6 +35,7 @@ import SysInfoFrame from './SysInfoFrame'
 import ConnectionFrame from './Auth/ConnectionFrame'
 import DisconnectFrame from './Auth/DisconnectFrame'
 import ServerStatusFrame from './Auth/ServerStatusFrame'
+import ServerSwitchFrame from './Auth/ServerSwitchFrame'
 import ChangePasswordFrame from './Auth/ChangePasswordFrame'
 import QueriesFrame from './Queries/QueriesFrame'
 import UserList from '../User/UserList'
@@ -45,6 +46,7 @@ import { getScrollToTop } from 'shared/modules/settings/settingsDuck'
 import { deepEquals } from 'services/utils'
 
 const getFrame = type => {
+  console.log('type: ', type)
   const trans = {
     error: ErrorFrame,
     cypher: CypherFrame,
@@ -64,6 +66,8 @@ const getFrame = type => {
     queries: QueriesFrame,
     sysinfo: SysInfoFrame,
     status: ServerStatusFrame,
+    'switch-success': ServerSwitchFrame,
+    'switch-fail': ServerSwitchFrame,
     default: Frame
   }
   return trans[type] || trans['default']

--- a/src/browser/modules/Stream/Stream.jsx
+++ b/src/browser/modules/Stream/Stream.jsx
@@ -46,7 +46,6 @@ import { getScrollToTop } from 'shared/modules/settings/settingsDuck'
 import { deepEquals } from 'services/utils'
 
 const getFrame = type => {
-  console.log('type: ', type)
   const trans = {
     error: ErrorFrame,
     cypher: CypherFrame,

--- a/src/shared/modules/app/appDuck.js
+++ b/src/shared/modules/app/appDuck.js
@@ -23,14 +23,20 @@ export const NAME = 'app'
 export const APP_START = `${NAME}/APP_START`
 export const USER_CLEAR = `${NAME}/USER_CLEAR`
 
+// State constants
+export const DESKTOP = 'DESKTOP'
+export const WEB = 'WEB'
+
 // Selectors
 export const getHostedUrl = state => (state[NAME] || {}).hostedUrl || null
+export const getEnv = state => (state[NAME] || {}).env || WEB
+export const inWebEnv = state => getEnv(state) === WEB
 
 // Reducer
 export default function reducer (state = { hostedUrl: null }, action) {
   switch (action.type) {
     case APP_START:
-      return { ...state, hostedUrl: action.url }
+      return { ...state, hostedUrl: action.url, env: action.env }
     default:
       return state
   }

--- a/src/shared/modules/commands/helpers/server.js
+++ b/src/shared/modules/commands/helpers/server.js
@@ -22,6 +22,7 @@ import { splitStringOnFirst, splitStringOnLast } from 'services/commandUtils'
 import * as connections from 'shared/modules/connections/connectionsDuck'
 import { add as addFrameAction } from 'shared/modules/stream/streamDuck'
 import { CONNECTION_ID as DISCOVERY_CONNECTION_ID } from 'shared/modules/discovery/discoveryDuck'
+import { shouldRetainConnectionCredentials } from 'shared/modules/dbMeta/dbMetaDuck'
 import {
   UnknownCommandError,
   getErrorMessage,
@@ -55,7 +56,7 @@ export function handleServerCommand (action, cmdchar, put, store) {
     return handleServerStatusCommand(action)
   }
   if (serverCmd === 'switch') {
-    return handleServerSwitchCommand(action, props)
+    return handleServerSwitchCommand(action, props, store)
   }
   return {
     ...action,
@@ -131,10 +132,21 @@ function handleServerStatusCommand (action) {
   return { ...action, type: 'status' }
 }
 
-function handleServerSwitchCommand (action, props) {
+function handleServerSwitchCommand (action, props, store) {
   switch (props) {
     case 'success':
-      return { ...action, type: 'switch-success' }
+      const activeConnectionData = connections.getActiveConnectionData(
+        store.getState()
+      )
+      const storeCredentials = shouldRetainConnectionCredentials(
+        store.getState()
+      )
+      return {
+        ...action,
+        type: 'switch-success',
+        activeConnectionData,
+        storeCredentials
+      }
     case 'fail':
       return { ...action, type: 'switch-fail' }
   }

--- a/src/shared/modules/commands/helpers/server.js
+++ b/src/shared/modules/commands/helpers/server.js
@@ -54,6 +54,9 @@ export function handleServerCommand (action, cmdchar, put, store) {
   if (serverCmd === 'status') {
     return handleServerStatusCommand(action)
   }
+  if (serverCmd === 'switch') {
+    return handleServerSwitchCommand(action, props)
+  }
   return {
     ...action,
     type: 'error',
@@ -126,4 +129,13 @@ function handleServerAddCommand (action, cmdchar, put, store) {
 
 function handleServerStatusCommand (action) {
   return { ...action, type: 'status' }
+}
+
+function handleServerSwitchCommand (action, props) {
+  switch (props) {
+    case 'success':
+      return { ...action, type: 'switch-success' }
+    case 'fail':
+      return { ...action, type: 'switch-fail' }
+  }
 }

--- a/src/shared/modules/connections/connectionsDuck.js
+++ b/src/shared/modules/connections/connectionsDuck.js
@@ -459,6 +459,8 @@ export const switchConnectionEpic = (action$, store) => {
     .do(() => store.dispatch(updateConnectionState(PENDING_STATE)))
     .mergeMap(action => {
       bolt.closeConnection()
+      const connectionInfo = { id: discovery.CONNECTION_ID, ...action }
+      store.dispatch(updateConnection(connectionInfo))
       return new Promise((resolve, reject) => {
         bolt
           .openConnection(
@@ -467,8 +469,6 @@ export const switchConnectionEpic = (action$, store) => {
             onLostConnection(store.dispatch)
           )
           .then(connection => {
-            const connectionInfo = { id: discovery.CONNECTION_ID, ...action }
-            store.dispatch(updateConnection(connectionInfo))
             store.dispatch(setActiveConnection(discovery.CONNECTION_ID))
             resolve({ type: SWTICH_CONNECTION_SUCCESS })
           })

--- a/src/shared/modules/discovery/discoveryDuck.js
+++ b/src/shared/modules/discovery/discoveryDuck.js
@@ -21,7 +21,7 @@
 import Rx from 'rxjs/Rx'
 import remote from 'services/remote'
 import { updateConnection } from 'shared/modules/connections/connectionsDuck'
-import { APP_START, USER_CLEAR } from 'shared/modules/app/appDuck'
+import { APP_START, USER_CLEAR, WEB } from 'shared/modules/app/appDuck'
 import { updateBoltRouting } from 'shared/modules/settings/settingsDuck'
 import { getDiscoveryEndpoint } from 'services/bolt/boltHelpers'
 import { getUrlParamValue, toBoltHost, isRoutingHost } from 'services/utils'
@@ -77,6 +77,7 @@ export const discoveryOnStartupEpic = (some$, store) => {
     .map(action => {
       if (action.type !== APP_START) return action // Only read on app startup
       if (!action.url) return action
+      if (action.env !== WEB) return action // Only when in a web environment
       const passedURL = getUrlParamValue('connectURL', action.url)
       if (!passedURL || !passedURL.length) return action
       const forceURL = decodeURIComponent(passedURL[0])
@@ -91,6 +92,7 @@ export const discoveryOnStartupEpic = (some$, store) => {
       return action
     })
     .mergeMap(action => {
+      if (action.env !== WEB) return Promise.resolve() // Only when in a web environment
       if (action.forceURL) {
         let updateAction
         if (action.username && action.password) {

--- a/src/shared/modules/discovery/discoveryDuck.js
+++ b/src/shared/modules/discovery/discoveryDuck.js
@@ -21,7 +21,7 @@
 import Rx from 'rxjs/Rx'
 import remote from 'services/remote'
 import { updateConnection } from 'shared/modules/connections/connectionsDuck'
-import { APP_START, USER_CLEAR, WEB } from 'shared/modules/app/appDuck'
+import { APP_START, USER_CLEAR, inWebEnv } from 'shared/modules/app/appDuck'
 import { updateBoltRouting } from 'shared/modules/settings/settingsDuck'
 import { getDiscoveryEndpoint } from 'services/bolt/boltHelpers'
 import { getUrlParamValue, toBoltHost, isRoutingHost } from 'services/utils'
@@ -77,7 +77,7 @@ export const discoveryOnStartupEpic = (some$, store) => {
     .map(action => {
       if (action.type !== APP_START) return action // Only read on app startup
       if (!action.url) return action
-      if (action.env !== WEB) return action // Only when in a web environment
+      if (!inWebEnv(store)) return action // Only when in a web environment
       const passedURL = getUrlParamValue('connectURL', action.url)
       if (!passedURL || !passedURL.length) return action
       const forceURL = decodeURIComponent(passedURL[0])
@@ -92,7 +92,7 @@ export const discoveryOnStartupEpic = (some$, store) => {
       return action
     })
     .mergeMap(action => {
-      if (action.env !== WEB) return Promise.resolve() // Only when in a web environment
+      if (!inWebEnv(store)) return Promise.resolve() // Only when in a web environment
       if (action.forceURL) {
         let updateAction
         if (action.username && action.password) {

--- a/src/shared/modules/discovery/discoveryDuck.test.js
+++ b/src/shared/modules/discovery/discoveryDuck.test.js
@@ -25,7 +25,7 @@ import { createBus, createReduxMiddleware } from 'suber'
 import nock from 'nock'
 
 import * as discovery from './discoveryDuck'
-import { APP_START } from 'shared/modules/app/appDuck'
+import { APP_START, WEB } from 'shared/modules/app/appDuck'
 import { updateBoltRouting } from 'shared/modules/settings/settingsDuck'
 import { getDiscoveryEndpoint } from 'services/bolt/boltHelpers'
 
@@ -85,7 +85,7 @@ describe('discoveryOnStartupEpic', () => {
 
   test('listens on APP_START and finds a bolt host and dispatches an action with the found host', done => {
     // Given
-    const action = { type: APP_START }
+    const action = { type: APP_START, env: WEB }
     const expectedHost = 'bolt://myhost:7777'
     nock(getDiscoveryEndpoint())
       .get('/')

--- a/src/shared/rootEpic.js
+++ b/src/shared/rootEpic.js
@@ -44,7 +44,10 @@ import {
   clearMetaOnDisconnectEpic
 } from './modules/dbMeta/dbMetaDuck'
 import { cancelRequestEpic } from './modules/requests/requestsDuck'
-import { discoveryOnStartupEpic } from './modules/discovery/discoveryDuck'
+import {
+  discoveryOnStartupEpic,
+  injectDiscoveryEpic
+} from './modules/discovery/discoveryDuck'
 import { clearLocalstorageEpic } from './modules/localstorage/localstorageDuck'
 import { populateEditorFromUrlEpic } from './modules/editor/editorDuck'
 import {
@@ -94,6 +97,7 @@ export default combineEpics(
   clearMetaOnDisconnectEpic,
   cancelRequestEpic,
   discoveryOnStartupEpic,
+  injectDiscoveryEpic,
   populateEditorFromUrlEpic,
   adHocCypherRequestEpic,
   cypherRequestEpic,

--- a/src/shared/rootEpic.js
+++ b/src/shared/rootEpic.js
@@ -37,7 +37,8 @@ import {
   connectionLostEpic,
   switchConnectionEpic,
   switchConnectionSuccessEpic,
-  switchConnectionFailEpic
+  switchConnectionFailEpic,
+  silentDisconnectEpic
 } from './modules/connections/connectionsDuck'
 import {
   dbMetaEpic,
@@ -88,6 +89,7 @@ export default combineEpics(
   checkSettingsForRoutingDriver,
   connectEpic,
   disconnectEpic,
+  silentDisconnectEpic,
   startupConnectEpic,
   disconnectSuccessEpic,
   startupConnectionSuccessEpic,

--- a/src/shared/rootEpic.js
+++ b/src/shared/rootEpic.js
@@ -34,7 +34,10 @@ import {
   startupConnectionSuccessEpic,
   startupConnectionFailEpic,
   detectActiveConnectionChangeEpic,
-  connectionLostEpic
+  connectionLostEpic,
+  switchConnectionEpic,
+  switchConnectionSuccessEpic,
+  switchConnectionFailEpic
 } from './modules/connections/connectionsDuck'
 import {
   dbMetaEpic,
@@ -75,6 +78,9 @@ export default combineEpics(
   postConnectCmdEpic,
   fetchGuideFromWhitelistEpic,
   connectionLostEpic,
+  switchConnectionEpic,
+  switchConnectionSuccessEpic,
+  switchConnectionFailEpic,
   retainCredentialsSettingsEpic,
   checkSettingsForRoutingDriver,
   connectEpic,

--- a/src/shared/services/bolt/boltHelpers.js
+++ b/src/shared/services/bolt/boltHelpers.js
@@ -22,7 +22,10 @@
 import bolt from './bolt'
 import { getUrlInfo } from 'services/utils'
 
-export const getEncryptionMode = () => {
+export const getEncryptionMode = options => {
+  if (options && typeof options['encrypted'] !== 'undefined') {
+    return options.encrypted
+  }
   return location.protocol === 'https:'
 }
 

--- a/src/shared/services/testUtils.js
+++ b/src/shared/services/testUtils.js
@@ -20,11 +20,15 @@
 
 import { mount as enyzmeMount } from 'enzyme'
 
-export const mount = Component => {
-  const wrapper = enyzmeMount(<Component />)
+export const mount = (Component, props = {}) => {
+  const wrapper = enyzmeMount(<Component {...props} />)
   return {
-    withProps: props => {
-      wrapper.setProps(props)
+    then: () => {
+      wrapper.update()
+      return Promise.resolve(wrapper)
+    },
+    withProps: (props = null) => {
+      if (props) wrapper.setProps(props)
       wrapper.update()
       return Promise.resolve(wrapper)
     }


### PR DESCRIPTION
## New component
We added the `DesktopIntegration` component which reads initial context and sets up a listener for events that the desktop att emits.
To react on events happening you attach props to the component in the form of `EVENT_NAME` -> `onEventName`.   
Example on react on `DATABASE_STARTED` -> 

```javascript
<DesktopIntegration 
  integrationPoint={window.neo4jDesktopApi} 
  onDatabaseStarted={(event, newContext, oldConext) => alert(event.type)}  
/>
```

To get the initial context on app load, you attach the 

```javascript
onMount={(activeGraph, boltCredentials, fullContext) => alert(activeGraph.id)}
```

## Features
In web env, no changes are expected.
In desktop env, this should be the behaviour:

**When browser is opened when a graph already is running:**
  - Get host + port from desktop api and populate the connection fields with those.
  - In the case of username and pw in browsers local storage not being correct, show `:server connect` and the host should be what the active graph has.
  - In the case of username and pw being correct, connect and show start frame.

**When browser is open and connected and graph is shut down:**
  - Show connect banner right away
  - Empty metadata
  - Keep username and pw in memory

**When browser is open but not connected to a graph and a graph starts:**
  - Get credentials (host and encryption mode) from desktop api and re-use stored username and pw and try to connect.
  - If successful
    - Show `:server switch success` frame and inform about the connection switch.
    - Update metadata
  - If unsuccessful
    - Show `:server switch fail` frame and inform about the failure
    - User clicks `:server connect` link to manually enter creds.

## Worth mentions

- To our `mount` function in `testUtils.js` we can now pass a second param with props to get to test the `componentDidMount` lifecycle method.
- Environment detection added. In `appDuck.js` there are now selectors to check what environment the browser lives in. Useful for code branching.
- The plan is that the functions in `DesktopIntegration/helpers.js` should be used by outside components to extract and compare data coming from the desktop api.

<img width="924" alt="oskarhane-mbpt 2017-10-13 at 13 59 05" src="https://user-images.githubusercontent.com/570998/31550584-2527921e-b032-11e7-86bf-528b59675e77.png">