### PR TITLE
Make sure path start / end nodes aren’t "type stamped" twice

### DIFF
--- a/e2e_tests/integration/types.spec.js
+++ b/e2e_tests/integration/types.spec.js
@@ -144,5 +144,16 @@ describe('Types in Browser', () => {
         .should('contain', 'date: "P11M3DT-78036.143000000S"')
         .and('contain', 'location: point({srid:4326, x:12.78, y:56.7})')
     })
+    it('renders types in paths in viz correctly', () => {
+      cy.executeCommand(':clear')
+      const query = 'MATCH p=(:Types)-[]-() RETURN p'
+      cy.executeCommand(query)
+      // cy.waitForCommandResult()
+      cy.get('circle.outline', { timeout: 10000 }).click()
+      cy
+        .get('[data-test-id="vizInspector"]')
+        .should('contain', 'date: "P11M3DT-78036.143000000S"')
+        .and('contain', 'location: point({srid:4326, x:12.78, y:56.7})')
+    })
   }
 })

--- a/e2e_tests/integration/types.spec.js
+++ b/e2e_tests/integration/types.spec.js
@@ -146,7 +146,7 @@ describe('Types in Browser', () => {
     })
     it('renders types in paths in viz correctly', () => {
       cy.executeCommand(':clear')
-      const query = 'MATCH p=(:Types)-[]-() RETURN p'
+      const query = 'MATCH p=(:Types) RETURN p'
       cy.executeCommand(query)
       // cy.waitForCommandResult()
       cy.get('circle.outline', { timeout: 10000 }).click()

--- a/src/shared/services/bolt/applyGraphTypes.test.js
+++ b/src/shared/services/bolt/applyGraphTypes.test.js
@@ -460,6 +460,62 @@ describe('applyGraphTypes', () => {
     const typedDate = applyGraphTypes(rawDate)
     expect(typedDate).toBeInstanceOf(neo4j.types.Time)
   })
+  test('should identify time in nodes in paths with refs for start and end', () => {
+    const date = new neo4j.types.Time(11, 1, 12, 3600)
+    const start = new neo4j.types.Node(neo4j.int(1), ['From'], { date })
+    const end = new neo4j.types.Node(neo4j.int(3), ['To'], {})
+    const rel = new neo4j.types.Relationship(
+      neo4j.int(2),
+      neo4j.int(1),
+      neo4j.int(3),
+      'TestType',
+      {}
+    )
+    const seg = new neo4j.types.PathSegment(start, rel, end)
+    const segments = [seg]
+    const path = new neo4j.types.Path(
+      segments[0].start,
+      segments[segments.length - 1].end,
+      segments
+    )
+
+    // When
+    const res = nativeTypesToCustom(path)
+    const typed = applyGraphTypes(res)
+
+    // Then
+    expect(typed.start.properties.date instanceof neo4j.types.Time).toBeTruthy()
+    expect(
+      typed.segments[0].start.properties.date instanceof neo4j.types.Time
+    ).toBeTruthy()
+  })
+  test('should identify time in nodes in paths', () => {
+    const date = new neo4j.types.Time(11, 1, 12, 3600)
+    const start = new neo4j.types.Node(neo4j.int(1), ['From'], { date })
+    const segmentStart = new neo4j.types.Node(neo4j.int(1), ['From'], { date })
+    const end = new neo4j.types.Node(neo4j.int(3), ['To'], {})
+    const segmentEnd = new neo4j.types.Node(neo4j.int(3), ['To'], {})
+    const rel = new neo4j.types.Relationship(
+      neo4j.int(2),
+      neo4j.int(1),
+      neo4j.int(3),
+      'TestType',
+      {}
+    )
+    const seg = new neo4j.types.PathSegment(segmentStart, rel, segmentEnd)
+    const segments = [seg]
+    const path = new neo4j.types.Path(start, end, segments)
+
+    // When
+    const res = nativeTypesToCustom(path)
+    const typed = applyGraphTypes(res)
+
+    // Then
+    expect(typed.start.properties.date instanceof neo4j.types.Time).toBeTruthy()
+    expect(
+      typed.segments[0].start.properties.date instanceof neo4j.types.Time
+    ).toBeTruthy()
+  })
 })
 
 const nativeTypesToCustom = x => {

--- a/src/shared/services/bolt/boltMappings.js
+++ b/src/shared/services/bolt/boltMappings.js
@@ -25,7 +25,8 @@ import {
   safetlyRemoveObjectProp,
   safetlyAddObjectProp,
   escapeReservedProps,
-  unEscapeReservedProps
+  unEscapeReservedProps,
+  hasReservedProp
 } from '../utils'
 
 export const reservedTypePropertyName = 'transport-class'
@@ -136,7 +137,10 @@ const collectHits = function (operator) {
   return hits
 }
 
-export function extractNodesAndRelationshipsFromRecords (records, types) {
+export function extractNodesAndRelationshipsFromRecords (
+  records,
+  types = neo4j.types
+) {
   if (records.length === 0) {
     return { nodes: [], relationships: [] }
   }
@@ -432,8 +436,12 @@ export const recursivelyTypeGraphItems = (item, types = neo4j.types) => {
   if (item instanceof types.Path) {
     safetlyAddObjectProp(item, reservedTypePropertyName, 'Path')
     item.segments = item.segments.map(x => recursivelyTypeGraphItems(x, types))
-    item.start = recursivelyTypeGraphItems(item.start, types)
-    item.end = recursivelyTypeGraphItems(item.end, types)
+    item.start = !hasReservedProp(item.start, reservedTypePropertyName)
+      ? recursivelyTypeGraphItems(item.start, types)
+      : item.start
+    item.end = !hasReservedProp(item.end, reservedTypePropertyName)
+      ? recursivelyTypeGraphItems(item.end, types)
+      : item.end
     return item
   }
   if (item instanceof types.Relationship) {

--- a/src/shared/services/utils.js
+++ b/src/shared/services/utils.js
@@ -348,7 +348,7 @@ export const safetlyAddObjectProp = (obj, prop, val) => {
 }
 
 export const safetlyRemoveObjectProp = (obj, prop) => {
-  if (!Object.prototype.hasOwnProperty.call(obj, prop)) {
+  if (!hasReservedProp(obj, prop)) {
     return obj
   }
   delete obj[prop]
@@ -357,7 +357,7 @@ export const safetlyRemoveObjectProp = (obj, prop) => {
 }
 
 export const escapeReservedProps = (obj, prop) => {
-  if (!Object.prototype.hasOwnProperty.call(obj, prop)) {
+  if (!hasReservedProp(obj, prop)) {
     return obj
   }
   obj = safetlyAddObjectProp(obj, getEscapedObjectProp(prop), obj[prop])
@@ -367,11 +367,11 @@ export const escapeReservedProps = (obj, prop) => {
 
 export const unEscapeReservedProps = (obj, prop) => {
   let propName = getEscapedObjectProp(prop)
-  if (!Object.prototype.hasOwnProperty.call(obj, propName)) {
+  if (!hasReservedProp(obj, propName)) {
     return obj
   }
   while (true) {
-    if (!Object.prototype.hasOwnProperty.call(obj, propName)) {
+    if (!hasReservedProp(obj, propName)) {
       break
     }
     obj[getUnescapedObjectProp(propName)] = obj[propName]
@@ -384,6 +384,9 @@ export const unEscapeReservedProps = (obj, prop) => {
 const getEscapedObjectProp = prop => `\\${prop}`
 const getUnescapedObjectProp = prop =>
   prop.indexOf('\\') === 0 ? prop.substr(1) : prop // A bit weird because of escape chars
+
+export const hasReservedProp = (obj, propName) =>
+  Object.prototype.hasOwnProperty.call(obj, propName)
 
 // Epic helpers
 export const put = dispatch => action => dispatch(action)


### PR DESCRIPTION
Due to `Path`'s start / end nodes being references to the `PathsSegment`'s first and last node they was encoded twice and weird happened.
Since this is an implementation detail in the driver and might change in the future, I secured it by checking before adding types.

### Before
<img width="584" alt="oskarhane-mbpt 2018-05-23 at 09 31 07" src="https://user-images.githubusercontent.com/570998/40409834-57c5c37e-5e6c-11e8-8002-474b8b63180c.png">

### After
<img width="572" alt="oskarhane-mbpt 2018-05-23 at 09 30 51" src="https://user-images.githubusercontent.com/570998/40409849-5ffc0238-5e6c-11e8-8767-898af84f0a0f.png">

changelog: Fix [object Object] output when returning paths with new types
