### PR TITLE
Add page cache hit ratio to :sysinfo frame

### DIFF
--- a/src/browser/modules/Stream/SysInfoFrame/index.jsx
+++ b/src/browser/modules/Stream/SysInfoFrame/index.jsx
@@ -99,6 +99,24 @@ export class SysInfoFrame extends Component {
       })
     }
 
+    const pageCache = [
+      { label: 'Faults', value: cache.Faults },
+      { label: 'Evictions', value: cache.Evictions },
+      { label: 'File Mappings', value: cache.FileMappings },
+      { label: 'Bytes Read', value: cache.BytesRead },
+      { label: 'Flushes', value: cache.Flushes },
+      { label: 'Eviction Exceptions', value: cache.EvictionExceptions },
+      { label: 'File Unmappings', value: cache.FileUnmappings },
+      { label: 'Bytes Written', value: cache.BytesWritten }
+    ]
+
+    if (cache.HitRatio) {
+      pageCache.push({
+        label: 'Hit Ratio',
+        value: `${(cache.HitRatio * 100).toFixed(2)}%`
+      })
+    }
+
     this.setState({
       storeSizes: [
         {
@@ -142,16 +160,7 @@ export class SysInfoFrame extends Component {
           value: primitive.NumberOfRelationshipTypeIdsInUse
         }
       ],
-      pageCache: [
-        { label: 'Faults', value: cache.Faults },
-        { label: 'Evictions', value: cache.Evictions },
-        { label: 'File Mappings', value: cache.FileMappings },
-        { label: 'Bytes Read', value: cache.BytesRead },
-        { label: 'Flushes', value: cache.Flushes },
-        { label: 'Eviction Exceptions', value: cache.EvictionExceptions },
-        { label: 'File Unmappings', value: cache.FileUnmappings },
-        { label: 'Bytes Written', value: cache.BytesWritten }
-      ],
+      pageCache,
       transactions: [
         { label: 'Last Tx Id', value: tx.LastCommittedTxId },
         { label: 'Current', value: tx.NumberOfOpenTransactions },


### PR DESCRIPTION
Add page cache hit ratio to :sysinfo frame.

_Restricts the value returned from `queryJmx` to two decimal places_
<img width="204" alt="screen shot 2018-03-12 at 15 19 54" src="https://user-images.githubusercontent.com/849508/37292623-23b5b9ae-2609-11e8-9b46-e419926d7233.png">
