### PR TITLE
Add tx metadata to queries that's generated by user actions

### DIFF
--- a/src/browser/modules/Editor/Editor.jsx
+++ b/src/browser/modules/Editor/Editor.jsx
@@ -55,6 +55,7 @@ import ratingStar from 'icons/rating-star.svg'
 import controlsPlay from 'icons/controls-play.svg'
 import eraser2 from 'icons/eraser-2.svg'
 import pencil from 'icons/pencil.svg'
+import { NEO4J_BROWSER_USER_ACTION_QUERY } from 'services/bolt/txMetadata'
 
 const shouldCheckForHints = code =>
   code.trim().length > 0 &&
@@ -280,7 +281,10 @@ export class Editor extends Component {
       ;((text, offset) => {
         this.props.bus.self(
           CYPHER_REQUEST,
-          { query: 'EXPLAIN ' + text },
+          {
+            query: 'EXPLAIN ' + text,
+            queryType: NEO4J_BROWSER_USER_ACTION_QUERY
+          },
           response => {
             if (
               response.success === true &&

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView.jsx
@@ -28,6 +28,7 @@ import { ExplorerComponent } from '../../D3Visualization/components/Explorer'
 import { StyledVisContainer } from './VisualizationView.styled'
 
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
+import { NEO4J_BROWSER_USER_ACTION_QUERY } from 'services/bolt/txMetadata'
 
 export class Visualization extends Component {
   state = {
@@ -95,22 +96,29 @@ export class Visualization extends Component {
                      currentNeighbourIds.length}`
     return new Promise((resolve, reject) => {
       this.props.bus &&
-        this.props.bus.self(CYPHER_REQUEST, { query: query }, response => {
-          if (!response.success) {
-            reject(new Error())
-          } else {
-            let count =
-              response.result.records.length > 0
-                ? parseInt(response.result.records[0].get('c').toString())
-                : 0
-            const resultGraph = bolt.extractNodesAndRelationshipsFromRecordsForOldVis(
-              response.result.records,
-              false
-            )
-            this.autoCompleteRelationships(this.graph._nodes, resultGraph.nodes)
-            resolve({ ...resultGraph, count: count })
+        this.props.bus.self(
+          CYPHER_REQUEST,
+          { query: query, queryType: NEO4J_BROWSER_USER_ACTION_QUERY },
+          response => {
+            if (!response.success) {
+              reject(new Error())
+            } else {
+              let count =
+                response.result.records.length > 0
+                  ? parseInt(response.result.records[0].get('c').toString())
+                  : 0
+              const resultGraph = bolt.extractNodesAndRelationshipsFromRecordsForOldVis(
+                response.result.records,
+                false
+              )
+              this.autoCompleteRelationships(
+                this.graph._nodes,
+                resultGraph.nodes
+              )
+              resolve({ ...resultGraph, count: count })
+            }
           }
-        })
+        )
     })
   }
   getInternalRelationships (existingNodeIds, newNodeIds) {
@@ -123,7 +131,11 @@ export class Visualization extends Component {
       this.props.bus &&
         this.props.bus.self(
           CYPHER_REQUEST,
-          { query, params: { existingNodeIds, newNodeIds } },
+          {
+            query,
+            params: { existingNodeIds, newNodeIds },
+            queryType: NEO4J_BROWSER_USER_ACTION_QUERY
+          },
           response => {
             if (!response.success) {
               reject(new Error())

--- a/src/browser/modules/Stream/Queries/QueriesFrame.jsx
+++ b/src/browser/modules/Stream/Queries/QueriesFrame.jsx
@@ -57,6 +57,7 @@ import { EnterpriseOnlyFrame } from 'browser-components/EditionView'
 import { RefreshIcon } from 'browser-components/icons/Icons'
 import Render from 'browser-components/Render'
 import FrameError from '../FrameError'
+import { NEO4J_BROWSER_USER_ACTION_QUERY } from 'services/bolt/txMetadata'
 
 export class QueriesFrame extends Component {
   state = {
@@ -97,7 +98,10 @@ export class QueriesFrame extends Component {
   getRunningQueries (suppressQuerySuccessMessage = false) {
     this.props.bus.self(
       this.isCC() ? CLUSTER_CYPHER_REQUEST : CYPHER_REQUEST,
-      { query: listQueriesProcedure() },
+      {
+        query: listQueriesProcedure(),
+        queryType: NEO4J_BROWSER_USER_ACTION_QUERY
+      },
       response => {
         if (response.success) {
           const queries = this.extractQueriesFromBoltResult(response.result)

--- a/src/browser/modules/Stream/SchemaFrame.jsx
+++ b/src/browser/modules/Stream/SchemaFrame.jsx
@@ -23,6 +23,7 @@ import { withBus } from 'react-suber'
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
 import FrameTemplate from '../Stream/FrameTemplate'
 import { StyledSchemaBody } from './styled'
+import { NEO4J_BROWSER_USER_ACTION_QUERY } from 'services/bolt/txMetadata'
 
 export class SchemaFrame extends Component {
   constructor (props) {
@@ -53,7 +54,8 @@ export class SchemaFrame extends Component {
       this.props.bus.self(
         CYPHER_REQUEST,
         {
-          query: 'CALL db.indexes()'
+          query: 'CALL db.indexes()',
+          queryType: NEO4J_BROWSER_USER_ACTION_QUERY
         },
         this.responseHandler('indexes')
       )
@@ -61,7 +63,8 @@ export class SchemaFrame extends Component {
       this.props.bus.self(
         CYPHER_REQUEST,
         {
-          query: 'CALL db.constraints()'
+          query: 'CALL db.constraints()',
+          queryType: NEO4J_BROWSER_USER_ACTION_QUERY
         },
         this.responseHandler('constraints')
       )

--- a/src/browser/modules/Stream/SysInfoFrame/index.jsx
+++ b/src/browser/modules/Stream/SysInfoFrame/index.jsx
@@ -43,6 +43,7 @@ import {
   AutoRefreshSpan,
   StatusbarWrapper
 } from '../AutoRefresh/styled'
+import { NEO4J_BROWSER_USER_ACTION_QUERY } from 'services/bolt/txMetadata'
 
 export class SysInfoFrame extends Component {
   constructor (props) {
@@ -235,7 +236,8 @@ export class SysInfoFrame extends Component {
       this.props.bus.self(
         CYPHER_REQUEST,
         {
-          query: 'CALL dbms.queryJmx("org.neo4j:*")'
+          query: 'CALL dbms.queryJmx("org.neo4j:*")',
+          queryType: NEO4J_BROWSER_USER_ACTION_QUERY
         },
         this.responseHandler.bind(this)
       )
@@ -243,7 +245,8 @@ export class SysInfoFrame extends Component {
         this.props.bus.self(
           CYPHER_REQUEST,
           {
-            query: 'CALL dbms.cluster.overview'
+            query: 'CALL dbms.cluster.overview',
+            queryType: NEO4J_BROWSER_USER_ACTION_QUERY
           },
           this.clusterResponseHandler.bind(this)
         )

--- a/src/browser/modules/User/UserAdd.jsx
+++ b/src/browser/modules/User/UserAdd.jsx
@@ -45,6 +45,7 @@ import {
   StyledTh
 } from 'browser-components/DataTables'
 import { StyledUserTd, StyledInput, StyledButtonContainer } from './styled'
+import { NEO4J_BROWSER_USER_ACTION_QUERY } from 'services/bolt/txMetadata'
 
 export class UserAdd extends Component {
   constructor (props) {
@@ -93,7 +94,10 @@ export class UserAdd extends Component {
       this.props.bus &&
         this.props.bus.self(
           CYPHER_REQUEST,
-          { query: addRoleToUser(this.state.username, role) },
+          {
+            query: addRoleToUser(this.state.username, role),
+            queryType: NEO4J_BROWSER_USER_ACTION_QUERY
+          },
           response => {
             if (!response.success) {
               return errors.add(response.error)
@@ -110,7 +114,7 @@ export class UserAdd extends Component {
     this.props.bus &&
       this.props.bus.self(
         CYPHER_REQUEST,
-        { query: listRolesQuery() },
+        { query: listRolesQuery(), queryType: NEO4J_BROWSER_USER_ACTION_QUERY },
         response => {
           if (!response.success) {
             const error =
@@ -153,7 +157,10 @@ export class UserAdd extends Component {
     this.props.bus &&
       this.props.bus.self(
         CYPHER_REQUEST,
-        { query: createDatabaseUser(this.state) },
+        {
+          query: createDatabaseUser(this.state),
+          queryType: NEO4J_BROWSER_USER_ACTION_QUERY
+        },
         response => {
           if (!response.success) {
             const error =

--- a/src/browser/modules/User/UserInformation.jsx
+++ b/src/browser/modules/User/UserInformation.jsx
@@ -37,6 +37,7 @@ import { StyledBodyTr } from 'browser-components/DataTables'
 import { StyledUserTd, StyledButtonContainer } from './styled'
 
 import RolesSelector from './RolesSelector'
+import { NEO4J_BROWSER_USER_ACTION_QUERY } from 'services/bolt/txMetadata'
 
 export class UserInformation extends Component {
   constructor (props) {
@@ -51,21 +52,30 @@ export class UserInformation extends Component {
   removeClick (thing) {
     this.props.bus.self(
       CYPHER_REQUEST,
-      { query: deleteUser(this.state.username) },
+      {
+        query: deleteUser(this.state.username),
+        queryType: NEO4J_BROWSER_USER_ACTION_QUERY
+      },
       this.handleResponse.bind(this)
     )
   }
   suspendUser () {
     this.props.bus.self(
       CYPHER_REQUEST,
-      { query: suspendUser(this.state.username) },
+      {
+        query: suspendUser(this.state.username),
+        queryType: NEO4J_BROWSER_USER_ACTION_QUERY
+      },
       this.handleResponse.bind(this)
     )
   }
   activateUser () {
     this.props.bus.self(
       CYPHER_REQUEST,
-      { query: activateUser(this.state.username) },
+      {
+        query: activateUser(this.state.username),
+        queryType: NEO4J_BROWSER_USER_ACTION_QUERY
+      },
       this.handleResponse.bind(this)
     )
   }
@@ -96,7 +106,10 @@ export class UserInformation extends Component {
           onClick={() => {
             this.props.bus.self(
               CYPHER_REQUEST,
-              { query: removeRoleFromUser(role, this.state.username) },
+              {
+                query: removeRoleFromUser(role, this.state.username),
+                queryType: NEO4J_BROWSER_USER_ACTION_QUERY
+              },
               this.handleResponse.bind(this)
             )
           }}
@@ -107,7 +120,10 @@ export class UserInformation extends Component {
   onRoleSelect (event) {
     this.props.bus.self(
       CYPHER_REQUEST,
-      { query: addRoleToUser(this.state.username, event.target.value) },
+      {
+        query: addRoleToUser(this.state.username, event.target.value),
+        queryType: NEO4J_BROWSER_USER_ACTION_QUERY
+      },
       this.handleResponse.bind(this)
     )
   }

--- a/src/browser/modules/User/UserList.jsx
+++ b/src/browser/modules/User/UserList.jsx
@@ -35,6 +35,7 @@ import { StyledButtonContainer } from './styled'
 
 import FrameTemplate from '../Stream/FrameTemplate'
 import { forceFetch } from 'shared/modules/currentUser/currentUserDuck'
+import { NEO4J_BROWSER_USER_ACTION_QUERY } from 'services/bolt/txMetadata'
 
 export class UserList extends Component {
   constructor (props) {
@@ -52,7 +53,7 @@ export class UserList extends Component {
   getUserList () {
     this.props.bus.self(
       CYPHER_REQUEST,
-      { query: listUsersQuery() },
+      { query: listUsersQuery(), queryType: NEO4J_BROWSER_USER_ACTION_QUERY },
       response => {
         if (response.success) {
           this.setState({
@@ -66,7 +67,7 @@ export class UserList extends Component {
   getRoles () {
     this.props.bus.self(
       CYPHER_REQUEST,
-      { query: listRolesQuery() },
+      { query: listRolesQuery(), queryType: NEO4J_BROWSER_USER_ACTION_QUERY },
       response => {
         const flatten = arr =>
           arr.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), [])

--- a/src/shared/modules/cypher/cypherDuck.js
+++ b/src/shared/modules/cypher/cypherDuck.js
@@ -27,7 +27,7 @@ import { getEncryptionMode } from 'services/bolt/boltHelpers'
 import { flatten } from 'services/utils'
 import { shouldUseCypherThread } from 'shared/modules/settings/settingsDuck'
 import { getUserTxMetadata } from 'services/bolt/txMetadata'
-import { canSendTxMetadata } from '../features/featuresDuck'
+import { canSendTxMetadata } from '../features/versionedFeatures'
 
 const NAME = 'cypher'
 export const CYPHER_REQUEST = NAME + '/REQUEST'

--- a/src/shared/modules/cypher/cypherDuck.js
+++ b/src/shared/modules/cypher/cypherDuck.js
@@ -26,6 +26,8 @@ import { getCausalClusterAddresses } from './queriesProcedureHelper'
 import { getEncryptionMode } from 'services/bolt/boltHelpers'
 import { flatten } from 'services/utils'
 import { shouldUseCypherThread } from 'shared/modules/settings/settingsDuck'
+import { getUserTxMetadata } from 'services/bolt/txMetadata'
+import { canSendTxMetadata } from '../features/featuresDuck'
 
 const NAME = 'cypher'
 export const CYPHER_REQUEST = NAME + '/REQUEST'
@@ -80,7 +82,10 @@ export const cypherRequestEpic = (some$, store) =>
     if (!action.$$responseChannel) return Rx.Observable.of(null)
     return bolt
       .directTransaction(action.query, action.params || undefined, {
-        useCypherThread: shouldUseCypherThread(store.getState())
+        useCypherThread: shouldUseCypherThread(store.getState()),
+        ...getUserTxMetadata(action.queryType || null)({
+          hasServerSupport: canSendTxMetadata(store.getState())
+        })
       })
       .then(r => ({ type: action.$$responseChannel, success: true, result: r }))
       .catch(e => ({

--- a/src/shared/modules/cypher/cypherRequestEpic.test.js
+++ b/src/shared/modules/cypher/cypherRequestEpic.test.js
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* global describe, afterEach, test, expect, beforeAll, jest */
+import configureMockStore from 'redux-mock-store'
+import { createEpicMiddleware } from 'redux-observable'
+import { createBus, createReduxMiddleware } from 'suber'
+
+import { cypherRequestEpic, CYPHER_REQUEST } from './cypherDuck'
+import {
+  NEO4J_BROWSER_USER_QUERY,
+  getUserDirectTxMetadata
+} from 'services/bolt/txMetadata'
+
+jest.mock('services/bolt/bolt', () => {
+  const orig = require.requireActual('services/bolt/bolt')
+  return {
+    ...orig,
+    directTransaction: jest.fn(() => Promise.resolve({ records: [] }))
+  }
+})
+const bolt = require.requireMock('services/bolt/bolt')
+
+jest.mock('shared/modules/dbMeta/dbMetaDuck')
+const dbMeta = require.requireMock('shared/modules/dbMeta/dbMetaDuck')
+
+describe('cypherRequestEpic', () => {
+  let store
+  const bus = createBus()
+  const epicMiddleware = createEpicMiddleware(cypherRequestEpic)
+  const mockStore = configureMockStore([
+    epicMiddleware,
+    createReduxMiddleware(bus)
+  ])
+  beforeAll(() => {
+    store = mockStore({
+      settings: { useCypherThread: false }
+    })
+  })
+  afterEach(() => {
+    bus.reset()
+    store.clearActions()
+  })
+
+  test('cypherRequestEpic passes along tx metadata if a queryType exists on action', () => {
+    // Given
+    dbMeta.getVersion.mockImplementation(() => '5.0.0') // has tx support
+    const action = {
+      type: CYPHER_REQUEST,
+      query: 'RETURN 1',
+      queryType: NEO4J_BROWSER_USER_QUERY,
+      $$responseChannel: 'test-1'
+    }
+
+    const p = new Promise((resolve, reject) => {
+      bus.take(action.$$responseChannel, () => {
+        // Then
+        try {
+          expect(bolt.directTransaction).toHaveBeenCalledTimes(1)
+          expect(bolt.directTransaction).toHaveBeenCalledWith(
+            action.query,
+            undefined,
+            {
+              useCypherThread: store.getState().settings.useCypherThread,
+              ...getUserDirectTxMetadata({ hasServerSupport: true })
+            }
+          )
+          resolve()
+        } catch (e) {
+          reject(e)
+        }
+      })
+    })
+
+    // When
+    store.dispatch(action)
+
+    // Return
+    return p
+  })
+  test('cypherRequestEpic does NOT pass along tx metadata if no server support', () => {
+    // Given
+    bolt.directTransaction.mockClear()
+    dbMeta.getVersion.mockImplementation(() => '1.0.0') // No tx metadata support
+
+    const action = {
+      type: CYPHER_REQUEST,
+      query: 'RETURN 1',
+      queryType: NEO4J_BROWSER_USER_QUERY,
+      $$responseChannel: 'test-1'
+    }
+
+    const p = new Promise((resolve, reject) => {
+      bus.take(action.$$responseChannel, () => {
+        // Then
+        try {
+          expect(bolt.directTransaction).toHaveBeenCalledTimes(1)
+          expect(bolt.directTransaction).toHaveBeenCalledWith(
+            action.query,
+            undefined,
+            {
+              useCypherThread: store.getState().settings.useCypherThread
+            }
+          )
+          resolve()
+        } catch (e) {
+          reject(e)
+        }
+      })
+    })
+
+    // When
+    store.dispatch(action)
+
+    // Return
+    return p
+  })
+  test('cypherRequestEpic handles actions without queryType', () => {
+    // Given
+    bolt.directTransaction.mockClear()
+    dbMeta.getVersion.mockImplementation(() => '5.0.0') // Has tx metadata support
+
+    // No queryType = no tx metadata
+    const action = {
+      type: CYPHER_REQUEST,
+      query: 'RETURN 1',
+      $$responseChannel: 'test-1'
+    }
+
+    const p = new Promise((resolve, reject) => {
+      bus.take(action.$$responseChannel, () => {
+        // Then
+        try {
+          expect(bolt.directTransaction).toHaveBeenCalledTimes(1)
+          expect(bolt.directTransaction).toHaveBeenCalledWith(
+            action.query,
+            undefined,
+            {
+              useCypherThread: store.getState().settings.useCypherThread
+            }
+          )
+          resolve()
+        } catch (e) {
+          reject(e)
+        }
+      })
+    })
+
+    // When
+    store.dispatch(action)
+
+    // Return
+    return p
+  })
+})

--- a/src/shared/services/bolt/txMetaData.test.js
+++ b/src/shared/services/bolt/txMetaData.test.js
@@ -19,7 +19,7 @@
  */
 
 import { version } from 'project-root/package.json'
-import { getBackgroundTxMetadata, getUserTxMetadata } from './txMetadata'
+import { getBackgroundTxMetadata, getUserDirectTxMetadata } from './txMetadata'
 
 test('getBackgroundTxMetadata has the expected format', () => {
   const res = getBackgroundTxMetadata({ hasServerSupport: true })
@@ -30,7 +30,7 @@ test('getBackgroundTxMetadata has the expected format', () => {
 })
 
 test('getUserTxMetadata has the expected format', () => {
-  const res = getUserTxMetadata({ hasServerSupport: true })
+  const res = getUserDirectTxMetadata({ hasServerSupport: true })
   expect(res.txMetadata).toEqual({
     type: 'user-direct',
     app: `neo4j-browser_v${version}`

--- a/src/shared/services/bolt/txMetadata.js
+++ b/src/shared/services/bolt/txMetadata.js
@@ -21,9 +21,11 @@
 import { version } from 'project-root/package.json'
 
 // Application info
-const NEO4J_BROWSER_BACKGROUND_QUERY = `system`
-const NEO4J_BROWSER_USER_QUERY = `user-direct`
-const NEO4J_BROWSER_APP_ID = `neo4j-browser_v${version}`
+export const NEO4J_BROWSER_BACKGROUND_QUERY = `system`
+export const NEO4J_BROWSER_USER_QUERY = `user-direct`
+export const NEO4J_BROWSER_USER_ACTION_QUERY = `user-action`
+export const NEO4J_BROWSER_USER_TRANSPILED_QUERY = `user-transpiled`
+export const NEO4J_BROWSER_APP_ID = `neo4j-browser_v${version}`
 
 export const getBackgroundTxMetadata = ({ hasServerSupport = false }) => {
   if (!hasServerSupport) {
@@ -37,14 +39,24 @@ export const getBackgroundTxMetadata = ({ hasServerSupport = false }) => {
   }
 }
 
-export const getUserTxMetadata = ({ hasServerSupport = false }) => {
-  if (!hasServerSupport) {
+export const getUserTxMetadata = type => ({ hasServerSupport = false }) => {
+  if (!hasServerSupport || !type) {
     return {}
   }
   return {
     txMetadata: {
-      type: NEO4J_BROWSER_USER_QUERY,
+      type: type,
       app: NEO4J_BROWSER_APP_ID
     }
   }
 }
+
+export const getUserDirectTxMetadata = getUserTxMetadata(
+  NEO4J_BROWSER_USER_QUERY
+)
+export const getUserActionTxMetadata = getUserTxMetadata(
+  NEO4J_BROWSER_USER_ACTION_QUERY
+)
+export const getUserTranspiledTxMetadata = getUserTxMetadata(
+  NEO4J_BROWSER_USER_TRANSPILED_QUERY
+)

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -61,7 +61,7 @@ import { fetchRemoteGrass } from 'shared/modules/commands/helpers/grass'
 import { parseGrass } from 'shared/services/grassUtils'
 import { shouldUseCypherThread } from 'shared/modules/settings/settingsDuck'
 import {
-  getUserTxMetadata,
+  getUserDirectTxMetadata,
   getBackgroundTxMetadata
 } from 'shared/services/bolt/txMetadata'
 
@@ -159,7 +159,7 @@ const availableCommands = [
         getParams(state),
         shouldUseCypherThread(state),
         action.type === SINGLE_COMMAND_QUEUED
-          ? getUserTxMetadata({
+          ? getUserDirectTxMetadata({
             hasServerSupport: canSendTxMetadata(store.getState())
           })
           : getBackgroundTxMetadata({


### PR DESCRIPTION
Added to these

- EXPLAIN query that's called when user types
- Viz actions like auto-connect and explore neighbors 
- `:queries` frame
- `:schema` frame
- `:sysinfo`
- `:server user add` and `:server user list`