### PR TITLE
Fix missing inspector items when spread over more than one line

### DIFF
--- a/src/browser/modules/D3Visualization/components/Graph.jsx
+++ b/src/browser/modules/D3Visualization/components/Graph.jsx
@@ -62,18 +62,11 @@ export class GraphComponent extends Component {
   }
 
   getVisualAreaHeight () {
-    if (this.props.frameHeight && this.props.fullscreen) {
-      return (
-        this.props.frameHeight -
-        (dim.frameStatusbarHeight + dim.frameTitlebarHeight * 2)
-      )
-    } else {
-      return (
-        this.props.frameHeight -
-          (dim.frameStatusbarHeight + dim.frameTitlebarHeight * 2) ||
-        this.svgElement.parentNode.offsetHeight
-      )
-    }
+    return this.props.frameHeight && this.props.fullscreen
+      ? this.props.frameHeight -
+          (dim.frameStatusbarHeight + dim.frameTitlebarHeight * 2)
+      : this.props.frameHeight - dim.frameStatusbarHeight ||
+          this.svgElement.parentNode.offsetHeight
   }
 
   componentDidMount () {

--- a/src/browser/modules/D3Visualization/components/styled.jsx
+++ b/src/browser/modules/D3Visualization/components/styled.jsx
@@ -197,13 +197,14 @@ export const StyledStatusBar = styled.div`
   line-height: 39px;
   color: ${props => props.theme.secondaryText};
   font-size: 13px;
-  position: relative;
+  position: absolute;
   background-color: ${props => props.theme.secondaryBackground};
   white-space: nowrap;
   overflow: hidden;
   border-top: 1px solid #e6e9ef;
-  ${props =>
-    props.fullscreen ? 'margin-top: -39px;' : 'margin-bottom: -39px;'};
+  bottom: 0;
+  left: 0;
+  right: 0;
 `
 
 export const StyledStatus = styled.div`
@@ -214,6 +215,8 @@ export const StyledStatus = styled.div`
   margin-bottom: 0;
   width: 100%;
   margin-top: 3px;
+  max-height: 64px;
+  overflow: auto;
 `
 
 export const StyledInspectorFooterRowListPair = styled(StyledInlineListItem)`
@@ -268,10 +271,11 @@ export const StyledLegendRow = styled.div`
 `
 export const StyledLegend = styled.div`
   background-color: ${props => props.theme.secondaryBackground};
-  margin-top: -${legendRowHeight * 2 + 1}px;
-  &.one-row {
-    margin-top: -${legendRowHeight}px;
-  }
+  position: absolute;
+  z-index: 1;
+  top: 0;
+  right: 0;
+  left: 0;
 `
 export const StyledLegendInlineList = styled(StyledInlineList)`
   padding: 7px 9px 0px 10px;
@@ -331,15 +335,8 @@ export const StyledCaptionSelector = styled.a`
 `
 
 export const StyledFullSizeContainer = styled.div`
+  position: relative;
   height: 100%;
-  padding-top: ${legendRowHeight * 2 + 1}px;
-  padding-bottom: ${props =>
-    props.forcePaddingBottom
-      ? props.forcePaddingBottom + 2 * pMarginTop + 'px'
-      : '39px'};
-  &.one-legend-row {
-    padding-top: ${legendRowHeight}px;
-  }
 `
 
 export const StyledInspectorFooterStatusMessage = styled.div`font-weight: bold;`

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView.styled.jsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView.styled.jsx
@@ -23,6 +23,8 @@ import { dim } from 'browser-styles/constants'
 
 export const StyledVisContainer = styled.div`
   width: 100%;
+  overflow: hidden;
+  ${props => (props.fullscreen ? 'padding-bottom: 39px' : null)};
   height: ${props =>
     props.fullscreen
       ? '100vh'


### PR DESCRIPTION
Fixes issue where expanding inspector would force the status bar content out of the viewport.
See #682 

Before:
<img width="448" alt="screen shot 2018-05-23 at 16 54 50" src="https://user-images.githubusercontent.com/849508/40436088-1a11fc3a-5eaa-11e8-9b5c-336a0d6b616e.png">

After:
<img width="443" alt="screen shot 2018-05-23 at 16 51 59" src="https://user-images.githubusercontent.com/849508/40435916-a5da45d4-5ea9-11e8-8427-05329455e1bb.png">
