### PR TITLE
Bugfixes from testing

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/AsciiView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/AsciiView.jsx
@@ -90,7 +90,11 @@ export class AsciiView extends Component {
     const { _asciiSetColWidth: maxColWidth = 70 } = this.props
     const { serializedRows, bodyMessage } = this.state
     let contents = <StyledBodyMessage>{bodyMessage}</StyledBodyMessage>
-    if (serializedRows !== undefined && serializedRows.length) {
+    if (
+      serializedRows !== undefined &&
+      serializedRows.length &&
+      serializedRows[0].length
+    ) {
       contents = (
         <pre>
           {asciitable.tableFromSerializedData(serializedRows, maxColWidth)}

--- a/src/browser/modules/Stream/SysInfoFrame/legacyHelpers.jsx
+++ b/src/browser/modules/Stream/SysInfoFrame/legacyHelpers.jsx
@@ -21,7 +21,7 @@
 import React from 'react'
 import {
   getTableDataFromRecords,
-  mapSysInfoRecords,
+  mapLegacySysInfoRecords,
   buildTableData
 } from './sysinfo-utils'
 import { toHumanReadableBytes } from 'services/utils'
@@ -240,7 +240,7 @@ export const clusterResponseHandler = setState =>
       setState({ error: 'No causal cluster results', success: false })
       return
     }
-    const mappedResult = mapSysInfoRecords(res.result.records)
+    const mappedResult = mapLegacySysInfoRecords(res.result.records)
     const mappedTableComponents = mappedResult.map(ccRecord => {
       const httpUrlForMember = ccRecord.addresses.filter(address => {
         return (

--- a/src/browser/modules/Stream/SysInfoFrame/sysinfo-utils.js
+++ b/src/browser/modules/Stream/SysInfoFrame/sysinfo-utils.js
@@ -83,6 +83,17 @@ export const mapSysInfoRecords = records => {
     return {
       id: record.get('id'),
       addresses: record.get('addresses'),
+      databases: record.get('databases'),
+      groups: record.get('groups')
+    }
+  })
+}
+
+export const mapLegacySysInfoRecords = records => {
+  return records.map(record => {
+    return {
+      id: record.get('id'),
+      addresses: record.get('addresses'),
       role: record.get('role'),
       groups: record.get('groups')
     }


### PR DESCRIPTION
This PR addresses two bugs discovered during testing:
- Browser dies when looking at "Text" window of new commands
- Browser breaks after running :sysinfo

### Browser breaks after running :sysinfo
The return value from sysinfo has changed. Changes had already been made to accommodate this, but there was a mapping util that had yet to be updated. It was simply referencing an old property

### Browser dies when looking at "Text" window of new commands
The error emanated from an underlying library `ascii-data-table` where the function `R.transpose` was referencing `arr[0]` without a guard. For now simply ensure that data is not undefined. When @oskarhane is back we can look at a more graceful fix.


