### PR TITLE
Fix issue with `:server user add`.

### DIFF
--- a/src/browser/modules/User/UserAdd.jsx
+++ b/src/browser/modules/User/UserAdd.jsx
@@ -300,7 +300,7 @@ export class UserAdd extends Component {
         <StyledFormElement>
           <StyledLabel>
             <StyledInput
-              onClick={this.updateForcePasswordChange.bind(this)}
+              onChange={this.updateForcePasswordChange.bind(this)}
               checked={this.state.forcePasswordChange}
               disabled={isLoading}
               type='checkbox'

--- a/src/shared/modules/cypher/boltUserHelper.js
+++ b/src/shared/modules/cypher/boltUserHelper.js
@@ -29,7 +29,7 @@ export function createDatabaseUser ({
   password,
   forcePasswordChange
 }) {
-  return `CALL dbms.security.createUser("${username}", "${password}", ${forcePasswordChange})`
+  return `CALL dbms.security.createUser("${username}", "${password}", ${!!forcePasswordChange})`
 }
 export function deleteUser (username) {
   return `CALL dbms.security.deleteUser("${username}")`


### PR DESCRIPTION
Force use password returns an empty string when unchecked but dbms.security.createUser expects a boolean.

changelog: Fix "Force password change" on `:server user add`