### PR TITLE
Refactor CSV export data contruction

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "codemirror": "^5.29.0",
     "cypher-codemirror": "^1.0.5",
     "dnd-core": "^2.5.1",
-    "file-saver": "^1.3.3",
+    "file-saver": "^1.3.8",
     "firebase": "^4.3.0",
     "husky": "^0.14.3",
     "isomorphic-fetch": "^2.2.1",

--- a/src/browser/modules/Stream/FrameTemplate.jsx
+++ b/src/browser/modules/Stream/FrameTemplate.jsx
@@ -104,7 +104,8 @@ class FrameTemplate extends Component {
           collapseToggle={this.toggleCollapse.bind(this)}
           pinned={this.state.pinned}
           togglePin={this.togglePin.bind(this)}
-          exportData={this.props.exportData}
+          numRecords={this.props.numRecords || 0}
+          getRecords={this.props.getRecords}
           visElement={this.props.visElement}
         />
         <StyledFrameBody

--- a/yarn.lock
+++ b/yarn.lock
@@ -3626,7 +3626,7 @@ file-loader@^0.11.1:
   dependencies:
     loader-utils "^1.0.2"
 
-file-saver@^1.3.3:
+file-saver@^1.3.8:
   version "1.3.8"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/file-saver/-/file-saver-1.3.8.tgz?dl=https://registry.npmjs.org/file-saver/-/file-saver-1.3.8.tgz#e68a30c7cb044e2fb362b428469feb291c2e09d8"
 


### PR DESCRIPTION
With this PR we skip constructing and passing a complete copy of the returned data from every query to the children of `CypherFrame`. Not everyone exports so it's often an unnecessary operation and also slows down rendering of CypherFrame's other view.
This is now done on demand.
We need to pass down something (`numRecords`) to indicate that we have a result so the export button will show at all when query state goes from 'pending' -> 'completed' so the children of CypherFrame re-renders.
Not sure about the real performance impact since it depends on the amount of data the queries return.
But is has no downside. 

Tested and verified in Chrome, FF, Safari on macOS and IE11, Edge on Windows 10.