### PR TITLE
Less re-renders for editor

### DIFF
--- a/src/browser/modules/Editor/Codemirror.jsx
+++ b/src/browser/modules/Editor/Codemirror.jsx
@@ -58,7 +58,8 @@ export default class CodeMirror extends Component {
       this.props.options
     )
     this.codeMirror = editor
-    this.codeMirror.on('change', this.codemirrorValueChanged.bind(this))
+    this.codeMirror.on('change', this.codemirrorValueChange) // Triggered before DOM update
+    this.codeMirror.on('changes', this.codemirrorValueChanges) // Triggered after DOM update
     this.codeMirror.on('focus', this.focusChanged.bind(this, true))
     this.codeMirror.on('blur', this.focusChanged.bind(this, false))
     this.codeMirror.on('scroll', this.scrollChanged.bind(this))
@@ -132,9 +133,14 @@ export default class CodeMirror extends Component {
     this.props.onScroll && this.props.onScroll(cm.getScrollInfo())
   }
 
-  codemirrorValueChanged (doc, change) {
+  codemirrorValueChange = (doc, change) => {
     if (this.props.onChange && change.origin !== 'setValue') {
       this.props.onChange(doc.getValue(), change)
+    }
+  }
+  codemirrorValueChanges = (doc, change) => {
+    if (this.props.onChanges && change.origin !== 'setValue') {
+      this.props.onChanges(doc.getValue(), change)
     }
   }
 

--- a/src/browser/modules/Editor/styled.jsx
+++ b/src/browser/modules/Editor/styled.jsx
@@ -28,7 +28,9 @@ export const BaseBar = styled.div`
   flex-direction: row;
   align-items: middle;
   min-height: ${props =>
-    Math.max(dim.editorbarHeight, props.minHeight + editorPadding * 2)}px;
+    props.expanded
+      ? '100vh'
+      : Math.max(dim.editorbarHeight, props.minHeight + editorPadding * 2)}px;
   overflow: hidden;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.1);
   margin: 0 24px;
@@ -63,7 +65,9 @@ const BaseEditorWrapper = styled.div`
   background-color: ${props => props.theme.editorBarBackground};
   font-family: Monaco, 'Courier New', Terminal, monospace;
   min-height: ${props =>
-    Math.max(dim.editorbarHeight, props.minHeight + editorPadding * 2)}px;
+    props.expanded
+      ? '100vh'
+      : Math.max(dim.editorbarHeight, props.minHeight + editorPadding * 2)}px;
   .CodeMirror {
     background-color: ${props => props.theme.editorBackground} !important;
     color: ${props => props.theme.editorCommandColor};

--- a/src/browser/styles/constants.js
+++ b/src/browser/styles/constants.js
@@ -22,7 +22,7 @@ export const font = {}
 
 export const dim = {
   // Editor bar
-  editorbarHeight: 70,
+  editorbarHeight: 71,
   // Frame
   frameBodyHeight: 550,
   frameTitlebarHeight: 39,


### PR DESCRIPTION
What’s done here are basically two things:

1. Don’t re-render for state changes that has no UI effect (through `shouldComponentUpdate `)
2. Instead of measuring the height and adjust on `componentDidUpdate`, change CM event listener from `change` to `changes` which is triggered after DOM has been updated. State will update and trigger a re-render only on height changes.

This should have a positive performance impact on the editor.