### PR TITLE
Remove temporary dev state in connections duck

### DIFF
--- a/src/shared/modules/connections/connectionsDuck.js
+++ b/src/shared/modules/connections/connectionsDuck.js
@@ -200,7 +200,7 @@ export default function (state = initialState, action) {
     case ADD:
       return addConnectionHelper(state, action.connection)
     case SET_ACTIVE:
-      let cState = PENDING_STATE
+      let cState = CONNECTED_STATE
       if (!action.connectionId) cState = DISCONNECTED_STATE
       return {
         ...state,


### PR DESCRIPTION
This PR reverts a temporary dev change to the connections duck that accidentally made it in to master. The reason for the change was to test the app in a specific state, and should have been reverted before https://github.com/neo4j/neo4j-browser/pull/955 was merged to master.

### STR
- Launch the app
- Note that slow connection warnings appear despite being connected