### PR TITLE
Fix race condition with data from jmx

### DIFF
--- a/src/shared/rootEpic.js
+++ b/src/shared/rootEpic.js
@@ -42,6 +42,7 @@ import {
 } from './modules/connections/connectionsDuck'
 import {
   dbMetaEpic,
+  serverConfigEpic,
   clearMetaOnDisconnectEpic
 } from './modules/dbMeta/dbMetaDuck'
 import { jmxEpic } from './modules/jmx/jmxDuck'
@@ -100,6 +101,7 @@ export default combineEpics(
   startupConnectionFailEpic,
   detectActiveConnectionChangeEpic,
   dbMetaEpic,
+  serverConfigEpic,
   clearMetaOnDisconnectEpic,
   cancelRequestEpic,
   discoveryOnStartupEpic,


### PR DESCRIPTION
Let all dbMeta data mapping items that rely on data from JMX wait for the JMX data before they run.
Since the JMX values update every 20 secs, the epic is straight forward.
Hard to test / validate the race condition, so I'll skip that.