### PR TITLE
Handle changelog url building in disconnected state

### DIFF
--- a/src/browser/modules/Sidebar/About.jsx
+++ b/src/browser/modules/Sidebar/About.jsx
@@ -134,6 +134,9 @@ const About = ({ serverVersion, serverEdition }) => (
 )
 
 const asChangeLogUrl = serverVersion => {
+  if (!serverVersion) {
+    return undefined
+  }
   const tokenisedServerVersion = serverVersion && serverVersion.split('.')
   const releaseTag = tokenisedServerVersion.join('')
   const urlServerVersion =


### PR DESCRIPTION
Fixes issue where app would crash when opening `About` drawer whilst disconnected from neo4j