### PR TITLE
Map 'Expressions' arguments from profile/explain

### DIFF
--- a/e2e_tests/integration/plan.spec.js
+++ b/e2e_tests/integration/plan.spec.js
@@ -64,5 +64,18 @@ describe('Plan output', () => {
     } else if (Cypress.config.serverVersion === 3.2) {
       el.should('contain', 'ConstantCachedIn').and('contain', 'GetDegree')
     }
+
+    cy.executeCommand(':clear')
+    cy.executeCommand(
+      `profile match (n:Person) with n where size ( (n)-[:Follows]->()) > 6 return n;`
+    )
+    cy.get('[data-test-id="planExpandButton"]', { timeout: 10000 }).click()
+    const el2 = cy.get('[data-test-id="planSvg"]', { timeout: 10000 })
+    el2.should('contain', 'NodeByLabelScan')
+    if (Cypress.config.serverVersion >= 3.3) {
+      el2.should('contain', 'GetDegreePrimitive')
+    } else if (Cypress.config.serverVersion === 3.2) {
+      el2.should('contain', 'ConstantCachedIn').and('contain', 'GetDegree')
+    }
   })
 })

--- a/src/browser/external/neoPlanner.js
+++ b/src/browser/external/neoPlanner.js
@@ -163,11 +163,13 @@ neo.queryPlan = function(element) {
       (expression =
         (left =
           (left1 =
-            operator.Expression != null
-              ? operator.Expression
-              : operator.LegacyExpression != null
-                ? operator.LegacyExpression
-                : operator.ExpandExpression) != null
+            operator.Expressions != null
+             ? operator.Expressions
+             : operator.Expression != null
+                ? operator.Expression
+                : operator.LegacyExpression != null
+                  ? operator.LegacyExpression
+                  : operator.ExpandExpression) != null
             ? left1
             : operator.LabelName) != null
           ? left


### PR DESCRIPTION
Fixes bug where 'Expressions' parameter was not being mapped correctly from cypher response

_Note: See 'projection'_

---

Before:
![plan-3 4](https://user-images.githubusercontent.com/849508/40303299-20749d38-5cea-11e8-9065-952133400afe.png)

---

After:
![plan-3 4-with-expressions](https://user-images.githubusercontent.com/849508/40303288-1641991a-5cea-11e8-854a-153133e85990.png)
