### PR TITLE
#584 - Removing max width from data table view

### DIFF
--- a/src/browser/components/DataTables.jsx
+++ b/src/browser/components/DataTables.jsx
@@ -52,6 +52,5 @@ export const StyledJsonPre = styled.pre`
   color: ${props => props.theme.preText};
   line-height: 26px;
   padding: 2px 10px;
-  max-width: 320px;
   white-space: pre-wrap;
 `


### PR DESCRIPTION
#584 
- Removing max-width from data table view since it makes really hard to visualise long length strings such as UUIDs and tokens.