### PR TITLE
Fix issue where editor buttons would overflow the viewport

### DIFF
--- a/src/browser/modules/Editor/styled.jsx
+++ b/src/browser/modules/Editor/styled.jsx
@@ -68,6 +68,7 @@ const BaseEditorWrapper = styled.div`
     props.expanded
       ? '100vh'
       : Math.max(dim.editorbarHeight, props.minHeight + editorPadding * 2)}px;
+  width: 0;
   .CodeMirror {
     background-color: ${props => props.theme.editorBackground} !important;
     color: ${props => props.theme.editorCommandColor};


### PR DESCRIPTION
Before:
![before](https://user-images.githubusercontent.com/849508/46012676-df289500-c0c1-11e8-9284-2ec7ebf94329.gif)

After:
![after](https://user-images.githubusercontent.com/849508/46012767-29117b00-c0c2-11e8-9370-7a74d3137377.gif)
