### PR TITLE
Server version specific e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@
 
 `yarn dev` to have continuous testing on every file change.
 
+#### E2E Suite
+`yarn e2e` to run the cypress js test suite (requires a fresh installation of neo4j to run against, expects neo4j 3.4 by default)
+`yarn e2e --env server=3.3` to only run cypress js tests valid for neo4j server version 3.3
+
 ## Devtools
 Download these two chrome extensions:
 - [Redux devtools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en)

--- a/e2e_tests/integration/params.spec.js
+++ b/e2e_tests/integration/params.spec.js
@@ -75,35 +75,37 @@ function runTests () {
   cy.resultContains('1.0')
   // })
 
-  // it(":param x => point({crs: 'wgs-84', latitude: 57.7346, longitude: 12.9082})", () => {
-  cy.executeCommand(':clear')
-  let query =
-    ":param x => point({{}crs: 'wgs-84', latitude: 57.7346, longitude: 12.9082})"
-  cy.executeCommand(query)
+  if (Cypress.config.serverVersion >= 3.4) {
+    // it(":param x => point({crs: 'wgs-84', latitude: 57.7346, longitude: 12.9082})", () => {
+    cy.executeCommand(':clear')
+    let query =
+      ":param x => point({{}crs: 'wgs-84', latitude: 57.7346, longitude: 12.9082})"
+    cy.executeCommand(query)
 
-  cy.get('[data-test-id="main"]', { timeout: 20000 }).then(contents => {
-    // Check for point type support
-    const errorList =
-      contents.find('[data-test-id="errorBanner"]', {
-        timeout: 120000
-      }) || []
-    if (errorList.length < 1) {
-      cy
-        .get('[data-test-id="rawParamData"]', { timeout: 20000 })
-        .first()
-        .should('contain', '"x": point({srid:4326, x:12.9082, y:57.7346})')
-      getParamQ = 'RETURN $x'
-      cy.executeCommand(getParamQ)
-      cy.waitForCommandResult()
-      cy
-        .get('[data-test-id="rawParamData"]', { timeout: 20000 })
-        .first()
-        .should('contain', 'point({srid:4326, x:12.9082, y:57.7346})')
-    } else {
-      cy
-        .get('[data-test-id="errorBanner"]', { timeout: 20000 })
-        .should('contain', 'wgs')
-    }
-  })
+    cy.get('[data-test-id="main"]', { timeout: 20000 }).then(contents => {
+      // Check for point type support
+      const errorList =
+        contents.find('[data-test-id="errorBanner"]', {
+          timeout: 120000
+        }) || []
+      if (errorList.length < 1) {
+        cy
+          .get('[data-test-id="rawParamData"]', { timeout: 20000 })
+          .first()
+          .should('contain', '"x": point({srid:4326, x:12.9082, y:57.7346})')
+        getParamQ = 'RETURN $x'
+        cy.executeCommand(getParamQ)
+        cy.waitForCommandResult()
+        cy
+          .get('[data-test-id="rawParamData"]', { timeout: 20000 })
+          .first()
+          .should('contain', 'point({srid:4326, x:12.9082, y:57.7346})')
+      } else {
+        cy
+          .get('[data-test-id="errorBanner"]', { timeout: 20000 })
+          .should('contain', 'wgs')
+      }
+    })
+  }
   // })
 }

--- a/e2e_tests/integration/params.spec.js
+++ b/e2e_tests/integration/params.spec.js
@@ -82,30 +82,14 @@ function runTests () {
       ":param x => point({{}crs: 'wgs-84', latitude: 57.7346, longitude: 12.9082})"
     cy.executeCommand(query)
 
-    cy.get('[data-test-id="main"]', { timeout: 20000 }).then(contents => {
-      // Check for point type support
-      const errorList =
-        contents.find('[data-test-id="errorBanner"]', {
-          timeout: 120000
-        }) || []
-      if (errorList.length < 1) {
-        cy
-          .get('[data-test-id="rawParamData"]', { timeout: 20000 })
-          .first()
-          .should('contain', '"x": point({srid:4326, x:12.9082, y:57.7346})')
-        getParamQ = 'RETURN $x'
-        cy.executeCommand(getParamQ)
-        cy.waitForCommandResult()
-        cy
-          .get('[data-test-id="rawParamData"]', { timeout: 20000 })
-          .first()
-          .should('contain', 'point({srid:4326, x:12.9082, y:57.7346})')
-      } else {
-        cy
-          .get('[data-test-id="errorBanner"]', { timeout: 20000 })
-          .should('contain', 'wgs')
-      }
-    })
+    cy
+      .get('[data-test-id="rawParamData"]', { timeout: 20000 })
+      .first()
+      .should('contain', '"x": point({srid:4326, x:12.9082, y:57.7346})')
+    getParamQ = 'RETURN $x'
+    cy.executeCommand(getParamQ)
+    cy.waitForCommandResult()
+    cy.resultContains('point({srid:4326, x:12.9082, y:57.7346})')
   }
   // })
 }

--- a/e2e_tests/integration/types.spec.js
+++ b/e2e_tests/integration/types.spec.js
@@ -28,167 +28,171 @@ describe('Types in Browser', () => {
     const password = Cypress.env('BROWSER_NEW_PASSWORD') || 'newpassword'
     cy.connect(password)
   })
-  it('presents the point type correctly', () => {
-    cy.executeCommand(':clear')
-    const query =
-      "WITH point({{}crs: 'wgs-84', longitude: 12.78, latitude: 56.7}) as p1 RETURN p1"
-    cy.executeCommand(query)
-    cy.waitForCommandResult()
+  if (Cypress.config.serverVersion >= 3.4) {
+    it('presents the point type correctly', () => {
+      cy.executeCommand(':clear')
+      const query =
+        "WITH point({{}crs: 'wgs-84', longitude: 12.78, latitude: 56.7}) as p1 RETURN p1"
+      cy.executeCommand(query)
+      cy.waitForCommandResult()
 
-    cy
-      .get('[data-test-id="frameContents"]', { timeout: 10000 })
-      .then(contents => {
-        // Check for point type support
-        if (contents.find('.table-row').length > 0) {
-          cy.resultContains('point({srid:4326, x:12.78, y:56.7})')
+      cy
+        .get('[data-test-id="frameContents"]', { timeout: 10000 })
+        .then(contents => {
+          // Check for point type support
+          if (contents.find('.table-row').length > 0) {
+            cy.resultContains('point({srid:4326, x:12.78, y:56.7})')
 
-          // Go to ascii view
-          cy
-            .get('[data-test-id="cypherFrameSidebarAscii"')
-            .first()
-            .click()
-          cy.resultContains('│point({srid:4326, x:12.78, y:56.7})')
-        } else {
-          cy.resultContains('ERROR')
-        }
-      })
-  })
-  it('presents datetime type correctly', () => {
-    cy.executeCommand(':clear')
-    const query =
-      'RETURN datetime({{}year:2015, month:7, day:20, hour:15, minute:11, second:42, timezone:"Europe/Stockholm"}) AS t1'
-    cy.executeCommand(query)
-    cy.waitForCommandResult()
-    cy
-      .get('[data-test-id="frameContents"]', { timeout: 10000 })
-      .then(contents => {
-        // Check for type support
-        if (contents.find('.table-row').length > 0) {
-          cy.resultContains('"2015-07-20T15:11:42.000000000[Europe/Stockholm]"')
-          // Go to ascii view
-          cy
-            .get('[data-test-id="cypherFrameSidebarAscii"')
-            .first()
-            .click()
-          cy.resultContains(
-            '│"2015-07-20T15:11:42.000000000[Europe/Stockholm]"'
-          )
-        } else {
-          cy.resultContains('ERROR')
-        }
-      })
-  })
-  it('presents local datetime type correctly', () => {
-    cy.executeCommand(':clear')
-    const query =
-      'RETURN localdatetime({{}year:2015, month:7, day:20, hour:15, minute:11, second:42}) AS t1'
-    cy.executeCommand(query)
-    cy.waitForCommandResult()
-    cy
-      .get('[data-test-id="frameContents"]', { timeout: 10000 })
-      .then(contents => {
-        // Check for type support
-        if (contents.find('.table-row').length > 0) {
-          cy.resultContains('"2015-07-20T15:11:42.000000000"')
-          // Go to ascii view
-          cy
-            .get('[data-test-id="cypherFrameSidebarAscii"')
-            .first()
-            .click()
-          cy.resultContains('│"2015-07-20T15:11:42.000000000"')
-        } else {
-          cy.resultContains('ERROR')
-        }
-      })
-  })
-  it('presents date type correctly', () => {
-    cy.executeCommand(':clear')
-    const query = 'RETURN date({{}year:2015, month:7, day:20}) AS t1'
-    cy.executeCommand(query)
-    cy.waitForCommandResult()
-    cy
-      .get('[data-test-id="frameContents"]', { timeout: 10000 })
-      .then(contents => {
-        // Check for type support
-        if (contents.find('.table-row').length > 0) {
-          cy.resultContains('"2015-07-20"')
-          // Go to ascii view
-          cy
-            .get('[data-test-id="cypherFrameSidebarAscii"')
-            .first()
-            .click()
-          cy.resultContains('│"2015-07-20"')
-        } else {
-          cy.resultContains('ERROR')
-        }
-      })
-  })
-  it('presents duration type correctly', () => {
-    cy.executeCommand(':clear')
-    const query =
-      'RETURN duration({{}months:14, days:3, seconds:14706, nanoseconds:0}) AS t1'
-    cy.executeCommand(query)
-    cy.waitForCommandResult()
-    cy
-      .get('[data-test-id="frameContents"]', { timeout: 10000 })
-      .then(contents => {
-        // Check for type support
-        if (contents.find('.table-row').length > 0) {
-          cy.resultContains('"P14M3DT14706.000000000S"')
-          // Go to ascii view
-          cy
-            .get('[data-test-id="cypherFrameSidebarAscii"')
-            .first()
-            .click()
-          cy.resultContains('│"P14M3DT14706.000000000S"')
-        } else {
-          cy.resultContains('ERROR')
-        }
-      })
-  })
-  it('presents time type correctly', () => {
-    cy.executeCommand(':clear')
-    const query =
-      'RETURN time({{}hour:14, minute:3, second:4, timezone: "Europe/Stockholm"}) AS t1'
-    cy.executeCommand(query)
-    cy.waitForCommandResult()
-    cy
-      .get('[data-test-id="frameContents"]', { timeout: 10000 })
-      .then(contents => {
-        // Check for type support
-        if (contents.find('.table-row').length > 0) {
-          cy.resultContains('"14:03:04.000000000+02:00"')
-          // Go to ascii view
-          cy
-            .get('[data-test-id="cypherFrameSidebarAscii"')
-            .first()
-            .click()
-          cy.resultContains('│"14:03:04.000000000+02:00"')
-        } else {
-          cy.resultContains('ERROR')
-        }
-      })
-  })
-  it('presents localtime type correctly', () => {
-    cy.executeCommand(':clear')
-    const query = 'RETURN localtime({{}hour:14, minute:3, second:4}) AS t1'
-    cy.executeCommand(query)
-    cy.waitForCommandResult()
-    cy
-      .get('[data-test-id="frameContents"]', { timeout: 10000 })
-      .then(contents => {
-        // Check for type support
-        if (contents.find('.table-row').length > 0) {
-          cy.resultContains('"14:03:04.000000000"')
-          // Go to ascii view
-          cy
-            .get('[data-test-id="cypherFrameSidebarAscii"')
-            .first()
-            .click()
-          cy.resultContains('│"14:03:04.000000000"')
-        } else {
-          cy.resultContains('ERROR')
-        }
-      })
-  })
+            // Go to ascii view
+            cy
+              .get('[data-test-id="cypherFrameSidebarAscii"')
+              .first()
+              .click()
+            cy.resultContains('│point({srid:4326, x:12.78, y:56.7})')
+          } else {
+            cy.resultContains('ERROR')
+          }
+        })
+    })
+    it('presents datetime type correctly', () => {
+      cy.executeCommand(':clear')
+      const query =
+        'RETURN datetime({{}year:2015, month:7, day:20, hour:15, minute:11, second:42, timezone:"Europe/Stockholm"}) AS t1'
+      cy.executeCommand(query)
+      cy.waitForCommandResult()
+      cy
+        .get('[data-test-id="frameContents"]', { timeout: 10000 })
+        .then(contents => {
+          // Check for type support
+          if (contents.find('.table-row').length > 0) {
+            cy.resultContains(
+              '"2015-07-20T15:11:42.000000000[Europe/Stockholm]"'
+            )
+            // Go to ascii view
+            cy
+              .get('[data-test-id="cypherFrameSidebarAscii"')
+              .first()
+              .click()
+            cy.resultContains(
+              '│"2015-07-20T15:11:42.000000000[Europe/Stockholm]"'
+            )
+          } else {
+            cy.resultContains('ERROR')
+          }
+        })
+    })
+    it('presents local datetime type correctly', () => {
+      cy.executeCommand(':clear')
+      const query =
+        'RETURN localdatetime({{}year:2015, month:7, day:20, hour:15, minute:11, second:42}) AS t1'
+      cy.executeCommand(query)
+      cy.waitForCommandResult()
+      cy
+        .get('[data-test-id="frameContents"]', { timeout: 10000 })
+        .then(contents => {
+          // Check for type support
+          if (contents.find('.table-row').length > 0) {
+            cy.resultContains('"2015-07-20T15:11:42.000000000"')
+            // Go to ascii view
+            cy
+              .get('[data-test-id="cypherFrameSidebarAscii"')
+              .first()
+              .click()
+            cy.resultContains('│"2015-07-20T15:11:42.000000000"')
+          } else {
+            cy.resultContains('ERROR')
+          }
+        })
+    })
+    it('presents date type correctly', () => {
+      cy.executeCommand(':clear')
+      const query = 'RETURN date({{}year:2015, month:7, day:20}) AS t1'
+      cy.executeCommand(query)
+      cy.waitForCommandResult()
+      cy
+        .get('[data-test-id="frameContents"]', { timeout: 10000 })
+        .then(contents => {
+          // Check for type support
+          if (contents.find('.table-row').length > 0) {
+            cy.resultContains('"2015-07-20"')
+            // Go to ascii view
+            cy
+              .get('[data-test-id="cypherFrameSidebarAscii"')
+              .first()
+              .click()
+            cy.resultContains('│"2015-07-20"')
+          } else {
+            cy.resultContains('ERROR')
+          }
+        })
+    })
+    it('presents duration type correctly', () => {
+      cy.executeCommand(':clear')
+      const query =
+        'RETURN duration({{}months:14, days:3, seconds:14706, nanoseconds:0}) AS t1'
+      cy.executeCommand(query)
+      cy.waitForCommandResult()
+      cy
+        .get('[data-test-id="frameContents"]', { timeout: 10000 })
+        .then(contents => {
+          // Check for type support
+          if (contents.find('.table-row').length > 0) {
+            cy.resultContains('"P14M3DT14706.000000000S"')
+            // Go to ascii view
+            cy
+              .get('[data-test-id="cypherFrameSidebarAscii"')
+              .first()
+              .click()
+            cy.resultContains('│"P14M3DT14706.000000000S"')
+          } else {
+            cy.resultContains('ERROR')
+          }
+        })
+    })
+    it('presents time type correctly', () => {
+      cy.executeCommand(':clear')
+      const query =
+        'RETURN time({{}hour:14, minute:3, second:4, timezone: "Europe/Stockholm"}) AS t1'
+      cy.executeCommand(query)
+      cy.waitForCommandResult()
+      cy
+        .get('[data-test-id="frameContents"]', { timeout: 10000 })
+        .then(contents => {
+          // Check for type support
+          if (contents.find('.table-row').length > 0) {
+            cy.resultContains('"14:03:04.000000000+02:00"')
+            // Go to ascii view
+            cy
+              .get('[data-test-id="cypherFrameSidebarAscii"')
+              .first()
+              .click()
+            cy.resultContains('│"14:03:04.000000000+02:00"')
+          } else {
+            cy.resultContains('ERROR')
+          }
+        })
+    })
+    it('presents localtime type correctly', () => {
+      cy.executeCommand(':clear')
+      const query = 'RETURN localtime({{}hour:14, minute:3, second:4}) AS t1'
+      cy.executeCommand(query)
+      cy.waitForCommandResult()
+      cy
+        .get('[data-test-id="frameContents"]', { timeout: 10000 })
+        .then(contents => {
+          // Check for type support
+          if (contents.find('.table-row').length > 0) {
+            cy.resultContains('"14:03:04.000000000"')
+            // Go to ascii view
+            cy
+              .get('[data-test-id="cypherFrameSidebarAscii"')
+              .first()
+              .click()
+            cy.resultContains('│"14:03:04.000000000"')
+          } else {
+            cy.resultContains('ERROR')
+          }
+        })
+    })
+  }
 })

--- a/e2e_tests/support/defaults.js
+++ b/e2e_tests/support/defaults.js
@@ -1,17 +1,3 @@
-// ***********************************************
-// This example defaults.js shows you how to
-// customize the internal behavior of Cypress.
-//
-// The defaults.js file is a great place to
-// override defaults used throughout all tests.
-//
-// ***********************************************
-//
-// Cypress.Server.defaults({
-//   delay: 500,
-//   whitelist: function(xhr){}
-// })
+/* global Cypress */
 
-// Cypress.Cookies.defaults({
-//   whitelist: ["session_id", "remember_token"]
-// })
+Cypress.config.serverVersion = parseFloat(Cypress.env('server'))

--- a/e2e_tests/support/defaults.js
+++ b/e2e_tests/support/defaults.js
@@ -1,3 +1,3 @@
 /* global Cypress */
 
-Cypress.config.serverVersion = parseFloat(Cypress.env('server'))
+Cypress.config.serverVersion = parseFloat(Cypress.env('server')) || 3.4


### PR DESCRIPTION
This pr reads in the `server` arg passed to `yarn e2e*` to only run test associated with that server version.

E.g. Neo4j server 3.3 does not support `data()` cypher function. By running `yarn e2e --env server=3.3` the test that exec these statements will be skipped

_If no version is set it falls back to the default 3.4 value_