### PR TITLE
Don’t add type hinting quotes on strings in CSV export

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/AsciiView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/AsciiView.jsx
@@ -20,7 +20,6 @@
 
 import { Component } from 'preact'
 import asciitable from 'ascii-data-table'
-import { v1 as neo4j } from 'neo4j-driver-alias'
 import Render from 'browser-components/Render'
 import Ellipsis from 'browser-components/Ellipsis'
 import { debounce, shallowEquals, deepEquals } from 'services/utils'
@@ -38,6 +37,7 @@ import {
   transformResultRecordsToResultArray,
   stringifyResultArray
 } from './helpers'
+import { stringFormat } from 'services/bolt/cypherTypesFormatting'
 
 export class AsciiView extends Component {
   constructor (props) {
@@ -80,7 +80,7 @@ export class AsciiView extends Component {
     const records = getRecordsToDisplayInTable(props.result, props.maxRows)
     const serializedRows =
       stringifyResultArray(
-        neo4j.isInt,
+        stringFormat,
         transformResultRecordsToResultArray(records)
       ) || []
     this.setState({ serializedRows })

--- a/src/browser/modules/Stream/CypherFrame/helpers.js
+++ b/src/browser/modules/Stream/CypherFrame/helpers.js
@@ -164,11 +164,11 @@ export const initialView = (props, state = {}) => {
  * It takes a replacer without enforcing quoting rules to it.
  * Used so we can have Neo4j integers as string without quotes.
  */
-export const stringifyResultArray = (intChecker = neo4j.isInt, arr = []) => {
+export const stringifyResultArray = (formatter = stringFormat, arr = []) => {
   return arr.map(col => {
     if (!col) return col
     return col.map(fVal => {
-      return stringifyMod(fVal, stringFormat)
+      return stringifyMod(fVal, formatter)
     })
   })
 }

--- a/src/browser/modules/Stream/CypherFrame/helpers.test.js
+++ b/src/browser/modules/Stream/CypherFrame/helpers.test.js
@@ -34,6 +34,7 @@ import {
   flattenGraphItemsInResultArray,
   stringifyResultArray
 } from './helpers'
+import { stringFormat, csvFormat } from 'services/bolt/cypherTypesFormatting'
 
 describe('helpers', () => {
   test('getRecordsToDisplayInTable should report if there are rows or not in the result', () => {
@@ -606,12 +607,46 @@ describe('helpers', () => {
         neo4j.isInt,
         step1
       )
-      const res = stringifyResultArray(neo4j.isInt, step2)
+      const res = stringifyResultArray(stringFormat, step2)
       // Then
       expect(res).toEqual([
         ['""neoInt""', '""int""', '""any""', '""backslash""'],
         ['882573709873217509', '100.0', '0.5', '""\\""'],
         ['300', '100.0', '"string"']
+      ])
+    })
+    test('stringifyResultArray can take different formatter function (csvFormat)', () => {
+      // Given
+      const records = [
+        {
+          keys: ['"neoInt"', '"int"', '"any"', '"backslash"', '"bool"'],
+          _fields: [
+            new neo4j.int('882573709873217509'),
+            100,
+            0.5,
+            '"\\"',
+            false
+          ]
+        },
+        {
+          keys: ['"neoInt"', '"int"', '"any"', '"string with comma"'],
+          _fields: [new neo4j.int(300), 100, 'string', 'my, string']
+        }
+      ]
+
+      // When
+      const step1 = extractRecordsToResultArray(records)
+      const step2 = flattenGraphItemsInResultArray(
+        neo4j.types,
+        neo4j.isInt,
+        step1
+      )
+      const res = stringifyResultArray(csvFormat, step2)
+      // Then
+      expect(res).toEqual([
+        ['"neoInt"', '"int"', '"any"', '"backslash"', '"bool"'],
+        ['882573709873217509', '100.0', '0.5', '"\\"', 'false'],
+        ['300', '100.0', 'string', 'my, string']
       ])
     })
     test('stringifyResultArray handles neo4j integers nested within graph items', () => {
@@ -646,7 +681,7 @@ describe('helpers', () => {
         neo4j.isInt,
         step1
       )
-      const res = stringifyResultArray(neo4j.isInt, step2)
+      const res = stringifyResultArray(stringFormat, step2)
       // Then
       expect(res).toEqual([
         ['""x""', '""y""', '""n""'],

--- a/src/browser/modules/Stream/CypherFrame/index.jsx
+++ b/src/browser/modules/Stream/CypherFrame/index.jsx
@@ -23,7 +23,6 @@ import { Component } from 'preact'
 import FrameTemplate from '../FrameTemplate'
 import { CypherFrameButton } from 'browser-components/buttons'
 import Centered from 'browser-components/Centered'
-import { v1 as neo4j } from 'neo4j-driver-alias'
 import { deepEquals } from 'services/utils'
 import { getRequest } from 'shared/modules/requests/requestsDuck'
 import FrameSidebar from '../FrameSidebar'
@@ -69,6 +68,7 @@ import {
   shouldAutoComplete
 } from 'shared/modules/settings/settingsDuck'
 import { setRecentView, getRecentView } from 'shared/modules/stream/streamDuck'
+import { csvFormat } from 'services/bolt/cypherTypesFormatting'
 
 export class CypherFrame extends Component {
   constructor (props) {
@@ -81,7 +81,7 @@ export class CypherFrame extends Component {
   }
   makeExportData (records) {
     return stringifyResultArray(
-      neo4j.isInt,
+      csvFormat,
       transformResultRecordsToResultArray(records)
     )
   }

--- a/src/shared/services/bolt/cypherTypesFormatting.js
+++ b/src/shared/services/bolt/cypherTypesFormatting.js
@@ -1,28 +1,55 @@
 import { v1 as neo4j } from 'neo4j-driver-alias'
 
-export const stringFormat = anything => {
+export const csvFormat = anything => {
   if (typeof anything === 'number') {
-    if (Math.floor(anything) === anything) {
-      return `${anything}.0`
-    }
-    return undefined
+    return numberFormat(anything)
   }
   if (neo4j.isInt(anything)) {
     return anything.toString()
   }
   if (anything instanceof neo4j.types.Point) {
-    const zString = anything.z ? `, z:${anything.z}` : ''
-    return `point({srid:${anything.srid}, x:${anything.x}, y:${anything.y}${zString}})`
+    return spacialFormat(anything)
   }
-  if (
-    anything instanceof neo4j.types.Date ||
-    anything instanceof neo4j.types.DateTime ||
-    anything instanceof neo4j.types.Duration ||
-    anything instanceof neo4j.types.LocalDateTime ||
-    anything instanceof neo4j.types.LocalTime ||
-    anything instanceof neo4j.types.Time
-  ) {
+  if (isTemporalType(anything)) {
+    return `"${anything.toString()}"`
+  }
+  if (typeof anything === 'string') {
+    return anything
+  }
+  return undefined
+}
+
+export const stringFormat = anything => {
+  if (typeof anything === 'number') {
+    return numberFormat(anything)
+  }
+  if (neo4j.isInt(anything)) {
+    return anything.toString()
+  }
+  if (anything instanceof neo4j.types.Point) {
+    return spacialFormat(anything)
+  }
+  if (isTemporalType(anything)) {
     return `"${anything.toString()}"`
   }
   return undefined
 }
+
+const numberFormat = anything => {
+  if (Math.floor(anything) === anything) {
+    return `${anything}.0`
+  }
+  return undefined
+}
+const spacialFormat = anything => {
+  const zString = anything.z ? `, z:${anything.z}` : ''
+  return `point({srid:${anything.srid}, x:${anything.x}, y:${anything.y}${zString}})`
+}
+
+const isTemporalType = anything =>
+  anything instanceof neo4j.types.Date ||
+  anything instanceof neo4j.types.DateTime ||
+  anything instanceof neo4j.types.Duration ||
+  anything instanceof neo4j.types.LocalDateTime ||
+  anything instanceof neo4j.types.LocalTime ||
+  anything instanceof neo4j.types.Time


### PR DESCRIPTION
The reformatting of results display mistakenly followed along to the CSV export. This fixes that.

The extra quotes in the CSV file headers comes from the drivers `keys` field and are not added by us and is not part of this regression.

Test query: `RETURN "string, yo", "yo", 1, 1.0, true`

### Before
```
"""""string, yo""""","""""yo""""","""1""","""1.0""","""true"""
"""string, yo""","""yo""",1,1.0,true
```

### After

```
"""string, yo""","""yo""",1,1.0,true
"string, yo",yo,1,1.0,true
```