### PR TITLE
Fix UI theme resolving logic

### DIFF
--- a/src/browser/hooks/useDerivedTheme.js
+++ b/src/browser/hooks/useDerivedTheme.js
@@ -17,28 +17,30 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 import { useState, useEffect } from 'react'
-import useDetectColorScheme from './useDetectColorScheme'
+import useAutoTheme from './useAutoTheme'
+import { AUTO_THEME, LIGHT_THEME } from 'shared/modules/settings/settingsDuck'
 
-export default function useAutoTheme (defaultTheme = 'light') {
-  const detectedScheme = useDetectColorScheme()
-  const [autoTheme, setAutoTheme] = useState(detectedScheme || defaultTheme)
-  const [overriddenTheme, overrideAutoTheme] = useState(null)
+export default function useDerivedTheme (
+  selectedTheme,
+  defaultTheme = LIGHT_THEME
+) {
+  const [derivedTheme, overrideAutoTheme] = useAutoTheme(defaultTheme)
+  const [environmentTheme, setEnvironmentTheme] = useState(null)
 
   useEffect(
     () => {
-      if (overriddenTheme) {
-        setAutoTheme(overriddenTheme)
+      if (environmentTheme && selectedTheme === AUTO_THEME) {
+        overrideAutoTheme(environmentTheme)
         return
       }
-      if (!detectedScheme && !overriddenTheme) {
-        setAutoTheme(defaultTheme)
-        return
+      if (selectedTheme !== AUTO_THEME) {
+        overrideAutoTheme(selectedTheme)
+      } else {
+        overrideAutoTheme(null)
       }
-      setAutoTheme(detectedScheme)
     },
-    [detectedScheme, overriddenTheme]
+    [selectedTheme, environmentTheme]
   )
-  return [autoTheme, overrideAutoTheme]
+  return [derivedTheme, setEnvironmentTheme]
 }

--- a/src/browser/hooks/useDerivedTheme.test.js
+++ b/src/browser/hooks/useDerivedTheme.test.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react'
+import { render, act } from 'react-testing-library'
+import useDerivedTheme from './useDerivedTheme'
+import {
+  LIGHT_THEME,
+  OUTLINE_THEME,
+  AUTO_THEME,
+  DARK_THEME
+} from 'shared/modules/settings/settingsDuck'
+
+describe('useDerivedTheme', () => {
+  it('uses light as default theme if no default is passed in', () => {
+    let resolvedTheme
+
+    const Comp = () => {
+      const [theme] = useDerivedTheme()
+      resolvedTheme = theme
+      return null
+    }
+
+    // When
+    render(<Comp />)
+
+    // Then
+    expect(resolvedTheme).toEqual(LIGHT_THEME) // Default
+  })
+  it('uses default theme if no can be detected + it can be overridden when user has AUTO theme selected', () => {
+    let resolvedTheme
+    let overrideThemeFn
+
+    const Comp = ({ selectedTheme, defaultTheme }) => {
+      const [derivedTheme, setEnvTheme] = useDerivedTheme(
+        selectedTheme,
+        defaultTheme
+      )
+      resolvedTheme = derivedTheme
+      overrideThemeFn = setEnvTheme
+      return null
+    }
+
+    // When
+    const { rerender } = render(
+      <Comp defaultTheme={LIGHT_THEME} selectedTheme={AUTO_THEME} />
+    )
+
+    // Then
+    expect(resolvedTheme).toEqual(LIGHT_THEME) // Default
+
+    // When
+    act(() => overrideThemeFn(OUTLINE_THEME)) // Override
+
+    // Then
+    expect(resolvedTheme).toEqual(OUTLINE_THEME)
+
+    // When user switches off AUTO theme and selects dark
+    rerender(<Comp defaultTheme={LIGHT_THEME} selectedTheme={DARK_THEME} />)
+
+    // Then
+    expect(resolvedTheme).toEqual(DARK_THEME)
+
+    // When switching back and resetting env theme
+    rerender(<Comp defaultTheme={LIGHT_THEME} selectedTheme={AUTO_THEME} />)
+    act(() => overrideThemeFn(null)) // Override
+
+    // Then
+    expect(resolvedTheme).toEqual(LIGHT_THEME)
+  })
+})

--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -73,25 +73,12 @@ import ErrorBoundary from 'browser-components/ErrorBoundary'
 import { getExperimentalFeatures } from 'shared/modules/experimentalFeatures/experimentalFeaturesDuck'
 import FeatureToggleProvider from '../FeatureToggle/FeatureToggleProvider'
 import { inWebEnv, URL_ARGUMENTS_CHANGE } from 'shared/modules/app/appDuck'
-import useAutoTheme from 'browser-hooks/useAutoTheme'
+import useDerivedTheme from 'browser-hooks/useDerivedTheme'
 
 export function App (props) {
-  const [autoTheme, overrideAutoTheme] = useAutoTheme(LIGHT_THEME)
-  const [desktopTheme, setDesktopTheme] = useState(null)
-
-  useEffect(
-    () => {
-      if (desktopTheme) {
-        overrideAutoTheme(desktopTheme)
-        return
-      }
-      if (props.theme !== AUTO_THEME) {
-        overrideAutoTheme(props.theme)
-      } else {
-        overrideAutoTheme(null)
-      }
-    },
-    [props.theme, desktopTheme]
+  const [derivedTheme, setEnvironmentTheme] = useDerivedTheme(
+    props.theme,
+    LIGHT_THEME
   )
 
   useEffect(() => {
@@ -106,12 +93,12 @@ export function App (props) {
 
   const detectDesktopThemeChanges = (_, newContext) => {
     if (newContext.global.prefersColorScheme) {
-      setDesktopTheme(newContext.global.prefersColorScheme)
+      setEnvironmentTheme(newContext.global.prefersColorScheme)
     } else {
-      setDesktopTheme(null)
+      setEnvironmentTheme(null)
     }
   }
-  const themeData = themes[autoTheme] || themes[LIGHT_THEME]
+  const themeData = themes[derivedTheme] || themes[LIGHT_THEME]
 
   const focusEditorOnSlash = e => {
     if (['INPUT', 'TEXTAREA'].indexOf(e.target.tagName) > -1) return

--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import React, { useEffect, useState } from 'react'
+import React, { useEffect } from 'react'
 import { connect } from 'react-redux'
 import { withBus } from 'react-suber'
 import { ThemeProvider } from 'styled-components'
@@ -27,7 +27,6 @@ import {
   getTheme,
   getCmdChar,
   getBrowserSyncConfig,
-  AUTO_THEME,
   LIGHT_THEME
 } from 'shared/modules/settings/settingsDuck'
 import { FOCUS, EXPAND } from 'shared/modules/editor/editorDuck'


### PR DESCRIPTION
Only let environment chose theme when the user has ‘AUTO’ selected.
Encapsulate this logic in a hook to make testing easier and less logic in base App component.