### PR TITLE
Add `Order` to plan output if it exists

### DIFF
--- a/e2e_tests/integration/plan.spec.js
+++ b/e2e_tests/integration/plan.spec.js
@@ -37,6 +37,18 @@ describe('Plan output', () => {
       password
     )
   })
+  if (Cypress.config.serverVersion >= 3.5) {
+    it('print Order in PROFILE', () => {
+      cy.executeCommand(':clear')
+      cy.executeCommand(`CREATE INDEX ON :Person(age)`)
+      cy.executeCommand(
+        `EXPLAIN MATCH (n:Person) WHERE n.age > 18 RETURN n.name ORDER BY n.age`
+      )
+      cy.get('[data-test-id="planExpandButton"]', { timeout: 10000 }).click()
+      const el = cy.get('[data-test-id="planSvg"]', { timeout: 10000 })
+      el.should('contain', 'Order by index: n.age ASC')
+    })
+  }
   if (Cypress.config.serverVersion >= 3.4) {
     it('print pagecache stats in PROFILE', () => {
       cy.executeCommand(':clear')

--- a/src/browser/modules/D3Visualization/lib/visualization/components/queryPlan.js
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/queryPlan.js
@@ -178,6 +178,11 @@ function queryPlan (element) {
       details.push({ className: 'padding' })
     }
 
+    if (operator.Order) {
+      wordWrap(`Order by index: ${operator.Order}`, 'order')
+      details.push({ className: 'padding' })
+    }
+
     if (operator.PageCacheHits || operator.PageCacheMisses) {
       details.push({
         className: 'pagecache-hits',


### PR DESCRIPTION
Only in neo4j >= 3.5.0.

## When connected to neo4j 3.4:

![plan 34](https://user-images.githubusercontent.com/570998/47295338-b4255880-d60f-11e8-974e-59bb86251dac.png)


## On 3.5.0 without index:

![plan 35](https://user-images.githubusercontent.com/570998/47295354-bf788400-d60f-11e8-8bed-a82b682790e7.png)


## On 3.5.0 with index:

![plan 33](https://user-images.githubusercontent.com/570998/47295359-c7d0bf00-d60f-11e8-8d69-fa81638162c9.png)
