### PR TITLE
Enable cheap updated checks for cypher frame

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/AsciiView.test.js
+++ b/src/browser/modules/Stream/CypherFrame/AsciiView.test.js
@@ -42,7 +42,7 @@ describe('AsciiViews', () => {
 
       // When
       const { container } = render(
-        <AsciiView setParentState={sps} result={result} />
+        <AsciiView setParentState={sps} result={result} maxRows={5} />
       )
 
       // Then

--- a/src/browser/modules/Stream/CypherFrame/PlanView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/PlanView.jsx
@@ -44,12 +44,7 @@ export class PlanView extends Component {
     this.extractPlan(this.props.result).catch(e => {})
   }
   componentWillReceiveProps (props) {
-    if (
-      !deepEquals(
-        (props.result || {}).summary,
-        (this.props.result || {}).summary
-      )
-    ) {
+    if (props.updated !== this.props.updated) {
       return this.extractPlan(props.result || {})
         .then(() => {
           this.ensureToggleExpand(props)
@@ -135,11 +130,8 @@ export class PlanView extends Component {
 }
 
 export class PlanStatusbar extends Component {
-  constructor (props) {
-    super(props)
-    this.state = {
-      extractedPlan: null
-    }
+  state = {
+    extractedPlan: null
   }
   componentDidMount () {
     if (this.props === undefined || this.props.result === undefined) return
@@ -171,8 +163,9 @@ export class PlanStatusbar extends Component {
             Cypher version: {plan.root.version}, planner: {plan.root.planner},
             runtime: {plan.root.runtime}.
             {plan.root.totalDbHits
-              ? ` ${plan.root
-                .totalDbHits} total db hits in ${result.summary.resultAvailableAfter
+              ? ` ${
+                plan.root.totalDbHits
+              } total db hits in ${result.summary.resultAvailableAfter
                 .add(result.summary.resultConsumedAfter)
                 .toNumber() || 0} ms.`
               : ``}
@@ -183,14 +176,16 @@ export class PlanStatusbar extends Component {
             <FrameButton
               data-test-id='planCollapseButton'
               onClick={() =>
-                this.props.setParentState({ _planExpand: 'COLLAPSE' })}
+                this.props.setParentState({ _planExpand: 'COLLAPSE' })
+              }
             >
               <DoubleUpIcon />
             </FrameButton>
             <FrameButton
               data-test-id='planExpandButton'
               onClick={() =>
-                this.props.setParentState({ _planExpand: 'EXPAND' })}
+                this.props.setParentState({ _planExpand: 'EXPAND' })
+              }
             >
               <DoubleDownIcon />
             </FrameButton>

--- a/src/browser/modules/Stream/CypherFrame/TableView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/TableView.jsx
@@ -34,7 +34,7 @@ import {
   StyledTd,
   StyledJsonPre
 } from 'browser-components/DataTables'
-import { deepEquals, shallowEquals, stringifyMod } from 'services/utils'
+import { shallowEquals, stringifyMod } from 'services/utils'
 import {
   getBodyAndStatusBarMessages,
   getRecordsToDisplayInTable,
@@ -89,13 +89,10 @@ const buildRow = item => {
 }
 
 export class TableView extends Component {
-  constructor (props) {
-    super(props)
-    this.state = {
-      columns: [],
-      data: [],
-      bodyMessage: ''
-    }
+  state = {
+    columns: [],
+    data: [],
+    bodyMessage: ''
   }
   componentDidMount () {
     this.makeState(this.props)
@@ -104,13 +101,15 @@ export class TableView extends Component {
     if (
       this.props === undefined ||
       this.props.result === undefined ||
-      !deepEquals(props.result.records, this.props.result.records)
+      this.props.updated !== props.updated
     ) {
       this.makeState(props)
     }
   }
   shouldComponentUpdate (props, state) {
-    return !shallowEquals(state, this.state)
+    return (
+      this.props.updated !== props.updated || !shallowEquals(state, this.state)
+    )
   }
   makeState (props) {
     const records = getRecordsToDisplayInTable(props.result, props.maxRows)
@@ -153,11 +152,8 @@ export class TableView extends Component {
 }
 
 export class TableStatusbar extends Component {
-  constructor (props) {
-    super(props)
-    this.state = {
-      statusBarMessage: ''
-    }
+  state = {
+    statusBarMessage: ''
   }
   componentDidMount () {
     this.makeState(this.props)

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView.jsx
@@ -70,14 +70,6 @@ export class Visualization extends Component {
       updated: new Date().getTime()
     })
   }
-  mergeToList (list1, list2) {
-    return list1.concat(
-      list2.filter(
-        itemInList2 =>
-          list1.findIndex(itemInList1 => itemInList1.id === itemInList2.id) < 0
-      )
-    )
-  }
   autoCompleteRelationships (existingNodes, newNodes) {
     if (this.props.autoComplete) {
       const existingNodeIds = existingNodes.map(node => parseInt(node.id))

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView.jsx
@@ -30,14 +30,9 @@ import { StyledVisContainer } from './VisualizationView.styled'
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
 
 export class Visualization extends Component {
-  constructor (props) {
-    super(props)
-    this.state = {
-      nodesAndRelationships: {
-        nodes: [],
-        relationships: []
-      }
-    }
+  state = {
+    nodes: [],
+    relationships: []
   }
   componentDidMount () {
     const { records = [] } = this.props.result
@@ -47,29 +42,32 @@ export class Visualization extends Component {
   }
   shouldComponentUpdate (props, state) {
     return (
-      !(
-        deepEquals(props.result.records, this.props.result.records) &&
-        deepEquals(props.graphStyleData, this.props.graphStyleData)
-      ) ||
-      !deepEquals(state, this.state) ||
-      !deepEquals(props.visElement, this.props.visElement) ||
+      this.props.updated !== props.updated ||
+      !deepEquals(props.graphStyleData, this.props.graphStyleData) ||
+      this.state.updated !== state.updated ||
       this.props.frameHeight !== props.frameHeight ||
       this.props.autoComplete !== props.autoComplete
     )
   }
   componentWillReceiveProps (props) {
     if (
-      !deepEquals(props.result.records, this.props.result.records) ||
+      this.props.updated !== props.updated ||
       this.props.autoComplete !== props.autoComplete
     ) {
       this.populateDataToStateFromProps(props)
     }
   }
   populateDataToStateFromProps (props) {
+    const {
+      nodes,
+      relationships
+    } = bolt.extractNodesAndRelationshipsFromRecordsForOldVis(
+      props.result.records
+    )
     this.setState({
-      nodesAndRelationships: bolt.extractNodesAndRelationshipsFromRecordsForOldVis(
-        props.result.records
-      )
+      nodes,
+      relationships,
+      updated: new Date().getTime()
     })
   }
   mergeToList (list1, list2) {
@@ -154,7 +152,7 @@ export class Visualization extends Component {
     this.autoCompleteRelationships([], this.graph._nodes)
   }
   render () {
-    if (!this.state.nodesAndRelationships.nodes.length) return null
+    if (!this.state.nodes.length) return null
 
     return (
       <StyledVisContainer fullscreen={this.props.fullscreen}>
@@ -164,8 +162,8 @@ export class Visualization extends Component {
           graphStyleData={this.props.graphStyleData}
           updateStyle={this.props.updateStyle}
           getNeighbours={this.getNeighbours.bind(this)}
-          nodes={this.state.nodesAndRelationships.nodes}
-          relationships={this.state.nodesAndRelationships.relationships}
+          nodes={this.state.nodes}
+          relationships={this.state.relationships}
           fullscreen={this.props.fullscreen}
           frameHeight={this.props.frameHeight}
           assignVisElement={this.props.assignVisElement}
@@ -194,5 +192,8 @@ const mapDispatchToProps = dispatch => {
 }
 
 export const VisualizationConnectedBus = withBus(
-  connect(mapStateToProps, mapDispatchToProps)(Visualization)
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(Visualization)
 )

--- a/src/browser/modules/Stream/CypherFrame/index.jsx
+++ b/src/browser/modules/Stream/CypherFrame/index.jsx
@@ -69,7 +69,9 @@ import { setRecentView, getRecentView } from 'shared/modules/stream/streamDuck'
 export class CypherFrame extends Component {
   state = {
     openView: undefined,
-    fullscreen: false
+    fullscreen: false,
+    collapse: false,
+    frameHeight: 472
   }
   changeView (view) {
     this.setState({ openView: view })
@@ -77,7 +79,7 @@ export class CypherFrame extends Component {
       this.props.onRecentViewChanged(view)
     }
   }
-  onResize (fullscreen, collapse, frameHeight) {
+  onResize = (fullscreen, collapse, frameHeight) => {
     if (frameHeight) {
       this.setState({ fullscreen, collapse, frameHeight })
     } else {
@@ -89,6 +91,8 @@ export class CypherFrame extends Component {
       this.props.request.updated !== props.request.updated ||
       this.state.openView !== state.openView ||
       this.state.fullscreen !== state.fullscreen ||
+      this.state.frameHeight !== state.frameHeight ||
+      this.state.collapse !== state.collapse ||
       this.state._asciiMaxColWidth !== state._asciiMaxColWidth ||
       this.state._asciiSetColWidth !== state._asciiSetColWidth ||
       this.state._planExpand !== state._planExpand
@@ -368,7 +372,7 @@ export class CypherFrame extends Component {
         statusbar={statusBar}
         numRecords={result && result.records ? result.records.length : 0}
         getRecords={this.getRecords}
-        onResize={this.onResize.bind(this)}
+        onResize={this.onResize}
         visElement={
           this.state.hasVis &&
           (this.state.openView === viewTypes.VISUALIZATION ||

--- a/src/browser/modules/Stream/CypherFrame/index.jsx
+++ b/src/browser/modules/Stream/CypherFrame/index.jsx
@@ -122,7 +122,7 @@ export class CypherFrame extends Component {
     }
     return []
   }
-  sidebar () {
+  sidebar = () => {
     return (
       <FrameSidebar>
         <Render if={resultHasNodes(this.props.request) && !this.state.errors}>
@@ -366,7 +366,7 @@ export class CypherFrame extends Component {
 
     return (
       <FrameTemplate
-        sidebar={this.sidebar.bind(this)}
+        sidebar={this.sidebar}
         header={frame}
         contents={frameContents}
         statusbar={statusBar}

--- a/src/browser/modules/Stream/CypherFrame/index.jsx
+++ b/src/browser/modules/Stream/CypherFrame/index.jsx
@@ -89,6 +89,8 @@ export class CypherFrame extends Component {
       this.props.request.updated !== props.request.updated ||
       this.state.openView !== state.openView ||
       this.state.fullscreen !== state.fullscreen ||
+      this.state._asciiMaxColWidth !== state._asciiMaxColWidth ||
+      this.state._asciiSetColWidth !== state._asciiSetColWidth ||
       this.state._planExpand !== state._planExpand
     )
   }

--- a/src/browser/modules/Stream/CypherFrame/index.jsx
+++ b/src/browser/modules/Stream/CypherFrame/index.jsx
@@ -88,7 +88,8 @@ export class CypherFrame extends Component {
     return (
       this.props.request.updated !== props.request.updated ||
       this.state.openView !== state.openView ||
-      this.state.fullscreen !== state.fullscreen
+      this.state.fullscreen !== state.fullscreen ||
+      this.state._planExpand !== state._planExpand
     )
   }
   componentDidUpdate () {
@@ -217,6 +218,7 @@ export class CypherFrame extends Component {
             {...this.state}
             maxRows={this.props.maxRows}
             result={result}
+            updated={this.props.request.updated}
             setParentState={this.setState.bind(this)}
           />
         </Display>
@@ -225,6 +227,7 @@ export class CypherFrame extends Component {
             {...this.state}
             maxRows={this.props.maxRows}
             result={result}
+            updated={this.props.request.updated}
             setParentState={this.setState.bind(this)}
           />
         </Display>
@@ -234,6 +237,7 @@ export class CypherFrame extends Component {
             result={result}
             request={request}
             query={query}
+            updated={this.props.request.updated}
             setParentState={this.setState.bind(this)}
           />
         </Display>
@@ -241,6 +245,7 @@ export class CypherFrame extends Component {
           <ErrorsView
             {...this.state}
             result={result}
+            updated={this.props.request.updated}
             setParentState={this.setState.bind(this)}
           />
         </Display>
@@ -248,6 +253,7 @@ export class CypherFrame extends Component {
           <WarningsView
             {...this.state}
             result={result}
+            updated={this.props.request.updated}
             setParentState={this.setState.bind(this)}
           />
         </Display>
@@ -255,6 +261,7 @@ export class CypherFrame extends Component {
           <PlanView
             {...this.state}
             result={result}
+            updated={this.props.request.updated}
             setParentState={this.setState.bind(this)}
             assignVisElement={(svgElement, graphElement) => {
               this.visElement = { svgElement, graphElement, type: 'plan' }
@@ -266,6 +273,7 @@ export class CypherFrame extends Component {
           <VisualizationConnectedBus
             {...this.state}
             result={result}
+            updated={this.props.request.updated}
             setParentState={this.setState.bind(this)}
             frameHeight={this.state.frameHeight}
             assignVisElement={(svgElement, graphElement) => {
@@ -288,6 +296,7 @@ export class CypherFrame extends Component {
             {...this.state}
             maxRows={this.props.maxRows}
             result={result}
+            updated={this.props.request.updated}
             setParentState={this.setState.bind(this)}
           />
         </Display>
@@ -296,6 +305,7 @@ export class CypherFrame extends Component {
             {...this.state}
             maxRows={this.props.maxRows}
             result={result}
+            updated={this.props.request.updated}
             setParentState={this.setState.bind(this)}
           />
         </Display>
@@ -303,6 +313,7 @@ export class CypherFrame extends Component {
           <CodeStatusbar
             {...this.state}
             result={result}
+            updated={this.props.request.updated}
             setParentState={this.setState.bind(this)}
           />
         </Display>
@@ -310,6 +321,7 @@ export class CypherFrame extends Component {
           <ErrorsStatusbar
             {...this.state}
             result={result}
+            updated={this.props.request.updated}
             setParentState={this.setState.bind(this)}
           />
         </Display>
@@ -317,6 +329,7 @@ export class CypherFrame extends Component {
           <WarningsStatusbar
             {...this.state}
             result={result}
+            updated={this.props.request.updated}
             setParentState={this.setState.bind(this)}
           />
         </Display>
@@ -324,6 +337,7 @@ export class CypherFrame extends Component {
           <PlanStatusbar
             {...this.state}
             result={result}
+            updated={this.props.request.updated}
             setParentState={this.setState.bind(this)}
           />
         </Display>

--- a/src/shared/modules/requests/requestsDuck.js
+++ b/src/shared/modules/requests/requestsDuck.js
@@ -51,7 +51,8 @@ export default function reducer (state = initialState, action) {
     case REQUEST_UPDATED:
       const newRequest = Object.assign({}, state[action.id], {
         result: action.result,
-        status: action.status
+        status: action.status,
+        updated: new Date().getTime()
       })
       return Object.assign({}, state, { [action.id]: newRequest })
     default:


### PR DESCRIPTION
Add an `updated` property to the request object and set that every time it’s updated with new data.
This avoids potential expensive `deepEquals` checks on every `shouldComponentUpdate` check.

Seems to speed up rendering of heavy queries by about 20%.