### PR TITLE
Add non-visiable config `editorLint` to toggle editor linting

### DIFF
--- a/src/browser/modules/Editor/Editor.jsx
+++ b/src/browser/modules/Editor/Editor.jsx
@@ -38,7 +38,8 @@ import {
 import { getHistory } from 'shared/modules/history/historyDuck'
 import {
   getCmdChar,
-  shouldEditorAutocomplete
+  shouldEditorAutocomplete,
+  shouldEditorLint
 } from 'shared/modules/settings/settingsDuck'
 import { Bar, ActionButtonSection, EditorWrapper } from './styled'
 import { EditorButton, EditModeEditorButton } from 'browser-components/buttons'
@@ -321,7 +322,7 @@ export class Editor extends Component {
       autofocus: true,
       smartIndent: false,
       lineNumberFormatter: this.lineNumberFormatter.bind(this),
-      lint: true,
+      lint: this.props.enableEditorLint,
       extraKeys: {
         'Ctrl-Space': 'autocomplete',
         Enter: this.handleEnter.bind(this),
@@ -439,6 +440,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
 const mapStateToProps = state => {
   return {
     enableEditorAutocomplete: shouldEditorAutocomplete(state),
+    enableEditorLint: shouldEditorLint(state),
     history: getHistory(state),
     cmdchar: getCmdChar(state),
     schema: {

--- a/src/shared/modules/settings/settingsDuck.js
+++ b/src/shared/modules/settings/settingsDuck.js
@@ -43,6 +43,7 @@ export const getInitialNodeDisplay = state =>
 export const getScrollToTop = state => state[NAME].scrollToTop
 export const shouldReportUdc = state => state[NAME].shouldReportUdc !== false
 export const shouldAutoComplete = state => state[NAME].autoComplete !== false
+export const shouldEditorLint = state => state[NAME].editorLint === true
 
 const browserSyncConfig = (host = 'https://auth.neo4j.com') => ({
   authWindowUrl: `${host}/indexNewBrowser.html`,
@@ -77,6 +78,7 @@ const initialState = {
   scrollToTop: true,
   maxFrames: 30,
   editorAutocomplete: true,
+  editorLint: false,
   useCypherThread: true
 }
 


### PR DESCRIPTION
default: false => no linting until we're up to date with the syntax

It does affect the syntax highlighting a little bit, see screenshots.

<img width="251" alt="oskarhane-mbpt 2018-04-24 at 15 58 09" src="https://user-images.githubusercontent.com/570998/39192164-e3c2bd14-47d8-11e8-9ffe-987f0317472a.png">
<img width="224" alt="oskarhane-mbpt 2018-04-24 at 15 58 33" src="https://user-images.githubusercontent.com/570998/39192166-e3e60dc8-47d8-11e8-81b6-9c2d92c2fa51.png">
<img width="1089" alt="oskarhane-mbpt 2018-04-24 at 16 05 43" src="https://user-images.githubusercontent.com/570998/39192472-85eb511e-47d9-11e8-9958-aebcfff24e1f.png">
<img width="1083" alt="oskarhane-mbpt 2018-04-24 at 16 06 07" src="https://user-images.githubusercontent.com/570998/39192473-86353478-47d9-11e8-923b-a34d3c2bcd86.png">
