### PR TITLE
Statusbar and Code ligature issues 

### DIFF
--- a/src/browser/modules/Carousel/style.less
+++ b/src/browser/modules/Carousel/style.less
@@ -298,6 +298,10 @@
     color: #c7254e;
     background-color: #f9f2f4;
     border-radius: 4px;
+
+    a {
+      color: #c7254e !important;
+    }
   }
   & figcaption {
     font-style: italic;

--- a/src/browser/modules/Carousel/style.less
+++ b/src/browser/modules/Carousel/style.less
@@ -62,7 +62,7 @@
     word-wrap: break-word;
 
     .disable-font-ligatures & {
-      font-variant-ligatures: none;
+      font-variant-ligatures: none !important;
     }
   }
   & th {
@@ -284,7 +284,7 @@
     text-decoration: none;
 
     .disable-font-ligatures & {
-      font-variant-ligatures: none;
+      font-variant-ligatures: none !important;
     }
   }
   & pre {

--- a/src/browser/modules/Editor/styled.jsx
+++ b/src/browser/modules/Editor/styled.jsx
@@ -76,7 +76,7 @@ const BaseEditorWrapper = styled.div`
   }
 
   .disable-font-ligatures & {
-    font-variant-ligatures: none;
+    font-variant-ligatures: none !important;
   }
 `
 

--- a/src/browser/modules/Frame/styled.jsx
+++ b/src/browser/modules/Frame/styled.jsx
@@ -186,6 +186,6 @@ export const StyledFrameCommand = styled.label`
     content: '$ ';
   }
   .disable-font-ligatures & {
-    font-variant-ligatures: none;
+    font-variant-ligatures: none !important;
   }
 `

--- a/src/browser/modules/Stream/Auth/styled.jsx
+++ b/src/browser/modules/Stream/Auth/styled.jsx
@@ -63,4 +63,8 @@ export const StyledCode = styled.code`
   cursor: pointer;
   border: none;
   padding: 2px 4px;
+
+  a {
+    color: #c7254e !important;
+  }
 `

--- a/src/browser/modules/Stream/AutoRefresh/styled.jsx
+++ b/src/browser/modules/Stream/AutoRefresh/styled.jsx
@@ -29,16 +29,10 @@ export const StatusbarWrapper = styled.div`
 export const StyledStatusBar = styled.div`
   min-height: 39px;
   line-height: 39px;
-  color: #788185;
-  background-color: #fff;
   white-space: nowrap;
   font-size: 13px;
   position: relative;
-  float: right;
   overflow: hidden;
-  border-top: 1px solid #e6e9ef;
-  margin-bottom: -39px;
-  padding-left: 16px;
   margin-top: 0;
   width: 100%;
 `
@@ -49,7 +43,7 @@ export const RefreshQueriesButton = styled(FrameButton)`
 
 export const AutoRefreshSpan = styled.span`
   float: right;
-  margin-right: 5px;
+  margin-right: 10px;
 `
 
 const ToggleLabel = styled.label`

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/ErrorsView.test.js.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/ErrorsView.test.js.snap
@@ -49,7 +49,7 @@ exports[`ErrorsViews ErrorsView displays procedure link if unknown procedure 1`]
         class="styled__StyledDiv-sc-1dtvgs1-7 hvhkie"
       >
         <pre
-          class="styled__StyledPreformattedArea-sc-1dtvgs1-19 kYkFhf"
+          class="styled__StyledPreformattedArea-sc-1dtvgs1-19 bNiVzc"
         >
           not found
         </pre>
@@ -97,7 +97,7 @@ exports[`ErrorsViews ErrorsView does displays an error 1`] = `
         class="styled__StyledDiv-sc-1dtvgs1-7 hvhkie"
       >
         <pre
-          class="styled__StyledPreformattedArea-sc-1dtvgs1-19 kYkFhf"
+          class="styled__StyledPreformattedArea-sc-1dtvgs1-19 bNiVzc"
         >
           Test error description
         </pre>

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/WarningsView.test.js.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/WarningsView.test.js.snap
@@ -36,7 +36,7 @@ exports[`WarningsViews WarningsView does displays a warning 1`] = `
           class="styled__StyledDiv-sc-1dtvgs1-7 hvhkie"
         >
           <pre
-            class="styled__StyledPreformattedArea-sc-1dtvgs1-19 kYkFhf"
+            class="styled__StyledPreformattedArea-sc-1dtvgs1-19 bNiVzc"
           >
             EXPLAIN MATCH xx3
             <br
@@ -86,7 +86,7 @@ exports[`WarningsViews WarningsView does displays multiple warnings 1`] = `
           class="styled__StyledDiv-sc-1dtvgs1-7 hvhkie"
         >
           <pre
-            class="styled__StyledPreformattedArea-sc-1dtvgs1-19 kYkFhf"
+            class="styled__StyledPreformattedArea-sc-1dtvgs1-19 bNiVzc"
           >
             EXPLAIN MATCH zz3
             <br
@@ -127,7 +127,7 @@ exports[`WarningsViews WarningsView does displays multiple warnings 1`] = `
           class="styled__StyledDiv-sc-1dtvgs1-7 hvhkie"
         >
           <pre
-            class="styled__StyledPreformattedArea-sc-1dtvgs1-19 kYkFhf"
+            class="styled__StyledPreformattedArea-sc-1dtvgs1-19 bNiVzc"
           >
             EXPLAIN MATCH zz3
             <br

--- a/src/browser/modules/Stream/Queries/styled.jsx
+++ b/src/browser/modules/Stream/Queries/styled.jsx
@@ -26,6 +26,10 @@ export const Code = styled.code`
   color: #c7254e;
   background-color: #f9f2f4;
   border-radius: 4px;
+
+  a {
+    color: #c7254e !important;
+  }
 `
 export const StyledTableWrapper = styled.div`
   margin: 20px 10px;

--- a/src/browser/modules/Stream/__snapshots__/SchemaFrame.test.js.snap
+++ b/src/browser/modules/Stream/__snapshots__/SchemaFrame.test.js.snap
@@ -3,7 +3,7 @@
 exports[`SchemaFrame renders empty 1`] = `
 <div>
   <pre
-    class="styled__StyledPreformattedArea-sc-1dtvgs1-19 styled__StyledSchemaBody-sc-1dtvgs1-25 jQHaiF"
+    class="styled__StyledPreformattedArea-sc-1dtvgs1-19 styled__StyledSchemaBody-sc-1dtvgs1-25 jaUnyF"
   >
     No indexes
 
@@ -16,7 +16,7 @@ No constraints
 exports[`SchemaFrame renders with result 1`] = `
 <div>
   <pre
-    class="styled__StyledPreformattedArea-sc-1dtvgs1-19 styled__StyledSchemaBody-sc-1dtvgs1-25 jQHaiF"
+    class="styled__StyledPreformattedArea-sc-1dtvgs1-19 styled__StyledSchemaBody-sc-1dtvgs1-25 jaUnyF"
   >
     Indexes
    ON :Movie(released) ONLINE 

--- a/src/browser/modules/Stream/styled.jsx
+++ b/src/browser/modules/Stream/styled.jsx
@@ -144,7 +144,7 @@ export const StyledPreformattedArea = styled.pre`
   color: ${props => props.theme.preText};
 
   .disable-font-ligatures & {
-    font-variant-ligatures: none;
+    font-variant-ligatures: none !important;
   }
 `
 

--- a/src/browser/styles/global-styles.js
+++ b/src/browser/styles/global-styles.js
@@ -58,7 +58,7 @@ export const GlobalStyle = createGlobalStyle`
     padding: 0 !important;
 
     .disable-font-ligatures & {
-      font-variant-ligatures: none;
+      font-variant-ligatures: none !important;
     }
   }
 


### PR DESCRIPTION
Fixes:

* Issue with the statusbar on the `:sysinfo` and `:queries` frames.
![image](https://user-images.githubusercontent.com/80759/68666383-1f580a80-0544-11ea-96e2-e1c525aabcf0.png)

* Issue where code ligatures in the editor aren't affected by the setting under 'Browser settings'.
![image](https://user-images.githubusercontent.com/80759/68666455-41ea2380-0544-11ea-952e-0a812f44f832.png)

* Issue where links are not visible in code-blocks in dark mode.
![image](https://user-images.githubusercontent.com/80759/68667060-65619e00-0545-11ea-9ee0-025cd2493339.png)

changelog: Fix various UI glitches