### PR TITLE
Introduce experimental features section in Settings

### DIFF
--- a/src/browser/index.jsx
+++ b/src/browser/index.jsx
@@ -45,7 +45,8 @@ applyKeys(
   'folders',
   'grass',
   'syncConsent',
-  'udc'
+  'udc',
+  'experimentalFeatures'
 )
 
 // Create suber bus

--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -66,6 +66,8 @@ import {
 } from 'browser-components/DesktopIntegration/helpers'
 import { getMetadata, getUserAuthStatus } from 'shared/modules/sync/syncDuck'
 import ErrorBoundary from 'browser-components/ErrorBoundary'
+import { getExperimentalFeatures } from 'shared/modules/experimentalFeatures/experimentalFeaturesDuck'
+import FeatureToggleProvider from '../FeatureToggle/FeatureToggleProvider'
 
 export class App extends Component {
   componentDidMount () {
@@ -100,49 +102,52 @@ export class App extends Component {
       syncConsent,
       browserSyncMetadata,
       browserSyncConfig,
-      browserSyncAuthStatus
+      browserSyncAuthStatus,
+      experimentalFeatures
     } = this.props
     const themeData = themes[theme] || themes['normal']
 
     return (
       <ErrorBoundary>
         <ThemeProvider theme={themeData}>
-          <StyledWrapper>
-            <DocTitle titleString={this.props.titleString} />
-            <UserInteraction />
-            <DesktopIntegration
-              integrationPoint={this.props.desktopIntegrationPoint}
-              onMount={this.props.setInitialConnectionData}
-              onGraphActive={this.props.switchConnection}
-              onGraphInactive={this.props.closeConnectionMaybe}
-            />
-            <Render if={loadExternalScripts}>
-              <Intercom appID='lq70afwx' />
-            </Render>
-            <Render if={syncConsent && loadExternalScripts && loadSync}>
-              <BrowserSyncInit
-                authStatus={browserSyncAuthStatus}
-                authData={browserSyncMetadata}
-                config={browserSyncConfig}
+          <FeatureToggleProvider features={experimentalFeatures}>
+            <StyledWrapper>
+              <DocTitle titleString={this.props.titleString} />
+              <UserInteraction />
+              <DesktopIntegration
+                integrationPoint={this.props.desktopIntegrationPoint}
+                onMount={this.props.setInitialConnectionData}
+                onGraphActive={this.props.switchConnection}
+                onGraphInactive={this.props.closeConnectionMaybe}
               />
-            </Render>
-            <StyledApp>
-              <StyledBody>
-                <ErrorBoundary>
-                  <Sidebar openDrawer={drawer} onNavClick={handleNavClick} />
-                </ErrorBoundary>
-                <StyledMainWrapper>
-                  <Main
-                    cmdchar={cmdchar}
-                    activeConnection={activeConnection}
-                    connectionState={connectionState}
-                    errorMessage={errorMessage}
-                    useBrowserSync={loadSync}
-                  />
-                </StyledMainWrapper>
-              </StyledBody>
-            </StyledApp>
-          </StyledWrapper>
+              <Render if={loadExternalScripts}>
+                <Intercom appID='lq70afwx' />
+              </Render>
+              <Render if={syncConsent && loadExternalScripts && loadSync}>
+                <BrowserSyncInit
+                  authStatus={browserSyncAuthStatus}
+                  authData={browserSyncMetadata}
+                  config={browserSyncConfig}
+                />
+              </Render>
+              <StyledApp>
+                <StyledBody>
+                  <ErrorBoundary>
+                    <Sidebar openDrawer={drawer} onNavClick={handleNavClick} />
+                  </ErrorBoundary>
+                  <StyledMainWrapper>
+                    <Main
+                      cmdchar={cmdchar}
+                      activeConnection={activeConnection}
+                      connectionState={connectionState}
+                      errorMessage={errorMessage}
+                      useBrowserSync={loadSync}
+                    />
+                  </StyledMainWrapper>
+                </StyledBody>
+              </StyledApp>
+            </StyledWrapper>
+          </FeatureToggleProvider>
         </ThemeProvider>
       </ErrorBoundary>
     )
@@ -152,6 +157,7 @@ export class App extends Component {
 const mapStateToProps = state => {
   const connectionData = getActiveConnectionData(state)
   return {
+    experimentalFeatures: getExperimentalFeatures(state),
     drawer: state.drawer,
     activeConnection: getActiveConnection(state),
     theme: getTheme(state),

--- a/src/browser/modules/FeatureToggle/FeatureToggle.jsx
+++ b/src/browser/modules/FeatureToggle/FeatureToggle.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { Consumer } from './FeatureToggleProvider'
+
+const FeatureToggle = ({ name, on, off }) => {
+  return (
+    <Consumer>
+      {showFeature => {
+        if (!name) {
+          throw new Error(
+            `No "name" property provided to FeatureToggle component.`
+          )
+        }
+        const shouldShow = showFeature(name)
+        if (!shouldShow && !off) {
+          return null
+        }
+        if (shouldShow && !on) {
+          throw new Error(
+            `No "on" property available for this enabled feature: ${name} for FeatureToggle component.`
+          )
+        }
+        return shouldShow ? on : off
+      }}
+    </Consumer>
+  )
+}
+
+export default FeatureToggle

--- a/src/browser/modules/FeatureToggle/FeatureToggle.test.js
+++ b/src/browser/modules/FeatureToggle/FeatureToggle.test.js
@@ -1,0 +1,157 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j, Inc"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* global describe, test, expect */
+import React from 'react'
+import { render, cleanup, waitForElement } from 'react-testing-library'
+import 'jest-dom/extend-expect'
+
+import FeatureToggle from './FeatureToggle'
+import { FeatureToggleProvider } from './FeatureToggleProvider'
+
+afterEach(cleanup)
+
+const On = () => {
+  return <h1>Yes</h1>
+}
+const Off = () => {
+  return <h1>No</h1>
+}
+
+class ErrorB extends React.Component {
+  state = {
+    error: ''
+  }
+  componentDidCatch (e) {
+    this.setState({ error: e })
+  }
+  render () {
+    if (!this.state.error) {
+      return this.props.children
+    }
+    return <span data-testid='error'>{this.state.error.toString()}</span>
+  }
+}
+
+describe('FeatureToggle', () => {
+  test('shows features when theres no context provider available', () => {
+    const { getByText, queryByText } = render(
+      <FeatureToggle name='testFeature' on={<On />} off={<Off />} />
+    )
+
+    // Then
+    expect(getByText('Yes')).not.toBeUndefined()
+    expect(queryByText('No')).toBeNull()
+  })
+  test('shows "on" features when context says so', () => {
+    // Given
+    const features = { testFeature: { on: true } }
+
+    const { getByText, queryByText } = render(
+      <FeatureToggleProvider features={features}>
+        <FeatureToggle name='testFeature' on={<On />} off={<Off />} />
+      </FeatureToggleProvider>
+    )
+
+    // Then
+    expect(getByText('Yes')).not.toBeUndefined()
+    expect(queryByText('No')).toBeNull()
+  })
+  test('shows "off" features when context says so', () => {
+    // Given
+    const features = { testFeature: { on: false } }
+
+    const { getByText, queryByText } = render(
+      <FeatureToggleProvider features={features}>
+        <FeatureToggle name='testFeature' on={<On />} off={<Off />} />
+      </FeatureToggleProvider>
+    )
+
+    // Then
+    expect(getByText('No')).not.toBeUndefined()
+    expect(queryByText('Yes')).toBeNull()
+  })
+  test('returns null if no "off" prop is availavle', () => {
+    // Given
+    const features = { testFeature: { on: false } }
+
+    const { queryByText } = render(
+      <FeatureToggleProvider features={features}>
+        <FeatureToggle name='testFeature' on={<On />} />
+      </FeatureToggleProvider>
+    )
+    // Then
+
+    expect(queryByText('Yes')).toBeNull()
+    expect(queryByText('No')).toBeNull()
+  })
+  test('throws if no "on" prop is available but the feature is to be shown', async () => {
+    // Given
+    const oldConsoleError = console.error
+    console.error = () => {}
+
+    const features = { testFeature: { on: true } }
+
+    // When
+    const { getByTestId } = render(
+      <ErrorB>
+        <FeatureToggleProvider features={features}>
+          <FeatureToggle name='testFeature' off={<Off />} />
+        </FeatureToggleProvider>
+      </ErrorB>
+    )
+
+    // Wait for error propagation
+    await waitForElement(() => getByTestId('error'))
+
+    // Then
+    expect(getByTestId('error')).toHaveTextContent(
+      `No "on" property available for this enabled feature: testFeature for FeatureToggle component.`
+    )
+
+    console.error = oldConsoleError
+  })
+  test('throws if no "name" property provided', async () => {
+    // Given
+    const oldConsoleError = console.error
+    console.error = () => {}
+
+    const features = { testFeature: { on: true } }
+
+    // When
+    const { getByTestId } = render(
+      <ErrorB>
+        <FeatureToggleProvider features={features}>
+          <FeatureToggle on={<On />} off={<Off />} />
+        </FeatureToggleProvider>
+      </ErrorB>
+    )
+
+    // Wait for error propagation
+    await waitForElement(() => getByTestId('error'))
+
+    // Then
+    expect(getByTestId('error')).toHaveTextContent(
+      `No "name" property provided to FeatureToggle component.`
+    )
+
+    console.error = oldConsoleError
+  })
+})

--- a/src/browser/modules/FeatureToggle/FeatureToggleProvider.jsx
+++ b/src/browser/modules/FeatureToggle/FeatureToggleProvider.jsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import { getExperimentalFeatures } from 'shared/modules/experimentalFeatures/experimentalFeaturesDuck'
+
+const FeatureToggleContext = new React.createContext(() => true) // eslint-disable-line new-cap
+
+class FeatureToggleProvider extends React.Component {
+  showFeature = featureName => {
+    if (
+      !this.props.features ||
+      !this.props.features.hasOwnProperty(featureName)
+    ) {
+      return true
+    }
+    return !!this.props.features[featureName].on
+  }
+  render () {
+    return (
+      <FeatureToggleContext.Provider value={this.showFeature}>
+        {this.props.children}
+      </FeatureToggleContext.Provider>
+    )
+  }
+}
+
+const mapStateToProps = state => {
+  const features = getExperimentalFeatures(state)
+  return {
+    features
+  }
+}
+
+const Consumer = FeatureToggleContext.Consumer
+
+export default connect(mapStateToProps)(FeatureToggleProvider)
+export { Consumer, FeatureToggleProvider }

--- a/src/browser/modules/FeatureToggle/FeatureToggleProvider.test.js
+++ b/src/browser/modules/FeatureToggle/FeatureToggleProvider.test.js
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j, Inc"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* global describe, test, expect */
+import React from 'react'
+import { render, cleanup } from 'react-testing-library'
+
+import { FeatureToggleProvider, Consumer } from './FeatureToggleProvider'
+
+afterEach(cleanup)
+
+const MyConsumer = () => {
+  return (
+    <h1>
+      <Consumer>
+        {showFeature => {
+          return showFeature('testFeature') ? 'Yes' : 'No'
+        }}
+      </Consumer>
+    </h1>
+  )
+}
+
+describe('FeatureToggleProvider', () => {
+  test('exposes "showFeature" in app context and returns the feature state (true)', () => {
+    // Given
+    const features = {
+      testFeature: { on: true },
+      anotherFeature: { on: false }
+    }
+    const { getByText, queryByText } = render(
+      <FeatureToggleProvider features={features}>
+        <MyConsumer />
+      </FeatureToggleProvider>
+    )
+
+    // Then
+    expect(getByText('Yes')).not.toBeUndefined()
+    expect(queryByText('No')).toBeNull()
+  })
+  test('exposes "showFeature" in app context and returns the feature state (false)', () => {
+    // Given
+    const features = {
+      testFeature: { on: false },
+      anotherFeature: { on: true }
+    }
+    const { getByText, queryByText } = render(
+      <FeatureToggleProvider features={features}>
+        <MyConsumer />
+      </FeatureToggleProvider>
+    )
+
+    // Then
+    expect(getByText('No')).not.toBeUndefined()
+    expect(queryByText('Yes')).toBeNull()
+  })
+  test('returns true for unknown features', () => {
+    // Given
+    const features = { anotherFeature: { on: false } }
+    const { getByText, queryByText } = render(
+      <FeatureToggleProvider features={features}>
+        <MyConsumer />
+      </FeatureToggleProvider>
+    )
+
+    // Then
+    expect(getByText('Yes')).not.toBeUndefined()
+    expect(queryByText('No')).toBeNull()
+  })
+})

--- a/src/browser/modules/Sidebar/__snapshots__/Settings.test.js.snap
+++ b/src/browser/modules/Sidebar/__snapshots__/Settings.test.js.snap
@@ -41,6 +41,9 @@ exports[`Settings renders with strange characters in display name 1`] = `
             />
           </div>
         </div>
+        <div
+          class="sc-EHOje fyzZhj"
+        />
       </div>
     </div>
   </div>

--- a/src/shared/modules/experimentalFeatures/experimentalFeaturesDuck.js
+++ b/src/shared/modules/experimentalFeatures/experimentalFeaturesDuck.js
@@ -1,0 +1,73 @@
+import { APP_START, USER_CLEAR } from 'shared/modules/app/appDuck'
+
+export const NAME = 'experimentalFeatures'
+const FEATURE_ON = NAME + '/FEATURE_ON'
+const FEATURE_OFF = NAME + '/FEATURE_OFF'
+
+export const getExperimentalFeatures = state => state[NAME]
+export const showFeature = (state, name) => !!(state[NAME][name] || {}).on
+
+export const experimentalFeatureSelfName = 'showSelf'
+
+export const initialState = {
+  [experimentalFeatureSelfName]: {
+    name: experimentalFeatureSelfName,
+    on: true,
+    displayName: 'Show experimental features',
+    tooltip: 'Show feature section in settings drawer'
+  }
+}
+
+// Helpers
+const cherrypickAndMergeStates = (base, stored) => {
+  if (!stored) {
+    return { ...base }
+  }
+  const existingFeatures = Object.keys(base)
+  return existingFeatures.reduce((all, name) => {
+    if (!stored.hasOwnProperty(name) || stored[name].on === undefined) {
+      all[name] = base[name]
+      return all
+    }
+    all[name] = { ...base[name], on: stored[name].on }
+    return all
+  }, {})
+}
+
+// Reducer
+export default function experimentalFeatures (state = initialState, action) {
+  if (action.type === APP_START) {
+    state = cherrypickAndMergeStates(initialState, state)
+  }
+
+  switch (action.type) {
+    case FEATURE_ON:
+      if (!state.hasOwnProperty(action.name)) {
+        return state
+      }
+      return { ...state, [action.name]: { ...state[action.name], on: true } }
+    case FEATURE_OFF:
+      if (!state.hasOwnProperty(action.name)) {
+        return state
+      }
+      return { ...state, [action.name]: { ...state[action.name], on: false } }
+    case USER_CLEAR:
+      return initialState
+    default:
+      return state
+  }
+}
+
+export const enableExperimentalFeature = name => {
+  return {
+    type: FEATURE_ON,
+    name
+  }
+}
+
+export const disableExperimentalFeature = name => {
+  return {
+    type: FEATURE_OFF,
+    name
+  }
+}

--- a/src/shared/modules/experimentalFeatures/experimentalFeaturesDuck.test.js
+++ b/src/shared/modules/experimentalFeatures/experimentalFeaturesDuck.test.js
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j, Inc"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* global describe, test, expect */
+import reducer, {
+  NAME,
+  enableExperimentalFeature,
+  disableExperimentalFeature,
+  getExperimentalFeatures,
+  showFeature,
+  experimentalFeatureSelfName,
+  initialState
+} from './experimentalFeaturesDuck'
+import { dehydrate } from 'services/duckUtils'
+import { APP_START } from '../app/appDuck'
+
+describe('experimentalFeatures reducer', () => {
+  test('handles initial value', () => {
+    const nextState = dehydrate(reducer(undefined, { type: '' }))
+    expect(nextState[experimentalFeatureSelfName].on).toEqual(true)
+  })
+
+  test('handles FEATURE_ON without initial state', () => {
+    const action = enableExperimentalFeature(experimentalFeatureSelfName)
+    const nextState = reducer(undefined, action)
+    expect(nextState[experimentalFeatureSelfName].on).toEqual(true)
+  })
+  test('handles FEATURE_ON with initial state', () => {
+    const action = enableExperimentalFeature(experimentalFeatureSelfName)
+    const nextState = reducer(
+      { [experimentalFeatureSelfName]: { on: false } },
+      action
+    )
+    expect(nextState[experimentalFeatureSelfName].on).toEqual(true)
+  })
+  test('handles FEATURE_OFF with initial state', () => {
+    const action = disableExperimentalFeature(experimentalFeatureSelfName)
+    const nextState = reducer(
+      { [experimentalFeatureSelfName]: { on: true } },
+      action
+    )
+    expect(nextState[experimentalFeatureSelfName].on).toEqual(false)
+  })
+  test('stips non existing features from state on initialization', () => {
+    // Given
+    const action = {
+      type: APP_START
+    }
+    const stateFromLocalStorage = {
+      nonExistingFeature: {
+        on: true
+      },
+      [experimentalFeatureSelfName]: {
+        on: false
+      }
+    }
+    const expectedState = {
+      ...initialState,
+      [experimentalFeatureSelfName]: {
+        ...initialState[experimentalFeatureSelfName],
+        on: false
+      }
+    }
+
+    // When
+    const nextState = reducer(stateFromLocalStorage, action)
+
+    // Then
+    expect(nextState).toEqual(expectedState)
+  })
+})
+
+describe('Selectors', () => {
+  test('getExperimentalFeatures returns all features', () => {
+    // Given
+    const action = enableExperimentalFeature(experimentalFeatureSelfName)
+
+    // When
+    const nextState = reducer(
+      {
+        ...initialState,
+        [experimentalFeatureSelfName]: {
+          ...initialState[experimentalFeatureSelfName],
+          on: false
+        }
+      },
+      action
+    )
+    const combinedState = { [NAME]: nextState }
+    const shouldBeAll = getExperimentalFeatures(combinedState)
+
+    // Then
+    expect(shouldBeAll).toEqual(initialState)
+  })
+  test('showFeature returns a features "on" state', () => {
+    // Given
+    const action = enableExperimentalFeature(experimentalFeatureSelfName)
+
+    // When
+    const nextState = reducer(
+      {
+        ...initialState,
+        [experimentalFeatureSelfName]: {
+          ...initialState[experimentalFeatureSelfName],
+          on: false
+        }
+      },
+      action
+    )
+    const combinedState = { [NAME]: nextState }
+    const shouldBeAll = showFeature(combinedState, experimentalFeatureSelfName)
+
+    // Then
+    expect(shouldBeAll).toEqual(true)
+  })
+})

--- a/src/shared/rootReducer.js
+++ b/src/shared/rootReducer.js
@@ -63,6 +63,9 @@ import commandsReducer, {
 } from 'shared/modules/commands/commandsDuck'
 import udcReducer, { NAME as udc } from 'shared/modules/udc/udcDuck'
 import appReducer, { NAME as app } from 'shared/modules/app/appDuck'
+import experimentalFeaturesReducer, {
+  NAME as experimentalFeatures
+} from 'shared/modules/experimentalFeatures/experimentalFeaturesDuck'
 
 export default {
   [connections]: connectionsReducer,
@@ -84,5 +87,6 @@ export default {
   [syncMetadata]: syncMetaDataReducer,
   [commands]: commandsReducer,
   [udc]: udcReducer,
-  [app]: appReducer
+  [app]: appReducer,
+  [experimentalFeatures]: experimentalFeaturesReducer
 }


### PR DESCRIPTION
This gives us a tool to rollout features that we want to get feedback on before releasing them.

At the same time as it gives users a list of available experimental features to chose from, users understand that they're experimental and can break at any time.

Users toggle the experimental features from the Settings sidebar, at the bottom.
With this PR it's hidden because there are no features to toggle.

Also note that to be able to persist the users settings we store this in the users local storage. However, men we move a feature off of the experimental list, it will still show up in users Settings sidebar if we don't check what should be there. 
That's the reason for the `cherrypickAndMerge` function in the experimental feature duck file.

This is what it looks like with a feature added:
<img width="373" alt="oskarhane-mbpt 2018-10-09 at 13 22 03" src="https://user-images.githubusercontent.com/570998/46666253-816a7180-cbc6-11e8-91d0-f54c8de6bc77.png">


To try manually, add this to the `initialState` of the experimental features reducer:

```
snake: {
    name: 'snake',
    on: true,
    displayName: 'Snake Game',
    tooltip: 'Enable the command :snake to play a game of snake'
  }
```

btw, the experimental features section in the Settings panel is feature toggled by the default entry. Non visible to change for the users though, but you can toggle it via local storage.