### PR TITLE
Display driver result summary in code view

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/CodeView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/CodeView.jsx
@@ -26,9 +26,32 @@ import {
   StyledTBody,
   StyledAlteringTr,
   StyledStrongTd,
-  StyledTd
+  StyledTd,
+  StyledExpandable
 } from '../styled'
 import { TableStatusbar } from './TableView'
+
+class ExpandableContent extends Component {
+  render () {
+    return (
+      <StyledAlteringTr>
+        <StyledStrongTd>
+          {this.props.title}
+          <StyledExpandable
+            onClick={() => this.setState({ expanded: !this.state.expanded })}
+            className={
+              this.state.expanded ? 'fa fa-caret-down' : 'fa fa-caret-right'
+            }
+            title={this.state.expanded ? 'Hide section' : 'Expand section'}
+          />
+        </StyledStrongTd>
+        <StyledTd>
+          {this.state.expanded ? this.props.content : this.props.summary}
+        </StyledTd>
+      </StyledAlteringTr>
+    )
+  }
+}
 
 export class CodeView extends Component {
   shouldComponentUpdate (props) {
@@ -37,6 +60,8 @@ export class CodeView extends Component {
   render () {
     const { request = {}, query } = this.props
     if (request.status !== 'success') return null
+    const resultJson = JSON.stringify(request.result.records, null, 2)
+    const summaryJson = JSON.stringify(request.result.summary, null, 2)
     return (
       <PaddedDiv>
         <StyledTable>
@@ -53,12 +78,16 @@ export class CodeView extends Component {
               <StyledStrongTd>Query</StyledStrongTd>
               <StyledTd>{query}</StyledTd>
             </StyledAlteringTr>
-            <StyledAlteringTr>
-              <StyledStrongTd>Response</StyledStrongTd>
-              <StyledTd>
-                <pre>{JSON.stringify(request.result.records, null, 2)}</pre>
-              </StyledTd>
-            </StyledAlteringTr>
+            <ExpandableContent
+              title='Summary'
+              content={<pre>{summaryJson}</pre>}
+              summary={summaryJson.split('\n').slice(0, 3) + ' ...'}
+            />
+            <ExpandableContent
+              title='Response'
+              content={<pre>{resultJson}</pre>}
+              summary={resultJson.split('\n').slice(0, 3) + ' ...'}
+            />
           </StyledTBody>
         </StyledTable>
       </PaddedDiv>

--- a/src/browser/modules/Stream/CypherFrame/CodeView.test.js
+++ b/src/browser/modules/Stream/CypherFrame/CodeView.test.js
@@ -51,7 +51,7 @@ describe('CodeViews', () => {
                 address: 'xx2'
               }
             },
-            records: [{ res: 'xx3' }, { res: 'xx4' }, { res: 'xx5' }]
+            records: [{ res: 'xx3' }]
           }
         }
       }
@@ -64,8 +64,6 @@ describe('CodeViews', () => {
           expect(text).toContain('xx1')
           expect(text).toContain('xx2')
           expect(text).toContain('xx3')
-          expect(text).toContain('xx4')
-          expect(text).toContain('xx5')
         })
 
       // Return test result (promise)

--- a/src/browser/modules/Stream/styled.jsx
+++ b/src/browser/modules/Stream/styled.jsx
@@ -398,8 +398,11 @@ export const StyledTBody = styled.tbody`
   & td:first-child {
     vertical-align: top;
     width: 170px;
+    min-width: 170px;
   }
 `
+
+export const StyledExpandable = styled.div`margin: 0 10px;`
 
 export const StyledAlteringTr = styled.tr`
   &:nth-child(even) {


### PR DESCRIPTION
- Displays `summary` from driver response in the cypher frame code view.
- Adds expand/collapse functionality to the `response` and `summary` properties

![summary](https://user-images.githubusercontent.com/849508/38243642-143d27b8-3730-11e8-9172-83723f531fc2.gif)
