### PR TITLE
Add toggle for multi statement cypher editor

### DIFF
--- a/src/browser/modules/Sidebar/Settings.jsx
+++ b/src/browser/modules/Sidebar/Settings.jsx
@@ -53,6 +53,13 @@ const visualSettings = [
           tooltip: 'Autocomplete and syntax highlighting in query editor',
           type: 'checkbox'
         }
+      },
+      {
+        enableMultiStatementMode: {
+          displayName: 'Enable multi statement query editor',
+          tooltip: 'Allows query editor to execute multiple statements',
+          type: 'checkbox'
+        }
       }
     ]
   },
@@ -193,6 +200,7 @@ export const Settings = ({
                   onSettingsSave(settings)
                 }}
                 checked={settings[setting]}
+                data-test-id={setting}
               />
               <StyledSettingLabel title={tooltip}>{visual}</StyledSettingLabel>
             </StyledSetting>

--- a/src/shared/modules/commands/commandsDuck.js
+++ b/src/shared/modules/commands/commandsDuck.js
@@ -34,7 +34,11 @@ import {
 } from 'services/utils'
 import helper from 'services/commandInterpreterHelper'
 import { addHistory } from '../history/historyDuck'
-import { getCmdChar, getMaxHistory } from '../settings/settingsDuck'
+import {
+  getCmdChar,
+  getMaxHistory,
+  shouldEnableMultiStatementMode
+} from '../settings/settingsDuck'
 import { fetchRemoteGuide } from './helpers/play'
 import { CONNECTION_SUCCESS } from '../connections/connectionsDuck'
 import {
@@ -137,7 +141,10 @@ export const handleCommandEpic = (action$, store) =>
       store.dispatch(clearErrorMessage())
       const maxHistory = getMaxHistory(store.getState())
       store.dispatch(addHistory(action.cmd, maxHistory))
-      const statements = extractStatementsFromString(action.cmd)
+      const statements = shouldEnableMultiStatementMode(store.getState())
+        ? extractStatementsFromString(action.cmd)
+        : [action.cmd]
+
       if (!statements.length || !statements[0]) {
         return
       }

--- a/src/shared/modules/commands/multiCommands.test.js
+++ b/src/shared/modules/commands/multiCommands.test.js
@@ -47,7 +47,8 @@ describe('handleCommandEpic', () => {
     store = mockStore({
       settings: {
         cmdchar: ':',
-        maxHistory: maxHistory
+        maxHistory: maxHistory,
+        enableMultiStatementMode: true
       },
       history: [':xxx'],
       connections: {},

--- a/src/shared/modules/settings/__snapshots__/settingsDuck.test.js.snap
+++ b/src/shared/modules/settings/__snapshots__/settingsDuck.test.js.snap
@@ -7,6 +7,7 @@ Object {
   "cmdchar": ":",
   "editorAutocomplete": true,
   "editorLint": false,
+  "enableMultiStatementMode": false,
   "initCmd": ":play start",
   "initialNodeDisplay": 300,
   "maxFrames": 30,

--- a/src/shared/modules/settings/settingsDuck.js
+++ b/src/shared/modules/settings/settingsDuck.js
@@ -44,6 +44,8 @@ export const getScrollToTop = state => state[NAME].scrollToTop
 export const shouldReportUdc = state => state[NAME].shouldReportUdc !== false
 export const shouldAutoComplete = state => state[NAME].autoComplete !== false
 export const shouldEditorLint = state => state[NAME].editorLint === true
+export const shouldEnableMultiStatementMode = state =>
+  state[NAME].enableMultiStatementMode
 
 const browserSyncConfig = (host = 'https://auth.neo4j.com') => ({
   authWindowUrl: `${host}/indexNewBrowser.html`,
@@ -79,7 +81,8 @@ const initialState = {
   maxFrames: 30,
   editorAutocomplete: true,
   editorLint: false,
-  useCypherThread: true
+  useCypherThread: true,
+  enableMultiStatementMode: false
 }
 
 export default function settings (state = initialState, action) {


### PR DESCRIPTION
Adds new toggle `Enable multi statement query editor` (in settings drawer) for enabling/disable multi statement query handling in the cypher editor
