### PR TITLE
Display more store sizes if they exist (> neo4j 3.2)

### DIFF
--- a/src/browser/modules/Stream/SysInfoFrame/index.jsx
+++ b/src/browser/modules/Stream/SysInfoFrame/index.jsx
@@ -124,37 +124,58 @@ export class SysInfoFrame extends Component {
       }
     ]
 
-    this.setState({
-      storeSizes: [
+    let storeSizes = [
+      {
+        label: 'Array Store',
+        value: toHumanReadableBytes(kernel.ArrayStoreSize)
+      },
+      {
+        label: 'Logical Log',
+        value: toHumanReadableBytes(kernel.LogicalLogSize)
+      },
+      {
+        label: 'Node Store',
+        value: toHumanReadableBytes(kernel.NodeStoreSize)
+      },
+      {
+        label: 'Property Store',
+        value: toHumanReadableBytes(kernel.PropertyStoreSize)
+      },
+      {
+        label: 'Relationship Store',
+        value: toHumanReadableBytes(kernel.RelationshipStoreSize)
+      },
+      {
+        label: 'String Store',
+        value: toHumanReadableBytes(kernel.StringStoreSize)
+      },
+      {
+        label: 'Total Store Size',
+        value: toHumanReadableBytes(kernel.TotalStoreSize)
+      }
+    ]
+    if (kernel.CountStoreSize) {
+      storeSizes = storeSizes.concat([
         {
-          label: 'Array Store',
-          value: toHumanReadableBytes(kernel.ArrayStoreSize)
+          label: 'Count Store',
+          value: toHumanReadableBytes(kernel.CountStoreSize)
         },
         {
-          label: 'Logical Log',
-          value: toHumanReadableBytes(kernel.LogicalLogSize)
+          label: 'Label Store',
+          value: toHumanReadableBytes(kernel.LabelStoreSize)
         },
         {
-          label: 'Node Store',
-          value: toHumanReadableBytes(kernel.NodeStoreSize)
+          label: 'Index Store',
+          value: toHumanReadableBytes(kernel.IndexStoreSize)
         },
         {
-          label: 'Property Store',
-          value: toHumanReadableBytes(kernel.PropertyStoreSize)
-        },
-        {
-          label: 'Relationship Store',
-          value: toHumanReadableBytes(kernel.RelationshipStoreSize)
-        },
-        {
-          label: 'String Store',
-          value: toHumanReadableBytes(kernel.StringStoreSize)
-        },
-        {
-          label: 'Total Store Size',
-          value: toHumanReadableBytes(kernel.TotalStoreSize)
+          label: 'Schema Store',
+          value: toHumanReadableBytes(kernel.SchemaStoreSize)
         }
-      ],
+      ])
+    }
+    this.setState({
+      storeSizes,
       idAllocation: [
         { label: 'Node ID', value: primitive.NumberOfNodeIdsInUse },
         { label: 'Property ID', value: primitive.NumberOfPropertyIdsInUse },


### PR DESCRIPTION
We forgot four sizes when we added these last time.

When they don't exist (< neo4j 3.2)

<img width="222" alt="oskarhane-mbpt 2018-04-17 at 09 11 13" src="https://user-images.githubusercontent.com/570998/38854076-9f908f9a-421f-11e8-992e-4ee5d8b24e58.png">

When they exist:
<img width="229" alt="oskarhane-mbpt 2018-04-17 at 09 06 54" src="https://user-images.githubusercontent.com/570998/38854083-a16ba1c4-421f-11e8-9b72-9285ea7eae22.png">
