### PR TITLE
Don’t auto-connect without credentials

### DIFF
--- a/src/browser/modules/Stream/Auth/ConnectForm.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectForm.jsx
@@ -24,10 +24,17 @@ import { FormButton } from 'browser-components/buttons'
 import {
   StyledConnectionForm,
   StyledConnectionTextInput,
+  StyledConnectionSelect,
   StyledConnectionLabel,
   StyledConnectionFormEntry
 } from './styled'
 import InputEnterStepping from 'browser-components/InputEnterStepping/InputEnterStepping'
+import { NATIVE, NO_AUTH } from 'services/bolt/boltHelpers'
+
+const readableauthenticationMethods = {
+  [NATIVE]: 'Username / Password',
+  [NO_AUTH]: 'No authentication'
+}
 
 export default class ConnectForm extends Component {
   state = {
@@ -63,31 +70,54 @@ export default class ConnectForm extends Component {
                     })}
                   />
                 </StyledConnectionFormEntry>
-
                 <StyledConnectionFormEntry>
-                  <StyledConnectionLabel>Username</StyledConnectionLabel>
-                  <StyledConnectionTextInput
+                  <StyledConnectionLabel>
+                    Authentication type
+                  </StyledConnectionLabel>
+                  <StyledConnectionSelect
                     {...getInputPropsForIndex(1, {
-                      'data-testid': 'username',
-                      onChange: this.props.onUsernameChange,
-                      defaultValue: this.props.username,
+                      'data-testid': 'authenticationMethod',
+                      onChange: this.props.onAuthenticationMethodChange,
+                      value: this.props.authenticationMethod,
                       ref: ref => setRefForIndex(1, ref)
                     })}
-                  />
+                  >
+                    {[NATIVE, NO_AUTH].map((auth, i) => (
+                      <option value={auth} key={i}>
+                        {readableauthenticationMethods[auth]}
+                      </option>
+                    ))}
+                  </StyledConnectionSelect>
                 </StyledConnectionFormEntry>
 
-                <StyledConnectionFormEntry>
-                  <StyledConnectionLabel>Password</StyledConnectionLabel>
-                  <StyledConnectionTextInput
-                    {...getInputPropsForIndex(2, {
-                      'data-testid': 'password',
-                      onChange: this.props.onPasswordChange,
-                      defaultValue: this.props.password,
-                      type: 'password',
-                      ref: ref => setRefForIndex(2, ref)
-                    })}
-                  />
-                </StyledConnectionFormEntry>
+                {this.props.authenticationMethod === NATIVE && (
+                  <StyledConnectionFormEntry>
+                    <StyledConnectionLabel>Username</StyledConnectionLabel>
+                    <StyledConnectionTextInput
+                      {...getInputPropsForIndex(2, {
+                        'data-testid': 'username',
+                        onChange: this.props.onUsernameChange,
+                        defaultValue: this.props.username,
+                        ref: ref => setRefForIndex(2, ref)
+                      })}
+                    />
+                  </StyledConnectionFormEntry>
+                )}
+
+                {this.props.authenticationMethod === NATIVE && (
+                  <StyledConnectionFormEntry>
+                    <StyledConnectionLabel>Password</StyledConnectionLabel>
+                    <StyledConnectionTextInput
+                      {...getInputPropsForIndex(3, {
+                        'data-testid': 'password',
+                        onChange: this.props.onPasswordChange,
+                        defaultValue: this.props.password,
+                        type: 'password',
+                        ref: ref => setRefForIndex(3, ref)
+                      })}
+                    />
+                  </StyledConnectionFormEntry>
+                )}
 
                 <Render if={!this.state.connecting}>
                   <FormButton data-testid='connect' {...getSubmitProps()}>

--- a/src/browser/modules/Stream/Auth/ConnectionForm.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectionForm.jsx
@@ -47,7 +47,8 @@ export class ConnectionForm extends Component {
     const connection =
       this.props.activeConnectionData || this.props.frame.connectionData
     const isConnected = !!props.activeConnection
-    const authenticationMethod = connection.authenticationMethod || NATIVE
+    const authenticationMethod =
+      (connection && connection.authenticationMethod) || NATIVE
 
     this.state = {
       ...connection,

--- a/src/browser/modules/Stream/Auth/ConnectionFrame.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectionFrame.jsx
@@ -59,7 +59,7 @@ export class ConnectionFrame extends Component {
                 <React.Fragment>
                   <H3>Connect to Neo4j</H3>
                   <Lead>
-                    Database access requires an authenticated connection.
+                    Database access might require an authenticated connection.
                   </Lead>
                 </React.Fragment>
               </Render>

--- a/src/browser/modules/Stream/Auth/styled.jsx
+++ b/src/browser/modules/Stream/Auth/styled.jsx
@@ -19,7 +19,7 @@
  */
 
 import styled from 'styled-components'
-import { StyledInput } from 'browser-components/Form'
+import { StyledInput, StyledSelect } from 'browser-components/Form'
 import { StyledFrameAside } from '../../Frame/styled'
 
 export const StyledConnectionForm = styled.form`
@@ -43,6 +43,12 @@ export const StyledConnectionTextInput = styled(StyledInput)`
   min-width: 200px;
   width: 44%;
 `
+
+export const StyledConnectionSelect = styled(StyledSelect)`
+  min-width: 200px;
+  width: 44%;
+`
+
 export const StyledConnectionBodyContainer = styled.div`
   flex: 1 1 auto;
 `

--- a/src/shared/modules/connections/connectionsDuck.test.js
+++ b/src/shared/modules/connections/connectionsDuck.test.js
@@ -200,7 +200,7 @@ describe('connectionsDucks Epics', () => {
           expect(store.getActions()).toEqual([
             action,
             connections.setActiveConnection(null),
-            updateDiscoveryConnection({ username: 'neo4j', password: '' }),
+            updateDiscoveryConnection({ username: '', password: '' }),
             currentAction
           ])
           expect(bolt.openConnection).toHaveBeenCalledTimes(0)
@@ -285,10 +285,10 @@ describe('startupConnectEpic', () => {
           expect(actions).toEqual([
             action,
             connections.setActiveConnection(null),
-            updateDiscoveryConnection({ username: 'neo4j', password: '' }),
+            updateDiscoveryConnection({ username: '', password: '' }),
             currentAction
           ])
-          expect(bolt.openConnection).toHaveBeenCalledTimes(2)
+          expect(bolt.openConnection).toHaveBeenCalledTimes(1)
           expect(bolt.closeConnection).toHaveBeenCalledTimes(1)
           resolve()
         } catch (e) {

--- a/src/shared/services/bolt/boltHelpers.js
+++ b/src/shared/services/bolt/boltHelpers.js
@@ -23,6 +23,7 @@ import { getUrlInfo } from 'services/utils'
 
 export const KERBEROS = 'KERBEROS'
 export const NATIVE = 'NATIVE'
+export const NO_AUTH = 'NO_AUTH'
 
 export const getEncryptionMode = options => {
   if (options && typeof options['encrypted'] !== 'undefined') {


### PR DESCRIPTION
Remove the initial empty auth check when neo4j-browser loads.
This is not no pollute the security log file with false positives for denied connection attempts.

Users will now always have to confirm their connection and authentication method if no credentials are stored.
The auto-connect on startup _with_ credentials is still there.


<img width="996" alt="oskarhane-mbpt 2019-11-13 at 09 28 06" src="https://user-images.githubusercontent.com/570998/68746307-9d75e900-05f8-11ea-8a0d-76c28b961dba.png">

<img width="1008" alt="oskarhane-mbpt 2019-11-13 at 09 27 47" src="https://user-images.githubusercontent.com/570998/68746311-a36bca00-05f8-11ea-81af-00f6eede6313.png">
