### PR TITLE
Optimise fetching/reading jmx information

### DIFF
--- a/src/shared/modules/dbMeta/dbMetaDuck.js
+++ b/src/shared/modules/dbMeta/dbMetaDuck.js
@@ -20,12 +20,9 @@
 
 import Rx from 'rxjs/Rx'
 import bolt from 'services/bolt/bolt'
-import {
-  getJmxValues,
-  getServerConfig,
-  isConfigValFalsy
-} from 'services/bolt/boltHelpers'
+import { isConfigValFalsy } from 'services/bolt/boltHelpers'
 import { APP_START } from 'shared/modules/app/appDuck'
+import { getJmxValues, forceFetchJmxValues } from 'shared/modules/jmx/jmxDuck'
 import {
   CONNECTED_STATE,
   CONNECTION_SUCCESS,
@@ -94,6 +91,31 @@ export const shouldRetainConnectionCredentials = state => {
 /**
  * Helpers
  */
+
+export const getServerConfig = (state, includePrefixes = []) => {
+  const confs = getJmxValues(state, [['Configuration']])
+
+  if (!confs) return {}
+  const conf = confs[0]
+  let filtered
+  if (conf) {
+    Object.keys(conf)
+      .filter(
+        key =>
+          includePrefixes.length < 1 ||
+          includePrefixes.some(pfx => key.startsWith(pfx))
+      )
+      .forEach(
+        key =>
+          (filtered = {
+            ...filtered,
+            [key]: bolt.itemIntToNumber(conf[key].value)
+          })
+      )
+  }
+  return filtered || conf
+}
+
 function updateMetaForContext (state, meta, context) {
   const notInCurrentContext = e => e.context !== context
   const mapResult = (metaIndex, mapFunction) =>
@@ -262,32 +284,36 @@ export const dbMetaEpic = (some$, store) =>
           )
           .filter(r => r)
           .do(res => store.dispatch(updateMeta(res)))
+          .do(res => store.dispatch(forceFetchJmxValues()))
           // Version and edition
-          .mergeMap(() => {
-            return Rx.Observable
-              .fromPromise(
-                getJmxValues([
-                  ['Kernel', 'KernelVersion'],
-                  ['Kernel', 'StoreId'],
-                  ['Kernel', 'DatabaseName'],
-                  ['Configuration', 'unsupported.dbms.edition'],
-                  ['Store file sizes', 'TotalStoreSize']
-                ])
-              )
-              .catch(e => Rx.Observable.of(null))
-          })
-          .do(res => {
-            if (!res) return
-            const [kvObj, storeObj, nameObj, edObj, sizeObj] = res
-            const versionMatch = kvObj.KernelVersion.match(/version:\s([^,$]+)/)
+          .do(() => {
+            const jmxValueResult = getJmxValues(store.getState(), [
+              ['Kernel', 'KernelVersion'],
+              ['Kernel', 'StoreId'],
+              ['Kernel', 'DatabaseName'],
+              ['Configuration', 'unsupported.dbms.edition'],
+              ['Store file sizes', 'TotalStoreSize']
+            ])
+
+            if (!jmxValueResult) return
+
+            const jmxValues = jmxValueResult.reduce((obj, item) => {
+              const key = Object.keys(item)[0]
+              obj[key] = item[key]
+              return obj
+            }, {})
+
+            const versionMatch = jmxValues.KernelVersion.match(
+              /version:\s([^,$]+)/
+            )
             const version =
               versionMatch !== null && versionMatch.length > 1
                 ? versionMatch[1]
                 : null
-            const edition = edObj['unsupported.dbms.edition']
-            const storeId = storeObj['StoreId']
-            const dbName = nameObj['DatabaseName']
-            const storeSize = sizeObj['TotalStoreSize']
+            const edition = jmxValues['unsupported.dbms.edition']
+            const storeId = jmxValues.StoreId
+            const dbName = jmxValues.DatabaseName
+            const storeSize = jmxValues.TotalStoreSize
             store.dispatch({
               type: UPDATE_SERVER,
               version,
@@ -298,47 +324,47 @@ export const dbMetaEpic = (some$, store) =>
             })
           })
           // Server config for browser
-          .mergeMap(() => {
-            return getServerConfig(['browser.']).then(settings => {
-              if (!settings) return
-              let retainCredentials = true
-              if (
-                // Check if we should wipe user creds from localstorage
-                typeof settings['browser.retain_connection_credentials'] !==
-                  'undefined' &&
-                isConfigValFalsy(
-                  settings['browser.retain_connection_credentials']
-                )
-              ) {
-                retainCredentials = false
-              }
-
-              // This assignment is workaround to have prettier
-              // play nice with standardJS
-              // Use isConfigValFalsy to cast undefined to true
-              const aocConfig = !isConfigValFalsy(
-                settings['browser.allow_outgoing_connections']
+          .do(() => {
+            const settings = getServerConfig(store.getState(), ['browser.'])
+            if (!settings) return
+            let retainCredentials = true
+            if (
+              // Check if we should wipe user creds from localstorage
+              typeof settings['browser.retain_connection_credentials'] !==
+                'undefined' &&
+              isConfigValFalsy(
+                settings['browser.retain_connection_credentials']
               )
-              settings[`browser.allow_outgoing_connections`] = aocConfig
+            ) {
+              retainCredentials = false
+            }
 
-              store.dispatch(setRetainCredentials(retainCredentials))
-              store.dispatch(updateSettings(settings))
-            })
+            // This assignment is workaround to have prettier
+            // play nice with standardJS
+            // Use isConfigValFalsy to cast undefined to true
+            const aocConfig = !isConfigValFalsy(
+              settings['browser.allow_outgoing_connections']
+            )
+            settings[`browser.allow_outgoing_connections`] = aocConfig
+
+            store.dispatch(setRetainCredentials(retainCredentials))
+            store.dispatch(updateSettings(settings))
           })
           // Server security settings
-          .mergeMap(() => {
-            return getServerConfig(['dbms.security']).then(settings => {
-              if (!settings) return
-              const authEnabledSetting = 'dbms.security.auth_enabled'
-              let authEnabled = true
-              if (
-                typeof settings[authEnabledSetting] !== 'undefined' &&
-                isConfigValFalsy(settings[authEnabledSetting])
-              ) {
-                authEnabled = false
-              }
-              store.dispatch(setAuthEnabled(authEnabled))
-            })
+          .do(() => {
+            const settings = getServerConfig(store.getState(), [
+              'dbms.security'
+            ])
+            if (!settings) return
+            const authEnabledSetting = 'dbms.security.auth_enabled'
+            let authEnabled = true
+            if (
+              typeof settings[authEnabledSetting] !== 'undefined' &&
+              isConfigValFalsy(settings[authEnabledSetting])
+            ) {
+              authEnabled = false
+            }
+            store.dispatch(setAuthEnabled(authEnabled))
           })
           // Cluster role
           .mergeMap(() =>

--- a/src/shared/modules/dbMeta/dbMetaDuck.js
+++ b/src/shared/modules/dbMeta/dbMetaDuck.js
@@ -22,7 +22,7 @@ import Rx from 'rxjs/Rx'
 import bolt from 'services/bolt/bolt'
 import { isConfigValFalsy } from 'services/bolt/boltHelpers'
 import { APP_START } from 'shared/modules/app/appDuck'
-import { getJmxValues, forceFetchJmxValues } from 'shared/modules/jmx/jmxDuck'
+import { getJmxValues } from 'shared/modules/jmx/jmxDuck'
 import {
   CONNECTED_STATE,
   CONNECTION_SUCCESS,
@@ -284,7 +284,6 @@ export const dbMetaEpic = (some$, store) =>
           )
           .filter(r => r)
           .do(res => store.dispatch(updateMeta(res)))
-          .do(res => store.dispatch(forceFetchJmxValues()))
           // Version and edition
           .do(() => {
             const jmxValueResult = getJmxValues(store.getState(), [

--- a/src/shared/modules/jmx/jmxDuck.js
+++ b/src/shared/modules/jmx/jmxDuck.js
@@ -29,7 +29,6 @@ import {
   UPDATE_CONNECTION_STATE,
   connectionLossFilter
 } from 'shared/modules/connections/connectionsDuck'
-import { CYPHER_SUCCEEDED } from 'shared/modules/commands/commandsDuck'
 import { FORCE_FETCH } from 'shared/modules/dbMeta/dbMetaDuck'
 
 export const NAME = 'jmx'
@@ -118,7 +117,6 @@ export const jmxEpic = (some$, store) =>
     .ofType(UPDATE_CONNECTION_STATE)
     .filter(s => s.state === CONNECTED_STATE)
     .merge(some$.ofType(CONNECTION_SUCCESS))
-    .merge(some$.ofType(CYPHER_SUCCEEDED))
     .mergeMap(() => {
       return Rx.Observable
         .timer(0, 20000)

--- a/src/shared/modules/jmx/jmxDuck.js
+++ b/src/shared/modules/jmx/jmxDuck.js
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j, Inc"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Rx from 'rxjs/Rx'
+import bolt from 'services/bolt/bolt'
+import { toObjects, extractFromNeoObjects } from 'services/bolt/boltMappings'
+import { APP_START } from 'shared/modules/app/appDuck'
+import {
+  CONNECTED_STATE,
+  CONNECTION_SUCCESS,
+  LOST_CONNECTION,
+  UPDATE_CONNECTION_STATE,
+  connectionLossFilter
+} from 'shared/modules/connections/connectionsDuck'
+import { CYPHER_SUCCEEDED } from 'shared/modules/commands/commandsDuck'
+import { FORCE_FETCH } from 'shared/modules/dbMeta/dbMetaDuck'
+
+export const NAME = 'jmx'
+export const UPDATE = NAME + '/UPDATE'
+export const UPDATE_JMX_VALUES = NAME + '/UPDATE_JMX_VALUES'
+
+/**
+ * Selectors
+ */
+
+export const getJmxValues = ({ jmx }, arr) => {
+  return arr.map(([name, attribute = null]) => {
+    if (!name) return null
+    const part = jmx.find(entry => entry.name.includes(name))
+    if (!part) return null
+    const attributes = part.attributes
+    if (!attribute) return attributes
+    const key = attribute
+    if (typeof attributes[key] === 'undefined') return null
+    const val = bolt.itemIntToNumber(attributes[key].value)
+    return { [key]: val }
+  })
+}
+
+/**
+ * Helpers
+ */
+
+const fetchJmxValues = () => {
+  return bolt
+    .directTransaction('CALL dbms.queryJmx("org.neo4j:*")')
+    .then(res => {
+      const converters = {
+        intChecker: bolt.neo4j.isInt,
+        intConverter: val => val.toString(),
+        objectConverter: extractFromNeoObjects
+      }
+      return toObjects(
+        res.records,
+        converters
+      ).map(([name, description, attributes]) => {
+        return {
+          name,
+          description,
+          attributes
+        }
+      })
+    })
+    .catch(e => {
+      return null
+    })
+}
+
+// Initial state
+const initialState = []
+
+/**
+ * Reducer
+ */
+export default function jmx (state = initialState, action) {
+  if (!action || action.type === APP_START) {
+    return state
+  }
+  switch (action.type) {
+    case UPDATE_JMX_VALUES:
+      return [...state, ...action.values]
+    default:
+      return state
+  }
+}
+
+// Actions
+export const updateJmxValues = values => ({
+  type: UPDATE_JMX_VALUES,
+  values
+})
+
+export const forceFetchJmxValues = () => ({
+  type: FORCE_FETCH
+})
+
+// Epics
+
+export const jmxEpic = (some$, store) =>
+  some$
+    .ofType(UPDATE_CONNECTION_STATE)
+    .filter(s => s.state === CONNECTED_STATE)
+    .merge(some$.ofType(CONNECTION_SUCCESS))
+    .merge(some$.ofType(CYPHER_SUCCEEDED))
+    .mergeMap(() => {
+      return Rx.Observable
+        .timer(0, 20000)
+        .merge(some$.ofType(FORCE_FETCH))
+        .mergeMap(() =>
+          Rx.Observable
+            .fromPromise(fetchJmxValues())
+            .catch(e => Rx.Observable.of(null))
+        )
+        .filter(r => r)
+        .do(res => store.dispatch(updateJmxValues(res)))
+        .takeUntil(some$.ofType(LOST_CONNECTION).filter(connectionLossFilter))
+        .mapTo({ type: 'NOOP' })
+    })

--- a/src/shared/modules/jmx/jmxDuck.js
+++ b/src/shared/modules/jmx/jmxDuck.js
@@ -106,10 +106,6 @@ export const updateJmxValues = values => ({
   values
 })
 
-export const forceFetchJmxValues = () => ({
-  type: FORCE_FETCH
-})
-
 // Epics
 
 export const jmxEpic = (some$, store) =>

--- a/src/shared/modules/jmx/jmxDuck.test.js
+++ b/src/shared/modules/jmx/jmxDuck.test.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j, Inc"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* global describe, test, expect */
+import reducer, * as jmx from './jmxDuck'
+import { APP_START } from 'shared/modules/app/appDuck'
+
+describe('hydrating state', () => {
+  test('should merge inital state and state on load', () => {
+    // Given
+    const action = { type: APP_START }
+    const state = [{ foo: 'bar' }]
+
+    // When
+    const hydratedState = reducer(state, action)
+
+    // Then
+    expect(hydratedState).toEqual(state)
+  })
+})
+describe('updating jmx', () => {
+  test('should update state when jmx is updated', () => {
+    // Given
+    const action = {
+      type: jmx.UPDATE_JMX_VALUES,
+      values: []
+    }
+
+    // When
+    let nextState = reducer(undefined, action)
+
+    // Then
+    expect(nextState).toEqual([])
+
+    // Given
+    const updatedJmxValues = {
+      type: jmx.UPDATE_JMX_VALUES,
+      values: [{ foo: 'bar' }, { abc: 'xyz' }]
+    }
+
+    // When
+    nextState = reducer(nextState, updatedJmxValues)
+
+    // Then
+    expect(nextState).toEqual([{ foo: 'bar' }, { abc: 'xyz' }])
+  })
+})
+
+describe('reading jmx', () => {
+  test('should return specific jmx values from state', () => {
+    const NumberOfRolledBackTransactions = {
+      description: 'The total number of rolled back transactions',
+      value: '396'
+    }
+    const value = {
+      name: 'org.neo4j:instance=kernel#0,name=Transactions',
+      description: 'Information about the Neo4j transaction manager',
+      attributes: {
+        NumberOfRolledBackTransactions,
+        NumberOfOpenTransactions: {
+          description: 'The number of currently open transactions',
+          value: '1'
+        }
+      }
+    }
+    const state = reducer([value])
+    const jmxValues = jmx.getJmxValues({ jmx: state }, [
+      ['Transactions', 'NumberOfRolledBackTransactions']
+    ])
+    expect(jmxValues).toHaveLength(1)
+    expect(jmxValues).toContainEqual({
+      NumberOfRolledBackTransactions: NumberOfRolledBackTransactions.value
+    })
+  })
+})

--- a/src/shared/rootEpic.js
+++ b/src/shared/rootEpic.js
@@ -44,6 +44,7 @@ import {
   dbMetaEpic,
   clearMetaOnDisconnectEpic
 } from './modules/dbMeta/dbMetaDuck'
+import { jmxEpic } from './modules/jmx/jmxDuck'
 import { cancelRequestEpic } from './modules/requests/requestsDuck'
 import {
   discoveryOnStartupEpic,
@@ -90,6 +91,7 @@ export default combineEpics(
   retainCredentialsSettingsEpic,
   checkSettingsForRoutingDriver,
   connectEpic,
+  jmxEpic,
   disconnectEpic,
   silentDisconnectEpic,
   startupConnectEpic,

--- a/src/shared/rootReducer.js
+++ b/src/shared/rootReducer.js
@@ -32,6 +32,7 @@ import userReducer, {
   NAME as currentUser
 } from 'shared/modules/currentUser/currentUserDuck'
 import dbMetaReducer, { NAME as dbMeta } from 'shared/modules/dbMeta/dbMetaDuck'
+import jmxReducer, { NAME as jmx } from 'shared/modules/jmx/jmxDuck'
 import favoritesReducer, {
   NAME as documents
 } from 'shared/modules/favorites/favoritesDuck'
@@ -71,6 +72,7 @@ export default {
   [history]: historyReducer,
   [currentUser]: userReducer,
   [dbMeta]: dbMetaReducer,
+  [jmx]: jmxReducer,
   [documents]: favoritesReducer,
   [folders]: foldersReducer,
   [sidebar]: sidebarReducer,


### PR DESCRIPTION
Populates state with the latest jmx values so that we don't have to hit the server every time jmx attributes are read.

_JMX values are refreshed at the same interval as metadata requests_

Before:
![before](https://user-images.githubusercontent.com/849508/37083571-d29cbeac-21e7-11e8-801b-c942c349e954.png)

After:
![after](https://user-images.githubusercontent.com/849508/37083590-d93bd4a0-21e7-11e8-913f-65459e64a30b.png)

