### PR TITLE
Support Neo4j Kerberos auth when in a Neo4j Desktop environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     }
   ],
   "scripts": {
-    "build": "NODE_ENV=\"production\" webpack --config ./build_scripts/webpack.config.js",
+    "build": "NODE_ENV=\"production\" webpack --config ./build_scripts/webpack.config.js --progress",
     "dev": "jest --watch",
     "e2e": "cypress run",
     "e2e-local": "CYPRESS_E2E_TEST_ENV=\"local\" cypress run",

--- a/src/browser/components/DesktopIntegration/helpers.js
+++ b/src/browser/components/DesktopIntegration/helpers.js
@@ -100,7 +100,7 @@ const isKerberosEnabled = context => {
   if (!configuration.authenticationMethods.kerberos.enabled) {
     return false
   }
-  return true
+  return configuration.authenticationMethods.kerberos
 }
 
 export const buildConnectionCredentialsObject = (
@@ -113,8 +113,8 @@ export const buildConnectionCredentialsObject = (
   const httpsCreds = getActiveCredentials('https', context)
   const httpCreds = getActiveCredentials('http', context)
   const kerberos = isKerberosEnabled(context)
-  if (kerberos) {
-    creds.password = getKerberosTicket()
+  if (kerberos !== false) {
+    creds.password = getKerberosTicket(kerberos.servicePrincipal)
   }
   const restApi =
     httpsCreds && httpsCreds.enabled

--- a/src/browser/components/DesktopIntegration/helpers.js
+++ b/src/browser/components/DesktopIntegration/helpers.js
@@ -18,9 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { NATIVE, KERBEROS } from 'shared/modules/connections/connectionsDuck'
-
-export { NATIVE, KERBEROS }
+import { NATIVE, KERBEROS } from 'services/bolt/boltHelpers'
 
 export const getActiveGraph = (context = {}) => {
   if (!context) return null

--- a/src/browser/components/DesktopIntegration/helpers.js
+++ b/src/browser/components/DesktopIntegration/helpers.js
@@ -18,8 +18,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export const KERBEROS = 'KERBEROS'
-export const NATIVE = 'NATIVE'
+import { NATIVE, KERBEROS } from 'shared/modules/connections/connectionsDuck'
+
+export { NATIVE, KERBEROS }
 
 export const getActiveGraph = (context = {}) => {
   if (!context) return null

--- a/src/browser/components/DesktopIntegration/helpers.js
+++ b/src/browser/components/DesktopIntegration/helpers.js
@@ -103,7 +103,7 @@ const isKerberosEnabled = context => {
   return configuration.authenticationMethods.kerberos
 }
 
-export const buildConnectionCredentialsObject = (
+export const buildConnectionCredentialsObject = async (
   context,
   existingData = {},
   getKerberosTicket = () => {}
@@ -114,7 +114,7 @@ export const buildConnectionCredentialsObject = (
   const httpCreds = getActiveCredentials('http', context)
   const kerberos = isKerberosEnabled(context)
   if (kerberos !== false) {
-    creds.password = getKerberosTicket(kerberos.servicePrincipal)
+    creds.password = await getKerberosTicket(kerberos.servicePrincipal)
   }
   const restApi =
     httpsCreds && httpsCreds.enabled

--- a/src/browser/components/DesktopIntegration/helpers.test.js
+++ b/src/browser/components/DesktopIntegration/helpers.test.js
@@ -24,10 +24,9 @@ import {
   eventToHandler,
   didChangeActiveGraph,
   getActiveCredentials,
-  buildConnectionCredentialsObject,
-  KERBEROS,
-  NATIVE
+  buildConnectionCredentialsObject
 } from './helpers'
+import { KERBEROS, NATIVE } from 'services/bolt/boltHelpers'
 
 test('getActiveGraph handles non objects and non-active projects', () => {
   // Given

--- a/src/browser/components/DesktopIntegration/index.jsx
+++ b/src/browser/components/DesktopIntegration/index.jsx
@@ -25,17 +25,26 @@ export default class DesktopIntegration extends Component {
   setupListener () {
     const { integrationPoint } = this.props
     if (integrationPoint && integrationPoint.onContextUpdate) {
+      const getKerberosTicket =
+        integrationPoint.getKerberosTicket || function () {}
       integrationPoint.onContextUpdate((event, newContext, oldContext) => {
         const handlerPropName = eventToHandler(event.type)
         if (!handlerPropName) return
         if (typeof this.props[handlerPropName] === 'undefined') return
-        this.props[handlerPropName](event, newContext, oldContext)
+        this.props[handlerPropName](
+          event,
+          newContext,
+          oldContext,
+          getKerberosTicket
+        )
       })
     }
   }
   loadInitialContext () {
     const { integrationPoint, onMount = null } = this.props
     if (integrationPoint && integrationPoint.getContext) {
+      const getKerberosTicket =
+        integrationPoint.getKerberosTicket || function () {}
       integrationPoint
         .getContext()
         .then(context => {
@@ -45,7 +54,12 @@ export default class DesktopIntegration extends Component {
               'bolt',
               activeGraph.connection || null
             )
-            onMount(activeGraph, connectionCredentials, context)
+            onMount(
+              activeGraph,
+              connectionCredentials,
+              context,
+              getKerberosTicket
+            )
           }
         })
         .catch(e => {}) // Catch but don't bother

--- a/src/browser/components/DesktopIntegration/index.test.js
+++ b/src/browser/components/DesktopIntegration/index.test.js
@@ -96,7 +96,8 @@ describe('<DesktopIntegration>', () => {
     const event = { type: 'XXX' }
     const nonListenEvent = { type: 'YYY' }
     const integrationPoint = {
-      onContextUpdate: fn => (componentOnContextUpdate = fn)
+      onContextUpdate: fn => (componentOnContextUpdate = fn),
+      getKerberosTicket: jest.fn()
     }
 
     // When
@@ -112,21 +113,36 @@ describe('<DesktopIntegration>', () => {
 
     // Then
     expect(fn).toHaveBeenCalledTimes(1)
-    expect(fn).toHaveBeenLastCalledWith(event, newContext, oldContext)
+    expect(fn).toHaveBeenLastCalledWith(
+      event,
+      newContext,
+      oldContext,
+      integrationPoint.getKerberosTicket
+    )
 
     // When
     componentOnContextUpdate(nonListenEvent, newContext, oldContext) // We don't listen for this
 
     // Then
     expect(fn).toHaveBeenCalledTimes(1)
-    expect(fn).toHaveBeenLastCalledWith(event, newContext, oldContext)
+    expect(fn).toHaveBeenLastCalledWith(
+      event,
+      newContext,
+      oldContext,
+      integrationPoint.getKerberosTicket
+    )
 
     // When
     componentOnContextUpdate(event, newContext, oldContext) // Another one we're listening on
 
     // Then
     expect(fn).toHaveBeenCalledTimes(2)
-    expect(fn).toHaveBeenLastCalledWith(event, newContext, oldContext)
+    expect(fn).toHaveBeenLastCalledWith(
+      event,
+      newContext,
+      oldContext,
+      integrationPoint.getKerberosTicket
+    )
     expect(container).toMatchSnapshot()
   })
 })

--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -211,6 +211,11 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
       stateProps.defaultConnectionData,
       getKerberosTicket
     )
+    // No connection. Probably no graph active.
+    if (!connectionCreds) {
+      ownProps.bus.send(SWITCH_CONNECTION_FAILED)
+      return
+    }
     ownProps.bus.send(INJECTED_DISCOVERY, connectionCreds)
   }
   const closeConnectionMaybe = (event, newContext, oldContext) => {

--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -187,26 +187,26 @@ const mapDispatchToProps = dispatch => {
 }
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
-  const switchConnection = (
+  const switchConnection = async (
     event,
     newContext,
     oldContext,
     getKerberosTicket
   ) => {
-    const connectionCreds = buildConnectionCredentialsObject(
+    const connectionCreds = await buildConnectionCredentialsObject(
       newContext,
       stateProps.defaultConnectionData,
       getKerberosTicket
     )
     ownProps.bus.send(SWITCH_CONNECTION, connectionCreds)
   }
-  const setInitialConnectionData = (
+  const setInitialConnectionData = async (
     graph,
     credentials,
     context,
     getKerberosTicket
   ) => {
-    const connectionCreds = buildConnectionCredentialsObject(
+    const connectionCreds = await buildConnectionCredentialsObject(
       context,
       stateProps.defaultConnectionData,
       getKerberosTicket

--- a/src/browser/modules/App/App.test.js
+++ b/src/browser/modules/App/App.test.js
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j, Inc"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* global jest, test, expect */
+import React from 'react'
+import { render } from 'react-testing-library'
+import { App } from './App'
+import { buildConnectionCredentialsObject } from 'browser-components/DesktopIntegration/helpers'
+import { flushPromises } from 'services/utils'
+
+jest.mock('../FeatureToggle/FeatureToggleProvider', () => {
+  return ({ children }) => <div>{children}</div>
+})
+jest.mock('./styled', () => {
+  const orig = require.requireActual('./styled')
+  return {
+    ...orig,
+    StyledApp: () => null
+  }
+})
+
+describe('App', () => {
+  test('App loads', async () => {
+    // Given
+    const getKerberosTicket = jest.fn(() => Promise.resolve('xxx'))
+    const desktopIntegrationPoint = getIntegrationPoint(true, getKerberosTicket)
+    let connectionCreds = null
+    const props = {
+      desktopIntegrationPoint,
+      setInitialConnectionData: async (
+        graph,
+        credentials,
+        context,
+        getKerberosTicket
+      ) => {
+        connectionCreds = await buildConnectionCredentialsObject(
+          context,
+          {},
+          getKerberosTicket
+        )
+      }
+    }
+
+    // When
+    render(<App {...props} />)
+
+    // Then
+    await flushPromises()
+    expect(connectionCreds).toMatchObject({
+      authenticationMethod: 'KERBEROS',
+      password: 'xxx'
+    })
+    expect(getKerberosTicket).toHaveBeenCalledTimes(1)
+  })
+})
+
+const getIntegrationPoint = (kerberosEnabled, getKerberosTicket) => {
+  const context = Promise.resolve(getDesktopContext(kerberosEnabled))
+  return {
+    getKerberosTicket: getKerberosTicket,
+    getContext: () => context
+  }
+}
+
+const getDesktopContext = (kerberosEnabled = false) => ({
+  projects: [
+    {
+      graphs: [
+        {
+          status: 'ACTIVE',
+          connection: {
+            type: 'REMOTE',
+            configuration: {
+              authenticationMethods: {
+                kerberos: {
+                  enabled: kerberosEnabled,
+                  servicePrincipal: 'KERBEROS'
+                }
+              },
+              protocols: {
+                bolt: {
+                  enabled: true,
+                  username: 'neo4j',
+                  password: 'password',
+                  tlsLevel: 'REQUIRED',
+                  url: `bolt://localhost:7687`
+                },
+                http: {
+                  enabled: true,
+                  username: 'neo4j',
+                  password: 'password',
+                  host: 'localhost',
+                  port: '7474'
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  ]
+})

--- a/src/shared/modules/commands/cypher.test.js
+++ b/src/shared/modules/commands/cypher.test.js
@@ -22,6 +22,7 @@
 import { version } from 'project-root/package.json'
 import { createEpicMiddleware } from 'redux-observable'
 import { createBus } from 'suber'
+import { flushPromises } from 'services/utils'
 import {
   executeSystemCommand,
   executeSingleCommand,
@@ -114,7 +115,3 @@ describe('tx metadata with cypher', () => {
     })
   })
 })
-
-function flushPromises () {
-  return new Promise(resolve => setImmediate(resolve))
-}

--- a/src/shared/modules/connections/connectionsDuck.js
+++ b/src/shared/modules/connections/connectionsDuck.js
@@ -60,9 +60,6 @@ export const DISCONNECTED_STATE = 0
 export const CONNECTED_STATE = 1
 export const PENDING_STATE = 2
 
-export const KERBEROS = 'KERBEROS'
-export const NATIVE = 'NATIVE'
-
 const initialState = {
   allConnectionIds: [],
   connectionsById: {},

--- a/src/shared/modules/connections/connectionsDuck.js
+++ b/src/shared/modules/connections/connectionsDuck.js
@@ -60,6 +60,9 @@ export const DISCONNECTED_STATE = 0
 export const CONNECTED_STATE = 1
 export const PENDING_STATE = 2
 
+export const KERBEROS = 'KERBEROS'
+export const NATIVE = 'NATIVE'
+
 const initialState = {
   allConnectionIds: [],
   connectionsById: {},

--- a/src/shared/services/bolt/bolt.js
+++ b/src/shared/services/bolt/bolt.js
@@ -32,10 +32,11 @@ import {
   POST_CANCEL_TRANSACTION_MESSAGE,
   BOLT_CONNECTION_ERROR_MESSAGE
 } from './boltWorkerMessages'
+import { NATIVE } from 'services/bolt/boltHelpers'
+
 /* eslint-disable import/no-webpack-loader-syntax */
 import BoltWorkerModule from 'worker-loader?inline!./boltWorker.js'
 /* eslint-enable import/no-webpack-loader-syntax */
-import { NATIVE } from 'shared/modules/connections/connectionsDuck'
 
 let connectionProperties = null
 let boltWorkPool = new WorkPool(() => new BoltWorkerModule(), 10)

--- a/src/shared/services/bolt/bolt.js
+++ b/src/shared/services/bolt/bolt.js
@@ -35,6 +35,7 @@ import {
 /* eslint-disable import/no-webpack-loader-syntax */
 import BoltWorkerModule from 'worker-loader?inline!./boltWorker.js'
 /* eslint-enable import/no-webpack-loader-syntax */
+import { NATIVE } from 'shared/modules/connections/connectionsDuck'
 
 let connectionProperties = null
 let boltWorkPool = new WorkPool(() => new BoltWorkerModule(), 10)
@@ -45,6 +46,7 @@ function openConnection (props, opts = {}, onLostConnection) {
       .openConnection(props, opts, onLostConnection)
       .then(r => {
         connectionProperties = {
+          authenticationMethod: props.authenticationMethod || NATIVE,
           username: props.username,
           password: props.password,
           host: props.host,

--- a/src/shared/services/bolt/boltConnection.js
+++ b/src/shared/services/bolt/boltConnection.js
@@ -22,7 +22,7 @@ import { v1 as neo4j } from 'neo4j-driver'
 import { v4 } from 'uuid'
 import { BoltConnectionError, createErrorObject } from '../exceptions'
 import { generateBoltHost } from 'services/utils'
-import { KERBEROS } from 'shared/modules/connections/connectionsDuck'
+import { KERBEROS } from 'services/bolt/boltHelpers'
 
 export const DIRECT_CONNECTION = 'DIRECT_CONNECTION'
 export const ROUTED_WRITE_CONNECTION = 'ROUTED_WRITE_CONNECTION'

--- a/src/shared/services/bolt/boltHelpers.js
+++ b/src/shared/services/bolt/boltHelpers.js
@@ -21,6 +21,9 @@
 /* global location */
 import { getUrlInfo } from 'services/utils'
 
+export const KERBEROS = 'KERBEROS'
+export const NATIVE = 'NATIVE'
+
 export const getEncryptionMode = options => {
   if (options && typeof options['encrypted'] !== 'undefined') {
     return options.encrypted

--- a/src/shared/services/utils.js
+++ b/src/shared/services/utils.js
@@ -483,3 +483,7 @@ export const generateBoltHost = host => {
   host = urlParts.length > 1 ? urlParts[1] : urlParts[0]
   return protocol + (host || 'localhost:7687')
 }
+
+export function flushPromises () {
+  return new Promise(resolve => setImmediate(resolve))
+}

--- a/src/shared/services/utils.test.js
+++ b/src/shared/services/utils.test.js
@@ -57,7 +57,7 @@ describe('utils', () => {
 
       utils.serialExecution(w1, w2, w3)
 
-      return flushPromises().then(() => {
+      return utils.flushPromises().then(() => {
         expect(w1.onStart).toHaveBeenCalledTimes(1)
         expect(w2.onStart).toHaveBeenCalledTimes(1)
         expect(w3.onStart).toHaveBeenCalledTimes(1)
@@ -99,7 +99,7 @@ describe('utils', () => {
       const res = utils.serialExecution(w1, w2, w3)
       res.catch(e => {}) // catch error from promise chain not to break test
 
-      return flushPromises().then(() => {
+      return utils.flushPromises().then(() => {
         expect(w1.onStart).toHaveBeenCalledTimes(1)
         expect(w1.onSuccess).toHaveBeenCalledTimes(1)
         expect(w1.onError).toHaveBeenCalledTimes(0)
@@ -695,7 +695,3 @@ describe('toKeyString', () => {
     })
   })
 })
-
-function flushPromises () {
-  return new Promise(resolve => setImmediate(resolve))
-}


### PR DESCRIPTION
Instead of using username + password, Neo4j Desktop can now pass means for graph applications to ask for a Kerberos ticket and use that to connect to Neo4j instead.

Docs: https://github.com/neo4j-apps/graph-app-starter#reference