### PR TITLE
Show new sync banner when not accepted terms yet

### DIFF
--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -29,12 +29,12 @@ import {
   getBrowserSyncConfig
 } from 'shared/modules/settings/settingsDuck'
 import { FOCUS, EXPAND } from 'shared/modules/editor/editorDuck'
+import { useBrowserSync } from 'shared/modules/features/featuresDuck'
 import {
   wasUnknownCommand,
   getErrorMessage
 } from 'shared/modules/commands/commandsDuck'
 import { allowOutgoingConnections } from 'shared/modules/dbMeta/dbMetaDuck'
-import { inWebEnv } from 'shared/modules/app/appDuck'
 import {
   getActiveConnection,
   getConnectionState,
@@ -137,6 +137,7 @@ class App extends Component {
                   connectionState={connectionState}
                   showUnknownCommandBanner={showUnknownCommandBanner}
                   errorMessage={errorMessage}
+                  useBrowserSync={loadSync}
                 />
               </StyledMainWrapper>
             </StyledBody>
@@ -165,7 +166,7 @@ const mapStateToProps = state => {
     browserSyncMetadata: getMetadata(state),
     browserSyncConfig: getBrowserSyncConfig(state),
     browserSyncAuthStatus: getUserAuthStatus(state),
-    loadSync: inWebEnv(state)
+    loadSync: useBrowserSync(state)
   }
 }
 

--- a/src/browser/modules/Main/Main.jsx
+++ b/src/browser/modules/Main/Main.jsx
@@ -35,6 +35,7 @@ import {
   StyledCodeBlockErrorBar
 } from './styled'
 import SyncReminderBanner from './SyncReminderBanner'
+import SyncConsentBanner from './SyncConsentBanner'
 
 const Main = props => {
   return (
@@ -65,7 +66,12 @@ const Main = props => {
           Connection to server lost. Reconnecting...
         </WarningBanner>
       </Render>
-      <SyncReminderBanner />
+      <Render if={props.useBrowserSync}>
+        <SyncReminderBanner />
+      </Render>
+      <Render if={props.useBrowserSync}>
+        <SyncConsentBanner />
+      </Render>
       <Stream />
     </StyledMain>
   )

--- a/src/browser/modules/Main/SyncConsentBanner.jsx
+++ b/src/browser/modules/Main/SyncConsentBanner.jsx
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2002-2017 "Neo4j, Inc,"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Component } from 'preact'
+import { connect } from 'preact-redux'
+import {
+  SyncDisconnectedBanner,
+  StyledCancelLink,
+  StyledSyncReminderSpan,
+  StyledSyncReminderButtonContainer,
+  SyncSignInBarButton
+} from './styled'
+import {
+  CONNECTED_STATE,
+  getConnectionState
+} from 'shared/modules/connections/connectionsDuck'
+import Render from 'browser-components/Render'
+import { toggle } from 'shared/modules/sidebar/sidebarDuck'
+import {
+  optOutSync,
+  getUserAuthStatus,
+  SIGNED_IN
+} from 'shared/modules/sync/syncDuck'
+
+class SyncReminderBanner extends Component {
+  render () {
+    const {
+      dbConnectionState,
+      syncConsent,
+      optOutSync,
+      authStatus
+    } = this.props
+    const dbConnected = dbConnectionState === CONNECTED_STATE
+    const syncConsentGiven = syncConsent && syncConsent.consented === true
+
+    const visible =
+      dbConnected &&
+      !syncConsentGiven &&
+      authStatus !== SIGNED_IN &&
+      !syncConsent.optedOut
+
+    return (
+      <Render if={visible}>
+        <SyncDisconnectedBanner height='100px'>
+          <StyledSyncReminderSpan>
+            To enjoy full experince of Neo4j Browser, we advice you to use{' '}
+            <strong>Neo4j Browser Sync</strong>. Toggle sidebar to get started.
+          </StyledSyncReminderSpan>
+          <StyledSyncReminderButtonContainer>
+            <SyncSignInBarButton onClick={this.props.onGetstartedClicked}>
+              Toggle sidebar
+            </SyncSignInBarButton>
+            <StyledCancelLink onClick={() => optOutSync()}>X</StyledCancelLink>
+          </StyledSyncReminderButtonContainer>
+        </SyncDisconnectedBanner>
+      </Render>
+    )
+  }
+}
+
+const mapStateToProps = state => {
+  return {
+    syncConsent: state.syncConsent,
+    authStatus: getUserAuthStatus(state),
+    dbConnectionState: getConnectionState(state)
+  }
+}
+
+const mapDispatchToProps = (dispatch, ownProps) => {
+  return {
+    optOutSync: () => {
+      dispatch(optOutSync())
+    },
+    onGetstartedClicked: () => {
+      dispatch(toggle('sync'))
+    }
+  }
+}
+
+export default connect(mapStateToProps, mapDispatchToProps)(SyncReminderBanner)

--- a/src/browser/modules/Sidebar/Sidebar.jsx
+++ b/src/browser/modules/Sidebar/Sidebar.jsx
@@ -28,7 +28,7 @@ import TabNavigation from 'browser-components/TabNavigation/Navigation'
 import Settings from './Settings'
 import BrowserSync from './../Sync/BrowserSync'
 import { isUserSignedIn } from 'shared/modules/sync/syncDuck'
-import { inWebEnv } from 'shared/modules/app/appDuck'
+import { useBrowserSync } from 'shared/modules/features/featuresDuck'
 import {
   PENDING_STATE,
   CONNECTED_STATE,
@@ -107,7 +107,7 @@ class Sidebar extends Component {
         onNavClick={onNavClick}
         topNavItems={topNavItemsList}
         bottomNavItems={
-          this.props.showSync
+          this.props.loadSync
             ? bottomNavItemsList
             : bottomNavItemsList.filter(item => item.name !== 'Sync')
         }
@@ -134,7 +134,7 @@ const mapStateToProps = state => {
   return {
     syncConnected: isUserSignedIn(state) || false,
     neo4jConnectionState: connectionState,
-    showSync: inWebEnv(state)
+    loadSync: useBrowserSync(state)
   }
 }
 

--- a/src/shared/modules/features/featuresDuck.js
+++ b/src/shared/modules/features/featuresDuck.js
@@ -19,7 +19,7 @@
  */
 
 import bolt from 'services/bolt/bolt'
-import { APP_START } from 'shared/modules/app/appDuck'
+import { APP_START, WEB } from 'shared/modules/app/appDuck'
 import { CONNECTION_SUCCESS } from 'shared/modules/connections/connectionsDuck'
 
 export const NAME = 'features'
@@ -31,14 +31,16 @@ export const isACausalCluster = state =>
   getAvailableProcedures(state).includes('dbms.cluster.overview')
 export const canAssignRolesToUser = state =>
   getAvailableProcedures(state).includes('dbms.security.addRoleToUser')
+export const useBrowserSync = state => !!state[NAME].browserSync
 
 const initialState = {
-  availableProcedures: []
+  availableProcedures: [],
+  browserSync: true
 }
 
 export default function (state = initialState, action) {
   if (action.type === APP_START) {
-    state = { ...initialState, ...state }
+    state = { ...initialState, ...state, browserSync: action.env === WEB }
   }
 
   switch (action.type) {

--- a/src/shared/modules/features/featuresDuck.test.js
+++ b/src/shared/modules/features/featuresDuck.test.js
@@ -25,7 +25,10 @@ import { dehydrate } from 'services/duckUtils'
 describe('features reducer', () => {
   test('handles initial value', () => {
     const nextState = reducer(undefined, { type: '' })
-    expect(dehydrate(nextState)).toEqual({ availableProcedures: [] })
+    expect(dehydrate(nextState)).toEqual({
+      availableProcedures: [],
+      browserSync: true
+    })
   })
 
   test('handles UPDATE_ALL_FEATURES without initial state', () => {
@@ -35,6 +38,7 @@ describe('features reducer', () => {
     }
     const nextState = reducer(undefined, action)
     expect(nextState.availableProcedures).toEqual(['proc'])
+    expect(nextState.browserSync).toEqual(true)
   })
 
   test('handles UPDATE_ALL_FEATURES', () => {

--- a/src/shared/modules/sync/syncDuck.js
+++ b/src/shared/modules/sync/syncDuck.js
@@ -132,7 +132,10 @@ export function syncConsentReducer (state = initialConsentState, action) {
 
   switch (action.type) {
     case CONSENT_SYNC:
-      return Object.assign({}, state, { consented: action.consent })
+      return Object.assign({}, state, {
+        consented: action.consent,
+        optedOut: action.consent ? false : state.optedOut
+      })
     case CLEAR_SYNC_AND_LOCAL:
       return { consented: false, optedOut: false }
     case OPT_OUT_SYNC:


### PR DESCRIPTION
Show new banner with a button to toggle sidebar for easy and visible access for new users.

This will only be shown if users not yet have accepted terms and not opted out (closed banner).

Feature toggle for Sync added as well for better code branching.
Still disabled in desktop env.

<img width="888" alt="oskarhane-mbpt 2017-10-20 at 09 08 23" src="https://user-images.githubusercontent.com/570998/31809664-03b44ec8-b579-11e7-9e04-2aa68fbdb3f1.png">
