### PR TITLE
Visualization: Avoid calling 'toString' on empty objects

### DIFF
--- a/src/browser/modules/D3Visualization/components/Inspector.jsx
+++ b/src/browser/modules/D3Visualization/components/Inspector.jsx
@@ -50,7 +50,7 @@ const mapItemProperties = itemProperties =>
           {prop.key + ': '}
         </StyledInspectorFooterRowListKey>
         <StyledInspectorFooterRowListValue className='value'>
-          {prop.value.toString()}
+          {prop.value ? prop.value.toString() : prop.value}
         </StyledInspectorFooterRowListValue>
       </StyledInspectorFooterRowListPair>
     ))

--- a/src/browser/modules/D3Visualization/components/Inspector.jsx
+++ b/src/browser/modules/D3Visualization/components/Inspector.jsx
@@ -19,7 +19,7 @@
  */
 
 import { Component } from 'preact'
-import { deepEquals } from 'services/utils'
+import { deepEquals, optionalToString } from 'services/utils'
 import {
   inspectorFooterContractedHeight,
   StyledInspectorFooterStatusMessage,
@@ -50,7 +50,7 @@ const mapItemProperties = itemProperties =>
           {prop.key + ': '}
         </StyledInspectorFooterRowListKey>
         <StyledInspectorFooterRowListValue className='value'>
-          {prop.value ? prop.value.toString() : prop.value}
+          {optionalToString(prop.value)}
         </StyledInspectorFooterRowListValue>
       </StyledInspectorFooterRowListPair>
     ))

--- a/src/browser/modules/D3Visualization/mapper.js
+++ b/src/browser/modules/D3Visualization/mapper.js
@@ -20,7 +20,7 @@
 
 const mapProperties = _ => Object.assign({}, ...stringifyValues(_))
 const stringifyValues = obj =>
-  Object.keys(obj).map(k => ({ [k]: obj[k].toString() }))
+  Object.keys(obj).map(k => ({ [k]: obj[k] ? obj[k].toString() : obj[k] }))
 
 export function createGraph (nodes, relationships) {
   let graph = new neo.models.Graph()

--- a/src/browser/modules/D3Visualization/mapper.js
+++ b/src/browser/modules/D3Visualization/mapper.js
@@ -18,9 +18,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { optionalToString } from 'services/utils'
+
 const mapProperties = _ => Object.assign({}, ...stringifyValues(_))
 const stringifyValues = obj =>
-  Object.keys(obj).map(k => ({ [k]: obj[k] ? obj[k].toString() : obj[k] }))
+  Object.keys(obj).map(k => ({ [k]: optionalToString(obj[k]) }))
 
 export function createGraph (nodes, relationships) {
   let graph = new neo.models.Graph()

--- a/src/shared/services/utils.js
+++ b/src/shared/services/utils.js
@@ -387,3 +387,8 @@ const getUnescapedObjectProp = prop =>
 
 // Epic helpers
 export const put = dispatch => action => dispatch(action)
+
+export const optionalToString = v =>
+  ![null, undefined].includes(v) && typeof v.toString === 'function'
+    ? v.toString()
+    : v

--- a/src/shared/services/utils.test.js
+++ b/src/shared/services/utils.test.js
@@ -511,4 +511,12 @@ describe('Object props manipulation', () => {
   test('arrayToObject', () => {
     expect(utils.arrayToObject([{ foo: 'bar' }])).toEqual({ foo: 'bar' })
   })
+  describe('optionalToString', () => {
+    test('will strings', () => {
+      expect(utils.optionalToString(null)).toBe(null)
+      expect(utils.optionalToString(1)).toBe('1')
+      expect(utils.optionalToString({ a: 'a' })).toBe('[object Object]')
+      expect(utils.optionalToString({ toString: () => 'a' })).toBe('a')
+    })
+  })
 })


### PR DESCRIPTION
Previously the visualisation would throw an error that would cause the render to break