### PR TITLE
Default scheme `bolt://` -> `neo4j://` in canary

### DIFF
--- a/src/browser/components/DesktopIntegration/helpers.js
+++ b/src/browser/components/DesktopIntegration/helpers.js
@@ -19,6 +19,7 @@
  */
 
 import { NATIVE, KERBEROS } from 'services/bolt/boltHelpers'
+import { getDefaultBoltScheme } from 'shared/modules/features/versionedFeatures'
 
 export const getActiveGraph = (context = {}) => {
   if (!context) return null
@@ -123,7 +124,9 @@ export const buildConnectionCredentialsObject = async (
     ...existingData,
     ...creds,
     encrypted: creds.tlsLevel === 'REQUIRED',
-    host: creds.url || `bolt://${creds.host}:${creds.port}`,
+    host:
+      creds.url ||
+      `${getDefaultBoltScheme('4.0.0')}${creds.host}:${creds.port}`,
     restApi,
     authenticationMethod: kerberos ? KERBEROS : NATIVE
   }

--- a/src/browser/components/DesktopIntegration/helpers.js
+++ b/src/browser/components/DesktopIntegration/helpers.js
@@ -105,7 +105,8 @@ const isKerberosEnabled = context => {
 export const buildConnectionCredentialsObject = async (
   context,
   existingData = {},
-  getKerberosTicket = () => {}
+  getKerberosTicket = () => {},
+  neo4jVersion = '4.0.0'
 ) => {
   const creds = getActiveCredentials('bolt', context)
   if (!creds) return // No connection. Ignore and let browser show connection lost msgs.
@@ -126,7 +127,7 @@ export const buildConnectionCredentialsObject = async (
     encrypted: creds.tlsLevel === 'REQUIRED',
     host:
       creds.url ||
-      `${getDefaultBoltScheme('4.0.0')}${creds.host}:${creds.port}`,
+      `${getDefaultBoltScheme(neo4jVersion)}${creds.host}:${creds.port}`,
     restApi,
     authenticationMethod: kerberos ? KERBEROS : NATIVE
   }

--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -32,7 +32,10 @@ import {
 import { FOCUS, EXPAND } from 'shared/modules/editor/editorDuck'
 import { useBrowserSync } from 'shared/modules/features/featuresDuck'
 import { getErrorMessage } from 'shared/modules/commands/commandsDuck'
-import { allowOutgoingConnections } from 'shared/modules/dbMeta/dbMetaDuck'
+import {
+  allowOutgoingConnections,
+  getVersion
+} from 'shared/modules/dbMeta/dbMetaDuck'
 import {
   getActiveConnection,
   getConnectionState,
@@ -219,7 +222,8 @@ const mapStateToProps = state => {
     browserSyncConfig: getBrowserSyncConfig(state),
     browserSyncAuthStatus: getUserAuthStatus(state),
     loadSync: useBrowserSync(state),
-    isWebEnv: inWebEnv(state)
+    isWebEnv: inWebEnv(state),
+    neo4jVersion: getVersion(state)
   }
 }
 
@@ -241,7 +245,8 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     const connectionCreds = await buildConnectionCredentialsObject(
       newContext,
       stateProps.defaultConnectionData,
-      getKerberosTicket
+      getKerberosTicket,
+      stateProps.neo4jVersion
     )
     ownProps.bus.send(SWITCH_CONNECTION, connectionCreds)
   }
@@ -254,7 +259,8 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     const connectionCreds = await buildConnectionCredentialsObject(
       context,
       stateProps.defaultConnectionData,
-      getKerberosTicket
+      getKerberosTicket,
+      stateProps.neo4jVersion
     )
     // No connection. Probably no graph active.
     if (!connectionCreds) {

--- a/src/browser/modules/Stream/Auth/ConnectionForm.test.js
+++ b/src/browser/modules/Stream/Auth/ConnectionForm.test.js
@@ -85,7 +85,7 @@ test('should print correct state for retaining credentials', async () => {
 
   // Then
   expect(getByText(/my-username/i)).toBeDefined()
-  expect(getByText(/bolt:\/\/my-host/i)).toBeDefined()
+  expect(getByText(/neo4j:\/\/my-host/i)).toBeDefined()
   expect(
     getByText(/Connection credentials are\sstored in your web browser./i)
   ).toBeDefined()
@@ -107,7 +107,7 @@ test('should print correct state for retaining credentials', async () => {
 
   // Then
   expect(getByText(/my-username/i)).toBeDefined()
-  expect(getByText(/bolt:\/\/my-host/i)).toBeDefined()
+  expect(getByText(/neo4j:\/\/my-host/i)).toBeDefined()
   expect(
     getByText(/Connection credentials are\snot\sstored in your web browser./i)
   ).toBeDefined()

--- a/src/browser/modules/Stream/Queries/QueriesFrame.jsx
+++ b/src/browser/modules/Stream/Queries/QueriesFrame.jsx
@@ -59,6 +59,7 @@ import { RefreshIcon } from 'browser-components/icons/Icons'
 import Render from 'browser-components/Render'
 import FrameError from '../../Frame/FrameError'
 import { NEO4J_BROWSER_USER_ACTION_QUERY } from 'services/bolt/txMetadata'
+import { getDefaultBoltScheme } from 'shared/modules/features/versionedFeatures'
 
 export class QueriesFrame extends Component {
   state = {
@@ -165,9 +166,10 @@ export class QueriesFrame extends Component {
         queryInfo[key] = bolt.itemIntToNumber(_fields[idx])
       })
       if (host) {
-        queryInfo.host = 'bolt://' + host
+        queryInfo.host = getDefaultBoltScheme('4.0.0') + host
       } else {
-        queryInfo.host = 'bolt://' + result.summary.server.address
+        queryInfo.host =
+          getDefaultBoltScheme('4.0.0') + result.summary.server.address
       }
       return queryInfo
     })

--- a/src/browser/modules/Stream/Queries/QueriesFrame.jsx
+++ b/src/browser/modules/Stream/Queries/QueriesFrame.jsx
@@ -60,6 +60,7 @@ import Render from 'browser-components/Render'
 import FrameError from '../../Frame/FrameError'
 import { NEO4J_BROWSER_USER_ACTION_QUERY } from 'services/bolt/txMetadata'
 import { getDefaultBoltScheme } from 'shared/modules/features/versionedFeatures'
+import { getVersion } from 'shared/modules/dbMeta/dbMetaDuck'
 
 export class QueriesFrame extends Component {
   state = {
@@ -166,10 +167,11 @@ export class QueriesFrame extends Component {
         queryInfo[key] = bolt.itemIntToNumber(_fields[idx])
       })
       if (host) {
-        queryInfo.host = getDefaultBoltScheme('4.0.0') + host
+        queryInfo.host = getDefaultBoltScheme(this.props.neo4jVersion) + host
       } else {
         queryInfo.host =
-          getDefaultBoltScheme('4.0.0') + result.summary.server.address
+          getDefaultBoltScheme(this.props.neo4jVersion) +
+          result.summary.server.address
       }
       return queryInfo
     })
@@ -355,7 +357,8 @@ export class QueriesFrame extends Component {
 const mapStateToProps = state => {
   return {
     availableProcedures: getAvailableProcedures(state) || [],
-    connectionState: getConnectionState(state)
+    connectionState: getConnectionState(state),
+    neo4jVersion: getVersion(state)
   }
 }
 

--- a/src/browser/modules/Stream/Queries/QueriesFrame.test.js
+++ b/src/browser/modules/Stream/Queries/QueriesFrame.test.js
@@ -80,7 +80,8 @@ it('can list and kill queries', () => {
   const props = {
     availableProcedures: ['dbms.listQueries'],
     connectionState: CONNECTED_STATE,
-    bus
+    bus,
+    neo4jVersion: '4.0.0'
   }
 
   const { getByText, getByTestId } = render(<QueriesFrame {...props} />)

--- a/src/browser/modules/Stream/Queries/QueriesFrame.test.js
+++ b/src/browser/modules/Stream/Queries/QueriesFrame.test.js
@@ -86,7 +86,7 @@ it('can list and kill queries', () => {
   const { getByText, getByTestId } = render(<QueriesFrame {...props} />)
 
   // Check that it's listed
-  expect(getByText('bolt://testhost.test')).not.toBeNull()
+  expect(getByText('neo4j://testhost.test')).not.toBeNull()
   expect(getByText('TEST RETURN')).not.toBeNull()
 
   // When

--- a/src/shared/modules/features/versionedFeatures.js
+++ b/src/shared/modules/features/versionedFeatures.js
@@ -80,6 +80,17 @@ export const getUsedDbName = state => {
   return getActiveDbName(state)
 }
 
+export const getDefaultBoltScheme = serverVersion => {
+  const pre4 = 'bolt://'
+  if (!semver.valid(serverVersion)) {
+    return pre4
+  }
+  if (semver.gte(serverVersion, NEO4J_4_0)) {
+    return 'neo4j://'
+  }
+  return pre4
+}
+
 export const changeUserPasswordQuery = (state, oldPw, newPw) => {
   const pre4 = {
     query: 'CALL dbms.security.changePassword($password)',

--- a/src/shared/services/utils.js
+++ b/src/shared/services/utils.js
@@ -21,6 +21,7 @@
 
 import parseUrl from 'url-parse'
 import { DESKTOP, CLOUD, WEB } from 'shared/modules/app/appDuck'
+import { getDefaultBoltScheme } from 'shared/modules/features/versionedFeatures'
 
 /**
  * The work objects expected shape:
@@ -149,8 +150,8 @@ export const isRoutingHost = host => {
 
 export const toBoltHost = host => {
   return (
-    'bolt://' +
-    (host || '') // prepend with bolt://
+    'neo4j://' +
+    (host || '') // prepend with neo4j://
       .replace(/(.*(?=@+)@|(bolt|bolt\+routing):\/\/)/, '') // remove bolt or bolt+routing protocol and auth info
   )
 }
@@ -480,7 +481,8 @@ export const toKeyString = str => btoa(encodeURIComponent(str))
 
 export const generateBoltHost = host => {
   const urlParts = (host || '').split('://')
-  const protocol = urlParts.length > 1 ? `${urlParts[0]}://` : 'bolt://'
+  const protocol =
+    urlParts.length > 1 ? `${urlParts[0]}://` : getDefaultBoltScheme('4.0.0')
   host = urlParts.length > 1 ? urlParts[1] : urlParts[0]
   return protocol + (host || 'localhost:7687')
 }

--- a/src/shared/services/utils.js
+++ b/src/shared/services/utils.js
@@ -21,7 +21,6 @@
 
 import parseUrl from 'url-parse'
 import { DESKTOP, CLOUD, WEB } from 'shared/modules/app/appDuck'
-import { getDefaultBoltScheme } from 'shared/modules/features/versionedFeatures'
 
 /**
  * The work objects expected shape:
@@ -481,8 +480,7 @@ export const toKeyString = str => btoa(encodeURIComponent(str))
 
 export const generateBoltHost = host => {
   const urlParts = (host || '').split('://')
-  const protocol =
-    urlParts.length > 1 ? `${urlParts[0]}://` : getDefaultBoltScheme('4.0.0')
+  const protocol = urlParts.length > 1 ? `${urlParts[0]}://` : 'neo4j://'
   host = urlParts.length > 1 ? urlParts[1] : urlParts[0]
   return protocol + (host || 'localhost:7687')
 }

--- a/src/shared/services/utils.test.js
+++ b/src/shared/services/utils.test.js
@@ -674,9 +674,9 @@ describe('toKeyString', () => {
   describe('generateBoltHost', () => {
     it('generates a bolt host as expected', () => {
       const tests = [
-        { host: '', expected: 'bolt://localhost:7687' },
-        { host: 'localhost', expected: 'bolt://localhost' },
-        { host: 'localhost:7688', expected: 'bolt://localhost:7688' },
+        { host: '', expected: 'neo4j://localhost:7687' },
+        { host: 'localhost', expected: 'neo4j://localhost' },
+        { host: 'localhost:7688', expected: 'neo4j://localhost:7688' },
         { host: 'bolt://localhost', expected: 'bolt://localhost' },
         { host: 'bolt://localhost:7688', expected: 'bolt://localhost:7688' },
         { host: 'neo4j://localhost:7688', expected: 'neo4j://localhost:7688' },
@@ -688,7 +688,7 @@ describe('toKeyString', () => {
           host: 'bolt+routing://localhost:7688',
           expected: 'bolt+routing://localhost:7688'
         },
-        { host: null, expected: 'bolt://localhost:7687' }
+        { host: null, expected: 'neo4j://localhost:7687' }
       ]
 
       tests.forEach(test => {


### PR DESCRIPTION
"Default scheme" = The scheme added by neo4j-browser if the user didn't enter a scheme themselves.
Cases like when the connect URL is entered as `localhost`, `localhost:7687` etc.


Notes:
This would need to be changed before merging canary into master since it's now hard coded in some places.
We need to figure out what scheme to use when not connected yet before merging canary into master.

For now we'll have to live with a disconnected master / canary.