### PR TITLE
Use driver transaction functions and set connection timeout to 30000 if connecting to cloud

### DIFF
--- a/src/shared/modules/connections/connectionHelpers.js
+++ b/src/shared/modules/connections/connectionHelpers.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+  NEO4J_CLOUD_DOMAINS,
+  getConnectionTimeout
+} from 'shared/modules/settings/settingsDuck'
+import parseUrl from 'url-parse'
+
+export const connectionTimeoutHelper = (state, host) => {
+  if (getConnectionTimeout(state)) return getConnectionTimeout(state)
+  for (const cloudDomain of NEO4J_CLOUD_DOMAINS) {
+    if (parseUrl(host).hostname.endsWith(cloudDomain)) {
+      return 10000
+    }
+  }
+  return 5000
+}

--- a/src/shared/modules/connections/connectionHelpers.test.js
+++ b/src/shared/modules/connections/connectionHelpers.test.js
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* global, describe, test, expect */
+
+import { NEO4J_CLOUD_DOMAINS } from 'shared/modules/settings/settingsDuck'
+import { connectionTimeoutHelper } from './connectionHelpers'
+
+describe('connectionTimeoutHelper', () => {
+  test('returns connectionTimeout setting value if setting exists', () => {
+    const connectionTimeout = Math.floor(Math.random() * 1000)
+    const state = {
+      settings: {
+        connectionTimeout
+      }
+    }
+    const timeout = connectionTimeoutHelper(state, '')
+    expect(timeout).toEqual(connectionTimeout)
+  })
+  test('returns 10000ms host has cloud domain', () => {
+    const state = {
+      settings: {}
+    }
+    const timeout = connectionTimeoutHelper(
+      state,
+      `bolt+routing://10763f30-databases.${NEO4J_CLOUD_DOMAINS[0]}`
+    )
+    expect(timeout).toEqual(10000)
+  })
+  test('returns 10000ms host has cloud domain before port', () => {
+    const state = {
+      settings: {}
+    }
+    const timeout = connectionTimeoutHelper(
+      state,
+      `bolt+routing://10763f30-databases.${NEO4J_CLOUD_DOMAINS[0]}:7687`
+    )
+    expect(timeout).toEqual(10000)
+  })
+  test('returns 5000ms if host does not include cloud domain', () => {
+    const state = {
+      settings: {}
+    }
+    const timeout = connectionTimeoutHelper(state, 'host')
+    expect(timeout).toEqual(5000)
+  })
+})

--- a/src/shared/modules/connections/connectionsDuck.test.js
+++ b/src/shared/modules/connections/connectionsDuck.test.js
@@ -28,7 +28,6 @@ import {
   CONNECTION_ID,
   updateDiscoveryConnection
 } from 'shared/modules/discovery/discoveryDuck'
-
 import bolt from 'services/bolt/bolt'
 jest.mock('services/bolt/bolt', () => {
   return {
@@ -262,7 +261,9 @@ describe('startupConnectEpic', () => {
         },
         allConnectionIds: [CONNECTION_ID]
       },
-      settings: {}
+      settings: {
+        connectionTimeout: 10
+      }
     })
   })
   afterEach(() => {
@@ -288,6 +289,23 @@ describe('startupConnectEpic', () => {
             currentAction
           ])
           expect(bolt.openConnection).toHaveBeenCalledTimes(2)
+          expect(bolt.openConnection).toHaveBeenCalledWith(
+            expect.any(Object),
+            {
+              withoutCredentials: true,
+              encrypted: expect.any(Boolean),
+              connectionTimeout: 10
+            },
+            expect.any(Function)
+          )
+          expect(bolt.openConnection).toHaveBeenCalledWith(
+            expect.any(Object),
+            {
+              encrypted: expect.any(Boolean),
+              connectionTimeout: 10
+            },
+            expect.any(Function)
+          )
           expect(bolt.closeConnection).toHaveBeenCalledTimes(1)
           resolve()
         } catch (e) {
@@ -377,7 +395,9 @@ describe('switchConnectionEpic', () => {
         },
         allConnectionIds: [CONNECTION_ID]
       },
-      settings: {}
+      settings: {
+        connectionTimeout: 10
+      }
     })
   })
   afterEach(() => {
@@ -410,6 +430,15 @@ describe('switchConnectionEpic', () => {
           ])
           expect(bolt.closeConnection).toHaveBeenCalledTimes(2) // Why 2?
           expect(bolt.openConnection).toHaveBeenCalledTimes(1)
+          expect(bolt.openConnection).toHaveBeenCalledWith(
+            expect.any(Object),
+            {
+              encrypted: expect.any(Boolean),
+              connectionTimeout: 10
+            },
+            expect.any(Function)
+          )
+
           resolve()
         } catch (e) {
           reject(e)
@@ -455,6 +484,14 @@ describe('switchConnectionEpic', () => {
           ])
           expect(bolt.closeConnection).toHaveBeenCalledTimes(3) // Why 3?
           expect(bolt.openConnection).toHaveBeenCalledTimes(2) // Why 2?
+          expect(bolt.openConnection).toHaveBeenCalledWith(
+            expect.any(Object),
+            {
+              encrypted: expect.any(Boolean),
+              connectionTimeout: 10
+            },
+            expect.any(Function)
+          )
           resolve()
         } catch (e) {
           reject(e)

--- a/src/shared/modules/connections/connectionsDuck.test.js
+++ b/src/shared/modules/connections/connectionsDuck.test.js
@@ -159,7 +159,8 @@ describe('connectionsDucks Epics', () => {
           }
         },
         allConnectionIds: [CONNECTION_ID]
-      }
+      },
+      settings: {}
     })
   })
   afterEach(() => {
@@ -260,7 +261,8 @@ describe('startupConnectEpic', () => {
           }
         },
         allConnectionIds: [CONNECTION_ID]
-      }
+      },
+      settings: {}
     })
   })
   afterEach(() => {
@@ -323,7 +325,8 @@ describe('retainCredentialsSettingsEpic', () => {
           xxx: { id: 'xxx', username: 'usr', password: 'pw' }
         },
         allConnectionIds: ['xxx']
-      }
+      },
+      settings: {}
     })
   })
   afterEach(() => {
@@ -373,7 +376,8 @@ describe('switchConnectionEpic', () => {
           }
         },
         allConnectionIds: [CONNECTION_ID]
-      }
+      },
+      settings: {}
     })
   })
   afterEach(() => {

--- a/src/shared/modules/settings/settingsDuck.js
+++ b/src/shared/modules/settings/settingsDuck.js
@@ -70,6 +70,7 @@ export const getCmdChar = state => state[NAME].cmdchar || initialState.cmdchar
 export const shouldEditorAutocomplete = state =>
   state[NAME].editorAutocomplete !== false
 export const shouldUseCypherThread = state => state[NAME].useCypherThread
+export const getConnectionTimeout = state => state[NAME].connectionTimeout
 
 const initialState = {
   cmdchar: ':',


### PR DESCRIPTION
Struggling to know how best to test these changes. boltConnection currently has no tests - so no obvious way to test the transaction function change. 

Similarly the connectionsDuck has tests but there is nothing actually checking what we pass to open connection. I could obviously add tests here to do that but not sure what the intended strategy is. Perhaps I should extract the connectionTimeoutHelper function and test this separately. 
