### PR TITLE
Update content for Neo4j Browser Sync banner

### DIFF
--- a/src/browser/modules/Main/SyncConsentBanner.jsx
+++ b/src/browser/modules/Main/SyncConsentBanner.jsx
@@ -60,13 +60,12 @@ class SyncReminderBanner extends Component {
       <Render if={visible}>
         <SyncDisconnectedBanner height='100px'>
           <StyledSyncReminderSpan>
-            To enjoy full experience of Neo4j Browser, we advise you to use{' '}
-            <strong>Neo4j Browser Sync</strong>. Toggle sidebar to get started.
+            To enjoy the full Neo4j Browser experience, we advise you to use
+            <SyncSignInBarButton onClick={this.props.onGetstartedClicked}>
+              Neo4j Browser Sync
+            </SyncSignInBarButton>
           </StyledSyncReminderSpan>
           <StyledSyncReminderButtonContainer>
-            <SyncSignInBarButton onClick={this.props.onGetstartedClicked}>
-              Toggle sidebar
-            </SyncSignInBarButton>
             <StyledCancelLink onClick={() => optOutSync()}>X</StyledCancelLink>
           </StyledSyncReminderButtonContainer>
         </SyncDisconnectedBanner>

--- a/src/browser/modules/Main/SyncReminderBanner.jsx
+++ b/src/browser/modules/Main/SyncReminderBanner.jsx
@@ -89,11 +89,11 @@ class SyncReminderBanner extends Component {
           <StyledSyncReminderSpan>
             You are currently not signed into Neo4j Browser Sync. Connect
             through a simple social sign-in to get started.
-          </StyledSyncReminderSpan>
-          <StyledSyncReminderButtonContainer>
             <SyncSignInBarButton onClick={this.logIn.bind(this)}>
               Sign In
             </SyncSignInBarButton>
+          </StyledSyncReminderSpan>
+          <StyledSyncReminderButtonContainer>
             <StyledCancelLink onClick={() => optOutSync()}>X</StyledCancelLink>
           </StyledSyncReminderButtonContainer>
         </SyncDisconnectedBanner>


### PR DESCRIPTION
A small update to the Neo4j Browser Sync banner.
- Update message
- Move drawer open button in to the main text area

From:
<img width="1142" alt="screen shot 2018-02-20 at 19 58 11" src="https://user-images.githubusercontent.com/849508/36443231-7e0d0358-1678-11e8-9210-83e31ff38642.png">

To:
<img width="1146" alt="screen shot 2018-02-20 at 19 55 20" src="https://user-images.githubusercontent.com/849508/36443251-87e9430a-1678-11e8-872e-9ff6b4262bad.png">
