### PR TITLE
Add button to confirm the deletion of favorites and folders

### DIFF
--- a/src/browser/components/buttons/ConfirmationButton.jsx
+++ b/src/browser/components/buttons/ConfirmationButton.jsx
@@ -19,12 +19,21 @@
  */
 
 import { Component } from 'preact'
-import styles from './style.css'
+import styled from 'styled-components'
 import {
   MinusIcon,
   RightArrowIcon,
   CancelIcon
 } from 'browser-components/icons/Icons'
+
+const IconButton = styled.button`
+  margin-left: 4px;
+  border: 0;
+  background: transparent;
+  &:focus {
+    outline: none;
+  }
+`
 
 export class ConfirmationButton extends Component {
   constructor (props) {
@@ -44,32 +53,25 @@ export class ConfirmationButton extends Component {
   render () {
     if (this.state.requested) {
       return (
-        <div>
-          <button
-            className={styles.icon}
+        <span>
+          <IconButton
             onClick={() => {
               this.setState({ requested: false })
               this.props.onConfirmed()
             }}
           >
             {this.confirmIcon}
-          </button>
-          <button
-            className={styles.icon}
-            onClick={() => this.setState({ requested: false })}
-          >
+          </IconButton>
+          <IconButton onClick={() => this.setState({ requested: false })}>
             {this.cancelIcon}
-          </button>
-        </div>
+          </IconButton>
+        </span>
       )
     } else {
       return (
-        <button
-          className={styles.icon}
-          onClick={() => this.setState({ requested: true })}
-        >
+        <IconButton onClick={() => this.setState({ requested: true })}>
           {this.requestIcon}
-        </button>
+        </IconButton>
       )
     }
   }

--- a/src/browser/components/buttons/style.css
+++ b/src/browser/components/buttons/style.css
@@ -1,9 +1,3 @@
-.icon {
-  min-width: 40px !important;
-  top: 4px !important;
-  border: 0;
-  background: transparent;
-}
 .tooltip {
   position: absolute;
   background-color: grey;

--- a/src/browser/components/icons/Icons.jsx
+++ b/src/browser/components/icons/Icons.jsx
@@ -206,8 +206,8 @@ export const ZoomOutIcon = () => (
 
 export const BinIcon = props => (
   <IconContainer
-    activeStyle={styles.white}
-    inactiveStyle={styles.inactive}
+    activeStyle={props.deleteAction ? styles.warningRed : styles.white}
+    inactiveStyle={props.deleteAction ? styles.warningRed : styles.white}
     {...props}
     className='sl-bin'
   />

--- a/src/browser/modules/Sidebar/Favorite.jsx
+++ b/src/browser/modules/Sidebar/Favorite.jsx
@@ -133,6 +133,7 @@ class FavoriteDp extends Component {
         <SytledFavFolderButtonSpan>
           <ConfirmationButton
             requestIcon={<BinIcon />}
+            confirmIcon={<BinIcon deleteAction />}
             onConfirmed={() => this.props.removeClick(this.props.id)}
           />
         </SytledFavFolderButtonSpan>

--- a/src/browser/modules/Sidebar/Favorite.jsx
+++ b/src/browser/modules/Sidebar/Favorite.jsx
@@ -29,7 +29,6 @@ import ItemTypes from './DragItemTypes'
 import {
   StyledListItem,
   StyledFavoriteText,
-  DeleteFavButton,
   ExecFavoriteButton,
   SytledFavFolderButtonSpan
 } from './styled'

--- a/src/browser/modules/Sidebar/Favorite.jsx
+++ b/src/browser/modules/Sidebar/Favorite.jsx
@@ -19,17 +19,20 @@
  */
 
 import { connect } from 'preact-redux'
+import { withBus } from 'preact-suber'
+import { Component } from 'preact'
+import { DragSource, DropTarget } from 'react-dnd'
 import * as favorite from 'shared/modules/favorites/favoritesDuck'
+import { ConfirmationButton } from 'browser-components/buttons/ConfirmationButton'
+import { BinIcon } from 'browser-components/icons/Icons'
+import ItemTypes from './DragItemTypes'
 import {
   StyledListItem,
   StyledFavoriteText,
   DeleteFavButton,
-  ExecFavoriteButton
+  ExecFavoriteButton,
+  SytledFavFolderButtonSpan
 } from './styled'
-import { withBus } from 'preact-suber'
-import { Component } from 'preact'
-import { DragSource, DropTarget } from 'react-dnd'
-import ItemTypes from './DragItemTypes'
 
 function extractNameFromCommand (input) {
   if (!input) {
@@ -127,11 +130,13 @@ class FavoriteDp extends Component {
         >
           {name}
         </StyledFavoriteText>
-        <DeleteFavButton
-          id={this.props.id}
-          removeClick={() => this.props.removeClick(this.props.id)}
-          isStatic={this.props.isStatic}
-        />
+
+        <SytledFavFolderButtonSpan>
+          <ConfirmationButton
+            requestIcon={<BinIcon />}
+            onConfirmed={() => this.props.removeClick(this.props.id)}
+          />
+        </SytledFavFolderButtonSpan>
       </StyledListItem>
     )
 

--- a/src/browser/modules/Sidebar/Folder.jsx
+++ b/src/browser/modules/Sidebar/Folder.jsx
@@ -104,6 +104,7 @@ class Folder extends Component {
               <SytledFavFolderButtonSpan>
                 <ConfirmationButton
                   requestIcon={<BinIcon />}
+                  confirmIcon={<BinIcon deleteAction />}
                   onConfirmed={() =>
                     this.props.removeClick(this.props.folder.id)}
                 />

--- a/src/browser/modules/Sidebar/Folder.jsx
+++ b/src/browser/modules/Sidebar/Folder.jsx
@@ -18,23 +18,25 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { Component } from 'preact'
+import { DropTarget } from 'react-dnd'
+import Render from 'browser-components/Render'
+import { ConfirmationButton } from 'browser-components/buttons/ConfirmationButton'
+import {
+  CollapseMenuIcon,
+  ExpandMenuIcon,
+  BinIcon
+} from 'browser-components/icons/Icons'
+import ItemTypes from './DragItemTypes'
 import {
   FoldersButton,
   StyledList,
   StyledListHeaderItem,
-  DeleteFavButton,
+  SytledFavFolderButtonSpan,
   EditFolderButton,
   FolderButtonContainer,
   EditFolderInput
 } from './styled'
-import { Component } from 'preact'
-import {
-  CollapseMenuIcon,
-  ExpandMenuIcon
-} from 'browser-components/icons/Icons'
-import { DropTarget } from 'react-dnd'
-import Render from 'browser-components/Render'
-import ItemTypes from './DragItemTypes'
 
 class Folder extends Component {
   constructor (props) {
@@ -99,11 +101,13 @@ class Folder extends Component {
                   }}
                 />
               </Render>&nbsp;
-              <DeleteFavButton
-                id={this.props.folder.id}
-                removeClick={this.props.removeClick}
-                isStatic={this.props.folder.isStatic}
-              />
+              <SytledFavFolderButtonSpan>
+                <ConfirmationButton
+                  requestIcon={<BinIcon />}
+                  onConfirmed={() =>
+                    this.props.removeClick(this.props.folder.id)}
+                />
+              </SytledFavFolderButtonSpan>
             </FolderButtonContainer>
           </StyledListHeaderItem>
           {this.state.active ? this.props.children : null}

--- a/src/browser/modules/Sidebar/styled.jsx
+++ b/src/browser/modules/Sidebar/styled.jsx
@@ -87,7 +87,7 @@ export const StyledListHeaderItem = styled.li`
 `
 export const StyledFavoriteText = styled.span`
   font-family: ${props => props.theme.primaryFontFamily};
-  width: 172px;
+  width: 168px;
   color: #bcc0c9;
   font-size: 13px;
   display: inline-block;

--- a/src/browser/modules/Sidebar/styled.jsx
+++ b/src/browser/modules/Sidebar/styled.jsx
@@ -87,7 +87,7 @@ export const StyledListHeaderItem = styled.li`
 `
 export const StyledFavoriteText = styled.span`
   font-family: ${props => props.theme.primaryFontFamily};
-  width: 182px;
+  width: 172px;
   color: #bcc0c9;
   font-size: 13px;
   display: inline-block;
@@ -110,7 +110,7 @@ const NewFolderStyledButton = styled.button`
   outline: none;
 `
 
-const SytledFavFolderButtonSpan = styled.span`float: right;`
+export const SytledFavFolderButtonSpan = styled.span`float: right;`
 
 export const FolderButtonContainer = styled.span`float: right;`
 


### PR DESCRIPTION
Reuses existing `<ConfirmationButton />` component
![confirm-remove](https://user-images.githubusercontent.com/849508/31628660-4a8ecb02-b2a9-11e7-9e6e-7a2d2dba8fda.gif)
