### PR TITLE
Export :history

### DIFF
--- a/src/browser/modules/Stream/FrameTitlebar.jsx
+++ b/src/browser/modules/Stream/FrameTitlebar.jsx
@@ -88,7 +88,17 @@ class FrameTitlebar extends Component {
     const { frame } = this.props
 
     if (frame.type === 'history') {
-      const asTxt = frame.result.join(';\n\n')
+      const asTxt = frame.result
+        .map(result => {
+          const safe = `${result}`.trim()
+
+          if (safe.startsWith(':')) {
+            return safe
+          }
+
+          return safe.endsWith(';') ? safe : `${safe};`
+        })
+        .join('\n\n')
       const blob = new Blob([asTxt], {
         type: 'text/plain;charset=utf-8'
       })

--- a/src/browser/modules/Stream/FrameTitlebar.jsx
+++ b/src/browser/modules/Stream/FrameTitlebar.jsx
@@ -63,11 +63,13 @@ import {
   transformResultRecordsToResultArray
 } from 'browser/modules/Stream/CypherFrame/helpers'
 import { csvFormat } from 'services/bolt/cypherTypesFormatting'
+import arrayHasItems from 'shared/utils/array-has-items'
 
 class FrameTitlebar extends Component {
   hasData () {
     return this.props.numRecords > 0
   }
+
   exportCSV (records) {
     const exportData = stringifyResultArray(
       csvFormat,
@@ -81,28 +83,54 @@ class FrameTitlebar extends Component {
     })
     saveAs(blob, 'export.csv')
   }
+
+  exportTXT = () => {
+    const { frame } = this.props
+
+    if (frame.type === 'history') {
+      const asTxt = frame.result.join(';\n\n')
+      const blob = new Blob([asTxt], {
+        type: 'text/plain;charset=utf-8'
+      })
+
+      saveAs(blob, 'history.txt')
+    }
+  }
+
   exportPNG () {
     const { svgElement, graphElement, type } = this.props.visElement
     downloadPNGFromSVG(svgElement, graphElement, type)
   }
+
   exportSVG () {
     const { svgElement, graphElement, type } = this.props.visElement
     downloadSVG(svgElement, graphElement, type)
   }
+
   exportGrass (data) {
     var blob = new Blob([data], {
       type: 'text/plain;charset=utf-8'
     })
     saveAs(blob, 'style.grass')
   }
+
   canExport = () => {
     let props = this.props
     const { frame = {} } = props
+
     return (
-      (frame.type === 'cypher' && (this.hasData() || props.visElement)) ||
+      this.canExportTXT() ||
+      (frame.type === 'cypher' && (this.hasData() || this.props.visElement)) ||
       (frame.type === 'style' && this.hasData())
     )
   }
+
+  canExportTXT () {
+    const { frame = {} } = this.props
+
+    return frame.type === 'history' && arrayHasItems(frame.result)
+  }
+
   render () {
     let props = this.props
     const { frame = {} } = props
@@ -140,6 +168,11 @@ class FrameTitlebar extends Component {
                       onClick={() => this.exportCSV(props.getRecords())}
                     >
                       Export CSV
+                    </DropdownItem>
+                  </Render>
+                  <Render if={this.canExportTXT()}>
+                    <DropdownItem onClick={this.exportTXT}>
+                      Export TXT
                     </DropdownItem>
                   </Render>
                   <Render if={this.hasData() && frame.type === 'style'}>

--- a/src/shared/utils/array-has-items.js
+++ b/src/shared/utils/array-has-items.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ * This file is part of Neo4j.
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+export default function arrayHasItems (arr) {
+  return Array.isArray(arr) && arr.length > 0
+}


### PR DESCRIPTION
This PR adds support for exporting the result of `:history` as TXT.

### STR
- run `:history`
- Select "Export TXT" from export dropdown

### Screenshots
<img width="1329" alt="Screenshot 2019-08-13 at 10 43 14" src="https://user-images.githubusercontent.com/52443771/62927618-2e99b180-bdb7-11e9-93ae-793a828f1e9b.png">

<img width="752" alt="Screenshot 2019-08-13 at 10 41 24" src="https://user-images.githubusercontent.com/52443771/62927534-0447f400-bdb7-11e9-8c29-062d297b3221.png">
