### PR TITLE
Fake server version depending on multidb support

### DIFF
--- a/src/shared/modules/features/versionedFeatures.js
+++ b/src/shared/modules/features/versionedFeatures.js
@@ -25,6 +25,11 @@ import { getUseDb } from '../connections/connectionsDuck'
 const NEO4J_TX_METADATA_VERSION = '3.5.0-alpha01'
 const NEO4J_4_0 = '4.0.0-alpha01'
 
+export const FIRST_MULTI_DB_SUPPORT = NEO4J_4_0
+// Keep the following as 3.4.0 as 3.5.X has a
+// compatible bolt server.
+export const FIRST_NO_MULTI_DB_SUPPORT = '3.4.0'
+
 export const canSendTxMetadata = state => {
   const serverVersion = getVersion(state)
   if (!semver.valid(serverVersion)) {


### PR DESCRIPTION
Dynamically figure out how to change pw, even when not connected properly.

The case is when the client don't know the server version and cannot ask the server for it because of forced pw change.
The driver does know, because it can identify the servers bolt version, and exposes a helpful `driver.supportsMultidb()` for us to use.