### PR TITLE
Show a helpful message for non js clients

### DIFF
--- a/src/browser/index.html
+++ b/src/browser/index.html
@@ -32,6 +32,30 @@
   <script type="text/javascript" src="assets/js/canvg/rgbcolor.js"></script>
   <script type="text/javascript" src="assets/js/canvg/StackBlur.js"></script>
   <script type="text/javascript" src="assets/js/canvg/canvg.js"></script>
+  <noscript>
+    <style>
+      .noscript-error {
+        margin: 0;
+        padding: 0;
+        background-color: #D2D5DA;
+        text-align: center;
+        height: 100vh;
+      }
+
+      .noscript-message {
+        margin: 300px auto;
+        border: 1px solid #E6E9EE;
+        padding: 30px;
+        display: inline-block;
+        background-color: white;
+      }
+    </style>
+    <div class="noscript-error">
+      <div class="noscript-message">
+        Neo4j Browser <strong>requires</strong> JavaScript to work properly. Please enable it and reload.
+      </div>
+    </div>
+  </noscript>
 </head>
 
 <body>


### PR DESCRIPTION
Using the `<noscript>` tag.

<img width="1375" alt="oskarhane-mbpt 2018-10-23 at 09 44 31" src="https://user-images.githubusercontent.com/570998/47345230-84775e80-d6aa-11e8-943c-627a3e5bcd7d.png">

fixes: https://github.com/neo4j/neo4j-browser/issues/699