### PR TITLE
Fix graph viz image export on re-runned frames

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/index.jsx
+++ b/src/browser/modules/Stream/CypherFrame/index.jsx
@@ -67,6 +67,7 @@ import {
 import { setRecentView, getRecentView } from 'shared/modules/stream/streamDuck'
 
 export class CypherFrame extends Component {
+  visElement = null
   state = {
     openView: undefined,
     fullscreen: false,
@@ -112,6 +113,10 @@ export class CypherFrame extends Component {
       if (openView) {
         this.setState({ openView })
       }
+    }
+    if (this.props.request.status === 'pending') {
+      this.visElement = null
+      this.setState({ hasVis: false })
     }
   }
   componentDidMount () {


### PR DESCRIPTION
Reset element and state in pending state.
The export previously referred to a non existing DOM element which resulted in broken images.