### PR TITLE
Retry reconnection on pw-change

### DIFF
--- a/src/browser/modules/Frame/FrameSuccess.jsx
+++ b/src/browser/modules/Frame/FrameSuccess.jsx
@@ -20,7 +20,7 @@
 import React from 'react'
 const FrameSuccess = props => {
   if (!props || !props.message) return null
-  return <span style={{ color: 'green' }}>{props.message}</span>
+  return <span className='statusbar--success'>{props.message}</span>
 }
 
 export default FrameSuccess

--- a/src/browser/modules/Frame/styled.jsx
+++ b/src/browser/modules/Frame/styled.jsx
@@ -126,6 +126,12 @@ export const StyledFrameStatusbar = styled.div`
   display: flex;
   flex-direction: row;
   flex: none;
+  align-items: center;
+  padding-left: 10px;
+
+  .statusbar--success {
+    color: ${props => props.theme.success};
+  }
 `
 
 export const StyledFrameSidebar = styled.ul`

--- a/src/browser/modules/Stream/Auth/ChangePasswordForm.jsx
+++ b/src/browser/modules/Stream/Auth/ChangePasswordForm.jsx
@@ -85,8 +85,13 @@ export default class ChangePasswordForm extends Component {
   }
   render () {
     const indexStart = this.props.showExistingPasswordInput ? 1 : 0
+    const { isLoading } = this.props
+    const classNames = []
+    if (isLoading) {
+      classNames.push('isLoading')
+    }
     return (
-      <StyledConnectionForm>
+      <StyledConnectionForm className={classNames.join(' ')}>
         <InputEnterStepping
           steps={this.props.showExistingPasswordInput ? 3 : 2}
           submitAction={this.validateSame}
@@ -108,7 +113,8 @@ export default class ChangePasswordForm extends Component {
                         type: 'password',
                         onChange: this.onExistingPasswordChange,
                         value: this.state.password,
-                        ref: ref => setRefForIndex(0, ref)
+                        ref: ref => setRefForIndex(0, ref),
+                        disabled: isLoading
                       })}
                     />
                   </StyledConnectionFormEntry>
@@ -122,7 +128,8 @@ export default class ChangePasswordForm extends Component {
                       type: 'password',
                       onChange: this.onNewPasswordChange,
                       value: this.state.newPassword,
-                      ref: ref => setRefForIndex(indexStart, ref)
+                      ref: ref => setRefForIndex(indexStart, ref),
+                      disabled: isLoading
                     })}
                   />
                 </StyledConnectionFormEntry>
@@ -136,15 +143,20 @@ export default class ChangePasswordForm extends Component {
                       type: 'password',
                       onChange: this.onNewPasswordChange2,
                       value: this.state.newPassword2,
-                      ref: ref => setRefForIndex(indexStart + 1, ref)
+                      ref: ref => setRefForIndex(indexStart + 1, ref),
+                      disabled: isLoading
                     })}
                   />
                 </StyledConnectionFormEntry>
-                <FormButton
-                  data-testid='changePassword'
-                  label='Change password'
-                  {...getSubmitProps()}
-                />
+                <Render if={!isLoading}>
+                  <FormButton
+                    data-testid='changePassword'
+                    label='Change password'
+                    disabled={isLoading}
+                    {...getSubmitProps()}
+                  />
+                </Render>
+                <Render if={isLoading}>Please wait...</Render>
               </React.Fragment>
             )
           }}

--- a/src/browser/modules/Stream/Auth/ChangePasswordFrame.jsx
+++ b/src/browser/modules/Stream/Auth/ChangePasswordFrame.jsx
@@ -19,6 +19,7 @@
  */
 
 import React, { Component } from 'react'
+import { connect } from 'react-redux'
 
 import ConnectionForm from './ConnectionForm'
 import FrameTemplate from '../../Frame/FrameTemplate'
@@ -26,7 +27,8 @@ import FrameError from '../../Frame/FrameError'
 import Render from 'browser-components/Render'
 import { H3 } from 'browser-components/headers'
 import { Lead } from 'browser-components/Text'
-import { StyledConnectionAside } from './styled'
+import { StyledConnectionFrame, StyledConnectionAside } from './styled'
+import { getActiveConnection } from 'shared/modules/connections/connectionsDuck'
 
 export class ChangePasswordFrame extends Component {
   constructor (props) {
@@ -51,13 +53,14 @@ export class ChangePasswordFrame extends Component {
   }
   render () {
     const content = (
-      <React.Fragment>
+      <StyledConnectionFrame>
         <StyledConnectionAside>
           <H3>Password change</H3>
           <Render if={!this.state.success}>
             <Lead>
-              Enter your current password and the new twice to change your
-              password.
+              {this.props.activeConnection
+                ? 'Enter your current password and the new twice to change your password.'
+                : 'Please connect to a database to change the password.'}
             </Lead>
           </Render>
           <Render if={this.state.success}>
@@ -65,14 +68,16 @@ export class ChangePasswordFrame extends Component {
           </Render>
         </StyledConnectionAside>
 
-        <ConnectionForm
-          {...this.props}
-          error={this.error}
-          onSuccess={this.onSuccess}
-          forcePasswordChange
-          showExistingPasswordInput
-        />
-      </React.Fragment>
+        <Render if={this.props.activeConnection}>
+          <ConnectionForm
+            {...this.props}
+            error={this.error}
+            onSuccess={this.onSuccess}
+            forcePasswordChange
+            showExistingPasswordInput
+          />
+        </Render>
+      </StyledConnectionFrame>
     )
     return (
       <FrameTemplate
@@ -88,4 +93,14 @@ export class ChangePasswordFrame extends Component {
     )
   }
 }
-export default ChangePasswordFrame
+
+const mapStateToProps = state => {
+  return {
+    activeConnection: getActiveConnection(state)
+  }
+}
+
+export default connect(
+  mapStateToProps,
+  () => ({})
+)(ChangePasswordFrame)

--- a/src/browser/modules/Stream/Auth/ChangePasswordFrame.jsx
+++ b/src/browser/modules/Stream/Auth/ChangePasswordFrame.jsx
@@ -27,7 +27,7 @@ import FrameError from '../../Frame/FrameError'
 import Render from 'browser-components/Render'
 import { H3 } from 'browser-components/headers'
 import { Lead } from 'browser-components/Text'
-import { StyledConnectionFrame, StyledConnectionAside } from './styled'
+import { StyledConnectionAside } from './styled'
 import { getActiveConnection } from 'shared/modules/connections/connectionsDuck'
 
 export class ChangePasswordFrame extends Component {
@@ -53,7 +53,7 @@ export class ChangePasswordFrame extends Component {
   }
   render () {
     const content = (
-      <StyledConnectionFrame>
+      <React.Fragment>
         <StyledConnectionAside>
           <H3>Password change</H3>
           <Render if={!this.state.success}>
@@ -77,7 +77,7 @@ export class ChangePasswordFrame extends Component {
             showExistingPasswordInput
           />
         </Render>
-      </StyledConnectionFrame>
+      </React.Fragment>
     )
     return (
       <FrameTemplate

--- a/src/browser/modules/Stream/Auth/ConnectionForm.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectionForm.jsx
@@ -137,7 +137,7 @@ export class ConnectionForm extends Component {
               if (res.error.code === 'Neo.ClientError.Security.Unauthorized') {
                 retries--
                 if (retries > 0) {
-                  this.connect(undefined, retryFn)
+                  setTimeout(() => this.connect(undefined, retryFn), 200)
                 }
               } else {
                 this.props.error(res.error)

--- a/src/browser/modules/Stream/Auth/ConnectionForm.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectionForm.jsx
@@ -67,11 +67,15 @@ export class ConnectionForm extends Component {
       }
     )
   }
-  connect = (doneFn = () => {}, onError = null) => {
+  connect = (
+    doneFn = () => {},
+    onError = null,
+    noResetConnectionOnFail = false
+  ) => {
     this.props.error({})
     this.props.bus.self(
       CONNECT,
-      { ...this.state, noResetConnectionOnFail: true },
+      { ...this.state, noResetConnectionOnFail },
       res => {
         doneFn()
         if (res.success) {
@@ -141,17 +145,29 @@ export class ConnectionForm extends Component {
               if (res.error.code === 'Neo.ClientError.Security.Unauthorized') {
                 retries--
                 if (retries > 0) {
-                  setTimeout(() => this.connect(() => {
-                    this.setState({ isLoading: false })
-                  }, retryFn), 200)
+                  setTimeout(
+                    () =>
+                      this.connect(
+                        () => {
+                          this.setState({ isLoading: false })
+                        },
+                        retryFn,
+                        true
+                      ),
+                    200
+                  )
                 }
               } else {
                 this.props.error(res.error)
               }
             }
-            this.connect(() => {
-              this.setState({ isLoading: false })
-            }, retryFn)
+            this.connect(
+              () => {
+                this.setState({ isLoading: false })
+              },
+              retryFn,
+              true
+            )
           })
         }
         this.setState({ isLoading: false })

--- a/src/browser/modules/Stream/Auth/ConnectionForm.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectionForm.jsx
@@ -113,6 +113,7 @@ export class ConnectionForm extends Component {
     this.props.error({})
   }
   onChangePassword ({ newPassword, error }) {
+    this.setState({ isLoading: true })
     if (error && error.code) {
       this.setState({ isLoading: false })
       return this.props.error(error)
@@ -152,9 +153,8 @@ export class ConnectionForm extends Component {
               this.setState({ isLoading: false })
             }, retryFn)
           })
-        } else {
-          this.setState({ isLoading: false })
         }
+        this.setState({ isLoading: false })
         this.props.error(response.error)
       }
     )

--- a/src/browser/modules/Stream/Auth/styled.jsx
+++ b/src/browser/modules/Stream/Auth/styled.jsx
@@ -24,6 +24,10 @@ import { StyledFrameAside } from '../../Frame/styled'
 
 export const StyledConnectionForm = styled.form`
   padding: 0 15px;
+
+  &.isLoading {
+    opacity: 0.5;
+  }
 `
 export const StyledConnectionAside = styled(StyledFrameAside)``
 export const StyledConnectionFormEntry = styled.div`

--- a/src/browser/modules/User/UserAdd.jsx
+++ b/src/browser/modules/User/UserAdd.jsx
@@ -59,9 +59,10 @@ export class UserAdd extends Component {
       username: '',
       password: '',
       confirmPassword: '',
-      forcePasswordChange: false,
+      forcePasswordChange: '',
       errors: null,
-      success: null
+      success: null,
+      isLoading: false
     }
   }
   componentWillMount () {
@@ -116,9 +117,17 @@ export class UserAdd extends Component {
         )
     })
     if (errors.length > 0) {
-      return this.setState({ errors: errors })
+      return this.setState({ errors: errors, isLoading: false })
     }
-    return this.setState({ success: `User '${this.state.username}' created` })
+    return this.setState({
+      success: `User '${this.state.username}' created`,
+      username: '',
+      password: '',
+      confirmPassword: '',
+      roles: [],
+      forcePasswordChange: '',
+      isLoading: false
+    })
   }
   getRoles () {
     this.props.bus &&
@@ -149,7 +158,7 @@ export class UserAdd extends Component {
       )
   }
   submit () {
-    this.setState({ success: null, errors: null })
+    this.setState({ isLoading: true, success: null, errors: null })
     let errors = []
     if (!this.state.username) errors.push('Missing username')
     if (!this.state.password) errors.push('Missing password')
@@ -178,7 +187,8 @@ export class UserAdd extends Component {
                 ? response.error.message
                 : 'Unknown error'
             return this.setState({
-              errors: ['Unable to create user', error]
+              errors: ['Unable to create user', error],
+              isLoading: false
             })
           }
           return this.addRoles()
@@ -211,6 +221,8 @@ export class UserAdd extends Component {
   }
 
   render () {
+    const { isLoading } = this.props
+
     const listOfAvailableRoles = rolesSelectorId =>
       this.state.availableRoles ? (
         <RolesSelector
@@ -244,7 +256,9 @@ export class UserAdd extends Component {
             className='username'
             name={usernameId}
             id={usernameId}
+            value={this.state.username}
             onChange={this.updateUsername.bind(this)}
+            disabled={isLoading}
           />
         </StyledFormElement>
 
@@ -256,7 +270,9 @@ export class UserAdd extends Component {
               className='password'
               name={passwordId}
               id={passwordId}
+              value={this.state.password}
               onChange={this.updatePassword.bind(this)}
+              disabled={isLoading}
             />
           </StyledFormElement>
           <StyledFormElement>
@@ -268,7 +284,9 @@ export class UserAdd extends Component {
               className='password-confirm'
               name={passwordConfirmId}
               id={passwordConfirmId}
+              value={this.state.confirmPassword}
               onChange={this.confirmUpdatePassword.bind(this)}
+              disabled={isLoading}
             />
           </StyledFormElement>
         </StyledFormElementWrapper>
@@ -283,6 +301,8 @@ export class UserAdd extends Component {
           <StyledLabel>
             <StyledInput
               onClick={this.updateForcePasswordChange.bind(this)}
+              checked={this.state.forcePasswordChange}
+              disabled={isLoading}
               type='checkbox'
             />
             Force password change
@@ -290,7 +310,11 @@ export class UserAdd extends Component {
         </StyledFormElement>
 
         <StyledFormElement>
-          <FormButton onClick={this.submit.bind(this)} label='Add User' />
+          <FormButton
+            onClick={this.submit.bind(this)}
+            label='Add User'
+            disabled={isLoading}
+          />
         </StyledFormElement>
 
         <StyledLink onClick={this.openListUsersFrame.bind(this)}>

--- a/src/shared/rootEpic.js
+++ b/src/shared/rootEpic.js
@@ -38,7 +38,8 @@ import {
   switchConnectionEpic,
   switchConnectionSuccessEpic,
   switchConnectionFailEpic,
-  silentDisconnectEpic
+  silentDisconnectEpic,
+  verifyConnectionCredentialsEpic
 } from './modules/connections/connectionsDuck'
 import {
   dbMetaEpic,
@@ -99,6 +100,7 @@ export default combineEpics(
   jmxEpic,
   disconnectEpic,
   silentDisconnectEpic,
+  verifyConnectionCredentialsEpic,
   startupConnectEpic,
   disconnectSuccessEpic,
   startupConnectionSuccessEpic,

--- a/src/shared/services/bolt/boltConnection.js
+++ b/src/shared/services/bolt/boltConnection.js
@@ -283,7 +283,7 @@ export const closeConnection = () => {
 }
 
 export const ensureConnection = (props, opts, onLostConnection) => {
-  const session = _drivers ? _drivers.getRoutedDriver().session() : false
+  const session = _drivers ? _drivers.getDirectDriver().session() : false
   if (session) {
     return new Promise((resolve, reject) => {
       session.close()

--- a/src/shared/services/bolt/boltConnection.js
+++ b/src/shared/services/bolt/boltConnection.js
@@ -283,7 +283,7 @@ export const closeConnection = () => {
 }
 
 export const ensureConnection = (props, opts, onLostConnection) => {
-  const session = _drivers ? _drivers.getDirectDriver().session() : false
+  const session = _drivers ? _drivers.getRoutedDriver().session() : false
   if (session) {
     return new Promise((resolve, reject) => {
       session.close()


### PR DESCRIPTION
If the new password successfully was set when changing password, but it’s not accepted when trying to connect, retry up to 5 times before failing.

Also, when validating old credentials, don’t reconstruct the main driver instance. Create a new one and validate on that one.