### PR TITLE
Don't show reconnect banner when connecting, only when an active connection breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,16 @@ The latter just opens Cypress runner so you can see the tests being executed and
 There are also e2e tests that covers import from CSV files. To run thise, copy the `e2e_tests/files/import.csv` to the `import/` directory of the database you want to run the tests on and then start the e2e tests with the `--env include-import-tests=true` flag.
 Example: `yarn e2e-local-open --env server=3.4,include-import-tests=true`
 
+Here are the avaialable options / env variables:
+
+```
+server=3.2|3.3|3.4|3.5 (default 3.4)
+browser-password=<your-pw> (default 'newpassword')
+include-import-tests=true|false (default false)
+E2E_TEST_ENV=local|null (if the initial set of pw should run or not)
+BROWSER_URL=<url to reach the browser to test>
+```
+
 ## Devtools
 
 Download these two chrome extensions:

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Here are the avaialable options / env variables:
 server=3.2|3.3|3.4|3.5 (default 3.4)
 browser-password=<your-pw> (default 'newpassword')
 include-import-tests=true|false (default false)
-E2E_TEST_ENV=local|null (if the initial set of pw should run or not)
-BROWSER_URL=<url to reach the browser to test>
+E2E_TEST_ENV=local|null (if the initial set of pw should run or not) (default undefined)
+BROWSER_URL=<url to reach the browser to test> (default http://localhost:8080)
 ```
 
 ## Devtools

--- a/e2e_tests/integration/0.index.spec.js
+++ b/e2e_tests/integration/0.index.spec.js
@@ -25,29 +25,6 @@ const SubmitQueryButton = '[data-test-id="submitQuery"]'
 const Editor = '.ReactCodeMirror textarea'
 
 describe('Neo4j Browser', () => {
-  it('sets new login credentials', () => {
-    const newPassword = Cypress.env('browser-password') || 'newpassword'
-    cy.setInitialPassword(newPassword)
-    cy.disconnect()
-  })
-  it('show "no connection" error when not using web workers', () => {
-    cy.executeCommand(':clear')
-    cy.executeCommand(':config useCypherThread: false')
-    cy.executeCommand('RETURN 1')
-    cy
-      .get('[data-test-id="frameContents"]', { timeout: 10000 })
-      .first()
-      .should('contain', 'No connection found, did you connect to Neo4j')
-  })
-  it('show "no connection" error when using web workers', () => {
-    cy.executeCommand(':clear')
-    cy.executeCommand(':config useCypherThread: true')
-    cy.executeCommand('RETURN 1')
-    cy
-      .get('[data-test-id="frameContents"]', { timeout: 10000 })
-      .first()
-      .should('contain', 'No connection found, did you connect to Neo4j')
-  })
   it('can connect', () => {
     const password = Cypress.env('browser-password') || 'newpassword'
     cy.connect('neo4j', password)

--- a/e2e_tests/integration/0.index.spec.js
+++ b/e2e_tests/integration/0.index.spec.js
@@ -25,6 +25,11 @@ const SubmitQueryButton = '[data-test-id="submitQuery"]'
 const Editor = '.ReactCodeMirror textarea'
 
 describe('Neo4j Browser', () => {
+  it('sets new login credentials', () => {
+    const newPassword = Cypress.env('browser-password') || 'newpassword'
+    cy.setInitialPassword(newPassword)
+    cy.disconnect()
+  })
   it('can connect', () => {
     const password = Cypress.env('browser-password') || 'newpassword'
     cy.connect('neo4j', password)

--- a/e2e_tests/integration/bolt.spec.js
+++ b/e2e_tests/integration/bolt.spec.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j, Inc"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* global cy, test, expect */
+
+describe('Bolt connections', () => {
+  it('show "no connection" error when not using web workers', () => {
+    cy.executeCommand(':clear')
+    cy.executeCommand(':config useCypherThread: false')
+    cy.executeCommand('RETURN 1')
+    cy.resultContains('No connection found, did you connect to Neo4j')
+  })
+  it('show "no connection" error when using web workers', () => {
+    cy.executeCommand(':clear')
+    cy.executeCommand(':config useCypherThread: true')
+    cy.executeCommand('RETURN 1')
+    cy.resultContains('No connection found, did you connect to Neo4j')
+  })
+  it('does not show the "Reconnect" banner when trying to connect', () => {
+    cy.connect('neo4j', 'x', 'bolt://localhost:7685', false) // Non open port
+    cy.wait(10000)
+    cy.get('[data-test-id="reconnectBanner"]').should('not.be.visible')
+    cy.get('[data-test-id="disconnectedBanner"]').should('be.visible')
+    cy
+      .get('[data-test-id="main"]', { timeout: 1000 })
+      .and('contain', 'Database access not available')
+      .should('not.contain', 'Connection lost')
+  })
+})

--- a/e2e_tests/support/commands.js
+++ b/e2e_tests/support/commands.js
@@ -41,37 +41,49 @@ Cypress.Commands.add('setInitialPassword', newPassword => {
     .get('[data-test-id="frameCommand"]', { timeout: 10000 })
     .should('contain', ':play start')
 })
-Cypress.Commands.add('connect', (username, password) => {
-  cy.executeCommand(':server disconnect')
-  cy.executeCommand(':clear')
-  cy.executeCommand(':server connect')
+Cypress.Commands.add(
+  'connect',
+  (
+    username,
+    password,
+    host = 'bolt://localhost:7687',
+    makeAssertions = true
+  ) => {
+    cy.executeCommand(':server disconnect')
+    cy.executeCommand(':clear')
+    cy.executeCommand(':server connect')
 
-  cy
-    .get('input[data-test-id="boltaddress"]')
-    .clear()
-    .type('bolt://localhost:7687')
+    cy
+      .get('input[data-test-id="boltaddress"]')
+      .clear()
+      .type(host)
 
-  cy.get('input[data-test-id="username"]').should('have.value', 'neo4j')
-  cy.get('input[data-test-id="password"]').should('have.value', '')
+    cy.get('input[data-test-id="username"]').should('have.value', 'neo4j')
+    cy.get('input[data-test-id="password"]').should('have.value', '')
 
-  cy
-    .get('input[data-test-id="username"]')
-    .clear()
-    .type(username)
-  cy
-    .get('input[data-test-id="password"]')
-    .clear()
-    .type(password)
+    cy
+      .get('input[data-test-id="username"]')
+      .clear()
+      .type(username)
+    cy
+      .get('input[data-test-id="password"]')
+      .clear()
+      .type(password)
 
-  cy.get('button[data-test-id="connect"]').click()
-  cy.get('[data-test-id="frame"]', { timeout: 10000 }).should('have.length', 2)
-  cy.wait(500)
-  cy
-    .get('[data-test-id="frameCommand"]')
-    .first()
-    .should('contain', ':play start')
-  cy.executeCommand(':clear')
-})
+    cy.get('button[data-test-id="connect"]').click()
+    if (makeAssertions) {
+      cy
+        .get('[data-test-id="frame"]', { timeout: 10000 })
+        .should('have.length', 2)
+      cy.wait(500)
+      cy
+        .get('[data-test-id="frameCommand"]')
+        .first()
+        .should('contain', ':play start')
+      cy.executeCommand(':clear')
+    }
+  }
+)
 Cypress.Commands.add('disconnect', () => {
   const query = ':server disconnect'
   cy.executeCommand(query)

--- a/e2e_tests/support/index.js
+++ b/e2e_tests/support/index.js
@@ -8,9 +8,6 @@ before(function () {
     .visit(Cypress.env('BROWSER_URL') || 'http://localhost:8080')
     .title()
     .should('include', 'Neo4j Browser')
-  const newPassword = Cypress.env('browser-password') || 'newpassword'
-  cy.setInitialPassword(newPassword)
-  cy.disconnect()
 })
 
 afterEach(function () {

--- a/e2e_tests/support/index.js
+++ b/e2e_tests/support/index.js
@@ -8,6 +8,9 @@ before(function () {
     .visit(Cypress.env('BROWSER_URL') || 'http://localhost:8080')
     .title()
     .should('include', 'Neo4j Browser')
+  const newPassword = Cypress.env('browser-password') || 'newpassword'
+  cy.setInitialPassword(newPassword)
+  cy.disconnect()
 })
 
 afterEach(function () {

--- a/src/browser/modules/Main/Main.jsx
+++ b/src/browser/modules/Main/Main.jsx
@@ -55,7 +55,7 @@ const Main = props => {
         </ErrorBanner>
       </Render>
       <Render if={props.connectionState === DISCONNECTED_STATE}>
-        <NotAuthedBanner>
+        <NotAuthedBanner data-test-id='disconnectedBanner'>
           Database access not available. Please use&nbsp;
           <ClickToCode CodeComponent={StyledCodeBlockAuthBar}>
             {props.cmdchar}server connect
@@ -64,7 +64,7 @@ const Main = props => {
         </NotAuthedBanner>
       </Render>
       <Render if={props.connectionState === PENDING_STATE}>
-        <WarningBanner>
+        <WarningBanner data-test-id='reconnectBanner'>
           Connection to server lost. Reconnecting...
         </WarningBanner>
       </Render>

--- a/src/shared/modules/connections/connectionsDuck.js
+++ b/src/shared/modules/connections/connectionsDuck.js
@@ -292,11 +292,7 @@ export const connectEpic = (action$, store) => {
     memoryUsername = ''
     memoryPassword = ''
     return bolt
-      .openConnection(
-        action,
-        { encrypted: getEncryptionMode(action) },
-        onLostConnection(store.dispatch)
-      )
+      .openConnection(action, { encrypted: getEncryptionMode(action) })
       .then(res => ({ type: action.$$responseChannel, success: true }))
       .catch(e => ({
         type: action.$$responseChannel,

--- a/src/shared/services/bolt/boltConnection.js
+++ b/src/shared/services/bolt/boltConnection.js
@@ -139,7 +139,7 @@ export function directConnect (
   return p
 }
 
-export function openConnection (props, opts = {}, onLostConnection) {
+export function openConnection (props, opts = {}, onLostConnection = () => {}) {
   const p = new Promise((resolve, reject) => {
     const onConnectFail = e => {
       onLostConnection(e)


### PR DESCRIPTION
We only want to show the 'reconnect' banner when an active connection breaks.
The current behavior is that the banner show when you're trying to connect to something that doesn't exists. 

I also did some e2e test refactoring as part of this PR to simplify writing tests. Also added more e2e info to README.

### Before
<img width="554" alt="oskarhane-mbpt 2018-05-31 at 09 34 07" src="https://user-images.githubusercontent.com/570998/40768516-d4222396-64b5-11e8-9756-9373c4aff5b2.png">

### After
<img width="581" alt="oskarhane-mbpt 2018-05-31 at 09 33 44" src="https://user-images.githubusercontent.com/570998/40768522-d5fb63bc-64b5-11e8-9fea-8a90414c2507.png">
