### PR TITLE
User handling, bolt+routing, :schema fixes

### DIFF
--- a/src/browser/modules/Stream/SchemaFrame.jsx
+++ b/src/browser/modules/Stream/SchemaFrame.jsx
@@ -20,6 +20,8 @@
 
 import React, { Component } from 'react'
 import { withBus } from 'react-suber'
+import { replace } from 'lodash-es'
+
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
 import FrameTemplate from '../Frame/FrameTemplate'
 import { StyledSchemaBody } from './styled'
@@ -86,7 +88,8 @@ export class SchemaFrame extends Component {
     } else {
       indexString = 'Indexes'
       indexString += indexes.reduce((acc, index) => {
-        acc += `\n  ${index.description.replace(
+        acc += `\n  ${replace(
+          index.description,
           'INDEX',
           ''
         )} ${index.state.toUpperCase()} ${

--- a/src/browser/modules/User/UserAdd.jsx
+++ b/src/browser/modules/User/UserAdd.jsx
@@ -21,6 +21,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { withBus } from 'react-suber'
 import uuid from 'uuid'
+import { map } from 'lodash-es'
 
 import { executeCommand } from 'shared/modules/commands/commandsDuck'
 import { canAssignRolesToUser } from 'shared/modules/features/featuresDuck'
@@ -160,8 +161,8 @@ export class UserAdd extends Component {
               []
             )
           return this.setState({
-            availableRoles: flatten(
-              this.extractUserNameAndRolesFromBolt(response.result)
+            availableRoles: map(response.result.records, record =>
+              record.get('role')
             )
           })
         }

--- a/src/browser/modules/User/UserAdd.jsx
+++ b/src/browser/modules/User/UserAdd.jsx
@@ -49,6 +49,7 @@ import {
 } from 'browser-components/Form'
 import { StyledInput, StyleRolesContainer } from './styled'
 import { NEO4J_BROWSER_USER_ACTION_QUERY } from 'services/bolt/txMetadata'
+import { driverDatabaseSelection } from 'shared/modules/features/versionedFeatures'
 
 export class UserAdd extends Component {
   constructor (props) {
@@ -106,12 +107,17 @@ export class UserAdd extends Component {
         this.props.bus.self(
           CYPHER_REQUEST,
           {
-            query: addRoleToUser(this.state.username, role),
-            queryType: NEO4J_BROWSER_USER_ACTION_QUERY
+            query: addRoleToUser(
+              this.state.username,
+              role,
+              Boolean(this.props.useSystemDb)
+            ),
+            queryType: NEO4J_BROWSER_USER_ACTION_QUERY,
+            useDb: this.props.useSystemDb
           },
           response => {
             if (!response.success) {
-              return errors.add(response.error)
+              return errors.push(response.error)
             }
           }
         )
@@ -133,7 +139,11 @@ export class UserAdd extends Component {
     this.props.bus &&
       this.props.bus.self(
         CYPHER_REQUEST,
-        { query: listRolesQuery(), queryType: NEO4J_BROWSER_USER_ACTION_QUERY },
+        {
+          query: listRolesQuery(Boolean(this.props.useSystemDb)),
+          queryType: NEO4J_BROWSER_USER_ACTION_QUERY,
+          useDb: this.props.useSystemDb
+        },
         response => {
           if (!response.success) {
             const error =
@@ -177,8 +187,12 @@ export class UserAdd extends Component {
       this.props.bus.self(
         CYPHER_REQUEST,
         {
-          query: createDatabaseUser(this.state),
-          queryType: NEO4J_BROWSER_USER_ACTION_QUERY
+          query: createDatabaseUser(
+            this.state,
+            Boolean(this.props.useSystemDb)
+          ),
+          queryType: NEO4J_BROWSER_USER_ACTION_QUERY,
+          useDb: this.props.useSystemDb
         },
         response => {
           if (!response.success) {
@@ -337,7 +351,7 @@ export class UserAdd extends Component {
         aside={
           <FrameAside
             title='Add user'
-            subtitle='Add a user to the current databse'
+            subtitle='Add a user to the current database'
           />
         }
         contents={frameContents}
@@ -348,8 +362,11 @@ export class UserAdd extends Component {
 }
 
 const mapStateToProps = state => {
+  const { database } = driverDatabaseSelection(state, 'system') || {}
+
   return {
-    canAssignRolesToUser: canAssignRolesToUser(state)
+    canAssignRolesToUser: canAssignRolesToUser(state),
+    useSystemDb: database
   }
 }
 

--- a/src/browser/modules/User/UserAdd.jsx
+++ b/src/browser/modules/User/UserAdd.jsx
@@ -113,6 +113,10 @@ export class UserAdd extends Component {
               role,
               Boolean(this.props.useSystemDb)
             ),
+            params: {
+              username: this.state.username,
+              role
+            },
             queryType: NEO4J_BROWSER_USER_ACTION_QUERY,
             useDb: this.props.useSystemDb
           },
@@ -192,6 +196,10 @@ export class UserAdd extends Component {
             this.state,
             Boolean(this.props.useSystemDb)
           ),
+          params: {
+            username: this.state.username,
+            password: this.state.password
+          },
           queryType: NEO4J_BROWSER_USER_ACTION_QUERY,
           useDb: this.props.useSystemDb
         },

--- a/src/browser/modules/User/UserInformation.jsx
+++ b/src/browser/modules/User/UserInformation.jsx
@@ -43,6 +43,8 @@ import {
 
 import RolesSelector from './RolesSelector'
 import { NEO4J_BROWSER_USER_ACTION_QUERY } from 'services/bolt/txMetadata'
+import { driverDatabaseSelection } from 'shared/modules/features/versionedFeatures'
+import { connect } from 'react-redux'
 
 export class UserInformation extends Component {
   constructor (props) {
@@ -50,16 +52,17 @@ export class UserInformation extends Component {
     this.state = {
       edit: false,
       availableRoles: this.props.availableRoles || [],
-      roles: this.props.roles || [],
-      username: this.props.username
+      roles: this.props.user.roles || [],
+      username: this.props.user.username
     }
   }
   removeClick (thing) {
     this.props.bus.self(
       CYPHER_REQUEST,
       {
-        query: deleteUser(this.state.username),
-        queryType: NEO4J_BROWSER_USER_ACTION_QUERY
+        query: deleteUser(this.state.username, Boolean(this.props.useSystemDb)),
+        queryType: NEO4J_BROWSER_USER_ACTION_QUERY,
+        useDb: this.props.useSystemDb
       },
       this.handleResponse.bind(this)
     )
@@ -68,8 +71,12 @@ export class UserInformation extends Component {
     this.props.bus.self(
       CYPHER_REQUEST,
       {
-        query: suspendUser(this.state.username),
-        queryType: NEO4J_BROWSER_USER_ACTION_QUERY
+        query: suspendUser(
+          this.state.username,
+          Boolean(this.props.useSystemDb)
+        ),
+        queryType: NEO4J_BROWSER_USER_ACTION_QUERY,
+        useDb: this.props.useSystemDb
       },
       this.handleResponse.bind(this)
     )
@@ -78,23 +85,26 @@ export class UserInformation extends Component {
     this.props.bus.self(
       CYPHER_REQUEST,
       {
-        query: activateUser(this.state.username),
-        queryType: NEO4J_BROWSER_USER_ACTION_QUERY
+        query: activateUser(
+          this.state.username,
+          Boolean(this.props.useSystemDb)
+        ),
+        queryType: NEO4J_BROWSER_USER_ACTION_QUERY,
+        useDb: this.props.useSystemDb
       },
       this.handleResponse.bind(this)
     )
   }
-  status = () =>
-    this.props.status.includes('is_suspended') ? 'Suspended' : 'Active'
+  status = () => (!this.props.user.active ? 'Suspended' : 'Active')
   statusButton () {
-    return this.props.status.includes('is_suspended') ? (
+    return !this.props.user.active ? (
       <FormButton label='Activate' onClick={this.activateUser.bind(this)} />
     ) : (
       <FormButton label='Suspend' onClick={this.suspendUser.bind(this)} />
     )
   }
   passwordChange = () =>
-    this.props.status.includes('password_change_required') ? 'Required' : '-'
+    this.props.user.passwordChangeRequired ? 'Required' : '-'
   listRoles () {
     return (
       !!this.state.roles.length && (
@@ -110,8 +120,13 @@ export class UserInformation extends Component {
                   this.props.bus.self(
                     CYPHER_REQUEST,
                     {
-                      query: removeRoleFromUser(role, this.state.username),
-                      queryType: NEO4J_BROWSER_USER_ACTION_QUERY
+                      query: removeRoleFromUser(
+                        role,
+                        this.state.username,
+                        Boolean(this.props.useSystemDb)
+                      ),
+                      queryType: NEO4J_BROWSER_USER_ACTION_QUERY,
+                      useDb: this.props.useSystemDb
                     },
                     this.handleResponse.bind(this)
                   )
@@ -127,8 +142,13 @@ export class UserInformation extends Component {
     this.props.bus.self(
       CYPHER_REQUEST,
       {
-        query: addRoleToUser(this.state.username, event.target.value),
-        queryType: NEO4J_BROWSER_USER_ACTION_QUERY
+        query: addRoleToUser(
+          this.state.username,
+          event.target.value,
+          Boolean(this.props.useSystemDb)
+        ),
+        queryType: NEO4J_BROWSER_USER_ACTION_QUERY,
+        useDb: this.props.useSystemDb
       },
       this.handleResponse.bind(this)
     )
@@ -139,14 +159,16 @@ export class UserInformation extends Component {
   }
   availableRoles () {
     return this.state.availableRoles.filter(
-      role => this.props.roles.indexOf(role) < 0
+      role => this.props.user.roles.indexOf(role) < 0
     )
   }
   render () {
     return (
       <StyledBodyTr className='user-info'>
         <StyledUserTd className='username' aria-labelledby='username'>
-          <StyledButtonContainer>{this.props.username}</StyledButtonContainer>
+          <StyledButtonContainer>
+            {this.props.user.username}
+          </StyledButtonContainer>
         </StyledUserTd>
         <StyledUserTd className='roles' aria-labelledby='roles'>
           <RolesSelector
@@ -160,23 +182,19 @@ export class UserInformation extends Component {
         </StyledUserTd>
         <StyledUserTd className='status' aria-labelledby='status'>
           <StyledButtonContainer
-            className={`status-indicator status-${this.status(
-              this.props.status
-            ).toLowerCase()}`}
+            className={`status-indicator status-${this.status().toLowerCase()}`}
           >
-            {this.status(this.props.status)}
+            {this.status()}
           </StyledButtonContainer>
         </StyledUserTd>
         <StyledUserTd className='status-action' aria-labelledby='status-action'>
-          {this.statusButton(this.props.status)}
+          {this.statusButton()}
         </StyledUserTd>
         <StyledUserTd
           className='password-change'
           aria-labelledby='password-change'
         >
-          <StyledButtonContainer>
-            {this.passwordChange(this.props.status)}
-          </StyledButtonContainer>
+          <StyledButtonContainer>{this.passwordChange()}</StyledButtonContainer>
         </StyledUserTd>
         <StyledUserTd className='delete' aria-labelledby='delete'>
           <FormButton
@@ -190,5 +208,17 @@ export class UserInformation extends Component {
     )
   }
 }
+const mapStateToProps = state => {
+  const { database } = driverDatabaseSelection(state, 'system') || {}
 
-export default withBus(UserInformation)
+  return {
+    useSystemDb: database
+  }
+}
+
+export default withBus(
+  connect(
+    mapStateToProps,
+    null
+  )(UserInformation)
+)

--- a/src/browser/modules/User/UserInformation.jsx
+++ b/src/browser/modules/User/UserInformation.jsx
@@ -61,6 +61,9 @@ export class UserInformation extends Component {
       CYPHER_REQUEST,
       {
         query: deleteUser(this.state.username, Boolean(this.props.useSystemDb)),
+        params: {
+          username: this.state.username
+        },
         queryType: NEO4J_BROWSER_USER_ACTION_QUERY,
         useDb: this.props.useSystemDb
       },
@@ -75,6 +78,9 @@ export class UserInformation extends Component {
           this.state.username,
           Boolean(this.props.useSystemDb)
         ),
+        params: {
+          username: this.state.username
+        },
         queryType: NEO4J_BROWSER_USER_ACTION_QUERY,
         useDb: this.props.useSystemDb
       },
@@ -89,6 +95,9 @@ export class UserInformation extends Component {
           this.state.username,
           Boolean(this.props.useSystemDb)
         ),
+        params: {
+          username: this.state.username
+        },
         queryType: NEO4J_BROWSER_USER_ACTION_QUERY,
         useDb: this.props.useSystemDb
       },
@@ -125,6 +134,10 @@ export class UserInformation extends Component {
                         this.state.username,
                         Boolean(this.props.useSystemDb)
                       ),
+                      params: {
+                        username: this.state.username,
+                        role
+                      },
                       queryType: NEO4J_BROWSER_USER_ACTION_QUERY,
                       useDb: this.props.useSystemDb
                     },
@@ -147,6 +160,10 @@ export class UserInformation extends Component {
           event.target.value,
           Boolean(this.props.useSystemDb)
         ),
+        params: {
+          username: this.state.username,
+          role: event.target.value
+        },
         queryType: NEO4J_BROWSER_USER_ACTION_QUERY,
         useDb: this.props.useSystemDb
       },

--- a/src/browser/modules/User/UserList.jsx
+++ b/src/browser/modules/User/UserList.jsx
@@ -107,8 +107,8 @@ export class UserList extends Component {
           arr.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), [])
         if (response.success) {
           this.setState({
-            listRoles: flatten(
-              this.extractUserNameAndRolesFromBolt(response.result)
+            listRoles: map(response.result.records, record =>
+              record.get('role')
             )
           })
         }

--- a/src/browser/modules/User/UserList.jsx
+++ b/src/browser/modules/User/UserList.jsx
@@ -22,6 +22,7 @@ import { executeCommand } from 'shared/modules/commands/commandsDuck'
 import React, { Component } from 'react'
 import uuid from 'uuid'
 import { withBus } from 'react-suber'
+import { map } from 'lodash-es'
 import {
   listUsersQuery,
   listRolesQuery
@@ -36,6 +37,8 @@ import { StyledButtonContainer } from './styled'
 import FrameTemplate from '../Frame/FrameTemplate'
 import { forceFetch } from 'shared/modules/currentUser/currentUserDuck'
 import { NEO4J_BROWSER_USER_ACTION_QUERY } from 'services/bolt/txMetadata'
+import { driverDatabaseSelection } from 'shared/modules/features/versionedFeatures'
+import { connect } from 'react-redux'
 
 export class UserList extends Component {
   constructor (props) {
@@ -50,14 +53,41 @@ export class UserList extends Component {
     tableArray.shift()
     return tableArray
   }
+
+  recordToUserObject = record => {
+    const is40 = Boolean(this.props.useSystemDb)
+
+    if (is40) {
+      return {
+        username: record.get('user'),
+        roles: record.get('roles'),
+        active: !record.get('suspended'),
+        passwordChangeRequired: record.get('passwordChangeRequired')
+      }
+    }
+
+    return {
+      username: record.get('username'),
+      roles: record.get('roles'),
+      active: !record.get('flags').includes('is_suspended'),
+      passwordChangeRequired: record
+        .get('flags')
+        .includes('password_change_required')
+    }
+  }
+
   getUserList () {
     this.props.bus.self(
       CYPHER_REQUEST,
-      { query: listUsersQuery(), queryType: NEO4J_BROWSER_USER_ACTION_QUERY },
+      {
+        query: listUsersQuery(Boolean(this.props.useSystemDb)),
+        queryType: NEO4J_BROWSER_USER_ACTION_QUERY,
+        useDb: this.props.useSystemDb
+      },
       response => {
         if (response.success) {
           this.setState({
-            userList: this.extractUserNameAndRolesFromBolt(response.result)
+            userList: map(response.result.records, this.recordToUserObject)
           })
           this.props.bus.send(forceFetch().type, forceFetch())
         }
@@ -67,7 +97,11 @@ export class UserList extends Component {
   getRoles () {
     this.props.bus.self(
       CYPHER_REQUEST,
-      { query: listRolesQuery(), queryType: NEO4J_BROWSER_USER_ACTION_QUERY },
+      {
+        query: listRolesQuery(Boolean(this.props.useSystemDb)),
+        queryType: NEO4J_BROWSER_USER_ACTION_QUERY,
+        useDb: this.props.useSystemDb
+      },
       response => {
         const flatten = arr =>
           arr.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), [])
@@ -98,9 +132,7 @@ export class UserList extends Component {
         <UserInformation
           className='user-information'
           key={uuid.v4()}
-          username={row[0]}
-          roles={row[1]}
-          status={row[2]}
+          user={row}
           refresh={this.getUserList.bind(this)}
           availableRoles={this.state.listRoles}
         />
@@ -152,5 +184,17 @@ export class UserList extends Component {
     return <FrameTemplate header={this.props.frame} contents={frameContents} />
   }
 }
+const mapStateToProps = state => {
+  const { database } = driverDatabaseSelection(state, 'system') || {}
 
-export default withBus(UserList)
+  return {
+    useSystemDb: database
+  }
+}
+
+export default withBus(
+  connect(
+    mapStateToProps,
+    null
+  )(UserList)
+)

--- a/src/shared/modules/cypher/boltUserHelper.js
+++ b/src/shared/modules/cypher/boltUserHelper.js
@@ -18,31 +18,65 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export function listUsersQuery () {
+export function listUsersQuery (is40 = false) {
+  if (is40) {
+    return 'SHOW USERS'
+  }
+
   return 'CALL dbms.security.listUsers'
 }
-export function listRolesQuery () {
+
+export function listRolesQuery (is40 = false) {
+  if (is40) {
+    return 'SHOW ALL ROLES'
+  }
+
   return 'CALL dbms.security.listRoles YIELD role'
 }
-export function createDatabaseUser ({
-  username,
-  password,
-  forcePasswordChange
-}) {
+export function createDatabaseUser (
+  { username, password, forcePasswordChange },
+  is40 = false
+) {
+  if (is40) {
+    return `CREATE USER ${username} SET PASSWORD "${password}" CHANGE ${
+      forcePasswordChange ? '' : 'NOT'
+    } REQUIRED`
+  }
+
   return `CALL dbms.security.createUser("${username}", "${password}", ${!!forcePasswordChange})`
 }
-export function deleteUser (username) {
+export function deleteUser (username, is40 = false) {
+  if (is40) {
+    return `DROP USER ${username}`
+  }
+
   return `CALL dbms.security.deleteUser("${username}")`
 }
-export function addRoleToUser (username, role) {
+export function addRoleToUser (username, role, is40 = false) {
+  if (is40) {
+    return `GRANT ROLE ${role} TO ${username}`
+  }
+
   return `CALL dbms.security.addRoleToUser("${role}", "${username}")`
 }
-export function removeRoleFromUser (role, username) {
+export function removeRoleFromUser (role, username, is40 = false) {
+  if (is40) {
+    return `REVOKE ROLE ${role} FROM ${username}`
+  }
+
   return `CALL dbms.security.removeRoleFromUser("${role}", "${username}")`
 }
-export function activateUser (username) {
+export function activateUser (username, is40 = false) {
+  if (is40) {
+    return `ALTER USER ${username} SET STATUS ACTIVE`
+  }
+
   return `CALL dbms.security.activateUser("${username}", false)`
 }
-export function suspendUser (username) {
+export function suspendUser (username, is40 = false) {
+  if (is40) {
+    return `ALTER USER ${username} SET STATUS SUSPENDED`
+  }
+
   return `CALL dbms.security.suspendUser("${username}")`
 }

--- a/src/shared/modules/cypher/boltUserHelper.js
+++ b/src/shared/modules/cypher/boltUserHelper.js
@@ -38,45 +38,45 @@ export function createDatabaseUser (
   is40 = false
 ) {
   if (is40) {
-    return `CREATE USER ${username} SET PASSWORD "${password}" CHANGE ${
+    return `CREATE USER ${username} SET PASSWORD $password CHANGE ${
       forcePasswordChange ? '' : 'NOT'
     } REQUIRED`
   }
 
-  return `CALL dbms.security.createUser("${username}", "${password}", ${!!forcePasswordChange})`
+  return `CALL dbms.security.createUser($username, $password, ${!!forcePasswordChange})`
 }
 export function deleteUser (username, is40 = false) {
   if (is40) {
     return `DROP USER ${username}`
   }
 
-  return `CALL dbms.security.deleteUser("${username}")`
+  return `CALL dbms.security.deleteUser($username)`
 }
 export function addRoleToUser (username, role, is40 = false) {
   if (is40) {
     return `GRANT ROLE ${role} TO ${username}`
   }
 
-  return `CALL dbms.security.addRoleToUser("${role}", "${username}")`
+  return `CALL dbms.security.addRoleToUser($role, $username)`
 }
 export function removeRoleFromUser (role, username, is40 = false) {
   if (is40) {
     return `REVOKE ROLE ${role} FROM ${username}`
   }
 
-  return `CALL dbms.security.removeRoleFromUser("${role}", "${username}")`
+  return `CALL dbms.security.removeRoleFromUser($role, $username)`
 }
 export function activateUser (username, is40 = false) {
   if (is40) {
     return `ALTER USER ${username} SET STATUS ACTIVE`
   }
 
-  return `CALL dbms.security.activateUser("${username}", false)`
+  return `CALL dbms.security.activateUser($username, false)`
 }
 export function suspendUser (username, is40 = false) {
   if (is40) {
     return `ALTER USER ${username} SET STATUS SUSPENDED`
   }
 
-  return `CALL dbms.security.suspendUser("${username}")`
+  return `CALL dbms.security.suspendUser($username)`
 }

--- a/src/shared/modules/cypher/boltUserHelper.js
+++ b/src/shared/modules/cypher/boltUserHelper.js
@@ -31,7 +31,7 @@ export function listRolesQuery (is40 = false) {
     return 'SHOW ALL ROLES'
   }
 
-  return 'CALL dbms.security.listRoles YIELD role'
+  return 'CALL dbms.security.listRoles'
 }
 export function createDatabaseUser (
   { username, password, forcePasswordChange },

--- a/src/shared/modules/cypher/cypherDuck.js
+++ b/src/shared/modules/cypher/cypherDuck.js
@@ -99,7 +99,8 @@ export const cypherRequestEpic = (some$, store) =>
         useCypherThread: shouldUseCypherThread(store.getState()),
         ...getUserTxMetadata(action.queryType || null)({
           hasServerSupport: canSendTxMetadata(store.getState())
-        })
+        }),
+        useDb: action.useDb
       })
       .then(r => ({ type: action.$$responseChannel, success: true, result: r }))
       .catch(e => ({
@@ -190,6 +191,7 @@ export const clusterCypherRequestEpic = (some$, store) =>
 export const handleForcePasswordChangeEpic = (some$, store) =>
   some$.ofType(FORCE_CHANGE_PASSWORD).mergeMap(action => {
     if (!action.$$responseChannel) return Rx.Observable.of(null)
+
     return new Promise((resolve, reject) => {
       bolt
         .directConnect(

--- a/src/shared/services/bolt/bolt.js
+++ b/src/shared/services/bolt/bolt.js
@@ -163,7 +163,7 @@ function directTransaction (input, parameters, requestMetaData = {}) {
     cancelable = false,
     onLostConnection = () => {},
     txMetadata = undefined,
-    useDb = _useDb
+    useDb
   } = requestMetaData
   if (useCypherThread && window.Worker) {
     const id = requestId || v4()
@@ -181,7 +181,7 @@ function directTransaction (input, parameters, requestMetaData = {}) {
           )
         ),
         txMetadata,
-        useDb
+        useDb: useDb || _useDb
       }
     )
     const workerPromise = setupBoltWorker(id, workFn, onLostConnection)

--- a/src/shared/services/utils.js
+++ b/src/shared/services/utils.js
@@ -478,11 +478,16 @@ export const optionalToString = v =>
 
 export const toKeyString = str => btoa(encodeURIComponent(str))
 
+const DEPRECATED_ROUTING_PROTOCOL = 'bolt+routing://'
+
 export const generateBoltHost = host => {
   const urlParts = (host || '').split('://')
   const protocol = urlParts.length > 1 ? `${urlParts[0]}://` : 'neo4j://'
   host = urlParts.length > 1 ? urlParts[1] : urlParts[0]
-  return protocol + (host || 'localhost:7687')
+  const aliasedProtocol =
+    protocol !== DEPRECATED_ROUTING_PROTOCOL ? protocol : 'neo4j://'
+
+  return aliasedProtocol + (host || 'localhost:7687')
 }
 
 export function flushPromises () {


### PR DESCRIPTION
This PR addresses changes to the `:schema` command, handling of depcrecated `bolt+routing` protocol,  as well as changes to user handling in anticipation of 4.0
- Fixed JS exception when calling `:schema` with created indexes
- Aliased `bolt+routing://` to `neo4j://`
- Added feature switch for new RBAC commands when on 4.0

### Screenshots
<img width="2953" alt="Screenshot 2019-11-21 at 12 42 58" src="https://user-images.githubusercontent.com/52443771/69335153-8ff5da00-0c5c-11ea-8aa0-d226dde7fcde.png">
