### PR TITLE
Fix render in IE11

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,8 @@
   "plugins": [
     "react-hot-loader/babel",
     "@babel/plugin-proposal-class-properties",
-    "@babel/plugin-syntax-dynamic-import"
+    "@babel/plugin-syntax-dynamic-import",
+    "styled-components"
   ],
   "presets": [
     ["@babel/preset-env", { "useBuiltIns": "entry" }],

--- a/build_scripts/webpack.config.js
+++ b/build_scripts/webpack.config.js
@@ -25,7 +25,7 @@ const helpers = require('./webpack-helpers')
 
 module.exports = {
   mode: helpers.isProduction ? 'production' : 'development',
-  entry: path.resolve(helpers.browserPath, 'index.jsx'),
+  entry: ['babel-polyfill', path.resolve(helpers.browserPath, 'index.jsx')],
   output: {
     filename: 'app-[hash].js',
     publicPath: '',
@@ -52,6 +52,7 @@ module.exports = {
   },
   devtool: helpers.isProduction ? false : 'inline-source-map',
   devServer: {
+    host: '0.0.0.0',
     port: 8080,
     disableHostCheck: true,
     hot: !helpers.isProduction

--- a/src/browser/init.js
+++ b/src/browser/init.js
@@ -17,7 +17,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import 'babel-polyfill'
 import './styles/bootstrap.grid-only.min.css'
 import './styles/streamline.css'
 import './styles/editor.css'

--- a/src/browser/modules/ClickToCode/__snapshots__/index.test.js.snap
+++ b/src/browser/modules/ClickToCode/__snapshots__/index.test.js.snap
@@ -5,7 +5,7 @@ exports[`ClickToCode does not render if no children 1`] = `<div />`;
 exports[`ClickToCode renders all children 1`] = `
 <div>
   <code
-    class="sc-bdVaJa biJQaZ"
+    class="styled__StyledCodeBlock-gc778v-0 hlKJHw"
   >
     <div>
       <span>
@@ -20,7 +20,7 @@ exports[`ClickToCode renders all children 1`] = `
 exports[`ClickToCode renders children as code if no code is provided 1`] = `
 <div>
   <code
-    class="sc-bdVaJa biJQaZ"
+    class="styled__StyledCodeBlock-gc778v-0 hlKJHw"
   >
     hellohi!
   </code>
@@ -30,7 +30,7 @@ exports[`ClickToCode renders children as code if no code is provided 1`] = `
 exports[`ClickToCode renders code as the code when code is available 1`] = `
 <div>
   <code
-    class="sc-bdVaJa biJQaZ"
+    class="styled__StyledCodeBlock-gc778v-0 hlKJHw"
   >
     hello
   </code>

--- a/src/browser/modules/Sidebar/__snapshots__/Settings.test.js.snap
+++ b/src/browser/modules/Sidebar/__snapshots__/Settings.test.js.snap
@@ -3,46 +3,46 @@
 exports[`Settings renders with strange characters in display name 1`] = `
 <div>
   <div
-    class="sc-bdVaJa HuWkI"
+    class="Drawer-sc-5bct1g-0 kPghdL"
     id="db-settings"
   >
     <h4
-      class="sc-bwzfXH gJZKwg"
+      class="Drawer__DrawerHeader-sc-5bct1g-1 bjmdEJ"
     >
       Browser Settings
     </h4>
     <div
-      class="sc-bZQynM gNquDR"
+      class="Drawer__DrawerBody-sc-5bct1g-6 fhYbsO"
     >
       <div
-        class="sc-ifAKCX kHWkUt"
+        class="Drawer__DrawerSection-sc-5bct1g-4 bEhGCY"
       >
         <div
-          class="sc-EHOje fyzZhj"
+          class="Drawer__DrawerSectionBody-sc-5bct1g-5 RMcRs"
         >
           <h5
-            class="sc-bxivhb jqgGlu"
+            class="Drawer__DrawerSubHeader-sc-5bct1g-3 laKfsi"
           >
             Test åäö settings
           </h5>
           <div
-            class="sc-VigVT gdkCQN"
+            class="styled__StyledSetting-xqaooh-0 dIwyQs"
           >
             <div
-              class="sc-jTzLTM cjMpzP"
+              class="styled__StyledSettingLabel-xqaooh-1 bTUavI"
               title=""
             >
               åäö üüü
             </div>
             <input
-              class="testSetting sc-fjdhpX hFlOzk"
+              class="testSetting styled__StyledSettingTextInput-xqaooh-2 coeKcS"
               title=""
               value="true"
             />
           </div>
         </div>
         <div
-          class="sc-EHOje fyzZhj"
+          class="Drawer__DrawerSectionBody-sc-5bct1g-5 RMcRs"
         />
       </div>
     </div>

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/AsciiView.test.js.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/AsciiView.test.js.snap
@@ -3,10 +3,10 @@
 exports[`AsciiViews AsciiStatusbar displays statusBarMessage if no rows 1`] = `
 <div>
   <div
-    class="sc-cvbbAY AtklN"
+    class="styled__StyledStatsBar-sc-1dtvgs1-32 hNrxzW"
   >
     <div
-      class="sc-bdVaJa kwzqrW"
+      class="Ellipsis-sc-1dn9bou-0 gzqRPC"
     >
       Completed after 10  ms.
     </div>
@@ -17,17 +17,17 @@ exports[`AsciiViews AsciiStatusbar displays statusBarMessage if no rows 1`] = `
 exports[`AsciiViews AsciiStatusbar displays statusBarMessage if no rows 2`] = `
 <div>
   <div
-    class="sc-cvbbAY AtklN"
+    class="styled__StyledStatsBar-sc-1dtvgs1-32 hNrxzW"
   >
     <div
-      class="sc-gipzik jvspFy"
+      class="styled__StyledRightPartial-sc-1dtvgs1-41 zWSxr"
     >
       <div
-        class="sc-Rmtcm dlMiJv"
+        class="styled__StyledWidthSliderContainer-sc-1dtvgs1-43 dWMHAj"
       >
         Max column width:
         <input
-          class="sc-bRBYWo ikSwwV"
+          class="styled__StyledWidthSlider-sc-1dtvgs1-44 dMpTet"
           max="3"
           min="3"
           type="range"
@@ -42,10 +42,10 @@ exports[`AsciiViews AsciiStatusbar displays statusBarMessage if no rows 2`] = `
 exports[`AsciiViews AsciiView displays bodyMessage if no rows 1`] = `
 <div>
   <div
-    class="sc-gzVnrw hPaHhb"
+    class="styled__PaddedDiv-sc-1dtvgs1-6 ccSRli"
   >
     <div
-      class="sc-cMljjf cIugeT"
+      class="styled__StyledBodyMessage-sc-1dtvgs1-35 hfUgGP"
     >
       (no changes, no records)
     </div>
@@ -56,7 +56,7 @@ exports[`AsciiViews AsciiView displays bodyMessage if no rows 1`] = `
 exports[`AsciiViews AsciiView does not display bodyMessage if rows 1`] = `
 <div>
   <div
-    class="sc-gzVnrw hPaHhb"
+    class="styled__PaddedDiv-sc-1dtvgs1-6 ccSRli"
   >
     <pre>
       ╒═══╕

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/CodeView.test.js.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/CodeView.test.js.snap
@@ -3,10 +3,10 @@
 exports[`CodeViews CodeStatusbar displays no statusBarMessage 1`] = `
 <div>
   <div
-    class="sc-eHgmQL ALSTw"
+    class="styled__StyledStatsBar-sc-1dtvgs1-32 hNrxzW"
   >
     <div
-      class="sc-caSCKo dBwEvm"
+      class="Ellipsis-sc-1dn9bou-0 gzqRPC"
     />
   </div>
 </div>
@@ -15,10 +15,10 @@ exports[`CodeViews CodeStatusbar displays no statusBarMessage 1`] = `
 exports[`CodeViews CodeStatusbar displays statusBarMessage 1`] = `
 <div>
   <div
-    class="sc-eHgmQL ALSTw"
+    class="styled__StyledStatsBar-sc-1dtvgs1-32 hNrxzW"
   >
     <div
-      class="sc-caSCKo dBwEvm"
+      class="Ellipsis-sc-1dn9bou-0 gzqRPC"
     >
       Started streaming 1 records after 5 ms and completed after 10  ms.
     </div>
@@ -31,88 +31,88 @@ exports[`CodeViews CodeView displays nothing if not successful query 1`] = `<div
 exports[`CodeViews CodeView displays request and response info if successful query 1`] = `
 <div>
   <div
-    class="sc-bZQynM bblfwJ"
+    class="styled__PaddedDiv-sc-1dtvgs1-6 ccSRli"
   >
     <table
-      class="sc-bRBYWo eaCMQw"
+      class="styled__StyledTable-sc-1dtvgs1-45 gRxPNQ"
     >
       <tbody
-        class="sc-hzDkRC cQdbyR"
+        class="styled__StyledTBody-sc-1dtvgs1-46 kjlJBA"
       >
         <tr
-          class="sc-fBuWsC gyJlGD"
+          class="styled__StyledAlteringTr-sc-1dtvgs1-48 bVMTCr"
         >
           <td
-            class="sc-fMiknA bVjRtJ"
+            class="styled__StyledStrongTd-sc-1dtvgs1-49 cyBixT"
           >
             Server version
           </td>
           <td
-            class="sc-dVhcbM fghLuF"
+            class="styled__StyledTd-sc-1dtvgs1-50 eFHdOJ"
           >
             xx1
           </td>
         </tr>
         <tr
-          class="sc-fBuWsC gyJlGD"
+          class="styled__StyledAlteringTr-sc-1dtvgs1-48 bVMTCr"
         >
           <td
-            class="sc-fMiknA bVjRtJ"
+            class="styled__StyledStrongTd-sc-1dtvgs1-49 cyBixT"
           >
             Server address
           </td>
           <td
-            class="sc-dVhcbM fghLuF"
+            class="styled__StyledTd-sc-1dtvgs1-50 eFHdOJ"
           >
             xx2
           </td>
         </tr>
         <tr
-          class="sc-fBuWsC gyJlGD"
+          class="styled__StyledAlteringTr-sc-1dtvgs1-48 bVMTCr"
         >
           <td
-            class="sc-fMiknA bVjRtJ"
+            class="styled__StyledStrongTd-sc-1dtvgs1-49 cyBixT"
           >
             Query
           </td>
           <td
-            class="sc-dVhcbM fghLuF"
+            class="styled__StyledTd-sc-1dtvgs1-50 eFHdOJ"
           >
             MATCH xx0
           </td>
         </tr>
         <tr
-          class="sc-fBuWsC gyJlGD"
+          class="styled__StyledAlteringTr-sc-1dtvgs1-48 bVMTCr"
         >
           <td
-            class="sc-fMiknA bVjRtJ"
+            class="styled__StyledStrongTd-sc-1dtvgs1-49 cyBixT"
           >
             Summary
             <div
-              class="fa fa-caret-right sc-jhAzac ZehGm"
+              class="fa fa-caret-right styled__StyledExpandable-sc-1dtvgs1-47 eeYvUX"
               title="Expand section"
             />
           </td>
           <td
-            class="sc-dVhcbM fghLuF"
+            class="styled__StyledTd-sc-1dtvgs1-50 eFHdOJ"
           >
             {,  "server": {,    "version": "xx1", ...
           </td>
         </tr>
         <tr
-          class="sc-fBuWsC gyJlGD"
+          class="styled__StyledAlteringTr-sc-1dtvgs1-48 bVMTCr"
         >
           <td
-            class="sc-fMiknA bVjRtJ"
+            class="styled__StyledStrongTd-sc-1dtvgs1-49 cyBixT"
           >
             Response
             <div
-              class="fa fa-caret-right sc-jhAzac ZehGm"
+              class="fa fa-caret-right styled__StyledExpandable-sc-1dtvgs1-47 eeYvUX"
               title="Expand section"
             />
           </td>
           <td
-            class="sc-dVhcbM fghLuF"
+            class="styled__StyledTd-sc-1dtvgs1-50 eFHdOJ"
           >
             [,  {,    "res": "xx3" ...
           </td>

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/ErrorsView.test.js.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/ErrorsView.test.js.snap
@@ -3,14 +3,14 @@
 exports[`ErrorsViews ErrorsStatusbar displays error 1`] = `
 <div>
   <div
-    class="sc-bdVaJa kwzqrW"
+    class="Ellipsis-sc-1dn9bou-0 gzqRPC"
   >
     <span
-      class="sc-hSdWYo xUFHm"
+      class="styled__ErrorText-sc-1dtvgs1-29 dMsRZb"
       title="Test.Error: Test error description"
     >
       <i
-        class="fa fa-exclamation-triangle sc-cHGsZl hAqKMX"
+        class="fa fa-exclamation-triangle IconContainer__I-sc-16whwc5-0 bXwiKG"
       />
        
       Test.Error: Test error description
@@ -26,42 +26,42 @@ exports[`ErrorsViews ErrorsView displays nothing if no errors 1`] = `<div />`;
 exports[`ErrorsViews ErrorsView displays procedure link if unknown procedure 1`] = `
 <div>
   <div
-    class="sc-jzJRlG jCEPTw"
+    class="styled__StyledHelpFrame-sc-1dtvgs1-14 IJQaq"
   >
     <div
-      class="sc-cSHVUG bDcxKR"
+      class="styled__StyledHelpContent-sc-1dtvgs1-15 jPcVVC"
     >
       <div
-        class="sc-kAzzGY jQzNna"
+        class="styled__StyledHelpDescription-sc-1dtvgs1-16 buBBgk"
       >
         <div
-          class="sc-ckVGcZ kiGfIh"
+          class="styled__StyledCypherErrorMessage-sc-1dtvgs1-22 izHDyp"
         >
           ERROR
         </div>
         <h4
-          class="sc-kEYyzF gfWKdx"
+          class="styled__StyledH4-sc-1dtvgs1-26 jXSkte"
         >
           Neo.ClientError.Procedure.ProcedureNotFound
         </h4>
       </div>
       <div
-        class="sc-chPdSV byfFmt"
+        class="styled__StyledDiv-sc-1dtvgs1-17 kkPWFM"
       >
         <pre
-          class="sc-iAyFgw hIxaSC"
+          class="styled__StyledPreformattedArea-sc-1dtvgs1-28 fxWKEH"
         >
           Neo.ClientError.Procedure.ProcedureNotFound: not found
         </pre>
       </div>
       <div
-        class="sc-kGXeez jXSbBA"
+        class="styled__StyledLinkContainer-sc-1dtvgs1-19 eorHIm"
       >
         <a
-          class="sc-kgoBCf chbNIl"
+          class="styled__StyledLink-sc-1dtvgs1-18 cLfBMz"
         >
           <i
-            class="fa fa-play-circle-o sc-kjoXOD dndEnR"
+            class="fa fa-play-circle-o IconContainer__I-sc-16whwc5-0 eTELIJ"
           />
            List available procedures
         </a>
@@ -74,30 +74,30 @@ exports[`ErrorsViews ErrorsView displays procedure link if unknown procedure 1`]
 exports[`ErrorsViews ErrorsView does displays an error 1`] = `
 <div>
   <div
-    class="sc-jzJRlG jCEPTw"
+    class="styled__StyledHelpFrame-sc-1dtvgs1-14 IJQaq"
   >
     <div
-      class="sc-cSHVUG bDcxKR"
+      class="styled__StyledHelpContent-sc-1dtvgs1-15 jPcVVC"
     >
       <div
-        class="sc-kAzzGY jQzNna"
+        class="styled__StyledHelpDescription-sc-1dtvgs1-16 buBBgk"
       >
         <div
-          class="sc-ckVGcZ kiGfIh"
+          class="styled__StyledCypherErrorMessage-sc-1dtvgs1-22 izHDyp"
         >
           ERROR
         </div>
         <h4
-          class="sc-kEYyzF gfWKdx"
+          class="styled__StyledH4-sc-1dtvgs1-26 jXSkte"
         >
           Test.Error
         </h4>
       </div>
       <div
-        class="sc-chPdSV byfFmt"
+        class="styled__StyledDiv-sc-1dtvgs1-17 kkPWFM"
       >
         <pre
-          class="sc-iAyFgw hIxaSC"
+          class="styled__StyledPreformattedArea-sc-1dtvgs1-28 fxWKEH"
         >
           Test.Error: Test error description
         </pre>

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/PlanView.test.js.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/PlanView.test.js.snap
@@ -3,13 +3,13 @@
 exports[`PlanViews PlanStatusbar displays statusBarMessage 1`] = `
 <div>
   <div
-    class="sc-gisBJw dqfpqi"
+    class="styled__StyledOneRowStatsBar-sc-1dtvgs1-33 dkmnzU"
   >
     <div
-      class="sc-kvZOFW gfNjxO"
+      class="styled__StyledLeftPartial-sc-1dtvgs1-42 cEQgJw"
     >
       <div
-        class="sc-hEsumM dpcDje"
+        class="Ellipsis-sc-1dn9bou-0 gzqRPC"
       >
         Cypher version: 
         xx0
@@ -22,25 +22,25 @@ exports[`PlanViews PlanStatusbar displays statusBarMessage 1`] = `
       </div>
     </div>
     <div
-      class="sc-frDJqD jrNxwj"
+      class="styled__StyledRightPartial-sc-1dtvgs1-41 zWSxr"
     >
       <ul
-        class="sc-hSdWYo dRKhSV"
+        class="styled__FrameTitlebarButtonSection-sc-1dtvgs1-10 dRnwVT"
       >
         <li
-          class="sc-gZMcBi xeFmB"
+          class="buttons__StyledFrameButton-sc-3xi0d5-10 cajKMw"
           data-test-id="planCollapseButton"
         >
           <i
-            class="sl-double-up sc-ktHwxA iKTexq"
+            class="sl-double-up IconContainer__I-sc-16whwc5-0 bXwiKG"
           />
         </li>
         <li
-          class="sc-gZMcBi xeFmB"
+          class="buttons__StyledFrameButton-sc-3xi0d5-10 cajKMw"
           data-test-id="planExpandButton"
         >
           <i
-            class="sl-double-down sc-cIShpX DUjig"
+            class="sl-double-down IconContainer__I-sc-16whwc5-0 bXwiKG"
           />
         </li>
       </ul>

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/TableView.test.js.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/TableView.test.js.snap
@@ -3,10 +3,10 @@
 exports[`TableViews TableStatusbar displays no statusBarMessage 1`] = `
 <div>
   <div
-    class="sc-eHgmQL ALSTw"
+    class="styled__StyledStatsBar-sc-1dtvgs1-32 hNrxzW"
   >
     <div
-      class="sc-caSCKo dBwEvm"
+      class="Ellipsis-sc-1dn9bou-0 gzqRPC"
     />
   </div>
 </div>
@@ -15,10 +15,10 @@ exports[`TableViews TableStatusbar displays no statusBarMessage 1`] = `
 exports[`TableViews TableStatusbar displays statusBarMessage 1`] = `
 <div>
   <div
-    class="sc-eHgmQL ALSTw"
+    class="styled__StyledStatsBar-sc-1dtvgs1-32 hNrxzW"
   >
     <div
-      class="sc-caSCKo dBwEvm"
+      class="Ellipsis-sc-1dn9bou-0 gzqRPC"
     >
       Started streaming 1 records after 5 ms and completed after 10  ms.
     </div>
@@ -29,10 +29,10 @@ exports[`TableViews TableStatusbar displays statusBarMessage 1`] = `
 exports[`TableViews TableView displays bodyMessage if no rows 1`] = `
 <div>
   <div
-    class="sc-gzVnrw jmtLCl"
+    class="styled__PaddedTableViewDiv-sc-1dtvgs1-7 iNSchp"
   >
     <div
-      class="sc-brqgnP bWxJLn"
+      class="styled__StyledBodyMessage-sc-1dtvgs1-35 hfUgGP"
     >
       (no changes, no records)
     </div>
@@ -43,15 +43,15 @@ exports[`TableViews TableView displays bodyMessage if no rows 1`] = `
 exports[`TableViews TableView does not display bodyMessage if rows 1`] = `
 <div>
   <div
-    class="sc-gzVnrw jmtLCl"
+    class="styled__PaddedTableViewDiv-sc-1dtvgs1-7 iNSchp"
   >
     <table
-      class="sc-gisBJw hMNjzC"
+      class="DataTables__StyledTable-bf850j-0 cZayOW"
     >
       <thead>
         <tr>
           <th
-            class="table-header sc-cHGsZl Sqoke"
+            class="table-header DataTables__StyledTh-bf850j-2 gjWFrA"
           >
             x
           </th>
@@ -59,10 +59,10 @@ exports[`TableViews TableView does not display bodyMessage if rows 1`] = `
       </thead>
       <tbody>
         <tr
-          class="table-row sc-kjoXOD fWuSOJ"
+          class="table-row DataTables__StyledBodyTr-bf850j-1 iGjwRr"
         >
           <td
-            class="table-properties sc-TOsTZ itLVPa"
+            class="table-properties DataTables__StyledTd-bf850j-3 jDsjVi"
           >
             "y"
           </td>

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/WarningsView.test.js.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/WarningsView.test.js.snap
@@ -5,42 +5,42 @@ exports[`WarningsViews WarningsView displays nothing if no notifications 1`] = `
 exports[`WarningsViews WarningsView does displays a warning 1`] = `
 <div>
   <div
-    class="sc-jTzLTM kHMley"
+    class="styled__StyledHelpFrame-sc-1dtvgs1-14 IJQaq"
   >
     <div
-      class="sc-fjdhpX gFIdYO"
+      class="styled__StyledHelpContent-sc-1dtvgs1-15 jPcVVC"
     >
       <div
-        class="sc-jzJRlG cOrBFf"
+        class="styled__StyledHelpDescription-sc-1dtvgs1-16 buBBgk"
       >
         <div
-          class="sc-kgoBCf jNgdNK"
+          class="styled__StyledCypherMessage-sc-1dtvgs1-20 hvZiFr"
         >
           WARNING xx0
         </div>
         <h4
-          class="sc-eNQAEJ fAbPPh"
+          class="styled__StyledH4-sc-1dtvgs1-26 jXSkte"
         >
           My xx1 warning
         </h4>
       </div>
       <div
-        class="sc-cSHVUG CAuLq"
+        class="styled__StyledDiv-sc-1dtvgs1-17 kkPWFM"
       >
         <div
-          class="sc-jzJRlG cOrBFf"
+          class="styled__StyledHelpDescription-sc-1dtvgs1-16 buBBgk"
         >
           This is xx2 warning
         </div>
         <div
-          class="sc-cSHVUG CAuLq"
+          class="styled__StyledDiv-sc-1dtvgs1-17 kkPWFM"
         >
           <pre
-            class="sc-kEYyzF dXKHJM"
+            class="styled__StyledPreformattedArea-sc-1dtvgs1-28 fxWKEH"
           >
             EXPLAIN MATCH xx3
             <br
-              class="sc-hMqMXs cPxEnv"
+              class="styled__StyledBr-sc-1dtvgs1-27 bdFSvo"
             />
                    
             ^
@@ -55,42 +55,42 @@ exports[`WarningsViews WarningsView does displays a warning 1`] = `
 exports[`WarningsViews WarningsView does displays multiple warnings 1`] = `
 <div>
   <div
-    class="sc-jTzLTM kHMley"
+    class="styled__StyledHelpFrame-sc-1dtvgs1-14 IJQaq"
   >
     <div
-      class="sc-fjdhpX gFIdYO"
+      class="styled__StyledHelpContent-sc-1dtvgs1-15 jPcVVC"
     >
       <div
-        class="sc-jzJRlG cOrBFf"
+        class="styled__StyledHelpDescription-sc-1dtvgs1-16 buBBgk"
       >
         <div
-          class="sc-kgoBCf jNgdNK"
+          class="styled__StyledCypherMessage-sc-1dtvgs1-20 hvZiFr"
         >
           WARNING xx0
         </div>
         <h4
-          class="sc-eNQAEJ fAbPPh"
+          class="styled__StyledH4-sc-1dtvgs1-26 jXSkte"
         >
           My xx1 warning
         </h4>
       </div>
       <div
-        class="sc-cSHVUG CAuLq"
+        class="styled__StyledDiv-sc-1dtvgs1-17 kkPWFM"
       >
         <div
-          class="sc-jzJRlG cOrBFf"
+          class="styled__StyledHelpDescription-sc-1dtvgs1-16 buBBgk"
         >
           This is xx2 warning
         </div>
         <div
-          class="sc-cSHVUG CAuLq"
+          class="styled__StyledDiv-sc-1dtvgs1-17 kkPWFM"
         >
           <pre
-            class="sc-kEYyzF dXKHJM"
+            class="styled__StyledPreformattedArea-sc-1dtvgs1-28 fxWKEH"
           >
             EXPLAIN MATCH zz3
             <br
-              class="sc-hMqMXs cPxEnv"
+              class="styled__StyledBr-sc-1dtvgs1-27 bdFSvo"
             />
                    
             ^
@@ -99,39 +99,39 @@ exports[`WarningsViews WarningsView does displays multiple warnings 1`] = `
       </div>
     </div>
     <div
-      class="sc-fjdhpX gFIdYO"
+      class="styled__StyledHelpContent-sc-1dtvgs1-15 jPcVVC"
     >
       <div
-        class="sc-jzJRlG cOrBFf"
+        class="styled__StyledHelpDescription-sc-1dtvgs1-16 buBBgk"
       >
         <div
-          class="sc-kgoBCf jNgdNK"
+          class="styled__StyledCypherMessage-sc-1dtvgs1-20 hvZiFr"
         >
           WARNING yy0
         </div>
         <h4
-          class="sc-eNQAEJ fAbPPh"
+          class="styled__StyledH4-sc-1dtvgs1-26 jXSkte"
         >
           My yy1 warning
         </h4>
       </div>
       <div
-        class="sc-cSHVUG CAuLq"
+        class="styled__StyledDiv-sc-1dtvgs1-17 kkPWFM"
       >
         <div
-          class="sc-jzJRlG cOrBFf"
+          class="styled__StyledHelpDescription-sc-1dtvgs1-16 buBBgk"
         >
           This is yy2 warning
         </div>
         <div
-          class="sc-cSHVUG CAuLq"
+          class="styled__StyledDiv-sc-1dtvgs1-17 kkPWFM"
         >
           <pre
-            class="sc-kEYyzF dXKHJM"
+            class="styled__StyledPreformattedArea-sc-1dtvgs1-28 fxWKEH"
           >
             EXPLAIN MATCH zz3
             <br
-              class="sc-hMqMXs cPxEnv"
+              class="styled__StyledBr-sc-1dtvgs1-27 bdFSvo"
             />
                
             ^

--- a/src/browser/modules/Stream/__snapshots__/HistoryRow.test.js.snap
+++ b/src/browser/modules/Stream/__snapshots__/HistoryRow.test.js.snap
@@ -3,7 +3,7 @@
 exports[`HistoryRow triggers function on click 1`] = `
 <div>
   <li
-    class="sc-fAjcbJ doumqX"
+    class="styled__StyledHistoryRow-sc-1dtvgs1-52 cIKDwr"
   >
     :clear
   </li>


### PR DESCRIPTION
This PR fixes an regression that came with the webpack 4 upgrade. 
neo4j-browser rendered completely blank due to a late load of babel-runtime.

What's awesome is that recent changes with dependencies and tooling upgrades also fixes the long stand bug of IE 11 re-rendering / flickering the stream.

Gif for proof.
![ie11](https://user-images.githubusercontent.com/570998/47284953-7dd4e280-d5e9-11e8-89a7-bedd61b8cbd9.gif)
