### PR TITLE
Add more info icon when running `:sysinfo` on a cc member

### DIFF
--- a/src/browser/components/icons/Icons.jsx
+++ b/src/browser/components/icons/Icons.jsx
@@ -44,6 +44,7 @@ class IconContainer extends Component {
       regulateSize,
       ...rest
     } = this.props
+
     const state =
       this.state.mouseover || isOpen ? activeStyle || '' : inactiveStyle || ''
     const newClass = this.props.suppressIconStyles
@@ -264,10 +265,11 @@ export const PlayIcon = () => (
 export const PlainPlayIcon = () => (
   <IconContainer className='fa fa-play-circle' />
 )
-export const QuestionIcon = () => (
+export const QuestionIcon = props => (
   <IconContainer
     activeStyle={styles.lightBlue}
     inactiveStyle={styles.blue}
+    {...props}
     className='fa fa-question-circle-o'
   />
 )

--- a/src/browser/modules/Stream/SysInfoFrame/index.jsx
+++ b/src/browser/modules/Stream/SysInfoFrame/index.jsx
@@ -33,6 +33,7 @@ import {
 import { toHumanReadableBytes } from 'services/utils'
 import { mapSysInfoRecords, getTableDataFromRecords } from './sysinfo'
 import Render from 'browser-components/Render'
+import { QuestionIcon } from 'browser-components/icons/Icons'
 
 export class SysInfoFrame extends Component {
   constructor (props) {
@@ -215,7 +216,15 @@ export class SysInfoFrame extends Component {
           {this.buildTableData(this.state.transactions)}
         </SysInfoTable>
         <Render if={this.props.isACausalCluster}>
-          <SysInfoTable header='Causal Cluster Members' colspan='3'>
+          <SysInfoTable
+            header={
+              <span>
+                Causal Cluster Members{' '}
+                <QuestionIcon title='Values shown in `:sysinfo` may differ between cluster members' />
+              </span>
+            }
+            colspan='3'
+          >
             <SysInfoTableEntry headers={['Roles', 'Addresses', 'Actions']} />
             {this.buildTableData(this.state.cc)}
           </SysInfoTable>


### PR DESCRIPTION
Mouse over text:
![a](https://user-images.githubusercontent.com/849508/37804939-f0d62ba8-2e2e-11e8-8571-2889bcc8f6c1.png)