### PR TITLE
Show message if neo4j-browser is opened without an active graph in a Neo4j Desktop environment

### DIFF
--- a/src/browser/components/DesktopIntegration/helpers.js
+++ b/src/browser/components/DesktopIntegration/helpers.js
@@ -31,7 +31,7 @@ export const getActiveGraph = (context = {}) => {
   return activeProject.graphs.find(({ status }) => status === 'ACTIVE')
 }
 
-export const getCredentials = (type, connection) => {
+export const getCredentials = (type, connection = null) => {
   if (!connection) return null
   const { configuration = null } = connection
   if (!configuration) {

--- a/src/browser/components/DesktopIntegration/index.jsx
+++ b/src/browser/components/DesktopIntegration/index.jsx
@@ -39,11 +39,11 @@ export default class DesktopIntegration extends Component {
       integrationPoint
         .getContext()
         .then(context => {
-          const activeGraph = getActiveGraph(context)
+          const activeGraph = getActiveGraph(context) || {}
           if (onMount) {
             const connectionCredentials = getCredentials(
               'bolt',
-              activeGraph.connection
+              activeGraph.connection || null
             )
             onMount(activeGraph, connectionCredentials, context)
           }

--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -39,7 +39,8 @@ import {
   isConnected,
   getConnectionData,
   SILENT_DISCONNECT,
-  SWITCH_CONNECTION
+  SWITCH_CONNECTION,
+  SWITCH_CONNECTION_FAILED
 } from 'shared/modules/connections/connectionsDuck'
 import { toggle } from 'shared/modules/sidebar/sidebarDuck'
 import {
@@ -207,7 +208,11 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
   }
   const setInitialConnectionData = (graph, credentials, context) => {
     const creds = getActiveCredentials('bolt', context)
-    if (!creds) return // No connection. Ignore and let browser show connection lost msgs.
+    // No connection. Probably no graph active.
+    if (!creds) {
+      ownProps.bus.send(SWITCH_CONNECTION_FAILED)
+      return
+    }
     const httpsCreds = getActiveCredentials('https', context)
     const httpCreds = getActiveCredentials('http', context)
     const restApi =

--- a/src/browser/modules/Stream/Auth/ServerSwitchFrame.jsx
+++ b/src/browser/modules/Stream/Auth/ServerSwitchFrame.jsx
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { Component } from 'react'
+import React from 'react'
 import FrameTemplate from '../FrameTemplate'
 import {
   StyledConnectionFrame,

--- a/src/browser/modules/Stream/Auth/ServerSwitchFrame.jsx
+++ b/src/browser/modules/Stream/Auth/ServerSwitchFrame.jsx
@@ -80,10 +80,11 @@ export const ServerSwitchFrame = props => {
           <StyledConnectionBody>
             The connection credentials provided could not be used to connect.
             <br />
-            Did you start a graph?
+            Do you have an active graph?
             <br />
             Execute <ClickToCode>:server connect</ClickToCode> to manually enter
-            credentials if you have a graph running.
+            credentials if you have an active graph but the provided credentials
+            were wrong.
           </StyledConnectionBody>
         </Render>
         <Render

--- a/src/browser/modules/Stream/Auth/ServerSwitchFrame.jsx
+++ b/src/browser/modules/Stream/Auth/ServerSwitchFrame.jsx
@@ -31,76 +31,104 @@ import { H3 } from 'browser-components/headers'
 import Render from 'browser-components/Render'
 import ClickToCode from '../../ClickToCode'
 
-class ServerStatusFrame extends Component {
-  render () {
-    const {
-      frame,
-      activeConnectionData: dynamicConnectionData = {}
-    } = this.props
-    const { activeConnectionData, storeCredentials } = frame
-    return (
-      <FrameTemplate
-        header={frame}
-        contents={
-          <StyledConnectionFrame>
-            <StyledConnectionAside>
-              <span>
-                <H3>Connection updated</H3>
-                You have switched connection.
-              </span>
-            </StyledConnectionAside>
-            <StyledConnectionBodyContainer>
-              <Render if={frame.type === 'switch-fail'}>
-                <StyledConnectionBody>
-                  The connection credentials provided could not be used to
-                  connect.
-                  <br />
-                  You are now disconnected.
-                  <br />
-                  Execute <ClickToCode>:server connect</ClickToCode> to manually
-                  enter credentials.
-                </StyledConnectionBody>
-              </Render>
-              <Render
-                if={
-                  frame.type === 'switch-success' &&
-                  activeConnectionData &&
-                  dynamicConnectionData &&
-                  dynamicConnectionData.authEnabled
-                }
-              >
-                <ConnectedView
-                  host={activeConnectionData && activeConnectionData.host}
-                  username={
-                    activeConnectionData && activeConnectionData.username
-                  }
-                  showHost
-                  storeCredentials={storeCredentials}
-                />
-              </Render>
-              <Render
-                if={
-                  frame.type === 'switch-success' &&
-                  activeConnectionData &&
-                  dynamicConnectionData &&
-                  !dynamicConnectionData.authEnabled
-                }
-              >
-                <div>
-                  <ConnectedView
-                    host={activeConnectionData && activeConnectionData.host}
-                    showHost
-                    hideStoreCredentials
-                    additionalFooter='You have a working connection with the Neo4j database and server auth is disabled.'
-                  />
-                </div>
-              </Render>
-            </StyledConnectionBodyContainer>
-          </StyledConnectionFrame>
-        }
-      />
-    )
-  }
+const connectionFailed = frame => {
+  return frame.type === 'switch-fail'
 }
 
-export default ServerStatusFrame
+const connectionSuccess = (
+  frame,
+  activeConnectionData,
+  dynamicConnectionData
+) => {
+  return (
+    frame.type === 'switch-success' &&
+    activeConnectionData &&
+    dynamicConnectionData &&
+    dynamicConnectionData.authEnabled
+  )
+}
+
+export const ServerSwitchFrame = props => {
+  const { frame, activeConnectionData: dynamicConnectionData = {} } = props
+  const { activeConnectionData, storeCredentials } = frame
+  return (
+    <StyledConnectionFrame>
+      <StyledConnectionAside>
+        <span>
+          <Render if={connectionFailed(frame)}>
+            <React.Fragment>
+              <H3>Connection failed</H3>
+              Could not connect.
+            </React.Fragment>
+          </Render>
+          <Render
+            if={connectionSuccess(
+              frame,
+              activeConnectionData,
+              dynamicConnectionData
+            )}
+          >
+            <React.Fragment>
+              <H3>Connection updated</H3>
+              You have switched connection.
+            </React.Fragment>
+          </Render>
+        </span>
+      </StyledConnectionAside>
+      <StyledConnectionBodyContainer>
+        <Render if={connectionFailed(frame)}>
+          <StyledConnectionBody>
+            The connection credentials provided could not be used to connect.
+            <br />
+            Did you start a graph?
+            <br />
+            Execute <ClickToCode>:server connect</ClickToCode> to manually enter
+            credentials if you have a graph running.
+          </StyledConnectionBody>
+        </Render>
+        <Render
+          if={connectionSuccess(
+            frame,
+            activeConnectionData,
+            dynamicConnectionData
+          )}
+        >
+          <ConnectedView
+            host={activeConnectionData && activeConnectionData.host}
+            username={activeConnectionData && activeConnectionData.username}
+            showHost
+            storeCredentials={storeCredentials}
+          />
+        </Render>
+        <Render
+          if={
+            frame.type === 'switch-success' &&
+            activeConnectionData &&
+            dynamicConnectionData &&
+            !dynamicConnectionData.authEnabled
+          }
+        >
+          <div>
+            <ConnectedView
+              host={activeConnectionData && activeConnectionData.host}
+              showHost
+              hideStoreCredentials
+              additionalFooter='You have a working connection with the Neo4j database and server auth is disabled.'
+            />
+          </div>
+        </Render>
+      </StyledConnectionBodyContainer>
+    </StyledConnectionFrame>
+  )
+}
+
+const Frame = props => {
+  return (
+    <FrameTemplate
+      header={props.frame}
+      contents={<ServerSwitchFrame {...props} />}
+    />
+  )
+}
+
+export default Frame

--- a/src/browser/modules/Stream/Auth/ServerSwitchFrame.test.js
+++ b/src/browser/modules/Stream/Auth/ServerSwitchFrame.test.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j, Inc"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* global describe, test, expect */
+import React from 'react'
+import { render } from 'react-testing-library'
+
+import { ServerSwitchFrame } from './ServerSwitchFrame'
+
+test('shows successful message if connection was successful', () => {
+  // Given
+  const frame = {
+    type: 'switch-success',
+    activeConnectionData: { host: 'test-host', username: 'test-username' },
+    storeCredentials: true
+  }
+  const activeConnectionData = { authEnabled: true }
+
+  // When
+  const { getByText } = render(
+    <ServerSwitchFrame
+      frame={frame}
+      activeConnectionData={activeConnectionData}
+    />
+  )
+
+  // Then
+  expect(getByText(frame.activeConnectionData.host)).not.toBe(null)
+  expect(getByText(frame.activeConnectionData.username)).not.toBe(null)
+  expect(getByText(/credentials are\s*stored/)).not.toBe(null)
+  expect(getByText(/You have switched connection/i)).not.toBe(null)
+})
+
+test('shows unsuccessful message if connection was unsuccessful', () => {
+  // Given
+  const frame = {
+    type: 'switch-fail',
+    activeConnectionData: { host: 'test-host', username: 'test-username' },
+    storeCredentials: true
+  }
+  const activeConnectionData = { authEnabled: true }
+
+  // When
+  const { getByText, queryByText } = render(
+    <ServerSwitchFrame
+      frame={frame}
+      activeConnectionData={activeConnectionData}
+    />
+  )
+
+  // Then
+  expect(getByText(/Connection failed/i)).not.toBe(null)
+  expect(getByText(/:server connect/i)).not.toBe(null)
+  expect(queryByText(frame.activeConnectionData.host)).toBe(null)
+  expect(queryByText(frame.activeConnectionData.username)).toBe(null)
+  expect(queryByText(/credentials are\s*stored/i)).toBe(null)
+})


### PR DESCRIPTION
Only for desktop env.
If neo4j-browser is launched when no graph in neo4j desktop is active the user was left with a blank stream.
This PR shows a connection failed frame.

## Before
<img width="1236" alt="oskarhane-mbpt 2018-10-25 at 12 32 24" src="https://user-images.githubusercontent.com/570998/47495502-9c8ae180-d854-11e8-9b4e-88ef2ca1d0ce.png">


## After
<img width="1310" alt="oskarhane-mbpt 2018-10-25 at 12 54 43" src="https://user-images.githubusercontent.com/570998/47495726-2c309000-d855-11e8-974d-4ad4c9da2741.png">


