### PR TITLE
Bugfix clickable urls

### DIFF
--- a/src/browser/components/clickable-urls.jsx
+++ b/src/browser/components/clickable-urls.jsx
@@ -22,7 +22,7 @@ export default function ClickableUrls ({ text }) {
   return (
     <span
       dangerouslySetInnerHTML={{
-        __html: sanitize(convertUrlsToHrefTags(text))
+        __html: convertUrlsToHrefTags(sanitize(text))
       }}
     />
   )

--- a/src/browser/modules/Stream/CypherFrame/TableView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/TableView.jsx
@@ -68,8 +68,8 @@ export const renderObject = entry => {
   return (
     <StyledJsonPre
       dangerouslySetInnerHTML={{
-        __html: sanitize(
-          convertUrlsToHrefTags(stringifyMod(entry, stringModifier, true))
+        __html: convertUrlsToHrefTags(
+          sanitize(stringifyMod(entry, stringModifier, true))
         )
       }}
     />


### PR DESCRIPTION
This PR addresses a bug where target=_blank attribute would not be preserved in final HTML