### PR TITLE
Fix Cypher warning position in Warnings View

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/WarningsView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/WarningsView.jsx
@@ -55,10 +55,7 @@ export class WarningsView extends Component {
     if (!notifications || !cypher) {
       return null
     }
-
     let cypherLines = cypher.split('\n')
-    cypherLines[0] = cypherLines[0].replace(/^EXPLAIN /, '')
-
     let notificationsList = notifications.map(notification => {
       return (
         <StyledHelpContent>
@@ -74,7 +71,7 @@ export class WarningsView extends Component {
               <StyledPreformattedArea>
                 {cypherLines[notification.position.line - 1]}
                 <StyledBr />
-                {Array(notification.position.column).join(' ')}^
+                {Array(notification.position.offset + 1).join(' ')}^
               </StyledPreformattedArea>
             </StyledDiv>
           </StyledDiv>

--- a/src/browser/modules/Stream/CypherFrame/WarningsView.test.js
+++ b/src/browser/modules/Stream/CypherFrame/WarningsView.test.js
@@ -50,7 +50,7 @@ describe('WarningsViews', () => {
                   title: 'My xx1 warning',
                   description: 'This is xx2 warning',
                   position: {
-                    column: 7,
+                    offset: 7,
                     line: 1
                   }
                 }
@@ -69,7 +69,7 @@ describe('WarningsViews', () => {
           expect(text).toContain('xx2')
           expect(text).toContain('xx3')
           expect(text).toContain('^')
-          expect(text).not.toContain('EXPLAIN')
+          expect(text).toContain('EXPLAIN')
         })
 
       // Return test result (promise)
@@ -87,7 +87,7 @@ describe('WarningsViews', () => {
                   title: 'My xx1 warning',
                   description: 'This is xx2 warning',
                   position: {
-                    column: 7,
+                    offset: 7,
                     line: 1
                   }
                 },
@@ -96,7 +96,7 @@ describe('WarningsViews', () => {
                   title: 'My yy1 warning',
                   description: 'This is yy2 warning',
                   position: {
-                    column: 3,
+                    offset: 3,
                     line: 1
                   }
                 }


### PR DESCRIPTION
Don’t strip ‘EXPLAIN’ and use 'offset' instead of 'column'.

<img width="707" alt="oskarhane-mbpt 2018-04-17 at 08 43 10" src="https://user-images.githubusercontent.com/570998/38852821-92ef0676-421b-11e8-8785-2a328d9b265a.png">
