### PR TITLE
Add URL param support for populating editor with Cypher and parameters

### DIFF
--- a/src/shared/modules/editor/editorDuck.js
+++ b/src/shared/modules/editor/editorDuck.js
@@ -33,7 +33,7 @@ export const NOT_SUPPORTED_URL_PARAM_COMMAND = `${NAME}/NOT_SUPPORTED_URL_PARAM_
 // Supported commands
 const validCommandTypes = {
   play: (cmdchar, args) => `${cmdchar}play ${args.join(' ')}`,
-  cypher: (_, args) => args.join('\n'),
+  edit: (_, args) => args.join('\n'),
   param: (cmdchar, args) => `${cmdchar}param ${args.join(' ')}`,
   params: (cmdchar, args) => `${cmdchar}params ${args.join(' ')}`
 }

--- a/src/shared/modules/editor/editorDuck.js
+++ b/src/shared/modules/editor/editorDuck.js
@@ -33,7 +33,9 @@ export const NOT_SUPPORTED_URL_PARAM_COMMAND = `${NAME}/NOT_SUPPORTED_URL_PARAM_
 // Supported commands
 const validCommandTypes = {
   play: (cmdchar, args) => `${cmdchar}play ${args.join(' ')}`,
-  cypher: (_, args) => args.join('\n')
+  cypher: (_, args) => args.join('\n'),
+  param: (cmdchar, args) => `${cmdchar}param ${args.join(' ')}`,
+  params: (cmdchar, args) => `${cmdchar}params ${args.join(' ')}`
 }
 
 export const setContent = newContent => ({

--- a/src/shared/modules/editor/editorDuck.js
+++ b/src/shared/modules/editor/editorDuck.js
@@ -28,6 +28,13 @@ export const SET_CONTENT = NAME + '/SET_CONTENT'
 export const EDIT_CONTENT = NAME + '/EDIT_CONTENT'
 export const FOCUS = `${NAME}/FOCUS`
 export const EXPAND = `${NAME}/EXPAND`
+export const NOT_SUPPORTED_URL_PARAM_COMMAND = `${NAME}/NOT_SUPPORTED_URL_PARAM_COMMAND`
+
+// Supported commands
+const validCommandTypes = {
+  play: (cmdchar, args) => `${cmdchar}play ${args.join(' ')}`,
+  cypher: (_, args) => args.join('\n')
+}
 
 export const setContent = newContent => ({
   type: SET_CONTENT,
@@ -45,13 +52,30 @@ export const populateEditorFromUrlEpic = (some$, store) => {
     .merge(some$.ofType(URL_ARGUMENTS_CHANGE))
     .delay(1) // Timing issue. Needs to be detached like this
     .mergeMap(action => {
-      if (!action.url) return Rx.Observable.never()
+      if (!action.url) {
+        return Rx.Observable.never()
+      }
       const cmdParam = getUrlParamValue('cmd', action.url)
-      if (!cmdParam || cmdParam[0] !== 'play') return Rx.Observable.never()
-      const cmdCommand = getSettings(store.getState()).cmdchar + cmdParam[0]
+
+      // No URL command param found
+      if (!cmdParam || !cmdParam[0]) {
+        return Rx.Observable.never()
+      }
+
+      // Not supported URL param command
+      if (!Object.keys(validCommandTypes).includes(cmdParam[0])) {
+        return Rx.Observable.of({
+          type: NOT_SUPPORTED_URL_PARAM_COMMAND,
+          command: cmdParam[0]
+        })
+      }
+
+      const commandType = cmdParam[0]
+      const cmdchar = getSettings(store.getState()).cmdchar
       const cmdArgs =
         getUrlParamValue('arg', decodeURIComponent(action.url)) || []
-      const fullCommand = `${cmdCommand} ${cmdArgs.join(' ')}`
+      const fullCommand = validCommandTypes[commandType](cmdchar, cmdArgs)
+
       return Rx.Observable.of({ type: SET_CONTENT, ...setContent(fullCommand) })
     })
 }

--- a/src/shared/modules/editor/editorDuck.test.js
+++ b/src/shared/modules/editor/editorDuck.test.js
@@ -87,6 +87,46 @@ describe('editorDuck Epics', () => {
     // When
     store.dispatch(action)
   })
+  test('Handles the param command', done => {
+    const cmd = 'param'
+    const arg = 'x => 1'
+    const action = {
+      type: APP_START,
+      url: `?cmd=${cmd}&arg=${encodeURIComponent(arg)}`
+    }
+
+    bus.take(SET_CONTENT, currentAction => {
+      // Then
+      expect(store.getActions()).toEqual([
+        action,
+        { type: SET_CONTENT, message: `:${cmd} ${arg}` }
+      ])
+      done()
+    })
+
+    // When
+    store.dispatch(action)
+  })
+  test('Handles the params command', done => {
+    const cmd = 'params'
+    const arg = '{x: 1, y: "hello"}'
+    const action = {
+      type: APP_START,
+      url: `?cmd=${cmd}&arg=${encodeURIComponent(arg)}`
+    }
+
+    bus.take(SET_CONTENT, currentAction => {
+      // Then
+      expect(store.getActions()).toEqual([
+        action,
+        { type: SET_CONTENT, message: `:${cmd} ${arg}` }
+      ])
+      done()
+    })
+
+    // When
+    store.dispatch(action)
+  })
   test('Accepts one or more Cypher queries from URL params and populates the editor', done => {
     const cmd = 'cypher'
     const args = ['RETURN 1;', 'RETURN rand();']

--- a/src/shared/modules/editor/editorDuck.test.js
+++ b/src/shared/modules/editor/editorDuck.test.js
@@ -128,7 +128,7 @@ describe('editorDuck Epics', () => {
     store.dispatch(action)
   })
   test('Accepts one or more Cypher queries from URL params and populates the editor', done => {
-    const cmd = 'cypher'
+    const cmd = 'edit'
     const args = ['RETURN 1;', 'RETURN rand();']
     const action = {
       type: APP_START,


### PR DESCRIPTION
Add newline for each query. 
Semi-colons are up to the user to add.

Example usages:  
`http://localhost:7474/?cmd=edit&arg=RETURN%201;&arg=RETURN%20rand();`  
`http://localhost:7474/?cmd=param&arg=x%20%3d%3E%201;`  
`http://localhost:7474/?cmd=params&arg={x:1.0,%20y:%22hello%22}`  

Since it's not limited to Cypher, but works for populating the editor with anything the command is was decided to be `edit`.

Cypher:  
<img width="543" alt="Screenshot 2020-01-07 16 11 56" src="https://user-images.githubusercontent.com/570998/71905452-76571600-3168-11ea-88f3-d0292085c521.png">


Param:  
<img width="444" alt="oskarhane-mbpt 2019-08-13 at 15 02 56" src="https://user-images.githubusercontent.com/570998/62943760-7d594280-bddb-11e9-8ead-7f7c12194c25.png">

Params:  
<img width="504" alt="oskarhane-mbpt 2019-08-13 at 15 06 05" src="https://user-images.githubusercontent.com/570998/62944008-112b0e80-bddc-11e9-8bb0-86531e2376cc.png">

