### PR TITLE
Send cache busting headers with remote guides requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:8-jessie
+
+WORKDIR /usr/src
+
+# Install dependencies
+COPY package.json yarn.lock ./
+RUN yarn
+
+# Copy the relevant files to the working directory
+COPY . .
+
+# Build and export the app
+RUN yarn build
+RUN cp -R dist /public

--- a/now.json
+++ b/now.json
@@ -1,21 +1,4 @@
 {
   "name": "neo4j-browser",
-  "engines": {
-    "node": "^8.11.2"
-  },
-  "public": true,
-  "files": [
-    "scripts/",
-    "src/",
-    ".babelrc",
-    ".eslintignore",
-    ".eslintrc.json",
-    ".yarnrc",
-    "cypress.json",
-    "jsconfig.json",
-    "postcss.config.js",
-    "webpack.config.js",
-    "yarn.lock",
-    "README.md"
-  ]
+  "type": "static"
 }

--- a/src/shared/modules/commands/helpers/play.js
+++ b/src/shared/modules/commands/helpers/play.js
@@ -31,8 +31,10 @@ export const fetchRemoteGuide = (url, whitelist = null) => {
     }
     resolve()
   }).then(() => {
-    return remote.get(url).then(r => {
-      return cleanHtml(r)
-    })
+    return remote
+      .get(url, { pragma: 'no-cache', 'cache-control': 'no-cache' })
+      .then(r => {
+        return cleanHtml(r)
+      })
   })
 }

--- a/src/shared/services/remote.js
+++ b/src/shared/services/remote.js
@@ -35,9 +35,10 @@ function request (method, url, data = null, extraHeaders = {}) {
   }).then(checkStatus)
 }
 
-function get (url) {
+function get (url, headers = {}) {
   return fetch(url, {
-    method: 'get'
+    method: 'get',
+    headers
   })
     .then(checkStatus)
     .then(function (response) {


### PR DESCRIPTION
To make sure content updated remotely always are shown.

These headers should be respected by remote servers.

Before:
<img width="397" alt="oskarhane-mbpt 2018-09-25 at 15 18 49" src="https://user-images.githubusercontent.com/570998/46016949-929b8480-c0d6-11e8-9080-06403696323a.png">

After:
<img width="361" alt="oskarhane-mbpt 2018-09-25 at 15 18 22" src="https://user-images.githubusercontent.com/570998/46016958-98916580-c0d6-11e8-9fba-f06de47414f9.png">

changelog: Fetch fresh version of remote guides on every request
