### PR TITLE
Fix http request issue when using Desktop

### DIFF
--- a/src/browser/components/DesktopIntegration/helpers.js
+++ b/src/browser/components/DesktopIntegration/helpers.js
@@ -85,6 +85,6 @@ export const didChangeActiveGraph = (newContext, oldContext) => {
 export const getActiveCredentials = (type, context) => {
   const activeGraph = getActiveGraph(context)
   if (!activeGraph || typeof activeGraph.connection === 'undefined') return null
-  const creds = getCredentials('bolt', activeGraph.connection)
+  const creds = getCredentials(type, activeGraph.connection)
   return creds || null
 }

--- a/src/browser/components/DesktopIntegration/helpers.test.js
+++ b/src/browser/components/DesktopIntegration/helpers.test.js
@@ -243,3 +243,38 @@ test('getActiveCredentials finds the active connection from a context object and
   expect(secondActive).toEqual(bolt2)
   expect(zeroActive).toEqual(null)
 })
+
+test('getActiveCredentials should extract https and http creds', () => {
+  const bolt = {
+    username: 'one',
+    password: 'one1'
+  }
+  const http = {
+    host: 'foo',
+    port: 'bar'
+  }
+
+  const https = {
+    host: 'abc',
+    port: 'xyz'
+  }
+  const createApiResponse = graphs => ({
+    projects: [{ graphs }]
+  })
+  const activeConnectionData = createApiResponse([
+    {
+      id: 1,
+      status: 'ACTIVE',
+      connection: {
+        configuration: {
+          protocols: { bolt, http, https }
+        }
+      }
+    }
+  ])
+
+  expect(getActiveCredentials('bolt', activeConnectionData)).toEqual(bolt)
+  expect(getActiveCredentials('http', activeConnectionData)).toEqual(http)
+  expect(getActiveCredentials('https', activeConnectionData)).toEqual(https)
+  expect(getActiveCredentials('foobar', activeConnectionData)).toBeFalsy()
+})

--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -194,12 +194,15 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const setInitialConnectionData = (graph, credentials, context) => {
     const creds = getActiveCredentials('bolt', context)
     if (!creds) return // No conection. Ignore and let browser show connection lost msgs.
+    const httpCreds = getActiveCredentials('http', context)
+    const restApi = `http://${httpCreds.host}:${httpCreds.port}`
     const connectionCreds = {
       // Use current connections creds until we get new from API
       ...stateProps.defaultConnectionData,
       ...creds,
       encrypted: creds.tlsLevel === 'REQUIRED',
-      host: `bolt://${creds.host}:${creds.port}`
+      host: `bolt://${creds.host}:${creds.port}`,
+      restApi
     }
     ownProps.bus.send(INJECTED_DISCOVERY, connectionCreds)
   }

--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -182,20 +182,29 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   const switchConnection = (event, newContext, oldContext) => {
     const creds = getActiveCredentials('bolt', newContext)
     if (!creds) return // No conection. Ignore and let browser show connection lost msgs.
+    const httpsCreds = getActiveCredentials('https', newContext)
+    const httpCreds = getActiveCredentials('http', newContext)
+    const restApi = httpsCreds.enabled
+      ? `https://${httpsCreds.host}:${httpsCreds.port}`
+      : `http://${httpCreds.host}:${httpCreds.port}`
     const connectionCreds = {
       // Use current connections creds until we get new from API
       ...stateProps.defaultConnectionData,
       ...creds,
       encrypted: creds.tlsLevel === 'REQUIRED',
-      host: `bolt://${creds.host}:${creds.port}`
+      host: `bolt://${creds.host}:${creds.port}`,
+      restApi
     }
     ownProps.bus.send(SWITCH_CONNECTION, connectionCreds)
   }
   const setInitialConnectionData = (graph, credentials, context) => {
     const creds = getActiveCredentials('bolt', context)
     if (!creds) return // No conection. Ignore and let browser show connection lost msgs.
+    const httpsCreds = getActiveCredentials('https', context)
     const httpCreds = getActiveCredentials('http', context)
-    const restApi = `http://${httpCreds.host}:${httpCreds.port}`
+    const restApi = httpsCreds.enabled
+      ? `https://${httpsCreds.host}:${httpsCreds.port}`
+      : `http://${httpCreds.host}:${httpCreds.port}`
     const connectionCreds = {
       // Use current connections creds until we get new from API
       ...stateProps.defaultConnectionData,

--- a/src/shared/modules/discovery/discoveryDuck.js
+++ b/src/shared/modules/discovery/discoveryDuck.js
@@ -87,6 +87,8 @@ const updateDiscoveryState = (action, store) => {
   if (typeof action.encrypted !== 'undefined') {
     updateObj.encrypted = action.encrypted
   }
+  updateObj.restApi = action.restApi
+
   const updateAction = updateDiscoveryConnection(updateObj)
   store.dispatch(updateAction)
 }

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -248,6 +248,10 @@ const availableCommands = [
             r.url,
             { hostnameOnly: true }
           )
+          const url =
+            !isValidURL(r.url) && connectionData.restApi
+              ? `${connectionData.restApi}${r.url}`
+              : r.url
           let authHeaders = {}
           if (isLocal || isSameHostnameAsConnection) {
             if (connectionData.username) {
@@ -262,7 +266,7 @@ const availableCommands = [
             }
           }
           remote
-            .request(r.method, r.url, r.data, authHeaders)
+            .request(r.method, url, r.data, authHeaders)
             .then(res => res.text())
             .then(res => {
               put(frames.add({ ...action, result: res, type: 'pre' }))


### PR DESCRIPTION
Populates the `restApi` property of the connection obj when using Neo4j Desktop. 
The value is consumed when the user passes a path to one of the http verb Browser commands. E.g. `:get /foobar` will call `${restApi}/foobar`

![desktop](https://user-images.githubusercontent.com/849508/34208269-b2d36baa-e585-11e7-8e62-f6ed7e435ebb.gif)