### PR TITLE
Add support for GraSS selectors (node labels and rel types) containing a `.`

### DIFF
--- a/src/browser/modules/D3Visualization/graphStyle.js
+++ b/src/browser/modules/D3Visualization/graphStyle.js
@@ -1,8 +1,3 @@
-import {
-  selectorStringToArray,
-  selectorArrayToString
-} from 'services/grassUtils'
-
 /*
  * Copyright (c) 2002-2018 "Neo4j, Inc"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
@@ -22,6 +17,11 @@ import {
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
+import {
+  selectorStringToArray,
+  selectorArrayToString
+} from 'services/grassUtils'
 
 export default function neoGraphStyle () {
   const defaultStyle = {

--- a/src/browser/modules/D3Visualization/graphStyle.js
+++ b/src/browser/modules/D3Visualization/graphStyle.js
@@ -1,3 +1,8 @@
+import {
+  selectorStringToArray,
+  selectorArrayToString
+} from 'services/grassUtils'
+
 /*
  * Copyright (c) 2002-2018 "Neo4j, Inc"
  * Network Engine for Objects in Lund AB [http://neotechnology.com]
@@ -148,14 +153,7 @@ export default function neoGraphStyle () {
     }
 
     Selector.prototype.toString = function () {
-      let str = this.tag
-      for (let i = 0; i < this.classes.length; i++) {
-        const classs = this.classes[i]
-        if (classs != null) {
-          str += '.' + classs
-        }
-      }
-      return str
+      return selectorArrayToString([this.tag].concat(this.classes))
     }
 
     return Selector
@@ -225,7 +223,7 @@ export default function neoGraphStyle () {
     }
 
     const parseSelector = function (key) {
-      let tokens = key.split('.')
+      let tokens = selectorStringToArray(key)
       return new Selector(tokens[0], tokens.slice(1))
     }
 

--- a/src/browser/modules/D3Visualization/graphStyle.test.js
+++ b/src/browser/modules/D3Visualization/graphStyle.test.js
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j, Inc"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/* global beforeEach, afterEach */
+import Grass from './graphStyle'
+
+describe('grass', () => {
+  it('can generate a default style', () => {
+    // Given
+    const grass = new Grass()
+
+    // When
+    const styleStr = grass.toString()
+
+    // Then
+    expect(styleStr).toEqual(
+      `node {
+  diameter: 50px;
+  color: #A5ABB6;
+  border-color: #9AA1AC;
+  border-width: 2px;
+  text-color-internal: #FFFFFF;
+  font-size: 10px;
+}
+
+relationship {
+  color: #A5ABB6;
+  shaft-width: 1px;
+  font-size: 8px;
+  padding: 3px;
+  text-color-external: #000000;
+  text-color-internal: #FFFFFF;
+  caption: '<type>';
+}
+
+`
+    )
+  })
+  it('can generate a style for a node with a simple label', () => {
+    // Given
+    const grass = new Grass()
+    const node = {
+      labels: ['foo']
+    }
+
+    // When
+    grass.forNode(node)
+    const styleStr = grass.toString()
+
+    // Then
+    expect(styleStr).toEqual(`node {
+  diameter: 50px;
+  color: #A5ABB6;
+  border-color: #9AA1AC;
+  border-width: 2px;
+  text-color-internal: #FFFFFF;
+  font-size: 10px;
+}
+
+relationship {
+  color: #A5ABB6;
+  shaft-width: 1px;
+  font-size: 8px;
+  padding: 3px;
+  text-color-external: #000000;
+  text-color-internal: #FFFFFF;
+  caption: '<type>';
+}
+
+node.foo {
+  color: #68BDF6;
+  border-color: #5CA8DB;
+  text-color-internal: #FFFFFF;
+  defaultCaption: <id>;
+}
+
+`)
+  })
+  it('can generate a style for a node with a label with a dot', () => {
+    // Given
+    const grass = new Grass()
+    const node = {
+      labels: ['foo.bar']
+    }
+
+    // When
+    grass.forNode(node)
+    const styleStr = grass.toString()
+
+    // Then
+    expect(styleStr).toEqual(`node {
+  diameter: 50px;
+  color: #A5ABB6;
+  border-color: #9AA1AC;
+  border-width: 2px;
+  text-color-internal: #FFFFFF;
+  font-size: 10px;
+}
+
+relationship {
+  color: #A5ABB6;
+  shaft-width: 1px;
+  font-size: 8px;
+  padding: 3px;
+  text-color-external: #000000;
+  text-color-internal: #FFFFFF;
+  caption: '<type>';
+}
+
+node.foo\\.bar {
+  color: #68BDF6;
+  border-color: #5CA8DB;
+  text-color-internal: #FFFFFF;
+  defaultCaption: <id>;
+}
+
+`)
+  })
+  it('can generate a style for a relationship with a type with a dot', () => {
+    // Given
+    const grass = new Grass()
+
+    // When
+    grass.loadRules()
+    grass.changeForSelector('relationship.REL\\.TYPE', {
+      caption: 'yo'
+    })
+    // grass.forRelationship(rel)
+    const styleStr = grass.toString()
+
+    // Then
+    expect(styleStr).toEqual(`node {
+  diameter: 50px;
+  color: #A5ABB6;
+  border-color: #9AA1AC;
+  border-width: 2px;
+  text-color-internal: #FFFFFF;
+  font-size: 10px;
+}
+
+relationship {
+  color: #A5ABB6;
+  shaft-width: 1px;
+  font-size: 8px;
+  padding: 3px;
+  text-color-external: #000000;
+  text-color-internal: #FFFFFF;
+  caption: '<type>';
+}
+
+relationship.REL\\.TYPE {
+  caption: 'yo';
+}
+
+`)
+  })
+})

--- a/src/shared/services/grassUtils.js
+++ b/src/shared/services/grassUtils.js
@@ -138,6 +138,10 @@ const quoteSpecialStyles = (style, value) =>
   (shouldQuoteStyle(style) ? '"' : '')
 
 export const selectorStringToArray = selector => {
+  // Negative lookbehind simulation since js support is very limited.
+  // We want to match all . that are not preceded by \\
+  // Instead we reverse and look
+  // for . that are not followed by \\ (negative lookahead)
   selector = selector
     .split('')
     .reverse()

--- a/src/shared/services/grassUtils.js
+++ b/src/shared/services/grassUtils.js
@@ -136,3 +136,30 @@ const quoteSpecialStyles = (style, value) =>
   (shouldQuoteStyle(style) ? '"' : '') +
   value +
   (shouldQuoteStyle(style) ? '"' : '')
+
+export const selectorStringToArray = selector => {
+  selector = selector
+    .split('')
+    .reverse()
+    .join('')
+  var re = /(.+?)(?!\.\\)(?:\.|$)/g
+  const out = []
+  let m
+  while ((m = re.exec(selector)) !== null) {
+    const res = m[1]
+      .split('')
+      .reverse()
+      .join('')
+    out.push(res)
+  }
+
+  return out
+    .filter(r => r)
+    .reverse()
+    .map(r => r.replace(/\\./g, '.'))
+}
+
+export const selectorArrayToString = selectors => {
+  const escaped = selectors.map(r => r.replace(/\./g, '\\.'))
+  return escaped.join('.')
+}

--- a/src/shared/services/grassUtils.test.js
+++ b/src/shared/services/grassUtils.test.js
@@ -18,7 +18,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 /* global beforeEach, afterEach */
-import { parseGrass, objToCss } from 'services/grassUtils'
+import {
+  parseGrass,
+  objToCss,
+  selectorStringToArray,
+  selectorArrayToString
+} from 'services/grassUtils'
 
 describe('parseGrass', () => {
   it('should create an object from a valid CSS string', () => {
@@ -134,5 +139,44 @@ relationship {
   it('does not break on undefined', () => {
     const css = objToCss()
     expect(css).toEqual(false)
+  })
+})
+
+describe('selectors', () => {
+  test('selectorStringToArray unescapes selectors with . in them', () => {
+    const tests = [
+      { test: 'foo', expect: ['foo'] },
+      { test: 'foo.bar', expect: ['foo', 'bar'] },
+      { test: 'foo.bar.baz', expect: ['foo', 'bar', 'baz'] },
+      { test: 'foo\\.bar', expect: ['foo.bar'] },
+      { test: 'foo\\.bar\\.baz', expect: ['foo.bar.baz'] },
+      { test: 'foo\\.bar.baz\\.baz', expect: ['foo.bar', 'baz.baz'] },
+      {
+        test: 'node.foo\\.bar\\.baz.bax',
+        expect: ['node', 'foo.bar.baz', 'bax']
+      }
+    ]
+
+    tests.forEach(t => {
+      expect(selectorStringToArray(t.test)).toEqual(t.expect)
+    })
+  })
+  test('selectorArrayToString escapes selectors with . in them', () => {
+    const tests = [
+      { expect: 'foo', test: ['foo'] },
+      { expect: 'foo.bar', test: ['foo', 'bar'] },
+      { expect: 'foo.bar.baz', test: ['foo', 'bar', 'baz'] },
+      { expect: 'foo\\.bar', test: ['foo.bar'] },
+      { expect: 'foo\\.bar\\.baz', test: ['foo.bar.baz'] },
+      { expect: 'foo\\.bar.baz\\.baz', test: ['foo.bar', 'baz.baz'] },
+      {
+        expect: 'node.foo\\.bar\\.baz.bax',
+        test: ['node', 'foo.bar.baz', 'bax']
+      }
+    ]
+
+    tests.forEach(t => {
+      expect(selectorArrayToString(t.test)).toEqual(t.expect)
+    })
   })
 })


### PR DESCRIPTION
Both support for changing the styling through the UI and uploading of grass files.

```
:style reset
CREATE (n:`foo.bar`) RETURN n
// Edit style in the UI through the legend
```

It's aligned with how CSS does it:

```
node {
  color: #ffffff;
}
node.foo\.bar {
  caption: '{name}';
}
```

<img width="731" alt="oskarhane-mbpt 2018-10-31 at 09 16 13" src="https://user-images.githubusercontent.com/570998/47774560-a5186780-dced-11e8-95d6-9a0a2bb06af9.png">

fixes: https://github.com/neo4j/neo4j-browser/issues/809