### PR TITLE
Keep bolt connections alive in web workers

### DIFF
--- a/src/shared/services/WorkPool.js
+++ b/src/shared/services/WorkPool.js
@@ -54,6 +54,9 @@ class WorkPool {
     this._next()
     return work
   }
+  messageAllWorkers (msg) {
+    this.register.forEach(worker => worker.worker.postMessage(msg))
+  }
 
   // Implemtation details
   _getFreeWorker (id) {

--- a/src/shared/services/WorkPool.test.js
+++ b/src/shared/services/WorkPool.test.js
@@ -23,7 +23,7 @@
 import { v4 as uuid } from 'uuid'
 import WorkPool from './WorkPool'
 
-describe('creating work', () => {
+describe('Workpool', () => {
   let createWorker
   let register
   let id
@@ -235,5 +235,46 @@ describe('creating work', () => {
       poolSize
     )
     expect(localRegister.getPoolSize(WorkPool.workerStates.BUSY)).toEqual(0)
+  })
+  test('Can message all workers at once', () => {
+    const message = { type: 'hello all' }
+    const postMessage1 = jest.fn()
+    const postMessage2 = jest.fn()
+    const postMessage3 = jest.fn()
+    const createWorker = jest
+      .fn()
+      .mockImplementationOnce(() => {
+        return {
+          postMessage: postMessage1
+        }
+      })
+      .mockImplementationOnce(() => {
+        return {
+          postMessage: postMessage2
+        }
+      })
+      .mockImplementationOnce(() => {
+        return {
+          postMessage: postMessage3
+        }
+      })
+    const localRegister = new WorkPool(createWorker)
+    const id1 = { id: uuid() } // No work, just to create workers
+    const id2 = { id: uuid() } // No work, just to create workers
+    const id3 = { id: uuid() } // No work, just to create workers
+
+    // When
+    localRegister.doWork(id1)
+    localRegister.doWork(id2)
+    localRegister.doWork(id3)
+    localRegister.messageAllWorkers(message)
+
+    // Then
+    expect(postMessage1).toHaveBeenCalledTimes(1)
+    expect(postMessage1).toHaveBeenCalledWith(message)
+    expect(postMessage2).toHaveBeenCalledTimes(1)
+    expect(postMessage2).toHaveBeenCalledWith(message)
+    expect(postMessage3).toHaveBeenCalledTimes(1)
+    expect(postMessage3).toHaveBeenCalledWith(message)
   })
 })

--- a/src/shared/services/bolt/bolt.js
+++ b/src/shared/services/bolt/bolt.js
@@ -27,6 +27,7 @@ import { generateBoltHost } from 'services/utils'
 import {
   runCypherMessage,
   cancelTransactionMessage,
+  closeConnectionMessage,
   CYPHER_ERROR_MESSAGE,
   CYPHER_RESPONSE_MESSAGE,
   POST_CANCEL_TRANSACTION_MESSAGE,
@@ -228,12 +229,17 @@ function setupBoltWorker (id, workFn, onLostConnection = () => {}) {
   return workerPromise
 }
 
+const closeConnectionInWorkers = () => {
+  boltWorkPool.messageAllWorkers(closeConnectionMessage())
+}
+
 export default {
   directConnect: boltConnection.directConnect,
   openConnection,
   closeConnection: () => {
     connectionProperties = null
     boltConnection.closeConnection()
+    closeConnectionInWorkers()
   },
   directTransaction,
   routedReadTransaction,

--- a/src/shared/services/bolt/boltWorker.js
+++ b/src/shared/services/bolt/boltWorker.js
@@ -24,7 +24,6 @@ import {
   ensureConnection,
   routedWriteTransaction,
   cancelTransaction,
-  closeConnection,
   routedReadTransaction,
   directTransaction,
   DIRECT_CONNECTION,
@@ -83,13 +82,11 @@ const onmessage = function (message) {
           .getPromise(res)
           .then(r => {
             self.postMessage(cypherResponseMessage(r))
-            closeConnection()
           })
           .catch(e => {
             self.postMessage(
               cypherErrorMessage({ code: e.code, message: e.message })
             )
-            closeConnection()
           })
       })
       .catch(e => {
@@ -100,7 +97,6 @@ const onmessage = function (message) {
   } else if (messageType === CANCEL_TRANSACTION_MESSAGE) {
     cancelTransaction(message.data.id, () => {
       self.postMessage(postCancelTransactionMessage())
-      closeConnection()
     })
   } else {
     self.postMessage(

--- a/src/shared/services/bolt/boltWorkerMessages.js
+++ b/src/shared/services/bolt/boltWorkerMessages.js
@@ -26,6 +26,7 @@ export const CYPHER_ERROR_MESSAGE = 'CYPHER_ERROR_MESSAGE'
 export const CYPHER_RESPONSE_MESSAGE = 'CYPHER_RESPONSE_MESSAGE'
 export const POST_CANCEL_TRANSACTION_MESSAGE = 'POST_CANCEL_TRANSACTION_MESSAGE'
 export const BOLT_CONNECTION_ERROR_MESSAGE = 'BOLT_CONNECTION_ERROR_MESSAGE'
+export const CLOSE_CONNECTION_MESSAGE = 'CLOSE_CONNECTION_MESSAGE'
 
 export const runCypherMessage = (
   input,
@@ -79,3 +80,7 @@ export const boltConnectionErrorMessage = error => {
     error
   }
 }
+
+export const closeConnectionMessage = () => ({
+  type: CLOSE_CONNECTION_MESSAGE
+})


### PR DESCRIPTION
Since we’re pooling web workers we can keep connecitons alive.
Prior to any query we ensure connection is valid anyway.

But we need to open at least one connection per thread since connections can't be shared between threads.
The maximum number of threads is set to 10, but new threads are only created if all existing ones are busy.

Example: Connect and type `RETURN 1` and execute.

`tail -f security.log` gives:

### Before
<img width="445" alt="oskarhane-mbpt 2018-12-18 at 12 49 51" src="https://user-images.githubusercontent.com/570998/50152549-2ccd2c00-02c4-11e9-9b99-0019161a6f22.png">

### After
<img width="399" alt="oskarhane-mbpt 2018-12-18 at 12 50 46" src="https://user-images.githubusercontent.com/570998/50152568-36ef2a80-02c4-11e9-9bbe-5b1698d4c761.png">