### PR TITLE
Use `url` field from Neo4j Desktop context if it exists

### DIFF
--- a/e2e_tests/integration/desktop-env-url.spec.js
+++ b/e2e_tests/integration/desktop-env-url.spec.js
@@ -19,11 +19,15 @@
  */
 
 /* global Cypress, cy, test, expect, before */
-import { getDesktopContext } from '../support/utils'
 
+import { getDesktopContext } from '../support/utils'
 let appContextListener
 
-describe('Neo4j Desktop environment', () => {
+// This file only esists to be able to test the auto connect using
+// the host field.
+// We can't load two times in the same file
+
+describe('Neo4j Desktop environment using url field', () => {
   before(() => {
     cy.visit(Cypress.config.url, {
       onBeforeLoad: win => {
@@ -35,7 +39,7 @@ describe('Neo4j Desktop environment', () => {
       }
     })
   })
-  it('can auto connect using host + post fields', () => {
+  it('can auto connect using url field', () => {
     const frames = cy.get('[data-test-id="frameCommand"]', { timeout: 10000 })
     frames.should('have.length', 2)
 
@@ -43,7 +47,7 @@ describe('Neo4j Desktop environment', () => {
     frames.first().should('contain', ':play start')
     cy.wait(1000)
   })
-  it('switches connection when that event is triggered using host + port fields', () => {
+  it('switches connection when that event is triggered using url field', () => {
     cy.executeCommand(':clear')
     cy.wait(1000).then(() => {
       appContextListener(

--- a/e2e_tests/support/utils.js
+++ b/e2e_tests/support/utils.js
@@ -1,0 +1,42 @@
+export const getDesktopContext = (config, connectionCredsType = 'host') => ({
+  projects: [
+    {
+      graphs: [
+        {
+          status: 'ACTIVE',
+          connection: {
+            type: 'REMOTE',
+            configuration: {
+              protocols: {
+                bolt: getBoltConfig(config, connectionCredsType),
+                http: {
+                  enabled: true,
+                  username: 'neo4j',
+                  password: config.password,
+                  host: 'localhost',
+                  port: '7474'
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+})
+
+const getBoltConfig = (config, type) => {
+  const obj = {
+    enabled: true,
+    username: 'neo4j',
+    password: config.password,
+    tlsLevel: config.url.startsWith('https') ? 'REQUIRED' : 'OPTIONAL'
+  }
+  if (type === 'url') {
+    obj.url = `bolt://${config.boltHost}:${config.boltPort}`
+  } else {
+    obj.host = config.boltHost
+    obj.port = config.boltPort
+  }
+  return obj
+}

--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -193,7 +193,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
       ...stateProps.defaultConnectionData,
       ...creds,
       encrypted: creds.tlsLevel === 'REQUIRED',
-      host: `bolt://${creds.host}:${creds.port}`,
+      host: creds.url || `bolt://${creds.host}:${creds.port}`,
       restApi
     }
     ownProps.bus.send(SWITCH_CONNECTION, connectionCreds)
@@ -212,7 +212,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
       ...stateProps.defaultConnectionData,
       ...creds,
       encrypted: creds.tlsLevel === 'REQUIRED',
-      host: `bolt://${creds.host}:${creds.port}`,
+      host: creds.url || `bolt://${creds.host}:${creds.port}`,
       restApi
     }
     ownProps.bus.send(INJECTED_DISCOVERY, connectionCreds)


### PR DESCRIPTION
New addition to Neo4j Desktop API (will be out in 1.1.11).
Keeps backwards compatibility.
Note that these URL:s can have the `bolt+routing` protocol.

changelog: Future proof Neo4j Desktop integration by using the `url` field in connection info.