### PR TITLE
Yarn startnodash

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 1. Install project dependencies: `yarn`
 
 ### Development server
-`yarn start` and point your web browser to `http://localhost:8080`.
+`yarn start` and point your web browser to `http://localhost:8080`. (Windows `yarn startnodash`)
 
 ### Testing
 `yarn test` to run a single test run. A linter will run first.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "start": "webpack-dashboard -t 'Neo4j Browser' -- webpack-dev-server --colors --no-info",
     "starts": "webpack-dashboard -t 'Neo4j Browser' -- webpack-dev-server --https --colors --no-info",
+    "startnodash": "webpack-dev-server --colors --no-info",
     "precommit": "lint-staged",
     "format": "prettier-eslint 'src/**/!(*.min).js' 'src/**/*.jsx' --write",
     "lint": "eslint --fix --ext .js --ext .jsx ./",


### PR DESCRIPTION
Fix for https://github.com/neo4j/neo4j-browser/issues/514

This gives a Windows start option "startnodash" which bypasses an issue where spawning webpack-dev-server via webpack-dashboard fails. It simply starts webpack-dev-server directly. There is also a small update to the readme to indicate to Windows users how to start via Yarn.

This is should not have any impact on existing code as it is only adding a new start option.