### PR TITLE
Update :sysinfo to display 'Store sizes' jmx values

### DIFF
--- a/src/browser/modules/Stream/SysInfoFrame/sysinfo.js
+++ b/src/browser/modules/Stream/SysInfoFrame/sysinfo.js
@@ -40,12 +40,12 @@ export const getTableDataFromRecords = records => {
   )
   const tx =
     flattenAttributes(result[`${jmxQueryPrefix},name=Transactions`]) || {}
-  const kernel = Object.assign(
-    {},
-    flattenAttributes(result[`${jmxQueryPrefix},name=Configuration`]),
-    flattenAttributes(result[`${jmxQueryPrefix},name=Kernel`]),
-    flattenAttributes(result[`${jmxQueryPrefix},name=Store file sizes`])
-  )
+  const kernel = {
+    ...flattenAttributes(result[`${jmxQueryPrefix},name=Configuration`]),
+    ...flattenAttributes(result[`${jmxQueryPrefix},name=Kernel`]),
+    ...flattenAttributes(result[`${jmxQueryPrefix},name=Store file sizes`]),
+    ...flattenAttributes(result[`${jmxQueryPrefix},name=Store sizes`])
+  }
   const ha = result[`${jmxQueryPrefix},name=High Availability`]
     ? flattenAttributes(result[`${jmxQueryPrefix},name=High Availability`])
     : null


### PR DESCRIPTION
This updates `:sysinfo` to display `Store sizes` from jmx rather than `Store file sizes` (deprecated).

To maintain backwards compatibility we first map `Store files sizes` and the then override those values with `Store sizes` (also retains `Logical Log` value as it is not available in `Store sizes`)