### PR TITLE
Word break long values in db info drawer

### DIFF
--- a/src/browser/modules/DatabaseInfo/styled.jsx
+++ b/src/browser/modules/DatabaseInfo/styled.jsx
@@ -22,6 +22,7 @@ import styled from 'styled-components'
 import { PlainPlayIcon } from 'browser-components/icons/Icons'
 
 const chip = styled.div`
+  word-break: break-all;
   cursor: pointer;
   font-family: ${props => props.theme.primaryFontFamily};
   font-weight: bold;


### PR DESCRIPTION
Before:
<img width="300" alt="screen shot 2018-05-24 at 10 32 05" src="https://user-images.githubusercontent.com/849508/40477312-09ad8b22-5f3e-11e8-82bd-89eabbf17857.png">

After:
<img width="300" alt="screen shot 2018-05-24 at 10 31 49" src="https://user-images.githubusercontent.com/849508/40477318-0e954814-5f3e-11e8-8cd4-a41f648af690.png">
