### PR TITLE
Fix hidden error on re-run when going from success -> error result

### DIFF
--- a/src/browser/components/Display.jsx
+++ b/src/browser/components/Display.jsx
@@ -44,8 +44,6 @@ export default class Display extends PureComponent {
       ...style,
       width: 'inherit',
       display: !this.props.if ? 'none' : this.props.inline ? 'inline' : 'block'
-          ? 'inline'
-          : 'block'
     }
     return <div style={modStyle}>{children}</div>
   }

--- a/src/browser/components/Display.jsx
+++ b/src/browser/components/Display.jsx
@@ -18,48 +18,32 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { Component } from 'react'
-import { shallowEquals } from 'services/utils'
+import React, { PureComponent } from 'react'
 
-export default class Display extends Component {
-  constructor (props) {
-    super(props)
-    this.state = {
-      displayed: false,
-      mounted: false
-    }
+export default class Display extends PureComponent {
+  state = {
+    mounted: false
   }
   componentDidMount () {
-    if (this.props.if === true) {
-      this.setState({ displayed: true, mounted: true })
+    if (this.props.if) {
+      this.setState({ mounted: true })
     }
   }
   componentWillReceiveProps (props) {
-    if (props.if && this.state.displayed === false) {
-      this.setState({ displayed: true, mounted: true })
-      return
+    if (this.state.mounted === false && props.if) {
+      this.setState({ mounted: true })
     }
-    if (!props.if && this.state.displayed === true) {
-      this.setState({ displayed: false })
-    }
-  }
-  shouldComponentUpdate (props, state) {
-    if (props.if === false && this.props.if === false) return false // Never rerender non displayed components
-    return !(
-      shallowEquals(props, this.props) && shallowEquals(state, this.state)
-    )
   }
   render () {
-    if (!this.state.displayed && !this.state.mounted && this.props.lazy) {
+    // If lazy, don't load anything until it's time
+    if (!this.props.if && !this.state.mounted && this.props.lazy) {
       return null
-    } // Lazy load it
+    }
     const { style = {}, children = [] } = this.props
     const modStyle = {
       ...style,
       width: 'inherit',
-      display: !this.state.displayed
-        ? 'none'
-        : this.props.inline
+      display: !this.props.if ? 'none' : this.props.inline ? 'inline' : 'block'
           ? 'inline'
           : 'block'
     }

--- a/src/browser/components/icons/Icons.jsx
+++ b/src/browser/components/icons/Icons.jsx
@@ -309,7 +309,10 @@ export const EditIcon = () => (
   />
 )
 export const Spinner = () => (
-  <IconContainer className='fa fa-spinner fa-spin fa-2x' />
+  <IconContainer
+    data-testid='spinner'
+    className='fa fa-spinner fa-spin fa-2x'
+  />
 )
 export const SmallSpinner = () => (
   <IconContainer className='fa fa-spinner fa-spin ' />

--- a/src/browser/modules/DatabaseInfo/UserDetails.jsx
+++ b/src/browser/modules/DatabaseInfo/UserDetails.jsx
@@ -69,7 +69,7 @@ export class UserDetails extends Component {
                     </StyledValue>
                   </tr>
                   <tr>
-                    <StyledKey className='user-list-button'></StyledKey>
+                    <StyledKey className='user-list-button' />
                     <StyledValue>
                       <Link
                         onClick={() =>

--- a/src/browser/modules/Stream/CypherFrame/helpers.js
+++ b/src/browser/modules/Stream/CypherFrame/helpers.js
@@ -143,9 +143,11 @@ export const initialView = (props, state = {}) => {
     return undefined
   }
   // If openView exists, this is not initial render
-  if (state.openView !== undefined) return state.openView
-  if (props.frame && props.frame.forceView) return props.frame.forceView
   if (props.request.status === 'error') return viewTypes.ERRORS
+  if (state.openView !== undefined && state.openView !== viewTypes.ERRORS) {
+    return state.openView
+  }
+  if (props.frame && props.frame.forceView) return props.frame.forceView
   if (resultHasPlan(props.request)) return viewTypes.PLAN
   if (!resultHasRows(props.request)) return viewTypes.TABLE
 

--- a/src/browser/modules/Stream/CypherFrame/helpers.test.js
+++ b/src/browser/modules/Stream/CypherFrame/helpers.test.js
@@ -228,7 +228,7 @@ describe('helpers', () => {
       // Given
       const props = {
         request: {
-          status: 'error'
+          status: 'success'
         },
         frame: {
           forceView: viewTypes.WARNINGS
@@ -241,6 +241,24 @@ describe('helpers', () => {
 
       // Then
       expect(view).toEqual(viewTypes.WARNINGS)
+    })
+    test('error overrides forced view', () => {
+      // Given
+      const props = {
+        request: {
+          status: 'error'
+        },
+        frame: {
+          forceView: viewTypes.WARNINGS
+        }
+      }
+      const state = {}
+
+      // When
+      const view = initialView(props, state)
+
+      // Then
+      expect(view).toEqual(viewTypes.ERRORS)
     })
     test('should return the plan view if plan is existent', () => {
       // Given
@@ -447,6 +465,20 @@ describe('helpers', () => {
 
       // Then
       expect(view).toEqual(viewTypes.TEXT)
+    })
+    test('an error overrides openView', () => {
+      // Given
+      const request = {
+        status: 'error'
+      }
+      const props = { request, recentView: viewTypes.VISUALIZATION }
+      const state = { openView: viewTypes.TEXT }
+
+      // When
+      const view = initialView(props, state)
+
+      // Then
+      expect(view).toEqual(viewTypes.ERRORS)
     })
     test('should return viz if the last view was plan but no plan exists and viz elements exists', () => {
       // Given

--- a/src/browser/modules/Stream/CypherFrame/index.jsx
+++ b/src/browser/modules/Stream/CypherFrame/index.jsx
@@ -104,17 +104,14 @@ export class CypherFrame extends Component {
   componentDidUpdate () {
     // When going from 'pending' to some other status
     // we want to show an initial view.
-    // This only happens on first render of a response
-    if (
-      this.props.request.status !== 'pending' &&
-      this.state.openView === undefined
-    ) {
+    // This happens on first render of a response and on re-runs
+    if (this.props.request.status !== 'pending') {
       const openView = initialView(this.props, this.state)
-      if (openView) {
-        this.setState({ openView })
+      if (openView !== this.state.openView) {
+        const hasVis = openView === viewTypes.ERRORS ? false : this.state.hasVis
+        this.setState({ openView, hasVis })
       }
-    }
-    if (this.props.request.status === 'pending') {
+    } else {
       this.visElement = null
       this.setState({ hasVis: false })
     }

--- a/src/browser/modules/Stream/CypherFrame/index.test.js
+++ b/src/browser/modules/Stream/CypherFrame/index.test.js
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2002-2018 "Neo4j, Inc"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* global describe, test, expect */
+import React from 'react'
+import { render } from 'react-testing-library'
+import { Provider } from 'react-redux'
+
+import { CypherFrame } from './index.jsx'
+
+const createProps = (status, result) => ({
+  recentView: undefined,
+  frame: {},
+  request: {
+    status,
+    updated: Math.random(),
+    result
+  }
+})
+const withProvider = (store, children) => {
+  return <Provider store={store}>{children}</Provider>
+}
+
+describe('CypherFrame', () => {
+  const store = {
+    subscribe: () => {},
+    dispatch: () => {},
+    getState: () => ({})
+  }
+  test('renders accordingly from pending to success to error to success', () => {
+    // Given
+    const pendingProps = createProps('pending', undefined)
+    const successProps = createProps('success', {
+      records: [{ keys: ['name'], _fields: ['Molly'], get: () => 'Molly' }]
+    })
+    const errorProps = createProps('error', { code: 'Test.Error' })
+
+    // When
+    const { queryByText, getByText, getByTestId, rerender } = render(
+      withProvider(store, <CypherFrame {...pendingProps} />)
+    )
+
+    // Then
+    expect(getByTestId('spinner')).not.toBeNull()
+    expect(getByText(/Table/i)).not.toBeNull()
+    expect(getByText(/Code/i)).not.toBeNull()
+    expect(queryByText(/Error/)).toBeNull()
+
+    // When successful request
+    rerender(withProvider(store, <CypherFrame {...successProps} />))
+
+    // Then
+    expect(getByText(/Molly/i)).not.toBeNull()
+    expect(getByText(/Table/i)).not.toBeNull()
+    expect(getByText(/Code/i)).not.toBeNull()
+    expect(queryByText(/Error/)).toBeNull()
+
+    // When error request
+    rerender(withProvider(store, <CypherFrame {...errorProps} />))
+
+    // Then
+    expect(queryByText(/Table/i)).toBeNull()
+    expect(queryByText(/Code/i)).toBeNull()
+    expect(getByText(/Error/)).not.toBeNull()
+    expect(getByText(/Test.Error/)).not.toBeNull()
+
+    // When successful request again
+    rerender(withProvider(store, <CypherFrame {...successProps} />))
+
+    // Then
+    expect(getByText(/Molly/i)).not.toBeNull()
+    expect(getByText(/Table/i)).not.toBeNull()
+    expect(getByText(/Code/i)).not.toBeNull()
+    expect(queryByText(/Error/)).toBeNull()
+  })
+})


### PR DESCRIPTION
The cypher result frame was rendered empty in this case:

1. Connect to a db
1. Run a query. Keep result frame in stream.
1. Disconnect
1. Click re-run on the result frame from past query

This PR fixes that and also adds tests for the behavior.