### PR TITLE
Prioritize bold_direct over bolt in discovery

### DIFF
--- a/src/shared/modules/discovery/discoveryDuck.js
+++ b/src/shared/modules/discovery/discoveryDuck.js
@@ -128,11 +128,12 @@ export const discoveryOnStartupEpic = (some$, store) => {
           // fake discovery response
           // Promise.resolve({ bolt: 'bolt+routing://localhost:7687' })
           .then(result => {
+            const host = result && (result.bolt_direct || result.bolt)
             // Try to get info from server
-            if (!result || !result.bolt) {
+            if (!host) {
               throw new Error('No bolt address found') // No bolt info from server, throw
             }
-            store.dispatch(updateDiscoveryConnection({ host: result.bolt })) // Update discovery host in redux
+            store.dispatch(updateDiscoveryConnection({ host })) // Update discovery host in redux
             return { type: DONE }
           })
           .catch(e => {

--- a/src/shared/modules/discovery/discoveryDuck.test.js
+++ b/src/shared/modules/discovery/discoveryDuck.test.js
@@ -101,6 +101,48 @@ describe('discoveryOnStartupEpic', () => {
     // When
     store.dispatch(action)
   })
+
+  test('listens on APP_START and finds a bolt_direct host and dispatches an action with the found host', done => {
+    // Given
+    const action = { type: APP_START, env: WEB }
+    const expectedHost = 'bolt://myhost:7777'
+    nock(getDiscoveryEndpoint())
+      .get('/')
+      .reply(200, { bolt_direct: expectedHost })
+    bus.take(discovery.DONE, currentAction => {
+      // Then
+      expect(store.getActions()).toEqual([
+        action,
+        discovery.updateDiscoveryConnection({ host: expectedHost }),
+        { type: discovery.DONE }
+      ])
+      done()
+    })
+
+    // When
+    store.dispatch(action)
+  })
+
+  test('listens on APP_START and finds both a bolt_direct and a bold host and dispatches an action with the found bolt_direct host', done => {
+    // Given
+    const action = { type: APP_START, env: WEB }
+    const expectedHost = 'bolt://myhost:7777'
+    nock(getDiscoveryEndpoint())
+      .get('/')
+      .reply(200, { bolt_direct: expectedHost, bolt: 'very://bad:1337' })
+    bus.take(discovery.DONE, currentAction => {
+      // Then
+      expect(store.getActions()).toEqual([
+        action,
+        discovery.updateDiscoveryConnection({ host: expectedHost }),
+        { type: discovery.DONE }
+      ])
+      done()
+    })
+
+    // When
+    store.dispatch(action)
+  })
   test('listens on APP_START and reads bolt URL from location URL and dispatches an action with the found host', done => {
     // Given
     const action = {


### PR DESCRIPTION
This PR adds support for the new `bolt_direct` field in discovery responses, prioritizing it over the old `bolt` field.

