### PR TITLE
Detect connection loss and display error message + show retry banner

### DIFF
--- a/e2e_tests/integration/index.spec.js
+++ b/e2e_tests/integration/index.spec.js
@@ -36,6 +36,14 @@ describe('Neo4j Browser', () => {
     cy.setInitialPassword(newPassword)
     cy.disconnect()
   })
+  it('show "no connection" error', () => {
+    cy.executeCommand(':clear')
+    cy.executeCommand('RETURN 1')
+    cy
+      .get('[data-test-id="frameContents"]', { timeout: 10000 })
+      .first()
+      .should('contain', 'No connection found, did you connect to Neo4j')
+  })
   it('can login', () => {
     cy.executeCommand(':clear')
     cy.executeCommand(':server connect')

--- a/e2e_tests/integration/index.spec.js
+++ b/e2e_tests/integration/index.spec.js
@@ -36,8 +36,18 @@ describe('Neo4j Browser', () => {
     cy.setInitialPassword(newPassword)
     cy.disconnect()
   })
-  it('show "no connection" error', () => {
+  it('show "no connection" error when not using web workers', () => {
     cy.executeCommand(':clear')
+    cy.executeCommand(':config useCypherThread: false')
+    cy.executeCommand('RETURN 1')
+    cy
+      .get('[data-test-id="frameContents"]', { timeout: 10000 })
+      .first()
+      .should('contain', 'No connection found, did you connect to Neo4j')
+  })
+  it('show "no connection" error when using web workers', () => {
+    cy.executeCommand(':clear')
+    cy.executeCommand(':config useCypherThread: true')
     cy.executeCommand('RETURN 1')
     cy
       .get('[data-test-id="frameContents"]', { timeout: 10000 })

--- a/src/browser/modules/Stream/CypherFrame/ErrorsView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/ErrorsView.jsx
@@ -61,7 +61,7 @@ export class ErrorsView extends Component {
         <StyledHelpContent>
           <StyledHelpDescription>
             <StyledCypherErrorMessage>ERROR</StyledCypherErrorMessage>
-            <StyledH4>{fullError.code}</StyledH4>
+            <StyledH4>{error.code}</StyledH4>
           </StyledHelpDescription>
           <StyledDiv>
             <StyledPreformattedArea>{fullError.message}</StyledPreformattedArea>

--- a/src/browser/modules/Stream/FrameTemplate.jsx
+++ b/src/browser/modules/Stream/FrameTemplate.jsx
@@ -116,6 +116,7 @@ class FrameTemplate extends Component {
             <StyledFrameContents
               fullscreen={this.state.fullscreen}
               innerRef={this.setFrameContentElement.bind(this)}
+              data-test-id='frameContents'
             >
               {this.props.contents}
             </StyledFrameContents>

--- a/src/shared/modules/connections/connectionsDuck.js
+++ b/src/shared/modules/connections/connectionsDuck.js
@@ -259,7 +259,7 @@ export const updateConnectionState = state => ({
   type: UPDATE_CONNECTION_STATE
 })
 
-const onLostConnection = dispatch => e => {
+export const onLostConnection = dispatch => e => {
   dispatch({ type: LOST_CONNECTION, error: e })
 }
 

--- a/src/shared/modules/dbMeta/dbMetaDuck.js
+++ b/src/shared/modules/dbMeta/dbMetaDuck.js
@@ -31,7 +31,8 @@ import {
   LOST_CONNECTION,
   UPDATE_CONNECTION_STATE,
   setRetainCredentials,
-  setAuthEnabled
+  setAuthEnabled,
+  onLostConnection
 } from 'shared/modules/connections/connectionsDuck'
 import { shouldUseCypherThread } from 'shared/modules/settings/settingsDuck'
 
@@ -285,7 +286,8 @@ export const dbMetaEpic = (some$, store) =>
                   metaQuery,
                   {},
                   {
-                    useCypherThread: shouldUseCypherThread(store.getState())
+                    useCypherThread: shouldUseCypherThread(store.getState()),
+                    onLostConnection: onLostConnection(store.dispatch)
                   }
                 )
               )

--- a/src/shared/services/bolt/boltConnection.js
+++ b/src/shared/services/bolt/boltConnection.js
@@ -58,12 +58,24 @@ const validateConnection = (driver, res, rej) => {
     })
 }
 
-export const getDriver = (host, auth, opts, protocol) => {
+export const getDriver = (
+  host,
+  auth,
+  opts,
+  protocol,
+  onConnectFail = () => {}
+) => {
   const boltHost = protocol + (host || '').split('bolt://').join('')
-  return neo4j.driver(boltHost, auth, opts)
+  try {
+    const res = neo4j.driver(boltHost, auth, opts)
+    return res
+  } catch (e) {
+    onConnectFail(e)
+    return null
+  }
 }
 
-export const getDriversObj = (props, opts = {}) => {
+export const getDriversObj = (props, opts = {}, onConnectFail = () => {}) => {
   const driversObj = {}
   const auth =
     opts.withoutCredentials || !props.username
@@ -71,13 +83,25 @@ export const getDriversObj = (props, opts = {}) => {
       : neo4j.auth.basic(props.username, props.password)
   const getDirectDriver = () => {
     if (driversObj.direct) return driversObj.direct
-    driversObj.direct = getDriver(props.host, auth, opts, 'bolt://')
+    driversObj.direct = getDriver(
+      props.host,
+      auth,
+      opts,
+      'bolt://',
+      onConnectFail
+    )
     return driversObj.direct
   }
   const getRoutedDriver = () => {
     if (!useRouting()) return getDirectDriver()
     if (driversObj.routed) return driversObj.routed
-    driversObj.routed = getDriver(props.host, auth, opts, 'bolt+routing://')
+    driversObj.routed = getDriver(
+      props.host,
+      auth,
+      opts,
+      'bolt+routing://',
+      onConnectFail
+    )
     return driversObj.routed
   }
   return {
@@ -117,13 +141,14 @@ export function directConnect (
 
 export function openConnection (props, opts = {}, onLostConnection) {
   const p = new Promise((resolve, reject) => {
-    const driversObj = getDriversObj(props, opts)
-    const driver = driversObj.getDirectDriver()
-    driver.onError = e => {
+    const onConnectFail = e => {
       onLostConnection(e)
       _drivers = null
       reject(e)
     }
+    const driversObj = getDriversObj(props, opts, onConnectFail)
+    const driver = driversObj.getDirectDriver()
+    driver.onError = onConnectFail
     const myResolve = driver => {
       _drivers = driversObj
       if (!props.hasOwnProperty('inheritedUseRouting')) {

--- a/src/shared/services/bolt/boltConnection.js
+++ b/src/shared/services/bolt/boltConnection.js
@@ -79,7 +79,7 @@ export const getDriversObj = (props, opts = {}, onConnectFail = () => {}) => {
   const driversObj = {}
   const auth =
     opts.withoutCredentials || !props.username
-      ? undefined
+      ? neo4j.auth.basic('', '')
       : neo4j.auth.basic(props.username, props.password)
   const getDirectDriver = () => {
     if (driversObj.direct) return driversObj.direct
@@ -123,7 +123,7 @@ export function directConnect (
   const p = new Promise((resolve, reject) => {
     const creds =
       opts.withoutCredentials || !props.username
-        ? undefined
+        ? neo4j.auth.basic('', '')
         : neo4j.auth.basic(props.username, props.password)
     const driver = getDriver(props.host, creds, opts, 'bolt://')
     driver.onError = e => {

--- a/src/shared/services/bolt/boltWorker.js
+++ b/src/shared/services/bolt/boltWorker.js
@@ -35,6 +35,7 @@ import {
   cypherErrorMessage,
   cypherResponseMessage,
   postCancelTransactionMessage,
+  boltConnectionErrorMessage,
   RUN_CYPHER_MESSAGE,
   CANCEL_TRANSACTION_MESSAGE
 } from './boltWorkerMessages'
@@ -66,7 +67,7 @@ const onmessage = function (message) {
 
     ensureConnection(connectionProperties, connectionProperties.opts, e => {
       self.postMessage(
-        cypherErrorMessage(createErrorObject(BoltConnectionError))
+        boltConnectionErrorMessage(createErrorObject(BoltConnectionError))
       )
     })
       .then(() => {

--- a/src/shared/services/bolt/boltWorkerMessages.js
+++ b/src/shared/services/bolt/boltWorkerMessages.js
@@ -25,6 +25,7 @@ export const CANCEL_TRANSACTION_MESSAGE = 'CANCEL_TRANSACTION_MESSAGE'
 export const CYPHER_ERROR_MESSAGE = 'CYPHER_ERROR_MESSAGE'
 export const CYPHER_RESPONSE_MESSAGE = 'CYPHER_RESPONSE_MESSAGE'
 export const POST_CANCEL_TRANSACTION_MESSAGE = 'POST_CANCEL_TRANSACTION_MESSAGE'
+export const BOLT_CONNECTION_ERROR_MESSAGE = 'BOLT_CONNECTION_ERROR_MESSAGE'
 
 export const runCypherMessage = (
   input,
@@ -69,5 +70,12 @@ export const cypherErrorMessage = error => {
 export const postCancelTransactionMessage = () => {
   return {
     type: POST_CANCEL_TRANSACTION_MESSAGE
+  }
+}
+
+export const boltConnectionErrorMessage = error => {
+  return {
+    type: BOLT_CONNECTION_ERROR_MESSAGE,
+    error
   }
 }


### PR DESCRIPTION
E2E test added for the error message.

This PR also fixes the ugly error message in server log when we try to connect without a scheme when checking if auth is off.
Empty username + pw ensures the same thing, but without the error message.

And one more thing in this pr: when using web workers, a connection loss wasn't showing the 'Connection to server lost, reconnecting...' banner.

<img width="649" alt="oskarhane-mbpt 2018-04-17 at 12 22 51" src="https://user-images.githubusercontent.com/570998/38864252-6b8f5f62-423a-11e8-8f6c-40338303e446.png">

<img width="391" alt="oskarhane-mbpt 2018-04-18 at 13 49 25" src="https://user-images.githubusercontent.com/570998/38930208-64a7a1ac-430f-11e8-9239-8c33f1181d42.png">
