### PR TITLE
Let the configuration initCmd be empty

### DIFF
--- a/src/browser/modules/Sidebar/Settings.jsx
+++ b/src/browser/modules/Sidebar/Settings.jsx
@@ -79,6 +79,13 @@ const visualSettings = [
           tooltip: 'Show sample scripts in favorites drawer.',
           type: 'checkbox'
         }
+      },
+      {
+        initCmd: {
+          displayName: 'Initial command to execute',
+          tooltip: 'This commands is executed once connected to a graph.',
+          type: 'input'
+        }
       }
     ]
   },

--- a/src/shared/modules/commands/commandsDuck.js
+++ b/src/shared/modules/commands/commandsDuck.js
@@ -205,9 +205,15 @@ export const handleSingleCommandEpic = (action$, store) =>
     )
     .mergeMap(({ action, interpreted, cmdchar }) => {
       return new Promise((resolve, reject) => {
-        if (interpreted.name !== 'cypher') action.cmd = cleanCommand(action.cmd)
-        const res = interpreted.exec(action, cmdchar, store.dispatch, store)
         const noop = { type: 'NOOP' }
+        if (!(action.cmd || '').trim().length) {
+          resolve(noop)
+          return
+        }
+        if (interpreted.name !== 'cypher') {
+          action.cmd = cleanCommand(action.cmd)
+        }
+        const res = interpreted.exec(action, cmdchar, store.dispatch, store)
         if (!res || !res.then) {
           resolve(noop)
         } else {

--- a/src/shared/modules/commands/commandsDuck.test.js
+++ b/src/shared/modules/commands/commandsDuck.test.js
@@ -111,6 +111,22 @@ describe('commandsDuck', () => {
       // See snoopOnActions above
     })
 
+    test('emtpy SYSTEM_COMMAND_QUEUED gets ignored', done => {
+      // Given
+      const cmd = ' '
+      const id = 2
+      const action = commands.executeSystemCommand(cmd, id)
+      bus.take('NOOP', () => {
+        // Then
+        const actions = store.getActions()
+        expect(actions[0]).toEqual(action)
+        expect(actions[1]).toEqual({ type: 'NOOP' })
+        done()
+      })
+      // When
+      store.dispatch(action)
+    })
+
     test('does the right thing for :param x: 2', done => {
       // Given
       const cmd = store.getState().settings.cmdchar + 'param'

--- a/src/shared/modules/settings/settingsDuck.js
+++ b/src/shared/modules/settings/settingsDuck.js
@@ -27,7 +27,7 @@ export const REPLACE = 'settings/REPLACE'
 export const getSettings = state => state[NAME]
 export const getMaxHistory = state =>
   state[NAME].maxHistory || initialState.maxHistory
-export const getInitCmd = state => state[NAME].initCmd || initialState.initCmd
+export const getInitCmd = state => (state[NAME].initCmd || '').trim()
 export const getTheme = state => state[NAME].theme || initialState.theme
 export const getUseBoltRouting = state =>
   state[NAME].useBoltRouting || initialState.useBoltRouting

--- a/src/shared/modules/settings/settingsDuck.test.js
+++ b/src/shared/modules/settings/settingsDuck.test.js
@@ -19,7 +19,13 @@
  */
 
 /* global describe, test, expect */
-import reducer, { NAME, UPDATE, REPLACE, shouldReportUdc } from './settingsDuck'
+import reducer, {
+  NAME,
+  UPDATE,
+  REPLACE,
+  shouldReportUdc,
+  getInitCmd
+} from './settingsDuck'
 import { dehydrate } from 'services/duckUtils'
 
 describe('settings reducer', () => {
@@ -87,6 +93,28 @@ describe('Selectors', () => {
         [NAME]: { shouldReportUdc: t.test }
       }
       expect(shouldReportUdc(state)).toEqual(t.expect)
+    })
+  })
+  test("let getInitCmd be falsy and cast to empty string if that's the case", () => {
+    // Given
+    const tests = [
+      { test: ':play start', expect: ':play start' },
+      { test: null, expect: '' },
+      { test: undefined, expect: '' },
+      { test: '', expect: '' },
+      { test: ' ', expect: '' },
+      {
+        test: '//Todays number is:\nRETURN rand()',
+        expect: '//Todays number is:\nRETURN rand()'
+      }
+    ]
+
+    // When && Then
+    tests.forEach(t => {
+      const state = {
+        [NAME]: { initCmd: t.test }
+      }
+      expect(getInitCmd(state)).toEqual(t.expect)
     })
   })
 })


### PR DESCRIPTION
Also add it to the settings sidebar.

fixes: https://github.com/neo4j/neo4j-browser/issues/780