### PR TITLE
Don't assume all Cypher warnings to have position info

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/WarningsView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/WarningsView.jsx
@@ -57,13 +57,13 @@ export class WarningsView extends Component {
     }
     let cypherLines = cypher.split('\n')
     let notificationsList = notifications.map(notification => {
+      // Detect generic warning without position information
+      const position = Object.keys(notification.position).length
+        ? notification.position
+        : { line: 1, offset: 0 }
       return (
         <StyledHelpContent
-          key={
-            notification.title +
-            notification.position.line +
-            notification.position.offset
-          }
+          key={notification.title + position.line + position.offset}
         >
           <StyledHelpDescription>
             {getWarningComponent(notification.severity)}
@@ -75,9 +75,9 @@ export class WarningsView extends Component {
             </StyledHelpDescription>
             <StyledDiv>
               <StyledPreformattedArea>
-                {cypherLines[notification.position.line - 1]}
+                {cypherLines[position.line - 1]}
                 <StyledBr />
-                {Array(notification.position.offset + 1).join(' ')}^
+                {Array(position.offset + 1).join(' ')}^
               </StyledPreformattedArea>
             </StyledDiv>
           </StyledDiv>


### PR DESCRIPTION
Checks if warning position info exists.

Before:
<img width="1157" alt="oskarhane-mbpt 2018-10-08 at 09 14 38" src="https://user-images.githubusercontent.com/570998/46595862-a7b2e300-cada-11e8-8b93-d51a44ffab9c.png">


After:
<img width="1122" alt="oskarhane-mbpt 2018-10-08 at 09 06 29" src="https://user-images.githubusercontent.com/570998/46595871-abdf0080-cada-11e8-8b28-7d880065b7fe.png">

fixes: #831 
changelog: Fix rare neo4j-browser crash when clicking on yellow Cypher warning triangle