### PR TITLE
if Relationship has the property weight, the shaft-width is adjusted …

### DIFF
--- a/src/browser/modules/D3Visualization/graphStyle.js
+++ b/src/browser/modules/D3Visualization/graphStyle.js
@@ -526,9 +526,15 @@ export default function neoGraphStyle () {
 
     GraphStyle.prototype.forRelationship = function (rel) {
       const selector = relationshipSelector(rel)
-      return this.calculateStyle(selector)
+      let style = this.calculateStyle(selector)
+      if (rel.propertyMap) {
+        if (typeof rel.propertyMap.weight !== 'undefined') {
+          let shaftWidth = Math.log2(rel.propertyMap.weight)
+          style['props']['shaft-width'] = shaftWidth
+        }
+      }
+      return style
     }
-
     return GraphStyle
   })()
   return new GraphStyle()


### PR DESCRIPTION
…automaticly by  width in pixel = log2(rel.weight)

if it is not set, nothing will happen.