### PR TITLE
Fix `:queries` frame so that connection errors are displayed

### DIFF
--- a/src/browser/modules/Stream/Queries/QueriesFrame.jsx
+++ b/src/browser/modules/Stream/Queries/QueriesFrame.jsx
@@ -191,12 +191,16 @@ export class QueriesFrame extends Component {
       queries.length
     } ${numQueriesMsg} ${numMachinesMsg}`
 
-    return errors.length > 0
-      ? `${successMessage} (${errors.length} unsuccessful)`
-      : successMessage
+    return errors.length > 0 ? (
+      <span>
+        {successMessage} ({errors.length} unsuccessful)
+      </span>
+    ) : (
+      successMessage
+    )
   }
 
-  constructViewFromQueryList (queries) {
+  constructViewFromQueryList (queries, errors) {
     if (queries.length === 0) {
       return null
     }
@@ -251,6 +255,14 @@ export class QueriesFrame extends Component {
       )
     })
 
+    const errorRows = errors.map((error, i) => (
+      <tr key={`error${i}`}>
+        <StyledTd colSpan='7' title={error.message}>
+          <Code>Error connecting to: {error.host}</Code>
+        </StyledTd>
+      </tr>
+    ))
+
     const tableHeaders = tableHeaderSizes.map((heading, i) => {
       return (
         <StyledTh width={heading[1]} key={heading[0]}>
@@ -264,7 +276,10 @@ export class QueriesFrame extends Component {
           <thead>
             <StyledHeaderRow>{tableHeaders}</StyledHeaderRow>
           </thead>
-          <tbody>{tableRows}</tbody>
+          <tbody>
+            {tableRows}
+            {errorRows}
+          </tbody>
         </StyledTable>
       </StyledTableWrapper>
     )
@@ -283,7 +298,10 @@ export class QueriesFrame extends Component {
     let statusbar
 
     if (this.canListQueries()) {
-      frameContents = this.constructViewFromQueryList(this.state.queries)
+      frameContents = this.constructViewFromQueryList(
+        this.state.queries,
+        this.state.errors
+      )
       statusbar = (
         <StatusbarWrapper>
           <Render if={this.state.errors && !this.state.success}>

--- a/src/browser/modules/Stream/Stream.jsx
+++ b/src/browser/modules/Stream/Stream.jsx
@@ -103,11 +103,7 @@ class Stream extends Component {
             activeConnectionData: this.props.activeConnectionData
           }
           const MyFrame = getFrame(frame.type)
-          return (
-            <div key={frame.id}>
-              <MyFrame {...frameProps} />
-            </div>
-          )
+          return <MyFrame {...frameProps} key={frame.id} />
         })}
       </StyledStream>
     )


### PR DESCRIPTION
Issue:

In a causal clustered setup when executing the `:queries` command, the resulting frame displays the records returned from running `call dbms.listQueries` on all cluster members. If the `username` and `password` used on the current session are invalid with any of the other cluster members, the frame would throw an error and cause Neo4j Browser to become unresponsive.

Fix:

Gracefully handle errors from the individual members and display the error to the user. A more detailed error message is displayed as an error row tooltip.

 <img width="824" alt="screen shot 2018-10-08 at 09 39 34" src="https://user-images.githubusercontent.com/849508/46599235-a5eb1e80-cade-11e8-9f54-a4793113e65f.png">

changelog: Fix crashing `:queries` frame in clustered environments when all members couldn't be reached