### PR TITLE
Add pagecache hits and misses to plan output

### DIFF
--- a/e2e_tests/integration/plan.spec.js
+++ b/e2e_tests/integration/plan.spec.js
@@ -23,7 +23,20 @@
 describe('Plan output', () => {
   it('can connect', () => {
     const password = Cypress.env('browser-password') || 'newpassword'
-    cy.connect('neo4j', password)
+    cy.connect(
+      'neo4j',
+      password
+    )
+  })
+  it('print pagecache stats in PROFILE', () => {
+    cy.executeCommand(':clear')
+    cy.executeCommand(
+      `PROFILE MATCH (n:VendorId {{}uid: "d8eedae3ef0b4c45a9a27308", vendor: "run"}) RETURN n.uid, n.vendor, id(n)`
+    )
+    cy.get('[data-test-id="planExpandButton"]', { timeout: 10000 }).click()
+    const el = cy.get('[data-test-id="planSvg"]', { timeout: 10000 })
+    el.should('contain', 'pagecache hits')
+    el.should('contain', 'pagecache misses')
   })
   it('ouputs and preselects plan when using PROFILE', () => {
     cy.executeCommand(':clear')
@@ -40,8 +53,7 @@ describe('Plan output', () => {
     LIMIT 50;`)
     cy.get('[data-test-id="planExpandButton"]', { timeout: 10000 }).click()
     const el = cy.get('[data-test-id="planSvg"]', { timeout: 10000 })
-    el
-      .should('contain', 'NodeByLabelScan')
+    el.should('contain', 'NodeByLabelScan')
       .and('contain', 'tag')
       .and('contain', ':Tag')
       .and('contain', 'Filter')

--- a/src/browser/external/neoPlanner.js
+++ b/src/browser/external/neoPlanner.js
@@ -164,8 +164,8 @@ neo.queryPlan = function(element) {
         (left =
           (left1 =
             operator.Expressions != null
-             ? operator.Expressions
-             : operator.Expression != null
+              ? operator.Expressions
+              : operator.Expression != null
                 ? operator.Expression
                 : operator.LegacyExpression != null
                   ? operator.LegacyExpression
@@ -177,6 +177,19 @@ neo.queryPlan = function(element) {
     ) {
       wordWrap(expression, 'expression')
       details.push({ className: 'padding' })
+    }
+
+    if (operator.PageCacheHits || operator.PageCacheMisses) {
+      details.push({
+        className: 'pagecache-hits',
+        key: 'pagecache hits',
+        value: formatNumber(operator.PageCacheHits)
+      })
+      details.push({
+        className: 'pagecache-misses',
+        key: 'pagecache misses',
+        value: formatNumber(operator.PageCacheMisses)
+      })
     }
 
     if (operator.Rows != null && operator.EstimatedRows != null) {


### PR DESCRIPTION
Show page cache stats right next to hits / estimated row stats.
I also added a E2E test for it.

<img width="507" alt="oskarhane-mbpt 2018-08-20 at 10 41 11" src="https://user-images.githubusercontent.com/570998/44330752-1cb55500-a468-11e8-9c23-b02153bbfa27.png">

_(Sorry for the formatting changes, I guess prettier got updated.)_