### PR TITLE
Show number of nodes and relationships in db sidebar

### DIFF
--- a/src/browser/modules/DatabaseInfo/DatabaseInfo.jsx
+++ b/src/browser/modules/DatabaseInfo/DatabaseInfo.jsx
@@ -49,7 +49,9 @@ export class DatabaseInfo extends Component {
       properties = [],
       userDetails,
       databaseKernelInfo,
-      onItemClick
+      onItemClick,
+      nodes,
+      relationships
     } = this.props
 
     return (
@@ -57,6 +59,7 @@ export class DatabaseInfo extends Component {
         <DrawerHeader>Database Information</DrawerHeader>
         <DrawerBody>
           <LabelItems
+            count={nodes}
             labels={labels.slice(0, this.state.labelsMax).map(l => l.val)}
             totalNumItems={labels.length}
             onItemClick={onItemClick}
@@ -64,6 +67,7 @@ export class DatabaseInfo extends Component {
             moreStep={this.state.moreStep}
           />
           <RelationshipItems
+            count={relationships}
             relationshipTypes={relationshipTypes
               .slice(0, this.state.relationshipsMax)
               .map(l => l.val)}

--- a/src/browser/modules/DatabaseInfo/MetaItems.jsx
+++ b/src/browser/modules/DatabaseInfo/MetaItems.jsx
@@ -57,11 +57,16 @@ const createItems = (
   onItemClick,
   RenderType,
   editorCommandTemplate,
-  showStar = true
+  showStar = true,
+  count
 ) => {
   let items = [...originalList]
   if (showStar) {
-    items.unshift('*')
+    let str = '*'
+    if (count) {
+      str = `${str}(${count})`
+    }
+    items.unshift(str)
   }
   return items.map((text, index) => {
     const getNodesCypher = editorCommandTemplate(text, index)
@@ -81,7 +86,8 @@ const LabelItems = ({
   totalNumItems,
   onItemClick,
   moreStep,
-  onMoreClick
+  onMoreClick,
+  count
 }) => {
   let labelItems = <p>There are no labels in database</p>
   if (labels.length) {
@@ -95,7 +101,9 @@ const LabelItems = ({
       labels,
       onItemClick,
       { component: StyledLabel },
-      editorCommandTemplate
+      editorCommandTemplate,
+      true,
+      count
     )
   }
   return (
@@ -122,7 +130,8 @@ const RelationshipItems = ({
   totalNumItems,
   onItemClick,
   moreStep,
-  onMoreClick
+  onMoreClick,
+  count
 }) => {
   let relationshipItems = <p>No relationships in database</p>
   if (relationshipTypes.length > 0) {
@@ -138,7 +147,9 @@ const RelationshipItems = ({
       relationshipTypes,
       onItemClick,
       { component: StyledRelationship },
-      editorCommandTemplate
+      editorCommandTemplate,
+      true,
+      count
     )
   }
   return (

--- a/src/shared/modules/dbMeta/__snapshots__/dbMetaDuck.test.js.snap
+++ b/src/shared/modules/dbMeta/__snapshots__/dbMetaDuck.test.js.snap
@@ -5,9 +5,11 @@ Object {
   "foo": "bar",
   "functions": Array [],
   "labels": Array [],
+  "nodes": 0,
   "procedures": Array [],
   "properties": Array [],
   "relationshipTypes": Array [],
+  "relationships": 0,
   "role": null,
   "server": Object {
     "dbName": null,
@@ -27,9 +29,11 @@ exports[`updating metadata can CLEAR to reset state 1`] = `
 Object {
   "functions": Array [],
   "labels": Array [],
+  "nodes": 0,
   "procedures": Array [],
   "properties": Array [],
   "relationshipTypes": Array [],
+  "relationships": 0,
   "role": null,
   "server": Object {
     "dbName": null,

--- a/src/shared/modules/dbMeta/dbMetaDuck.test.js
+++ b/src/shared/modules/dbMeta/dbMetaDuck.test.js
@@ -19,6 +19,7 @@
  */
 
 /* global describe, test, expect */
+import { v1 as neo4j } from 'neo4j-driver-alias'
 import reducer, * as meta from './dbMetaDuck'
 import { APP_START } from 'shared/modules/app/appDuck'
 
@@ -78,6 +79,15 @@ describe('updating metadata', () => {
         ]
       }
     }
+    const returnedNodes = {
+      a: 'nodes',
+      get: () => neo4j.int(5)
+    }
+    const returnedRelationships = {
+      a: 'relationships',
+      get: () => neo4j.int(10)
+    }
+
     const action = {
       type: meta.UPDATE_META,
       meta: {
@@ -86,7 +96,9 @@ describe('updating metadata', () => {
           returnedRelationshipTypes,
           returnedProperties,
           returnedFunctions,
-          returnedProcedures
+          returnedProcedures,
+          returnedNodes,
+          returnedRelationships
         ]
       },
       context: 'mycontext'
@@ -122,10 +134,13 @@ describe('updating metadata', () => {
         description: 'procedureDescription'
       }
     ])
+    expect(nextState.nodes).toEqual(5)
+    expect(nextState.relationships).toEqual(10)
   })
 
   test('should update state with empty metadata', () => {
     const returnNothing = () => []
+    const returnNull = () => null
     const action = {
       type: meta.UPDATE_META,
       meta: {
@@ -134,7 +149,9 @@ describe('updating metadata', () => {
           { a: 'relationshipTypes', get: returnNothing },
           { a: 'properties', get: returnNothing },
           { a: 'functions', get: returnNothing },
-          { a: 'procedures', get: returnNothing }
+          { a: 'procedures', get: returnNothing },
+          { a: 'nodes', get: returnNull },
+          { a: 'realtionships', get: returnNull }
         ]
       },
       context: 'mycontext'
@@ -147,6 +164,8 @@ describe('updating metadata', () => {
     expect(nextState.properties).toEqual([])
     expect(nextState.functions).toEqual([])
     expect(nextState.procedures).toEqual([])
+    expect(nextState.nodes).toEqual(0)
+    expect(nextState.relationships).toEqual(0)
   })
   test('can update server settings', () => {
     // Given


### PR DESCRIPTION
Count the number of nodes and relationships on every db-meta update.

Display like we do in the viz legend.

<img width="272" alt="oskarhane-mbpt 2018-06-04 at 15 08 03" src="https://user-images.githubusercontent.com/570998/40958616-3893dc06-689a-11e8-87fb-2f27b1fcb350.png">
