### PR TITLE
Cypher action templates for editing the graph

### DIFF
--- a/src/browser/modules/D3Visualization/GraphEventHandler.js
+++ b/src/browser/modules/D3Visualization/GraphEventHandler.js
@@ -27,6 +27,10 @@ export class GraphEventHandler {
     getNodeNeighbours,
     onItemMouseOver,
     onItemSelected,
+    onItemEdit,
+    onItemDelete,
+    onNodeConnect,
+    onRelationshipEdit,
     onGraphModelChange
   ) {
     this.graph = graph
@@ -35,7 +39,13 @@ export class GraphEventHandler {
     this.selectedItem = null
     this.onItemMouseOver = onItemMouseOver
     this.onItemSelected = onItemSelected
+    this.onItemEdit = onItemEdit
+    this.onItemDelete = onItemDelete
+    this.onNodeConnect = onNodeConnect
     this.onGraphModelChange = onGraphModelChange
+    this.onRelationshipEdit = onRelationshipEdit
+
+    this.connectionSource = null
   }
 
   graphModelChanged () {
@@ -74,6 +84,24 @@ export class GraphEventHandler {
     this.graphModelChanged()
   }
 
+  nodeDelete (d) {
+    this.onItemDelete({
+      type: 'node',
+      item: { id: d.id }
+    })
+  }
+
+  nodeConnect (d) {
+    this.connectionSource = d.id
+  }
+
+  nodeEdit (d) {
+    this.onItemEdit({
+      type: 'node',
+      item: { id: d.id, properties: d.propertyList }
+    })
+  }
+
   nodeClicked (d) {
     d.fixed = true
     if (!d.selected) {
@@ -85,6 +113,27 @@ export class GraphEventHandler {
     } else {
       this.deselectItem()
     }
+
+    if (this.connectionSource !== null) {
+      this.onNodeConnect({
+        type: 'relationship',
+        item: { source: this.connectionSource, target: d.id }
+      })
+
+      this.connectionSource = null
+    }
+  }
+
+  relationshipDblClicked (d) {
+    this.onRelationshipEdit({
+      type: 'relationship',
+      item: {
+        id: d.id,
+        properties: d.propertyList,
+        source: d.source.id,
+        target: d.target.id
+      }
+    })
   }
 
   nodeUnlock (d) {
@@ -182,8 +231,12 @@ export class GraphEventHandler {
       .on('relationshipClicked', this.onRelationshipClicked.bind(this))
       .on('canvasClicked', this.onCanvasClicked.bind(this))
       .on('nodeClose', this.nodeClose.bind(this))
+      .on('nodeDelete', this.nodeDelete.bind(this))
+      .on('nodeConnect', this.nodeConnect.bind(this))
+      .on('nodeEdit', this.nodeEdit.bind(this))
       .on('nodeClicked', this.nodeClicked.bind(this))
       .on('nodeDblClicked', this.nodeDblClicked.bind(this))
+      .on('relationshipDblClicked', this.relationshipDblClicked.bind(this))
       .on('nodeUnlock', this.nodeUnlock.bind(this))
     this.onItemMouseOut()
   }

--- a/src/browser/modules/D3Visualization/components/Graph.jsx
+++ b/src/browser/modules/D3Visualization/components/Graph.jsx
@@ -104,6 +104,10 @@ export class GraphComponent extends Component {
         this.props.getNodeNeighbours,
         this.props.onItemMouseOver,
         this.props.onItemSelect,
+        this.props.onItemEdit,
+        this.props.onItemDelete,
+        this.props.onNodeConnect,
+        this.props.onRelationshipEdit,
         this.props.onGraphModelChange
       )
       this.graphEH.bindEventHandlers()

--- a/src/browser/modules/D3Visualization/lib/visualization/components/visualization.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/visualization.coffee
@@ -65,6 +65,11 @@ neo.viz = (el, measureSize, graph, layout, style) ->
     updateViz = no
     viz.trigger('relationshipClicked', relationship)
 
+  onRelationshipDblClick = (relationship) =>
+    d3.event.stopPropagation()
+    updateViz = no
+    viz.trigger('relationshipDblClicked', relationship)
+
   onNodeMouseOver = (node) -> viz.trigger('nodeMouseOver', node)
   onNodeMouseOut = (node) -> viz.trigger('nodeMouseOut', node)
 
@@ -226,7 +231,7 @@ neo.viz = (el, measureSize, graph, layout, style) ->
 
     relationshipGroups.enter().append("g")
     .attr("class", "relationship")
-    .on("mousedown", onRelationshipClick)
+    .call(relClickHandler)
     .on('mouseover', onRelMouseOver)
     .on('mouseout', onRelMouseOut)
 
@@ -281,5 +286,9 @@ neo.viz = (el, measureSize, graph, layout, style) ->
   clickHandler = neo.utils.clickHandler()
   clickHandler.on 'click', onNodeClick
   clickHandler.on 'dblclick', onNodeDblClick
+
+  relClickHandler = neo.utils.clickHandler()
+  relClickHandler.on 'click', onRelationshipClick
+  relClickHandler.on 'dblclick', onRelationshipDblClick
 
   viz

--- a/src/browser/modules/D3Visualization/lib/visualization/renders/menu.coffee
+++ b/src/browser/modules/D3Visualization/lib/visualization/renders/menu.coffee
@@ -23,7 +23,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 do ->
   noop = ->
 
-  numberOfItemsInContextMenu = 3
+  numberOfItemsInContextMenu = 6
 
   arc = (radius, itemNumber, width = 30) ->
     itemNumber = itemNumber - 1
@@ -115,6 +115,27 @@ do ->
     onTick: noop
   )
 
+  donutDeleteNode = new neo.Renderer(
+    onGraphChange: (selection, viz) -> createMenuItem(selection, viz, 'nodeDelete', 4, 'delete_node', [0, 0], '\uf1f8', 'Permanently delete node from graph')
+
+    onTick: noop
+  )
+
+  donutConnectNode = new neo.Renderer(
+    onGraphChange: (selection, viz) -> createMenuItem(selection, viz, 'nodeConnect', 5, 'connect_node', [0, 0], '\uf060', 'Draw connection from here')
+
+    onTick: noop
+  )
+
+  donutEditNode = new neo.Renderer(
+    onGraphChange: (selection, viz) -> createMenuItem(selection, viz, 'nodeEdit', 6, 'edit_node', [0, 0], '\uf044', 'Update properties')
+
+    onTick: noop
+  )
+
   neo.renderers.menu.push(donutExpandNode)
   neo.renderers.menu.push(donutRemoveNode)
   neo.renderers.menu.push(donutUnlockNode)
+  neo.renderers.menu.push(donutDeleteNode)
+  neo.renderers.menu.push(donutConnectNode)
+  neo.renderers.menu.push(donutEditNode)

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView.jsx
@@ -24,7 +24,7 @@ import { deepEquals } from 'services/utils'
 import * as grassActions from 'shared/modules/grass/grassDuck'
 import bolt from 'services/bolt/bolt'
 import { withBus } from 'react-suber'
-import { ExplorerComponent } from '../../D3Visualization/components/Explorer'
+import { ExplorerComponentWithBus } from '../../D3Visualization/components/Explorer'
 import { StyledVisContainer } from './VisualizationView.styled'
 
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
@@ -158,7 +158,7 @@ export class Visualization extends Component {
 
     return (
       <StyledVisContainer fullscreen={this.props.fullscreen}>
-        <ExplorerComponent
+        <ExplorerComponentWithBus
           maxNeighbours={this.props.maxNeighbours}
           initialNodeDisplay={this.props.initialNodeDisplay}
           graphStyleData={this.props.graphStyleData}
@@ -194,5 +194,8 @@ const mapDispatchToProps = dispatch => {
 }
 
 export const VisualizationConnectedBus = withBus(
-  connect(mapStateToProps, mapDispatchToProps)(Visualization)
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(Visualization)
 )


### PR DESCRIPTION
Inspired by #510 I added some buttons for cypher templates manipulating the graph without visualization side-effects.

* edit node
* remove node permanently  
* create relation

What easily could be done as well:

* add node (dbl-click on canvas)
* edit relation
