### PR TITLE
:param v2

### DIFF
--- a/e2e_tests/integration/0.index.spec.js
+++ b/e2e_tests/integration/0.index.spec.js
@@ -39,7 +39,9 @@ describe('Neo4j Browser', () => {
   })
   it('populates the editor when clicking the connect banner', () => {
     cy.get('[data-testid="disconnectedBannerCode"]').click()
-    cy.get('.ReactCodeMirror').should('contain', ':server connect')
+    cy.get('[data-testid="frameCommand"]')
+      .first()
+      .should('contain', ':server connect')
     cy.get(ClearEditorButton).click()
   })
   it('can connect', () => {

--- a/e2e_tests/integration/multistatements.spec.js
+++ b/e2e_tests/integration/multistatements.spec.js
@@ -74,7 +74,7 @@ describe('Multi statements', () => {
     cy.get('[data-testid="frameCommand"]', { timeout: 10000 })
       .first()
       .should('contain', validQuery)
-    cy.get('[data-testid="frameStatusbar"]', { timeout: 10000 })
+    cy.get('[data-testid="frameContents"]', { timeout: 10000 })
       .first()
       .should('contain', 'Error')
 

--- a/e2e_tests/integration/params.spec.js
+++ b/e2e_tests/integration/params.spec.js
@@ -67,8 +67,8 @@ function runTests () {
   // it(':param x => {prop: 1} multi line', () => {
   // Set param
   cy.executeCommand(':clear')
-  setParamQ = `:param x => {
-    prop: 1
+  setParamQ = `:param [x] => {
+    RETURN {{}prop: 1} AS x
   }`
   cy.executeCommand(setParamQ)
   cy.resultContains('"prop": 1')

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,9 @@ module.exports = {
     '/dist/',
     '/node_modules/'
   ],
-  transformIgnorePatterns: [`/node_modules/(?!lodash-es)`],
+  transformIgnorePatterns: [
+    `/node_modules/(?!lodash-es|@neo4j/browser-lambda-parser)`
+  ],
   moduleNameMapper: {
     '\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga|html)$':
       '<rootDir>/test_utils/__mocks__/fileMock.js',

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "xml2js": "^0.4.19"
   },
   "dependencies": {
-    "@neo4j/browser-lambda-parser": "1.0.0",
+    "@neo4j/browser-lambda-parser": "^1.0.3",
     "ascii-data-table": "^2.1.1",
     "classnames": "^2.2.5",
     "codemirror": "^5.29.0",

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "xml2js": "^0.4.19"
   },
   "dependencies": {
+    "@neo4j/browser-lambda-parser": "1.0.0",
     "ascii-data-table": "^2.1.1",
     "classnames": "^2.2.5",
     "codemirror": "^5.29.0",

--- a/src/browser/components/Directives.jsx
+++ b/src/browser/components/Directives.jsx
@@ -106,9 +106,7 @@ export const Directives = props => {
         const elems = elem.querySelectorAll(directive.selector)
         Array.from(elems).forEach(e => {
           if (e.firstChild.nodeName !== 'I') {
-            directive.selector === '[help-topic]'
-              ? prependHelpIcon(e)
-              : prependPlayIcon(e)
+            prependPlayIcon(e)
           }
 
           e.onclick = () => {

--- a/src/browser/components/Directives.jsx
+++ b/src/browser/components/Directives.jsx
@@ -69,10 +69,6 @@ const directives = [
   }
 ]
 
-const prependHelpIcon = element => {
-  prependIcon(element, 'fa fa-question-circle-o')
-}
-
 const prependPlayIcon = element => {
   prependIcon(element, 'fa fa-play-circle-o')
 }

--- a/src/browser/components/__snapshots__/Directives.test.js.snap
+++ b/src/browser/components/__snapshots__/Directives.test.js.snap
@@ -9,7 +9,7 @@ exports[`Directives should attach all directives when contents has both attribut
         help-topic="help"
       >
         <i
-          class="fa fa-question-circle-o"
+          class="fa fa-play-circle-o"
           style="padding-right:4px"
         />
         help
@@ -37,7 +37,7 @@ exports[`Directives should attach help topic directive when contents has a play-
       help-topic="hello"
     >
       <i
-        class="fa fa-question-circle-o"
+        class="fa fa-play-circle-o"
         style="padding-right:4px"
       />
       link

--- a/src/browser/modules/Help/html/param.html
+++ b/src/browser/modules/Help/html/param.html
@@ -18,6 +18,12 @@
         <code>:param x => 1</code> and to set it as a float, do
         <code>:param x => 1.0</code>.
       </p>
+      <p>
+        If you need more fine-grained control or advanced Cypher queries, you can use the explicit syntax: <code>x => { ... RETURN 1 as foo }</code>
+        <br/> Explicit returns yield a list of records, matching that of your Cypher query: <code>x => { RETURN 1 as foo }</code> yields <code>$x = [{foo: 1}]</code>
+        <br/> You can pick out individual values from your result using destructuring: <code> [{foo}] => { RETURN 1 as foo }</code> yields <code>$foo = 1</code>
+        <br/> You can also rename destructured params: <code> [{foo: bar}] => { RETURN 1 as foo }</code> yields <code>$bar = 1</code>
+      </p>
       <p>Cypher query example with a param:&nbsp;
         <code>MATCH (n:Person) WHERE n.name = $name</code>
       </p>

--- a/src/browser/modules/Main/Main.jsx
+++ b/src/browser/modules/Main/Main.jsx
@@ -26,19 +26,17 @@ import {
 import Editor from '../Editor/Editor'
 import Stream from '../Stream/Stream'
 import Render from 'browser-components/Render'
-import ClickToCode from '../ClickToCode'
 import {
   StyledMain,
   WarningBanner,
   ErrorBanner,
-  NotAuthedBanner,
-  StyledCodeBlockAuthBar,
-  StyledCodeBlockErrorBar
+  NotAuthedBanner
 } from './styled'
 import SyncReminderBanner from './SyncReminderBanner'
 import SyncConsentBanner from './SyncConsentBanner'
 import ErrorBoundary from 'browser-components/ErrorBoundary'
 import { useSlowConnectionState } from './main.hooks'
+import AutoExecButton from '../Stream/auto-exec-button'
 
 const Main = React.memo(function Main (props) {
   const [past5Sec, past10Sec] = useSlowConnectionState(props)
@@ -51,11 +49,8 @@ const Main = React.memo(function Main (props) {
       <Render if={props.showUnknownCommandBanner}>
         <ErrorBanner>
           Type&nbsp;
-          <ClickToCode CodeComponent={StyledCodeBlockErrorBar}>
-            {props.cmdchar}
-            help commands
-          </ClickToCode>
-          &nbsp; for a list of available commands.
+          <AutoExecButton cmd={`${props.cmdchar}help commands`} />
+          &nbsp;for a list of available commands.
         </ErrorBanner>
       </Render>
       <Render if={props.errorMessage}>
@@ -66,13 +61,10 @@ const Main = React.memo(function Main (props) {
       <Render if={props.connectionState === DISCONNECTED_STATE}>
         <NotAuthedBanner data-testid='disconnectedBanner'>
           Database access not available. Please use&nbsp;
-          <ClickToCode
+          <AutoExecButton
+            cmd={`${props.cmdchar}server connect`}
             data-testid='disconnectedBannerCode'
-            CodeComponent={StyledCodeBlockAuthBar}
-          >
-            {props.cmdchar}
-            server connect
-          </ClickToCode>
+          />
           &nbsp; to establish connection. There's a graph waiting for you.
         </NotAuthedBanner>
       </Render>

--- a/src/browser/modules/Stream/CypherFrame/ErrorsView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/ErrorsView.jsx
@@ -35,7 +35,7 @@ import { errorMessageFormater } from './../errorMessageFormater'
 import {
   StyledCypherErrorMessage,
   StyledHelpContent,
-  StyledH4,
+  StyledErrorH4,
   StyledPreformattedArea,
   StyledHelpDescription,
   StyledDiv,
@@ -54,14 +54,14 @@ export class ErrorsView extends Component {
     if (!error || !error.code) {
       return null
     }
-    const fullError = errorMessageFormater(error.code, error.message)
+    const fullError = errorMessageFormater(null, error.message)
 
     return (
       <StyledHelpFrame>
         <StyledHelpContent>
           <StyledHelpDescription>
             <StyledCypherErrorMessage>ERROR</StyledCypherErrorMessage>
-            <StyledH4>{error.code}</StyledH4>
+            <StyledErrorH4>{error.code}</StyledErrorH4>
           </StyledHelpDescription>
           <StyledDiv>
             <StyledPreformattedArea>{fullError.message}</StyledPreformattedArea>

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/AsciiView.test.js.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/AsciiView.test.js.snap
@@ -3,7 +3,7 @@
 exports[`AsciiViews AsciiStatusbar displays statusBarMessage if no rows 1`] = `
 <div>
   <div
-    class="styled__StyledStatsBar-sc-1dtvgs1-32 hNrxzW"
+    class="styled__StyledStatsBar-sc-1dtvgs1-33 cjTact"
   >
     <div
       class="Ellipsis-sc-1dn9bou-0 gzqRPC"
@@ -17,17 +17,17 @@ exports[`AsciiViews AsciiStatusbar displays statusBarMessage if no rows 1`] = `
 exports[`AsciiViews AsciiStatusbar displays statusBarMessage if no rows 2`] = `
 <div>
   <div
-    class="styled__StyledStatsBar-sc-1dtvgs1-32 hNrxzW"
+    class="styled__StyledStatsBar-sc-1dtvgs1-33 cjTact"
   >
     <div
-      class="styled__StyledRightPartial-sc-1dtvgs1-41 zWSxr"
+      class="styled__StyledRightPartial-sc-1dtvgs1-42 ifFzJO"
     >
       <div
-        class="styled__StyledWidthSliderContainer-sc-1dtvgs1-43 dWMHAj"
+        class="styled__StyledWidthSliderContainer-sc-1dtvgs1-44 eZIjEo"
       >
         Max column width:
         <input
-          class="styled__StyledWidthSlider-sc-1dtvgs1-44 dMpTet"
+          class="styled__StyledWidthSlider-sc-1dtvgs1-45 gkWCPI"
           max="3"
           min="3"
           type="range"
@@ -45,7 +45,7 @@ exports[`AsciiViews AsciiView displays bodyMessage if no rows 1`] = `
     class="styled__PaddedDiv-sc-1dtvgs1-6 ccSRli"
   >
     <div
-      class="styled__StyledBodyMessage-sc-1dtvgs1-35 hfUgGP"
+      class="styled__StyledBodyMessage-sc-1dtvgs1-36 dLAxdh"
     >
       (no changes, no records)
     </div>

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/CodeView.test.js.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/CodeView.test.js.snap
@@ -3,7 +3,7 @@
 exports[`CodeViews CodeStatusbar displays no statusBarMessage 1`] = `
 <div>
   <div
-    class="styled__StyledStatsBar-sc-1dtvgs1-32 hNrxzW"
+    class="styled__StyledStatsBar-sc-1dtvgs1-33 cjTact"
   >
     <div
       class="Ellipsis-sc-1dn9bou-0 gzqRPC"
@@ -15,7 +15,7 @@ exports[`CodeViews CodeStatusbar displays no statusBarMessage 1`] = `
 exports[`CodeViews CodeStatusbar displays statusBarMessage 1`] = `
 <div>
   <div
-    class="styled__StyledStatsBar-sc-1dtvgs1-32 hNrxzW"
+    class="styled__StyledStatsBar-sc-1dtvgs1-33 cjTact"
   >
     <div
       class="Ellipsis-sc-1dn9bou-0 gzqRPC"
@@ -34,85 +34,85 @@ exports[`CodeViews CodeView displays request and response info if successful que
     class="styled__PaddedDiv-sc-1dtvgs1-6 ccSRli"
   >
     <table
-      class="styled__StyledTable-sc-1dtvgs1-45 gRxPNQ"
+      class="styled__StyledTable-sc-1dtvgs1-46 fTaAJu"
     >
       <tbody
-        class="styled__StyledTBody-sc-1dtvgs1-46 kjlJBA"
+        class="styled__StyledTBody-sc-1dtvgs1-47 bwJrql"
       >
         <tr
-          class="styled__StyledAlteringTr-sc-1dtvgs1-48 bVMTCr"
+          class="styled__StyledAlteringTr-sc-1dtvgs1-49 dgZoom"
         >
           <td
-            class="styled__StyledStrongTd-sc-1dtvgs1-49 cyBixT"
+            class="styled__StyledStrongTd-sc-1dtvgs1-50 iVZzKL"
           >
             Server version
           </td>
           <td
-            class="styled__StyledTd-sc-1dtvgs1-50 eFHdOJ"
+            class="styled__StyledTd-sc-1dtvgs1-51 gDipvD"
           >
             xx1
           </td>
         </tr>
         <tr
-          class="styled__StyledAlteringTr-sc-1dtvgs1-48 bVMTCr"
+          class="styled__StyledAlteringTr-sc-1dtvgs1-49 dgZoom"
         >
           <td
-            class="styled__StyledStrongTd-sc-1dtvgs1-49 cyBixT"
+            class="styled__StyledStrongTd-sc-1dtvgs1-50 iVZzKL"
           >
             Server address
           </td>
           <td
-            class="styled__StyledTd-sc-1dtvgs1-50 eFHdOJ"
+            class="styled__StyledTd-sc-1dtvgs1-51 gDipvD"
           >
             xx2
           </td>
         </tr>
         <tr
-          class="styled__StyledAlteringTr-sc-1dtvgs1-48 bVMTCr"
+          class="styled__StyledAlteringTr-sc-1dtvgs1-49 dgZoom"
         >
           <td
-            class="styled__StyledStrongTd-sc-1dtvgs1-49 cyBixT"
+            class="styled__StyledStrongTd-sc-1dtvgs1-50 iVZzKL"
           >
             Query
           </td>
           <td
-            class="styled__StyledTd-sc-1dtvgs1-50 eFHdOJ"
+            class="styled__StyledTd-sc-1dtvgs1-51 gDipvD"
           >
             MATCH xx0
           </td>
         </tr>
         <tr
-          class="styled__StyledAlteringTr-sc-1dtvgs1-48 bVMTCr"
+          class="styled__StyledAlteringTr-sc-1dtvgs1-49 dgZoom"
         >
           <td
-            class="styled__StyledStrongTd-sc-1dtvgs1-49 cyBixT"
+            class="styled__StyledStrongTd-sc-1dtvgs1-50 iVZzKL"
           >
             Summary
             <div
-              class="fa fa-caret-right styled__StyledExpandable-sc-1dtvgs1-47 eeYvUX"
+              class="fa fa-caret-right styled__StyledExpandable-sc-1dtvgs1-48 jBrOTl"
               title="Expand section"
             />
           </td>
           <td
-            class="styled__StyledTd-sc-1dtvgs1-50 eFHdOJ"
+            class="styled__StyledTd-sc-1dtvgs1-51 gDipvD"
           >
             {,  "server": {,    "version": "xx1", ...
           </td>
         </tr>
         <tr
-          class="styled__StyledAlteringTr-sc-1dtvgs1-48 bVMTCr"
+          class="styled__StyledAlteringTr-sc-1dtvgs1-49 dgZoom"
         >
           <td
-            class="styled__StyledStrongTd-sc-1dtvgs1-49 cyBixT"
+            class="styled__StyledStrongTd-sc-1dtvgs1-50 iVZzKL"
           >
             Response
             <div
-              class="fa fa-caret-right styled__StyledExpandable-sc-1dtvgs1-47 eeYvUX"
+              class="fa fa-caret-right styled__StyledExpandable-sc-1dtvgs1-48 jBrOTl"
               title="Expand section"
             />
           </td>
           <td
-            class="styled__StyledTd-sc-1dtvgs1-50 eFHdOJ"
+            class="styled__StyledTd-sc-1dtvgs1-51 gDipvD"
           >
             [,  {,    "res": "xx3" ...
           </td>

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/ErrorsView.test.js.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/ErrorsView.test.js.snap
@@ -6,7 +6,7 @@ exports[`ErrorsViews ErrorsStatusbar displays error 1`] = `
     class="Ellipsis-sc-1dn9bou-0 gzqRPC"
   >
     <span
-      class="styled__ErrorText-sc-1dtvgs1-29 dMsRZb"
+      class="styled__ErrorText-sc-1dtvgs1-30 kqUQfd"
       title="Test.Error: Test error description"
     >
       <i
@@ -40,7 +40,7 @@ exports[`ErrorsViews ErrorsView displays procedure link if unknown procedure 1`]
           ERROR
         </div>
         <h4
-          class="styled__StyledH4-sc-1dtvgs1-26 jXSkte"
+          class="styled__StyledErrorH4-sc-1dtvgs1-27 kqKuFe"
         >
           Neo.ClientError.Procedure.ProcedureNotFound
         </h4>
@@ -49,9 +49,9 @@ exports[`ErrorsViews ErrorsView displays procedure link if unknown procedure 1`]
         class="styled__StyledDiv-sc-1dtvgs1-17 kkPWFM"
       >
         <pre
-          class="styled__StyledPreformattedArea-sc-1dtvgs1-28 fxWKEH"
+          class="styled__StyledPreformattedArea-sc-1dtvgs1-29 ezHXzL"
         >
-          Neo.ClientError.Procedure.ProcedureNotFound: not found
+          not found
         </pre>
       </div>
       <div
@@ -88,7 +88,7 @@ exports[`ErrorsViews ErrorsView does displays an error 1`] = `
           ERROR
         </div>
         <h4
-          class="styled__StyledH4-sc-1dtvgs1-26 jXSkte"
+          class="styled__StyledErrorH4-sc-1dtvgs1-27 kqKuFe"
         >
           Test.Error
         </h4>
@@ -97,9 +97,9 @@ exports[`ErrorsViews ErrorsView does displays an error 1`] = `
         class="styled__StyledDiv-sc-1dtvgs1-17 kkPWFM"
       >
         <pre
-          class="styled__StyledPreformattedArea-sc-1dtvgs1-28 fxWKEH"
+          class="styled__StyledPreformattedArea-sc-1dtvgs1-29 ezHXzL"
         >
-          Test.Error: Test error description
+          Test error description
         </pre>
       </div>
     </div>

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/PlanView.test.js.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/PlanView.test.js.snap
@@ -3,10 +3,10 @@
 exports[`PlanViews PlanStatusbar displays statusBarMessage 1`] = `
 <div>
   <div
-    class="styled__StyledStatsBar-sc-1dtvgs1-32 styled__StyledOneRowStatsBar-sc-1dtvgs1-33 dkmnzU"
+    class="styled__StyledStatsBar-sc-1dtvgs1-33 styled__StyledOneRowStatsBar-sc-1dtvgs1-34 fVAUbt"
   >
     <div
-      class="styled__StyledLeftPartial-sc-1dtvgs1-42 cEQgJw"
+      class="styled__StyledLeftPartial-sc-1dtvgs1-43 Wnjnc"
     >
       <div
         class="Ellipsis-sc-1dn9bou-0 gzqRPC"
@@ -22,7 +22,7 @@ exports[`PlanViews PlanStatusbar displays statusBarMessage 1`] = `
       </div>
     </div>
     <div
-      class="styled__StyledRightPartial-sc-1dtvgs1-41 zWSxr"
+      class="styled__StyledRightPartial-sc-1dtvgs1-42 ifFzJO"
     >
       <ul
         class="styled__FrameTitlebarButtonSection-sc-1dtvgs1-10 dRnwVT"

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/TableView.test.js.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/TableView.test.js.snap
@@ -3,7 +3,7 @@
 exports[`TableViews TableStatusbar displays no statusBarMessage 1`] = `
 <div>
   <div
-    class="styled__StyledStatsBar-sc-1dtvgs1-32 hNrxzW"
+    class="styled__StyledStatsBar-sc-1dtvgs1-33 cjTact"
   >
     <div
       class="Ellipsis-sc-1dn9bou-0 gzqRPC"
@@ -15,7 +15,7 @@ exports[`TableViews TableStatusbar displays no statusBarMessage 1`] = `
 exports[`TableViews TableStatusbar displays statusBarMessage 1`] = `
 <div>
   <div
-    class="styled__StyledStatsBar-sc-1dtvgs1-32 hNrxzW"
+    class="styled__StyledStatsBar-sc-1dtvgs1-33 cjTact"
   >
     <div
       class="Ellipsis-sc-1dn9bou-0 gzqRPC"
@@ -32,7 +32,7 @@ exports[`TableViews TableView displays bodyMessage if no rows 1`] = `
     class="styled__PaddedDiv-sc-1dtvgs1-6 styled__PaddedTableViewDiv-sc-1dtvgs1-7 iNSchp"
   >
     <div
-      class="styled__StyledBodyMessage-sc-1dtvgs1-35 hfUgGP"
+      class="styled__StyledBodyMessage-sc-1dtvgs1-36 dLAxdh"
     >
       (no changes, no records)
     </div>

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/WarningsView.test.js.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/WarningsView.test.js.snap
@@ -36,11 +36,11 @@ exports[`WarningsViews WarningsView does displays a warning 1`] = `
           class="styled__StyledDiv-sc-1dtvgs1-17 kkPWFM"
         >
           <pre
-            class="styled__StyledPreformattedArea-sc-1dtvgs1-28 fxWKEH"
+            class="styled__StyledPreformattedArea-sc-1dtvgs1-29 ezHXzL"
           >
             EXPLAIN MATCH xx3
             <br
-              class="styled__StyledBr-sc-1dtvgs1-27 bdFSvo"
+              class="styled__StyledBr-sc-1dtvgs1-28 bQIEoZ"
             />
                    
             ^
@@ -86,11 +86,11 @@ exports[`WarningsViews WarningsView does displays multiple warnings 1`] = `
           class="styled__StyledDiv-sc-1dtvgs1-17 kkPWFM"
         >
           <pre
-            class="styled__StyledPreformattedArea-sc-1dtvgs1-28 fxWKEH"
+            class="styled__StyledPreformattedArea-sc-1dtvgs1-29 ezHXzL"
           >
             EXPLAIN MATCH zz3
             <br
-              class="styled__StyledBr-sc-1dtvgs1-27 bdFSvo"
+              class="styled__StyledBr-sc-1dtvgs1-28 bQIEoZ"
             />
                    
             ^
@@ -127,11 +127,11 @@ exports[`WarningsViews WarningsView does displays multiple warnings 1`] = `
           class="styled__StyledDiv-sc-1dtvgs1-17 kkPWFM"
         >
           <pre
-            class="styled__StyledPreformattedArea-sc-1dtvgs1-28 fxWKEH"
+            class="styled__StyledPreformattedArea-sc-1dtvgs1-29 ezHXzL"
           >
             EXPLAIN MATCH zz3
             <br
-              class="styled__StyledBr-sc-1dtvgs1-27 bdFSvo"
+              class="styled__StyledBr-sc-1dtvgs1-28 bQIEoZ"
             />
                
             ^

--- a/src/browser/modules/Stream/CypherFrame/index.jsx
+++ b/src/browser/modules/Stream/CypherFrame/index.jsx
@@ -373,13 +373,14 @@ export class CypherFrame extends Component {
         this.getFrameContents(request, result, query)
       )
     const statusBar =
-      this.state.openView !== viewTypes.VISUALIZATION
+      this.state.openView !== viewTypes.VISUALIZATION &&
+      requestStatus !== 'error'
         ? this.getStatusbar(result)
         : null
 
     return (
       <FrameTemplate
-        sidebar={this.sidebar}
+        sidebar={requestStatus !== 'error' ? this.sidebar : null}
         header={frame}
         contents={frameContents}
         statusbar={statusBar}

--- a/src/browser/modules/Stream/ErrorFrame.jsx
+++ b/src/browser/modules/Stream/ErrorFrame.jsx
@@ -56,16 +56,16 @@ export const ErrorView = ({ frame }) => {
         </StyledDiv>
       </StyledHelpContent>
       {frame.showHelpForCmd ? (
-        <>
+        <React.Fragment>
           Use <AutoExecButton cmd={`help ${frame.showHelpForCmd}`} /> for more
           information.
-        </>
+        </React.Fragment>
       ) : null}
       {errorCode === UnknownCommandError.name ? (
-        <>
+        <React.Fragment>
           Use <AutoExecButton cmd={'help commands'} /> to list available
           commands.
-        </>
+        </React.Fragment>
       ) : null}
     </StyledHelpFrame>
   )

--- a/src/browser/modules/Stream/ErrorFrame.jsx
+++ b/src/browser/modules/Stream/ErrorFrame.jsx
@@ -18,19 +18,21 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import React from 'react'
+
 import FrameTemplate from './FrameTemplate'
 import * as e from 'services/exceptionMessages'
-import { createErrorObject } from 'services/exceptions'
+import { createErrorObject, UnknownCommandError } from 'services/exceptions'
 import { errorMessageFormater } from './errorMessageFormater'
 import {
   StyledCypherErrorMessage,
   StyledHelpContent,
-  StyledH4,
+  StyledErrorH4,
   StyledPreformattedArea,
   StyledHelpDescription,
   StyledDiv,
   StyledHelpFrame
 } from './styled'
+import AutoExecButton from './auto-exec-button'
 
 export const ErrorView = ({ frame }) => {
   if (!frame) return null
@@ -41,18 +43,30 @@ export const ErrorView = ({ frame }) => {
     const eObj = createErrorObject(errorCode, error)
     errorContents = eObj.message
   }
-  const fullError = errorMessageFormater(errorCode, errorContents)
+  const fullError = errorMessageFormater(null, errorContents)
   return (
     <StyledHelpFrame>
       <StyledHelpContent>
         <StyledHelpDescription>
           <StyledCypherErrorMessage>ERROR</StyledCypherErrorMessage>
-          <StyledH4>{errorCode}</StyledH4>
+          <StyledErrorH4>{errorCode}</StyledErrorH4>
         </StyledHelpDescription>
         <StyledDiv>
           <StyledPreformattedArea>{fullError.message}</StyledPreformattedArea>
         </StyledDiv>
       </StyledHelpContent>
+      {frame.showHelpForCmd ? (
+        <>
+          Use <AutoExecButton cmd={`help ${frame.showHelpForCmd}`} /> for more
+          information.
+        </>
+      ) : null}
+      {errorCode === UnknownCommandError.name ? (
+        <>
+          Use <AutoExecButton cmd={'help commands'} /> to list available
+          commands.
+        </>
+      ) : null}
     </StyledHelpFrame>
   )
 }

--- a/src/browser/modules/Stream/ErrorFrame.test.js
+++ b/src/browser/modules/Stream/ErrorFrame.test.js
@@ -23,18 +23,28 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import 'jest-dom/extend-expect'
 import { ErrorView } from './ErrorFrame'
+import { createStore } from 'redux'
+import { Provider } from 'react-redux'
+
+// credit: https://testing-library.com/docs/example-react-redux
+
+const initialState = { settings: { cmdchar: ':' } }
+const store = createStore(() => initialState, initialState)
+function renderWithRedux (ui) {
+  return render(<Provider store={store}>{ui}</Provider>)
+}
 
 describe('ErrorFrame', () => {
   test('displays UndefinedError if no error specified', async () => {
     // Given
-    const { getByText } = render(<ErrorView frame={{}} />)
+    const { getByText } = renderWithRedux(<ErrorView frame={{}} />)
 
     // Then
     expect(getByText('UndefinedError')).toBeInTheDocument()
   })
   test('does display an error if info provided', () => {
     // Given
-    const { getByText } = render(
+    const { getByText } = renderWithRedux(
       <ErrorView
         frame={{
           error: {
@@ -47,11 +57,12 @@ describe('ErrorFrame', () => {
 
     // Then
     expect(getByText('ERROR')).toBeInTheDocument()
-    expect(getByText('Test.Error: Test error description')).toBeInTheDocument()
+    expect(getByText('Test.Error')).toBeInTheDocument()
+    expect(getByText('Test error description')).toBeInTheDocument()
   })
   test('does display a known error if only code provided', () => {
     // Given
-    const { getByText } = render(
+    const { getByText } = renderWithRedux(
       <ErrorView
         frame={{
           error: {
@@ -65,8 +76,7 @@ describe('ErrorFrame', () => {
 
     // Then
     expect(getByText('ERROR')).toBeInTheDocument()
-    expect(
-      getByText('UnknownCommandError: Unknown command :unknown-command')
-    ).toBeInTheDocument()
+    expect(getByText('UnknownCommandError')).toBeInTheDocument()
+    expect(getByText('Unknown command :unknown-command')).toBeInTheDocument()
   })
 })

--- a/src/browser/modules/Stream/ParamsFrame.jsx
+++ b/src/browser/modules/Stream/ParamsFrame.jsx
@@ -26,7 +26,7 @@ import { stringifyMod } from 'services/utils'
 import FrameTemplate from './FrameTemplate'
 import { PaddedDiv, ErrorText, SuccessText, StyledStatsBar } from './styled'
 import { applyGraphTypes } from 'services/bolt/boltMappings'
-import ClickToCode from 'browser/modules/ClickToCode'
+import AutoExecButton from './auto-exec-button'
 
 const ParamsFrame = ({ frame }) => {
   const params = applyGraphTypes(frame.params)
@@ -38,11 +38,8 @@ const ParamsFrame = ({ frame }) => {
         </pre>
       </Render>
       <div style={{ marginTop: '20px' }}>
-        See{' '}
-        <ClickToCode code=':help param' execute>
-          :help param
-        </ClickToCode>{' '}
-        for usage of the <code>:param</code> command.
+        See <AutoExecButton cmd='help param' /> for usage of the{' '}
+        <code>:param</code> command.
       </div>
     </PaddedDiv>
   )

--- a/src/browser/modules/Stream/__snapshots__/HistoryRow.test.js.snap
+++ b/src/browser/modules/Stream/__snapshots__/HistoryRow.test.js.snap
@@ -3,7 +3,7 @@
 exports[`HistoryRow triggers function on click 1`] = `
 <div>
   <li
-    class="styled__StyledHistoryRow-sc-1dtvgs1-52 cIKDwr"
+    class="styled__StyledHistoryRow-sc-1dtvgs1-53 gScRaN"
   >
     :clear
   </li>

--- a/src/browser/modules/Stream/__snapshots__/SchemaFrame.test.js.snap
+++ b/src/browser/modules/Stream/__snapshots__/SchemaFrame.test.js.snap
@@ -3,7 +3,7 @@
 exports[`SchemaFrame renders empty 1`] = `
 <div>
   <pre
-    class="styled__StyledPreformattedArea-sc-1dtvgs1-28 styled__StyledSchemaBody-sc-1dtvgs1-34 fFNIDH"
+    class="styled__StyledPreformattedArea-sc-1dtvgs1-29 styled__StyledSchemaBody-sc-1dtvgs1-35 gZeYef"
   >
     No indexes
 
@@ -16,7 +16,7 @@ No constraints
 exports[`SchemaFrame renders with result 1`] = `
 <div>
   <pre
-    class="styled__StyledPreformattedArea-sc-1dtvgs1-28 styled__StyledSchemaBody-sc-1dtvgs1-34 fFNIDH"
+    class="styled__StyledPreformattedArea-sc-1dtvgs1-29 styled__StyledSchemaBody-sc-1dtvgs1-35 gZeYef"
   >
     Indexes
    ON :Movie(released) ONLINE 

--- a/src/browser/modules/Stream/auto-exec-button.jsx
+++ b/src/browser/modules/Stream/auto-exec-button.jsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ * This file is part of Neo4j.
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import React, { useCallback } from 'react'
+import { connect } from 'react-redux'
+import { withBus } from 'react-suber'
+import styled from 'styled-components'
+
+import { executeCommand } from '../../../shared/modules/commands/commandsDuck'
+
+const StyledAutoExecButton = styled.button`
+  border-radius: 3px;
+  border: 1px solid #dadada;
+  display: inline-block;
+  font-family: Monaco, 'Courier New', Terminal, monospace;
+  font-size: 12px;
+  line-height: 18px;
+  padding: 0 4px;
+  color: #428bca;
+  cursor: pointer;
+  text-decoration: none;
+  background-color: #f8f8f8;
+  outline: transparent;
+`
+
+function AutoExecButtonComponent ({ bus, cmd, cmdChar }) {
+  const onClick = useCallback(
+    () => {
+      const action = executeCommand(`${cmdChar}${cmd}`)
+
+      bus.send(action.type, action)
+    },
+    [cmd]
+  )
+
+  return (
+    <StyledAutoExecButton type='button' onClick={onClick}>
+      <i className='fa fa-play-circle-o' /> {cmdChar}
+      {cmd}
+    </StyledAutoExecButton>
+  )
+}
+
+const mapStateToProps = ({ settings }) => ({
+  cmdChar: settings.cmdchar
+})
+const AutoExecButton = withBus(
+  connect(mapStateToProps)(AutoExecButtonComponent)
+)
+
+export default AutoExecButton

--- a/src/browser/modules/Stream/auto-exec-button.jsx
+++ b/src/browser/modules/Stream/auto-exec-button.jsx
@@ -37,7 +37,7 @@ const StyledAutoExecButton = styled.button`
   outline: transparent;
 `
 
-function AutoExecButtonComponent ({ bus, cmd, cmdChar }) {
+function AutoExecButtonComponent ({ bus, cmd, cmdChar, ...rest }) {
   const onClick = useCallback(
     () => {
       const action = executeCommand(`${cmdChar}${cmd}`)
@@ -48,7 +48,7 @@ function AutoExecButtonComponent ({ bus, cmd, cmdChar }) {
   )
 
   return (
-    <StyledAutoExecButton type='button' onClick={onClick}>
+    <StyledAutoExecButton type='button' onClick={onClick} {...rest}>
       <i className='fa fa-play-circle-o' /> {cmdChar}
       {cmd}
     </StyledAutoExecButton>
@@ -58,8 +58,11 @@ function AutoExecButtonComponent ({ bus, cmd, cmdChar }) {
 const mapStateToProps = ({ settings }) => ({
   cmdChar: settings.cmdchar
 })
-const AutoExecButton = withBus(
-  connect(mapStateToProps)(AutoExecButtonComponent)
+
+export const AutoExecButtonNoBus = connect(mapStateToProps)(
+  AutoExecButtonComponent
 )
+
+const AutoExecButton = withBus(AutoExecButtonNoBus)
 
 export default AutoExecButton

--- a/src/browser/modules/Stream/auto-exec-button.test.jsx
+++ b/src/browser/modules/Stream/auto-exec-button.test.jsx
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ * This file is part of Neo4j.
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import React from 'react'
+import 'jest-dom/extend-expect'
+import { render, fireEvent } from '@testing-library/react'
+import { createStore } from 'redux'
+import { Provider } from 'react-redux'
+
+import { AutoExecButtonNoBus } from './auto-exec-button'
+
+const send = jest.fn()
+
+// credit: https://testing-library.com/docs/example-react-redux
+const initialState = { settings: { cmdchar: ':' } }
+const store = createStore(() => initialState, initialState)
+
+function renderWithRedux (ui) {
+  return render(<Provider store={store}>{ui}</Provider>)
+}
+
+describe('AutoExecButton', function () {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+  test('should display command with cmd char', () => {
+    // Given
+    const { getByText } = renderWithRedux(
+      <AutoExecButtonNoBus bus={{ send }} cmd='help params' />
+    )
+
+    // Then
+    expect(getByText(':help params')).toBeInTheDocument()
+    expect(send).not.toHaveBeenCalled()
+  })
+
+  test('should auto execute when clicked', () => {
+    // Given
+    const { getByText } = renderWithRedux(
+      <AutoExecButtonNoBus bus={{ send }} cmd='help params' />
+    )
+
+    fireEvent.click(getByText(':help params'))
+
+    // Then
+    expect(getByText(':help params')).toBeInTheDocument()
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(send).toHaveBeenCalledWith('commands/COMMAND_QUEUED', {
+      cmd: ':help params',
+      id: undefined,
+      parentId: undefined,
+      requestId: undefined,
+      type: 'commands/COMMAND_QUEUED'
+    })
+  })
+
+  test('supports any random cmd string', () => {
+    // Given
+    const { getByText } = renderWithRedux(
+      <AutoExecButtonNoBus bus={{ send }} cmd='foo bar' />
+    )
+
+    fireEvent.click(getByText(':foo bar'))
+
+    // Then
+    expect(getByText(':foo bar')).toBeInTheDocument()
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(send).toHaveBeenCalledWith('commands/COMMAND_QUEUED', {
+      cmd: ':foo bar',
+      id: undefined,
+      parentId: undefined,
+      requestId: undefined,
+      type: 'commands/COMMAND_QUEUED'
+    })
+  })
+})

--- a/src/browser/modules/Stream/styled.jsx
+++ b/src/browser/modules/Stream/styled.jsx
@@ -246,6 +246,10 @@ export const StyledInfoMessage = styled(StyledCypherMessage)`
 
 export const StyledH4 = styled.h4``
 
+export const StyledErrorH4 = styled.h4`
+  display: inline-block;
+`
+
 export const StyledBr = styled.br``
 
 export const StyledPreformattedArea = styled.pre`

--- a/src/shared/modules/commands/helpers/lambdas.js
+++ b/src/shared/modules/commands/helpers/lambdas.js
@@ -75,10 +75,7 @@ export function parseLambdaStatement (lambda) {
     })
 }
 
-export function collectLambdaValues (
-  { parameters, query, variant, returnValues },
-  requestId
-) {
+export function collectLambdaValues ({ parameters, query, variant }, requestId) {
   return bolt
     .routedWriteTransaction(
       query,
@@ -92,15 +89,12 @@ export function collectLambdaValues (
     .then(({ records }) => {
       if (variant === IMPLICIT) {
         const firstResult = head(records)
-        const firstReturn = head(returnValues)
 
         return firstResult
           ? recursivelyTypeGraphItems({
-            [parameters.value]: firstResult.get(
-              firstReturn.alias || firstReturn.value
-            )
+            [parameters.value]: firstResult.get(head(firstResult.keys))
           })
-          : null
+          : {}
       }
 
       if (parameters.type === TOKEN) {
@@ -123,7 +117,7 @@ export function collectLambdaValues (
       }
 
       // future proofing
-      if (parameters.type !== ARRAY) return null
+      if (parameters.type !== ARRAY) return {}
 
       const { items } = parameters
       const extractedRecords = map(

--- a/src/shared/modules/commands/helpers/lambdas.js
+++ b/src/shared/modules/commands/helpers/lambdas.js
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ * This file is part of Neo4j.
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+import {
+  assign,
+  head,
+  join,
+  map,
+  reduce,
+  slice,
+  split,
+  tail,
+  trim
+} from 'lodash-es'
+import { parseLambda } from '@neo4j/browser-lambda-parser'
+
+import bolt from '../../../services/bolt/bolt'
+import { recursivelyTypeGraphItems } from '../../../services/bolt/boltMappings'
+import arrayHasItems from '../../../utils/array-has-items'
+
+const FAT_ARROW = '=>'
+const TOKEN = 'token'
+const ARRAY = 'array'
+const IMPLICIT = 'implicit'
+const NEARLEY_ERROR_SPLIT =
+  'Instead, I was expecting to see one of the following:'
+
+export function parseLambdaStatement (lambda) {
+  return Promise.resolve()
+    .then(() => {
+      const ast = parseLambda(trim(lambda))
+
+      if (!arrayHasItems(ast)) {
+        throw new Error(
+          `Unrecognized input. Sorry we couldn't be more specific.`
+        )
+      }
+
+      const [
+        {
+          parameters,
+          variant,
+          body: { returnValues }
+        }
+      ] = ast
+      const statement = trim(join(tail(split(lambda, FAT_ARROW)), FAT_ARROW))
+      const query =
+        variant === IMPLICIT
+          ? `RETURN ${statement}`
+          : statement.slice(1, statement.length - 1)
+
+      return {
+        parameters,
+        query,
+        variant,
+        returnValues
+      }
+    })
+    .catch(e => {
+      throw new Error(head(split(e, NEARLEY_ERROR_SPLIT)))
+    })
+}
+
+export function collectLambdaValues (
+  { parameters, query, variant, returnValues },
+  requestId
+) {
+  return bolt
+    .routedWriteTransaction(
+      query,
+      {},
+      {
+        useCypherThread: false,
+        requestId,
+        cancelable: false
+      }
+    )
+    .then(({ records }) => {
+      if (variant === IMPLICIT) {
+        const firstResult = head(records)
+        const firstReturn = head(returnValues)
+
+        return firstResult
+          ? recursivelyTypeGraphItems({
+            [parameters.value]: firstResult.get(
+              firstReturn.alias || firstReturn.value
+            )
+          })
+          : null
+      }
+
+      if (parameters.type === TOKEN) {
+        const extractedRecords = map(records, record =>
+          reduce(
+            record.keys,
+            (agg, next) =>
+              assign(agg, {
+                [next]: record.get(next)
+              }),
+            {}
+          )
+        )
+
+        return {
+          [parameters.value]: map(extractedRecords, record =>
+            recursivelyTypeGraphItems(record)
+          )
+        }
+      }
+
+      // future proofing
+      if (parameters.type !== ARRAY) return null
+
+      const { items } = parameters
+      const extractedRecords = map(
+        slice(records, 0, items.length),
+        (record, index) => {
+          const item = items[index]
+          const keys = item.type === TOKEN ? [item] : item.keys // item.type === OBJECT
+
+          return reduce(
+            keys,
+            (agg, next) =>
+              assign(agg, {
+                [next.alias || next.value]: record.get(next.value)
+              }),
+            {}
+          )
+        }
+      )
+
+      return reduce(
+        extractedRecords,
+        (agg, record) => assign(agg, recursivelyTypeGraphItems(record)),
+        {}
+      )
+    })
+}

--- a/src/shared/modules/commands/helpers/params.js
+++ b/src/shared/modules/commands/helpers/params.js
@@ -18,15 +18,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import jsonic from 'jsonic'
-import bolt from 'services/bolt/bolt'
-import { recursivelyTypeGraphItems } from 'services/bolt/boltMappings'
-import {
-  splitStringOnFirst,
-  mapParamToCypherStatement
-} from 'services/commandUtils'
+import { splitStringOnFirst } from 'services/commandUtils'
 import { update, replace } from 'shared/modules/params/paramsDuck'
+import { collectLambdaValues, parseLambdaStatement } from './lambdas'
 
 export const extractParams = param => {
+  // early bail, now handled by parser
+  if (param.includes('=>')) {
+    return {
+      isFn: true
+    }
+  }
+
   const matchParam = param.match(/^(".*"|'.*'|\S+)\s?(:|=>)\s([^$]*)$/)
   if (!matchParam) return {}
   const [, paramName, delimiter, paramValue] = matchParam
@@ -56,72 +59,56 @@ export const extractParams = param => {
   }
 }
 
-const resolveAndStoreJsonValue = (param, put, resolve, reject) => {
+const resolveAndStoreJsonValue = (param, put) => {
   try {
     const json = `{${param}}`
     const res = jsonic(json)
     put(update(res))
-    return resolve({ result: res, type: 'param' })
+    return { result: res, type: 'param' }
   } catch (e) {
-    return reject(
-      new Error('Could not parse input. Usage: `:param x => 2`. ' + e)
-    )
+    throw new Error('Could not parse input. Usage: `:param x => 2`. ' + e)
   }
 }
+
+export const getParamName = (input, cmdchar) => {
+  const strippedCmd = input.cmd.substr(cmdchar.length)
+  const parts = splitStringOnFirst(strippedCmd, ' ')
+
+  return parts[0].trim()
+}
+
 export const handleParamsCommand = (action, cmdchar, put) => {
   const strippedCmd = action.cmd.substr(cmdchar.length)
   const parts = splitStringOnFirst(strippedCmd, ' ')
   const param = parts[1].trim()
-  const p = new Promise((resolve, reject) => {
+
+  return Promise.resolve().then(() => {
     if (/^"?\{.*\}"?$/.test(param)) {
       // JSON object string {"x": 2, "y":"string"}
       try {
         const res = jsonic(param.replace(/^"/, '').replace(/"$/, '')) // Remove any surrounding quotes
         put(replace(res))
-        return resolve({ result: res, type: 'params' })
+        return { result: res, type: 'params' }
       } catch (e) {
-        return reject(
-          new Error(
-            'Could not parse input. Usage: `:params {"x":1,"y":"string"}`. ' + e
-          )
+        throw new Error(
+          'Could not parse input. Usage: `:params {"x":1,"y":"string"}`. ' + e
         )
-      }
-    } else {
-      // Single param
-      const { key, value, isFn, originalParamValue } = extractParams(param)
-
-      if (!isFn || !key || value === undefined) {
-        return resolveAndStoreJsonValue(param, put, resolve, reject)
-      }
-      try {
-        const cypherStatement = mapParamToCypherStatement(
-          key,
-          originalParamValue
-        )
-        bolt
-          .routedWriteTransaction(
-            cypherStatement,
-            {},
-            {
-              useCypherThread: false,
-              requestId: action.requestId,
-              cancelable: false
-            }
-          )
-          .then(res => {
-            let obj = {}
-            res.records.forEach(record => {
-              obj[key] = record.get(key)
-            })
-            const result = recursivelyTypeGraphItems(obj)
-            put(update(result))
-            resolve({ result, type: 'param' })
-          })
-          .catch(e => reject(e))
-      } catch (e) {
-        reject(new Error('Could not parse input. Usage: `:param x => 2`. ' + e))
       }
     }
+
+    // Single param
+    const { key, value, isFn } = extractParams(param)
+
+    if (!isFn && (!key || value === undefined)) {
+      return resolveAndStoreJsonValue(param, put)
+    }
+
+    return parseLambdaStatement(param)
+      .then(ast => collectLambdaValues(ast, action.requestId))
+      .then(result => {
+        put(update(result))
+
+        return { result, type: 'param' }
+      })
   })
-  return p
 }

--- a/src/shared/modules/commands/helpers/params.js
+++ b/src/shared/modules/commands/helpers/params.js
@@ -97,9 +97,9 @@ export const handleParamsCommand = (action, cmdchar, put) => {
     }
 
     // Single param
-    const { key, value, isFn } = extractParams(param)
+    const { key, isFn } = extractParams(param)
 
-    if (!isFn && (!key || value === undefined)) {
+    if (!isFn && Boolean(key)) {
       return resolveAndStoreJsonValue(param, put)
     }
 

--- a/src/shared/modules/commands/helpers/params.test.js
+++ b/src/shared/modules/commands/helpers/params.test.js
@@ -37,16 +37,15 @@ describe('commandsDuck params helper', () => {
     const put = jest.fn()
 
     // When
-    const p = params.handleParamsCommand(action, cmdchar, put)
-
-    // Then
-    return expect(p)
-      .rejects.toEqual(
-        new Error(
-          'Could not parse input. Usage: `:param x => 2`. SyntaxError: Expected ":" but "x" found.'
-        )
-      )
-      .then(() => expect(put).not.toHaveBeenCalled())
+    return params
+      .handleParamsCommand(action, cmdchar, put)
+      .then(() => {
+        throw Error('THIS SHOULD NEVER HAPPEN')
+      })
+      .catch(error => {
+        expect(error.message).toMatch('Error: Syntax error at line 1 col 3:')
+        expect(put).not.toHaveBeenCalled()
+      })
   })
   test('handles :param "x": 2 and calls the update action creator', () => {
     // Given
@@ -138,28 +137,6 @@ describe('commandsDuck params helper', () => {
         value: 'bar',
         originalParamValue: 'bar',
         isFn: false
-      })
-    })
-    test('<key with space>=><value>', () => {
-      expect(params.extractParams('"f o o" => 2')).toEqual({
-        key: 'f o o',
-        value: 2,
-        originalParamValue: '2',
-        isFn: true
-      })
-    })
-    test('<key>=><obj>', () => {
-      expect(
-        params.extractParams(`foo => {
-        x: 1
-      }`)
-      ).toEqual({
-        key: 'foo',
-        value: { x: 1 },
-        originalParamValue: `{
-        x: 1
-      }`,
-        isFn: true
       })
     })
   })

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -48,7 +48,10 @@ import {
   unsuccessfulCypher,
   SINGLE_COMMAND_QUEUED
 } from 'shared/modules/commands/commandsDuck'
-import { handleParamsCommand } from 'shared/modules/commands/helpers/params'
+import {
+  getParamName,
+  handleParamsCommand
+} from 'shared/modules/commands/helpers/params'
 import {
   handleGetConfigCommand,
   handleUpdateConfigCommand
@@ -117,13 +120,23 @@ const availableCommands = [
           put(updateQueryResult(action.requestId, res, 'success'))
           return true
         })
-        .catch(e => {
-          // Don't show error message bar if it's a sub command
+        .catch(error => {
+          // Don't show error message if it's a sub command
           if (!action.parentId) {
-            put(showErrorMessage(e.message))
+            put(
+              frames.add({
+                ...action,
+                error: {
+                  type: 'Syntax Error',
+                  message: error.message.substring('Error: '.length)
+                },
+                showHelpForCmd: getParamName(action, cmdchar),
+                type: 'error'
+              })
+            )
           }
-          put(updateQueryResult(action.requestId, e, 'error'))
-          throw e
+          put(updateQueryResult(action.requestId, error, 'error'))
+          throw error
         })
     }
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1074,6 +1074,13 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
+"@neo4j/browser-lambda-parser@^1.0.3":
+  version "1.0.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/@neo4j/browser-lambda-parser/-/browser-lambda-parser-1.0.3.tgz#d49675122aa673e0ed888e5959e4519d66cf20ff"
+  integrity sha1-1JZ1Eiqmc+DtiI5ZWeRRnWbPIP8=
+  dependencies:
+    nearley "2.18.0"
+
 "@sheerun/mutationobserver-shim@^0.3.2":
   version "0.3.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.2.tgz#8013f2af54a2b7d735f71560ff360d3a8176a87b"
@@ -3437,6 +3444,11 @@ dir-glob@^2.0.0:
   dependencies:
     arrify "^1.0.1"
     path-type "^3.0.0"
+
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+  integrity sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=
 
 disposables@^1.0.1:
   version "1.0.2"
@@ -7097,6 +7109,11 @@ moment@2.24.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha1-DQVdU/UFKqZTyfbraLtdEr9cK1s=
 
+moo@^0.4.3:
+  version "0.4.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/moo/-/moo-0.4.3.tgz#3f847a26f31cf625a956a87f2b10fbc013bfd10e"
+  integrity sha1-P4R6JvMc9iWpVqh/KxD7wBO/0Q4=
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -7173,6 +7190,17 @@ ncp@^2.0.0:
   version "2.0.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
   integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
+
+nearley@2.18.0:
+  version "2.18.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/nearley/-/nearley-2.18.0.tgz#a9193612dd6d528a2e47e743b1dc694cfe105223"
+  integrity sha1-qRk2Et1tUoouR+dDsdxpTP4QUiM=
+  dependencies:
+    commander "^2.19.0"
+    moo "^0.4.3"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
+    semver "^5.4.1"
 
 needle@^2.2.1:
   version "2.4.0"
@@ -8793,10 +8821,23 @@ raf@^3.4.0:
   dependencies:
     performance-now "^2.1.0"
 
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+  integrity sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=
+
 ramda@0.24.1:
   version "0.24.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/ramda/-/ramda-0.24.1.tgz#c3b7755197f35b8dc3502228262c4c91ddb6b857"
   integrity sha1-w7d1UZfzW43DUCIoJixMkd22uFc=
+
+randexp@0.4.6:
+  version "0.4.6"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  integrity sha1-6YatXl4x2uE93W97MBmqfIf2DKM=
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
 
 randomatic@^3.0.0:
   version "3.1.0"


### PR DESCRIPTION
This PR adds support for the `:param` v2 syntax (explicit returns). In addition, it also cleans up and standardizes the error frame appearance regardless of error origin. Finally it standardizes the appearance of `:help` buttons.

### Todo
- [x] Fix tests once `@neo4j/browser-lambda-parser` is published

### STR
- run `:help param` and follow the instructions for explicit returns

### Screenshots
Setting parameters
<img width="1492" alt="Screenshot 2019-08-27 at 15 45 57" src="https://user-images.githubusercontent.com/52443771/63776486-c8964980-c8e1-11e9-956b-696f3c2e1f8e.png">

Error
<img width="1496" alt="Screenshot 2019-08-27 at 14 31 15" src="https://user-images.githubusercontent.com/52443771/63776586-f8455180-c8e1-11e9-9991-795628f4425f.png">

`:help` commands
<img width="1496" alt="Screenshot 2019-08-27 at 15 43 16" src="https://user-images.githubusercontent.com/52443771/63776607-fe3b3280-c8e1-11e9-81f2-9e0881a88642.png">
