### PR TITLE
Fix issue where action stream was being stored in memory

### DIFF
--- a/src/shared/modules/commands/commandsDuck.js
+++ b/src/shared/modules/commands/commandsDuck.js
@@ -154,8 +154,8 @@ export const handleCommandsEpic = (action$, store) =>
 
 export const postConnectCmdEpic = (some$, store) =>
   some$.ofType(CONNECTION_SUCCESS).mergeMap(() =>
-    Rx.Observable
-      .from(some$.ofType(UPDATE_SETTINGS))
+    some$
+      .ofType(UPDATE_SETTINGS)
       .map(() => {
         const serverSettings = getAvailableSettings(store.getState())
         if (serverSettings && serverSettings['browser.post_connect_cmd']) {

--- a/src/shared/modules/commands/commandsDuck.js
+++ b/src/shared/modules/commands/commandsDuck.js
@@ -154,7 +154,7 @@ export const handleCommandsEpic = (action$, store) =>
 
 export const postConnectCmdEpic = (some$, store) =>
   some$
-    .zip(some$.ofType(CONNECTION_SUCCESS), some$.ofType(UPDATE_SETTINGS))
+    .concat(some$.ofType(CONNECTION_SUCCESS), some$.ofType(UPDATE_SETTINGS))
     .do(() => {
       const serverSettings = getAvailableSettings(store.getState())
       if (serverSettings && serverSettings['browser.post_connect_cmd']) {


### PR DESCRIPTION
This change replaces `zip` from the `postConnectCmdEpic` with `concat`.

The usage of _`zip` (in this epic) was storing the complete history of the action stream and causing a memory leak._
