### PR TITLE
Make every type of Bolt transactions use web workers

### DIFF
--- a/src/shared/modules/commands/helpers/cypher.js
+++ b/src/shared/modules/commands/helpers/cypher.js
@@ -27,13 +27,11 @@ export const handleCypherCommand = (
   params = {},
   shouldUseCypherThread = false
 ) => {
-  const [id, request] = bolt.routedWriteTransaction(
-    action.cmd,
-    params,
-    action.requestId,
-    true,
-    shouldUseCypherThread
-  )
+  const [id, request] = bolt.routedWriteTransaction(action.cmd, params, {
+    useCypherThread: shouldUseCypherThread,
+    requestId: action.requestId,
+    cancelable: true
+  })
   put(send('cypher', id))
   return [id, request]
 }

--- a/src/shared/modules/cypher/cypherDuck.js
+++ b/src/shared/modules/cypher/cypherDuck.js
@@ -69,13 +69,9 @@ export const cypherRequestEpic = (some$, store) =>
   some$.ofType(CYPHER_REQUEST).mergeMap(action => {
     if (!action.$$responseChannel) return Rx.Observable.of(null)
     return bolt
-      .directTransaction(
-        action.query,
-        action.params || undefined,
-        undefined,
-        undefined,
-        shouldUseCypherThread(store.getState())
-      )
+      .directTransaction(action.query, action.params || undefined, {
+        useCypherThread: shouldUseCypherThread(store.getState())
+      })
       .then(r => ({ type: action.$$responseChannel, success: true, result: r }))
       .catch(e => ({
         type: action.$$responseChannel,
@@ -99,10 +95,8 @@ export const clusterCypherRequestEpic = (some$, store) =>
       return bolt
         .directTransaction(
           getCausalClusterAddresses,
-          undefined,
-          undefined,
-          undefined,
-          shouldUseCypherThread(store.getState())
+          {},
+          { useCypherThread: shouldUseCypherThread(store.getState()) }
         )
         .then(res => {
           const addresses = flatten(

--- a/src/shared/modules/dbMeta/dbMetaDuck.js
+++ b/src/shared/modules/dbMeta/dbMetaDuck.js
@@ -33,6 +33,7 @@ import {
   setRetainCredentials,
   setAuthEnabled
 } from 'shared/modules/connections/connectionsDuck'
+import { shouldUseCypherThread } from 'shared/modules/settings/settingsDuck'
 
 export const NAME = 'meta'
 export const UPDATE = 'meta/UPDATE'
@@ -279,7 +280,15 @@ export const dbMetaEpic = (some$, store) =>
           // Labels, types and propertyKeys
           .mergeMap(() =>
             Rx.Observable
-              .fromPromise(bolt.routedReadTransaction(metaQuery))
+              .fromPromise(
+                bolt.routedReadTransaction(
+                  metaQuery,
+                  undefined,
+                  undefined,
+                  undefined,
+                  shouldUseCypherThread(store.getState())
+                )
+              )
               .catch(e => Rx.Observable.of(null))
           )
           .filter(r => r)
@@ -372,7 +381,13 @@ export const dbMetaEpic = (some$, store) =>
           .mergeMap(() =>
             Rx.Observable
               .fromPromise(
-                bolt.directTransaction('CALL dbms.cluster.role() YIELD role')
+                bolt.directTransaction(
+                  'CALL dbms.cluster.role() YIELD role',
+                  undefined,
+                  undefined,
+                  undefined,
+                  shouldUseCypherThread(store.getState())
+                )
               )
               .catch(e => Rx.Observable.of(null))
               .do(res => {

--- a/src/shared/modules/dbMeta/dbMetaDuck.js
+++ b/src/shared/modules/dbMeta/dbMetaDuck.js
@@ -283,10 +283,10 @@ export const dbMetaEpic = (some$, store) =>
               .fromPromise(
                 bolt.routedReadTransaction(
                   metaQuery,
-                  undefined,
-                  undefined,
-                  undefined,
-                  shouldUseCypherThread(store.getState())
+                  {},
+                  {
+                    useCypherThread: shouldUseCypherThread(store.getState())
+                  }
                 )
               )
               .catch(e => Rx.Observable.of(null))
@@ -383,10 +383,8 @@ export const dbMetaEpic = (some$, store) =>
               .fromPromise(
                 bolt.directTransaction(
                   'CALL dbms.cluster.role() YIELD role',
-                  undefined,
-                  undefined,
-                  undefined,
-                  shouldUseCypherThread(store.getState())
+                  {},
+                  { useCypherThread: shouldUseCypherThread(store.getState()) }
                 )
               )
               .catch(e => Rx.Observable.of(null))

--- a/src/shared/modules/features/featuresDuck.js
+++ b/src/shared/modules/features/featuresDuck.js
@@ -69,10 +69,8 @@ export const featuresDiscoveryEpic = (action$, store) => {
       return bolt
         .routedReadTransaction(
           'CALL dbms.procedures YIELD name',
-          undefined,
-          undefined,
-          undefined,
-          shouldUseCypherThread(store.getState())
+          {},
+          { useCypherThread: shouldUseCypherThread(store.getState()) }
         )
         .then(res => {
           store.dispatch(

--- a/src/shared/modules/features/featuresDuck.js
+++ b/src/shared/modules/features/featuresDuck.js
@@ -21,6 +21,7 @@
 import bolt from 'services/bolt/bolt'
 import { APP_START, WEB } from 'shared/modules/app/appDuck'
 import { CONNECTION_SUCCESS } from 'shared/modules/connections/connectionsDuck'
+import { shouldUseCypherThread } from 'shared/modules/settings/settingsDuck'
 
 export const NAME = 'features'
 export const RESET = 'features/RESET'
@@ -66,7 +67,13 @@ export const featuresDiscoveryEpic = (action$, store) => {
     .ofType(CONNECTION_SUCCESS)
     .mergeMap(() => {
       return bolt
-        .routedReadTransaction('CALL dbms.procedures YIELD name')
+        .routedReadTransaction(
+          'CALL dbms.procedures YIELD name',
+          undefined,
+          undefined,
+          undefined,
+          shouldUseCypherThread(store.getState())
+        )
         .then(res => {
           store.dispatch(
             updateFeatures(res.records.map(record => record.get('name')))

--- a/src/shared/modules/jmx/jmxDuck.js
+++ b/src/shared/modules/jmx/jmxDuck.js
@@ -63,10 +63,8 @@ const fetchJmxValues = store => {
   return bolt
     .directTransaction(
       'CALL dbms.queryJmx("org.neo4j:*")',
-      undefined,
-      undefined,
-      undefined,
-      shouldUseCypherThread(store.getState())
+      {},
+      { useCypherThread: shouldUseCypherThread(store.getState()) }
     )
     .then(res => {
       const converters = {

--- a/src/shared/services/bolt/bolt.js
+++ b/src/shared/services/bolt/bolt.js
@@ -29,7 +29,6 @@ import {
   CYPHER_RESPONSE_MESSAGE,
   POST_CANCEL_TRANSACTION_MESSAGE
 } from './boltWorkerMessages'
-
 /* eslint-disable import/no-webpack-loader-syntax */
 import BoltWorkerModule from 'worker-loader?inline!./boltWorker.js'
 /* eslint-enable import/no-webpack-loader-syntax */
@@ -76,50 +75,18 @@ function routedWriteTransaction (
 ) {
   if (useCypherThread && window.Worker) {
     const id = requestId || v4()
-    const boltWorker = new BoltWorkerModule()
-    boltWorkerRegister[id] = boltWorker
-
-    const workerFinalizer = getWorkerFinalizer(
-      boltWorkerRegister,
-      cancellationRegister,
-      id
-    )
-
-    const workerPromise = new Promise((resolve, reject) => {
-      boltWorker.postMessage(
-        runCypherMessage(input, parameters, id, cancelable, {
-          ...connectionProperties,
-          inheritedUseRouting: boltConnection.useRouting()
-        })
-      )
-      boltWorker.onmessage = msg => {
-        if (msg.data.type === CYPHER_ERROR_MESSAGE) {
-          workerFinalizer(boltWorker)
-          reject(msg.data.error)
-        } else if (msg.data.type === CYPHER_RESPONSE_MESSAGE) {
-          let records = msg.data.result.records.map(record => {
-            const typedRecord = new neo4j.types.Record(
-              record.keys,
-              record._fields,
-              record._fieldLookup
-            )
-            if (typedRecord._fields) {
-              typedRecord._fields = mappings.applyGraphTypes(
-                typedRecord._fields
-              )
-            }
-            return typedRecord
-          })
-
-          let summary = mappings.applyGraphTypes(msg.data.result.summary)
-          workerFinalizer(boltWorker)
-          resolve({ summary, records })
-        } else if (msg.data.type === POST_CANCEL_TRANSACTION_MESSAGE) {
-          workerFinalizer(boltWorker)
-        }
+    const workFn = runCypherMessage(
+      input,
+      parameters,
+      boltConnection.ROUTED_WRITE_CONNECTION,
+      id,
+      cancelable,
+      {
+        ...connectionProperties,
+        inheritedUseRouting: boltConnection.useRouting()
       }
-    })
-
+    )
+    const workerPromise = setupBoltWorker(id, workFn)
     return [id, workerPromise]
   } else {
     return boltConnection.routedWriteTransaction(
@@ -129,6 +96,107 @@ function routedWriteTransaction (
       cancelable
     )
   }
+}
+
+function routedReadTransaction (
+  input,
+  parameters,
+  requestId = null,
+  cancelable = false,
+  useCypherThread
+) {
+  if (useCypherThread && window.Worker) {
+    const id = requestId || v4()
+    const workFn = runCypherMessage(
+      input,
+      parameters,
+      boltConnection.ROUTED_READ_CONNECTION,
+      id,
+      cancelable,
+      {
+        ...connectionProperties,
+        inheritedUseRouting: boltConnection.useRouting()
+      }
+    )
+    const workerPromise = setupBoltWorker(id, workFn)
+    return workerPromise
+  } else {
+    return boltConnection.routedReadTransaction(
+      input,
+      parameters,
+      requestId,
+      cancelable
+    )
+  }
+}
+
+function directTransaction (
+  input,
+  parameters,
+  requestId = null,
+  cancelable = false,
+  useCypherThread
+) {
+  if (useCypherThread && window.Worker) {
+    const id = requestId || v4()
+    const workFn = runCypherMessage(
+      input,
+      parameters,
+      boltConnection.DIRECT_CONNECTION,
+      id,
+      cancelable,
+      {
+        ...connectionProperties,
+        inheritedUseRouting: false
+      }
+    )
+    const workerPromise = setupBoltWorker(id, workFn)
+    return workerPromise
+  } else {
+    return boltConnection.directTransaction(
+      input,
+      parameters,
+      requestId,
+      cancelable
+    )
+  }
+}
+
+function setupBoltWorker (id, workFn) {
+  const boltWorker = new BoltWorkerModule()
+  const onFinished = registerBoltWorker(id, boltWorker)
+  const workerPromise = new Promise((resolve, reject) => {
+    boltWorker.postMessage(workFn)
+    boltWorker.onmessage = msg => {
+      if (msg.data.type === CYPHER_ERROR_MESSAGE) {
+        onFinished(boltWorker)
+        reject(msg.data.error)
+      } else if (msg.data.type === CYPHER_RESPONSE_MESSAGE) {
+        let records = msg.data.result.records.map(record => {
+          const typedRecord = new neo4j.types.Record(
+            record.keys,
+            record._fields,
+            record._fieldLookup
+          )
+          if (typedRecord._fields) {
+            typedRecord._fields = mappings.applyGraphTypes(typedRecord._fields)
+          }
+          return typedRecord
+        })
+        let summary = mappings.applyGraphTypes(msg.data.result.summary)
+        onFinished(boltWorker)
+        resolve({ summary, records })
+      } else if (msg.data.type === POST_CANCEL_TRANSACTION_MESSAGE) {
+        onFinished(boltWorker)
+      }
+    }
+  })
+  return workerPromise
+}
+
+function registerBoltWorker (id, boltWorker) {
+  boltWorkerRegister[id] = boltWorker
+  return getWorkerFinalizer(boltWorkerRegister, cancellationRegister, id)
 }
 
 function getWorkerFinalizer (workerRegister, cancellationRegister, workerId) {
@@ -153,8 +221,8 @@ export default {
     connectionProperties = null
     boltConnection.closeConnection()
   },
-  directTransaction: boltConnection.directTransaction,
-  routedReadTransaction: boltConnection.routedReadTransaction,
+  directTransaction,
+  routedReadTransaction,
   routedWriteTransaction,
   cancelTransaction,
   useRoutingConfig: shouldWe => boltConnection.setUseRoutingConfig(shouldWe),

--- a/src/shared/services/bolt/bolt.js
+++ b/src/shared/services/bolt/bolt.js
@@ -66,13 +66,12 @@ function cancelTransaction (id, cb) {
   }
 }
 
-function routedWriteTransaction (
-  input,
-  parameters,
-  requestId = null,
-  cancelable = false,
-  useCypherThread
-) {
+function routedWriteTransaction (input, parameters, requestMetaData = {}) {
+  const {
+    useCypherThread = false,
+    requestId = null,
+    cancelable = false
+  } = requestMetaData
   if (useCypherThread && window.Worker) {
     const id = requestId || v4()
     const workFn = runCypherMessage(
@@ -98,13 +97,12 @@ function routedWriteTransaction (
   }
 }
 
-function routedReadTransaction (
-  input,
-  parameters,
-  requestId = null,
-  cancelable = false,
-  useCypherThread
-) {
+function routedReadTransaction (input, parameters, requestMetaData = {}) {
+  const {
+    useCypherThread = false,
+    requestId = null,
+    cancelable = false
+  } = requestMetaData
   if (useCypherThread && window.Worker) {
     const id = requestId || v4()
     const workFn = runCypherMessage(
@@ -130,13 +128,12 @@ function routedReadTransaction (
   }
 }
 
-function directTransaction (
-  input,
-  parameters,
-  requestId = null,
-  cancelable = false,
-  useCypherThread
-) {
+function directTransaction (input, parameters, requestMetaData = {}) {
+  const {
+    useCypherThread = false,
+    requestId = null,
+    cancelable = false
+  } = requestMetaData
   if (useCypherThread && window.Worker) {
     const id = requestId || v4()
     const workFn = runCypherMessage(

--- a/src/shared/services/bolt/boltConnection.js
+++ b/src/shared/services/bolt/boltConnection.js
@@ -22,6 +22,10 @@ import { v1 as neo4j } from 'neo4j-driver-alias'
 import { v4 } from 'uuid'
 import { BoltConnectionError, createErrorObject } from '../exceptions'
 
+export const DIRECT_CONNECTION = 'DIRECT_CONNECTION'
+export const ROUTED_WRITE_CONNECTION = 'ROUTED_WRITE_CONNECTION'
+export const ROUTED_READ_CONNECTION = 'ROUTED_READ_CONNECTION'
+
 const runningQueryRegister = {}
 
 let _drivers = null

--- a/src/shared/services/bolt/boltWorkerMessages.js
+++ b/src/shared/services/bolt/boltWorkerMessages.js
@@ -18,6 +18,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { recursivelyTypeGraphItems } from './boltMappings'
+import { ROUTED_WRITE_CONNECTION } from './boltConnection'
+
 export const RUN_CYPHER_MESSAGE = 'RUN_CYPHER_MESSAGE'
 export const CANCEL_TRANSACTION_MESSAGE = 'CANCEL_TRANSACTION_MESSAGE'
 export const CYPHER_ERROR_MESSAGE = 'CYPHER_ERROR_MESSAGE'
@@ -27,6 +29,7 @@ export const POST_CANCEL_TRANSACTION_MESSAGE = 'POST_CANCEL_TRANSACTION_MESSAGE'
 export const runCypherMessage = (
   input,
   parameters,
+  connectionType = ROUTED_WRITE_CONNECTION,
   requestId = null,
   cancelable = false,
   connectionProperties
@@ -35,6 +38,7 @@ export const runCypherMessage = (
     type: RUN_CYPHER_MESSAGE,
     input,
     parameters,
+    connectionType,
     requestId,
     cancelable,
     connectionProperties


### PR DESCRIPTION
Refactor the worker initialisation to not be bound to (routed) write transactions, but to accept (routed) read transactions as we as (non routed read) direct transactions.
All cypher queries get's sent through this with this change except the `bolt.directConnect` which is used to create a persistent driver.

The benefit is that no background queries will have any effect on UI fps.