### PR TITLE
Force jar to be packaged using java 1.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,6 +9,8 @@
   <url>https://github.com/neo4j/neo4j</url>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <license-text.header>GPL-3-header.txt</license-text.header>
     <licensing.prepend.text>notice-gpl-prefix.txt</licensing.prepend.text>
     <attach-javadoc-phase>none</attach-javadoc-phase>


### PR DESCRIPTION
Previous: 
```
Manifest-Version: 1.0
Package: org/neo4j/client
Archiver-Version: Plexus Archiver
Created-By: Apache Maven x.x.x
Built-By: foobar
Build-Jdk: 10.0.1
```

Now:
```
Manifest-Version: 1.0
Package: org/neo4j/client
Archiver-Version: Plexus Archiver
Created-By: Apache Maven x.x.x
Built-By: foobar
Build-Jdk: 1.8.0_162
```