### PR TITLE
Bugfix saved favorites

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
   "dependencies": {
     "@neo4j/browser-lambda-parser": "^1.0.3",
     "@relate-by-ui/css": "^1.0.4",
-    "@relate-by-ui/saved-scripts": "^1.0.3",
+    "@relate-by-ui/saved-scripts": "^1.0.4",
     "ascii-data-table": "^2.1.1",
     "classnames": "^2.2.5",
     "codemirror": "^5.29.0",

--- a/src/browser/modules/Sidebar/favorites.utils.js
+++ b/src/browser/modules/Sidebar/favorites.utils.js
@@ -134,9 +134,9 @@ export function mapNewFavoritesToOld (newFavorites, update = {}) {
     assign(
       {
         id,
-        content: update.name ? addNameComment(contents, update.name) : contents,
-        folder: folder && folder.id
+        content: update.name ? addNameComment(contents, update.name) : contents
       },
+      folder ? { folder: folder.id } : {},
       omit(update, 'name')
     )
   )

--- a/src/shared/services/export-favorites/export-favorites.utils.js
+++ b/src/shared/services/export-favorites/export-favorites.utils.js
@@ -63,7 +63,8 @@ export function mapOldFavoritesAndFolders (
     const newFavorite = {
       id: favorite.id,
       contents: favorite.content,
-      path: addScriptPathPrefix(SLASH, get(folder, 'name', ''))
+      path: addScriptPathPrefix(SLASH, get(folder, 'name', '')),
+      isSuggestion: favorite.not_executable
     }
 
     if (folder) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1243,10 +1243,10 @@
     react-dom "^16.8.6"
     react-placeholder "^3.0.2"
 
-"@relate-by-ui/saved-scripts@^1.0.3":
-  version "1.0.3"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/@relate-by-ui/saved-scripts/-/saved-scripts-1.0.3.tgz#291514a1a7e2d987b5d8caa336a419a5ec035ab5"
-  integrity sha1-KRUUoafi2Ye12MqjNqQZpewDWrU=
+"@relate-by-ui/saved-scripts@^1.0.4":
+  version "1.0.4"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/@relate-by-ui/saved-scripts/-/saved-scripts-1.0.4.tgz#df50dae1c98c589637e12097031a42311e78279f"
+  integrity sha1-31Da4cmMWJY34SCXAxpCMR54J58=
   dependencies:
     "@emotion/core" "10.0.10"
     "@emotion/styled" "10.0.10"


### PR DESCRIPTION
This PR addresses some bugs introduced by https://github.com/neo4j/neo4j-browser/pull/964.
- Updating the name of top level favorites would lead to a firebase exception due to property `folder` having a value of `undefined`
- CSS fixes where ellipsis would not show due to a wrapping div used for react-dnd
- Addressed bug where static scripts marked `not_executable` would still show as executable
- Increased font size of headers as per design request

### Screenshots
<img width="402" alt="Screenshot 2019-09-13 at 15 12 07" src="https://user-images.githubusercontent.com/52443771/64865105-dfa29e80-d638-11e9-9ff5-93f5cb6d84bf.png">


### Unrelated
- During testing I noticed that browser-sync will reset favorites when it finally loads. This is not a new behaviour but still a bit unexpected.