### PR TITLE
Add link to `:server user list`

### DIFF
--- a/src/browser/modules/DatabaseInfo/UserDetails.jsx
+++ b/src/browser/modules/DatabaseInfo/UserDetails.jsx
@@ -61,6 +61,18 @@ export class UserDetails extends Component {
                     <StyledValue>
                       <Link
                         onClick={() =>
+                          this.props.onItemClick(':server user list')
+                        }
+                      >
+                        :server user list
+                      </Link>
+                    </StyledValue>
+                  </tr>
+                  <tr>
+                    <StyledKey className='user-list-button'></StyledKey>
+                    <StyledValue>
+                      <Link
+                        onClick={() =>
                           this.props.onItemClick(':server user add')
                         }
                       >


### PR DESCRIPTION
Adds a helper link to the `User List` above the `User Add`.

Before:
![screen shot 2019-01-03 at 10 42 02 am](https://user-images.githubusercontent.com/746731/50647088-b710c380-0f45-11e9-90a1-349c90ac8e65.png)

After:
![screen shot 2019-01-03 at 10 50 15 am](https://user-images.githubusercontent.com/746731/50647094-bf68fe80-0f45-11e9-9184-23f7e263842b.png)
