### PR TITLE
Fix auto-completed relationships not showing in viz legend on first render

### DIFF
--- a/e2e_tests/integration/viz.zpec.js
+++ b/e2e_tests/integration/viz.zpec.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j, Inc"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* global Cypress, cy, test, expect, before */
+
+describe('Viz rendering', () => {
+  before(function () {
+    cy.visit(Cypress.config.url)
+      .title()
+      .should('include', 'Neo4j Browser')
+  })
+  it('can connect', () => {
+    const password = Cypress.config.password
+    cy.connect(
+      'neo4j',
+      password
+    )
+  })
+  it('shows legend with rel types + node labels on first render', () => {
+    cy.executeCommand(':clear')
+    cy.executeCommand(
+      `CREATE (a:TestLabel)-[:CONNECTS]->(b:TestLabel) RETURN a, b`
+    )
+    cy.get(`[data-test-id="viz-legend-reltypes"]`, { timeout: 5000 }).contains(
+      'CONNECTS'
+    )
+    cy.get(`[data-test-id="viz-legend-labels"]`, { timeout: 5000 }).contains(
+      'TestLabel'
+    )
+    cy.executeCommand(`MATCH (a:TestLabel) DETACH DELETE a`)
+  })
+})

--- a/src/browser/modules/D3Visualization/components/Explorer.jsx
+++ b/src/browser/modules/D3Visualization/components/Explorer.jsx
@@ -72,6 +72,7 @@ export class ExplorerComponent extends Component {
     this.state = {
       stats: { labels: {}, relTypes: {} },
       graphStyle,
+      styleVersion: 0,
       nodes,
       relationships,
       selectedItem
@@ -149,7 +150,10 @@ export class ExplorerComponent extends Component {
       if (props.graphStyleData) {
         const rebasedStyle = deepmerge(this.defaultStyle, props.graphStyleData)
         this.state.graphStyle.loadRules(rebasedStyle)
-        this.setState({ graphStyle: this.state.graphStyle })
+        this.setState({
+          graphStyle: this.state.graphStyle,
+          styleVersion: this.state.styleVersion + 1
+        })
       } else {
         this.state.graphStyle.resetToDefault()
         this.setState(
@@ -160,14 +164,6 @@ export class ExplorerComponent extends Component {
           }
         )
       }
-    }
-
-    if (!deepEquals(props.nodes, this.props.nodes)) {
-      this.setState({ nodes: props.nodes })
-    }
-
-    if (!deepEquals(props.relationships, this.props.relationships)) {
-      this.setState({ relationships: props.relationships })
     }
   }
 
@@ -227,6 +223,7 @@ export class ExplorerComponent extends Component {
           onItemMouseOver={this.onItemMouseOver.bind(this)}
           onItemSelect={this.onItemSelect.bind(this)}
           graphStyle={this.state.graphStyle}
+          styleVersion={this.state.styleVersion} // cheap way for child to check style updates
           onGraphModelChange={this.onGraphModelChange.bind(this)}
           assignVisElement={this.props.assignVisElement}
           getAutoCompleteCallback={this.props.getAutoCompleteCallback}

--- a/src/browser/modules/D3Visualization/components/Legend.jsx
+++ b/src/browser/modules/D3Visualization/components/Legend.jsx
@@ -75,8 +75,9 @@ export class LegendComponent extends Component {
                 className='token token-label'
               >
                 {legendItemKey}
-                <StyledTokenCount className='count'>{`(${labels[legendItemKey]
-                  .count})`}</StyledTokenCount>
+                <StyledTokenCount className='count'>{`(${
+                  labels[legendItemKey].count
+                })`}</StyledTokenCount>
               </StyledLabelToken>
             </StyledLegendContents>
           </StyledLegendInlineListItem>

--- a/src/browser/modules/D3Visualization/components/Legend.jsx
+++ b/src/browser/modules/D3Visualization/components/Legend.jsx
@@ -67,7 +67,7 @@ export class LegendComponent extends Component {
           color: styleForItem.get('text-color-internal')
         }
         return (
-          <StyledLegendInlineListItem key={i}>
+          <StyledLegendInlineListItem key={i} data-test-id='viz-legend-labels'>
             <StyledLegendContents className='contents'>
               <StyledLabelToken
                 onClick={onClick}
@@ -125,7 +125,10 @@ export class LegendComponent extends Component {
           color: styleForItem.get('text-color-internal')
         }
         return (
-          <StyledLegendInlineListItem key={i}>
+          <StyledLegendInlineListItem
+            key={i}
+            data-test-id='viz-legend-reltypes'
+          >
             <StyledLegendContents className='contents'>
               <StyledTokenRelationshipType
                 onClick={onClick}


### PR DESCRIPTION
Also remove unnecessary and expensive comparisons.
This component unmounts on a frame re-un, so no need to have node checks in cwrp.
We also checked the styling twice. I moved that to a versioning instead.

I also added e2e tests for it.

Before:
<img width="880" alt="oskarhane-mbpt 2018-10-10 at 12 48 14" src="https://user-images.githubusercontent.com/570998/46731425-e8515e80-cc8a-11e8-842c-99f692813a81.png">


After:
<img width="730" alt="oskarhane-mbpt 2018-10-10 at 12 48 03" src="https://user-images.githubusercontent.com/570998/46731438-ee473f80-cc8a-11e8-864f-b4a90faa44b5.png">
