### PR TITLE
Various small improvements to sysinfo

### DIFF
--- a/src/browser/modules/Stream/AutoRefresh/styled.jsx
+++ b/src/browser/modules/Stream/AutoRefresh/styled.jsx
@@ -31,6 +31,7 @@ export const StyledStatusBar = styled.div`
   line-height: 39px;
   white-space: nowrap;
   font-size: 13px;
+  color: ${props => props.theme.secondaryText};
   position: relative;
   overflow: hidden;
   margin-top: 0;

--- a/src/browser/modules/Stream/SysInfoFrame/helpers.js
+++ b/src/browser/modules/Stream/SysInfoFrame/helpers.js
@@ -24,8 +24,13 @@ import {
   flattenAttributes,
   mapSysInfoRecords
 } from './sysinfo-utils'
-import { SysInfoTableContainer, SysInfoTable } from 'browser-components/Tables'
 import { toHumanReadableBytes } from 'services/utils'
+import {
+  SysInfoTableContainer,
+  SysInfoTable,
+  SysInfoTableEntry
+} from 'browser-components/Tables'
+import { QuestionIcon } from 'browser-components/icons/Icons'
 import Render from 'browser-components/Render/index'
 
 const jmxPrefix = 'neo4j.metrics:name='
@@ -89,7 +94,9 @@ export const Sysinfo = ({
   pageCache,
   storeSizes,
   idAllocation,
-  transactions
+  transactions,
+  isACausalCluster,
+  cc
 }) => {
   const mappedDatabases = databases.map(db => {
     return {
@@ -114,6 +121,24 @@ export const Sysinfo = ({
       <SysInfoTable key='databases' header='Databases'>
         {buildTableData(mappedDatabases)}
       </SysInfoTable>
+      <Render if={isACausalCluster}>
+        <SysInfoTable
+          key='cc-table'
+          header={
+            <span data-testid='sysinfo-casual-cluster-members-title'>
+              Causal Cluster Members{' '}
+              <QuestionIcon title='Values shown in `:sysinfo` may differ between cluster members' />
+            </span>
+          }
+          colspan='3'
+        >
+          <SysInfoTableEntry
+            key='cc-entry'
+            headers={['Roles', 'Addresses', 'Actions']}
+          />
+          {buildTableData(cc)}
+        </SysInfoTable>
+      </Render>
     </SysInfoTableContainer>
   )
 }

--- a/src/browser/modules/Stream/SysInfoFrame/index.jsx
+++ b/src/browser/modules/Stream/SysInfoFrame/index.jsx
@@ -21,6 +21,7 @@
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { withBus } from 'react-suber'
+import dateFormat from 'dateformat'
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
 import { isACausalCluster } from 'shared/modules/features/featuresDuck'
 import {
@@ -49,6 +50,7 @@ export class SysInfoFrame extends Component {
   constructor (props) {
     super(props)
     this.state = {
+      lastFetch: null,
       cc: [],
       ha: [],
       haInstances: [],
@@ -82,6 +84,7 @@ export class SysInfoFrame extends Component {
   }
   getSysInfo () {
     if (this.props.bus && this.props.isConnected) {
+      this.setState({ lastFetch: Date.now() })
       this.props.bus.self(
         CYPHER_REQUEST,
         {
@@ -137,6 +140,8 @@ export class SysInfoFrame extends Component {
             </Render>
             <Render if={this.state.success}>
               <StyledStatusBar>
+                {this.state.lastFetch &&
+                  `Updated: ${dateFormat(this.state.lastFetch)}`}
                 {this.state.success}
                 <RefreshQueriesButton onClick={() => this.getSysInfo()}>
                   <RefreshIcon />

--- a/src/browser/modules/Stream/SysInfoFrame/legacyHelpers.jsx
+++ b/src/browser/modules/Stream/SysInfoFrame/legacyHelpers.jsx
@@ -25,6 +25,7 @@ import {
   buildTableData
 } from './sysinfo-utils'
 import { toHumanReadableBytes } from 'services/utils'
+import arrayHasItems from 'shared/utils/array-has-items'
 import Render from 'browser-components/Render'
 import {
   SysInfoTableContainer,
@@ -68,21 +69,21 @@ export const Sysinfo = ({
               <QuestionIcon title='Values shown in `:sysinfo` may differ between cluster members' />
             </span>
           }
-          colspan='3'
+          colspan='5'
         >
           <SysInfoTableEntry
             key='cc-entry'
-            headers={['Roles', 'Addresses', 'Actions']}
+            headers={['Roles', 'Addresses', 'Groups', 'Database', 'Actions']}
           />
           {buildTableData(cc)}
         </SysInfoTable>
       </Render>
-      <Render if={ha}>
+      <Render if={arrayHasItems(ha)}>
         <SysInfoTable key='ha-table' header='High Availability'>
           {buildTableData(ha)}
         </SysInfoTable>
       </Render>
-      <Render if={haInstances}>
+      <Render if={arrayHasItems(haInstances)}>
         <SysInfoTable key='cluster-table' header='Cluster' colspan='4'>
           <SysInfoTableEntry
             key='ha-entry'
@@ -253,6 +254,8 @@ export const clusterResponseHandler = setState =>
       return [
         ccRecord.role,
         ccRecord.addresses.join(', '),
+        ccRecord.groups.join(', '),
+        ccRecord.database,
         <Render if={httpUrlForMember.length !== 0}>
           <a target='_blank' href={httpUrlForMember[0]}>
             Open

--- a/src/browser/modules/Stream/SysInfoFrame/legacyHelpers.jsx
+++ b/src/browser/modules/Stream/SysInfoFrame/legacyHelpers.jsx
@@ -254,7 +254,7 @@ export const clusterResponseHandler = setState =>
       return [
         ccRecord.role,
         ccRecord.addresses.join(', '),
-        ccRecord.groups.join(', '),
+        (ccRecord.groups || []).join(', '),
         ccRecord.database,
         <Render if={httpUrlForMember.length !== 0}>
           <a target='_blank' href={httpUrlForMember[0]}>

--- a/src/browser/modules/Stream/SysInfoFrame/sysinfo-utils.js
+++ b/src/browser/modules/Stream/SysInfoFrame/sysinfo-utils.js
@@ -95,7 +95,8 @@ export const mapLegacySysInfoRecords = records => {
       id: record.get('id'),
       addresses: record.get('addresses'),
       role: record.get('role'),
-      groups: record.get('groups')
+      groups: record.get('groups'),
+      database: record.get('database')
     }
   })
 }


### PR DESCRIPTION
This PR addresses three requested improvements for `:sysinfo`:
- Add datetime output to frames to show user when information was last updated
- Show Store Size
- Display changes to dbms.cluster.overview

### Screenshots
Cluster
<img width="1600" alt="Screenshot 2019-11-21 at 14 32 55" src="https://user-images.githubusercontent.com/52443771/69342832-af94fe80-0c6c-11ea-861b-c3197e3eef81.png">
3.x
<img width="3254" alt="Screenshot 2019-11-21 at 14 37 09" src="https://user-images.githubusercontent.com/52443771/69342834-af94fe80-0c6c-11ea-983a-5712368ef75e.png">
4.x
<img width="3262" alt="Screenshot 2019-11-21 at 14 38 37" src="https://user-images.githubusercontent.com/52443771/69342836-b02d9500-0c6c-11ea-8ae5-1d399ec509a3.png">

