### PR TITLE
use new output of show databases

### DIFF
--- a/src/browser/modules/DBMSInfo/DatabaseSelector.jsx
+++ b/src/browser/modules/DBMSInfo/DatabaseSelector.jsx
@@ -25,6 +25,7 @@ import {
   DrawerSubHeader,
   DrawerSectionBody
 } from 'browser-components/drawer/index'
+import { uniqBy } from 'lodash-es'
 
 const Select = styled.select`
   width: 100%;
@@ -48,10 +49,13 @@ export const DatabaseSelector = ({
     }
     onChange(target.value)
   }
+
   let databasesList = databases
   if (!selectedDb) {
     databasesList = [].concat([{ name: EMPTY_OPTION, status: null }], databases)
   }
+  const uniqDatabases = uniqBy(databasesList, 'name')
+
   return (
     <DrawerSection>
       <DrawerSubHeader>Use database</DrawerSubHeader>
@@ -61,13 +65,13 @@ export const DatabaseSelector = ({
           data-testid='database-selection-list'
           onChange={selectionChange}
         >
-          {databasesList.map(db => {
+          {uniqDatabases.map(db => {
             const defaultStr = db.default ? ' - default' : ''
-            const statusStr = db.status ? `(${db.status})` : ''
+
             return (
               <option key={db.name} value={db.name}>
                 {db.name}
-                {defaultStr} {statusStr}
+                {defaultStr}
               </option>
             )
           })}

--- a/src/browser/modules/Stream/SysInfoFrame/helpers.js
+++ b/src/browser/modules/Stream/SysInfoFrame/helpers.js
@@ -30,7 +30,6 @@ import {
   SysInfoTable,
   SysInfoTableEntry
 } from 'browser-components/Tables'
-import { QuestionIcon } from 'browser-components/icons/Icons'
 import Render from 'browser-components/Render/index'
 
 const jmxPrefix = 'neo4j.metrics:name='

--- a/src/browser/modules/Stream/SysInfoFrame/helpers.js
+++ b/src/browser/modules/Stream/SysInfoFrame/helpers.js
@@ -98,12 +98,21 @@ export const Sysinfo = ({
   isACausalCluster,
   cc
 }) => {
-  const mappedDatabases = databases.map(db => {
-    return {
-      label: db.name,
-      value: db.status
+  const mappedDatabases = [
+    {
+      value: databases.map(db => {
+        return [
+          db.name,
+          db.address,
+          db.role,
+          db.status,
+          db.default ? 'true' : '-',
+          db.error
+        ]
+      })
     }
-  })
+  ]
+
   return (
     <SysInfoTableContainer>
       <SysInfoTable key='StoreSize' header='Store Size' colspan='2'>
@@ -118,27 +127,13 @@ export const Sysinfo = ({
       <SysInfoTable key='Transactionss' header='Transactions'>
         {buildTableData(transactions)}
       </SysInfoTable>
-      <SysInfoTable key='databases' header='Databases'>
+      <SysInfoTable key='database-table' header='Databases' colspan='6'>
+        <SysInfoTableEntry
+          key='database-entry'
+          headers={['Name', 'Address', 'Role', 'Status', 'Default', 'Error']}
+        />
         {buildTableData(mappedDatabases)}
       </SysInfoTable>
-      <Render if={isACausalCluster}>
-        <SysInfoTable
-          key='cc-table'
-          header={
-            <span data-testid='sysinfo-casual-cluster-members-title'>
-              Causal Cluster Members{' '}
-              <QuestionIcon title='Values shown in `:sysinfo` may differ between cluster members' />
-            </span>
-          }
-          colspan='3'
-        >
-          <SysInfoTableEntry
-            key='cc-entry'
-            headers={['Roles', 'Addresses', 'Actions']}
-          />
-          {buildTableData(cc)}
-        </SysInfoTable>
-      </Render>
     </SysInfoTableContainer>
   )
 }

--- a/src/shared/modules/dbMeta/dbMetaDuck.js
+++ b/src/shared/modules/dbMeta/dbMetaDuck.js
@@ -42,6 +42,7 @@ import {
   getDbClusterRole
 } from '../features/versionedFeatures'
 import { extractServerInfo } from './dbMeta.utils'
+import { assign, reduce } from 'lodash-es'
 
 export const NAME = 'meta'
 export const UPDATE = 'meta/UPDATE'
@@ -447,13 +448,14 @@ export const dbMetaEpic = (some$, store) =>
               })
               .do(res => {
                 if (!res) return Rx.Observable.of(null)
-                const databases = res.records.map(record => {
-                  return {
-                    name: record.get('name'),
-                    status: record.get('currentStatus'),
-                    default: record.get('default')
-                  }
-                })
+                const databases = res.records.map(record => ({
+                  ...reduce(
+                    record.keys,
+                    (agg, key) => assign(agg, { [key]: record.get(key) }),
+                    {}
+                  ),
+                  status: record.get('currentStatus')
+                }))
 
                 store.dispatch(update({ databases }))
 


### PR DESCRIPTION
This PR fixes breaking changes to SHOW DATABASES:
- Show only unique names in database selector
- Use only SHOW DATABASES output in :sysinfo, as it now also contains the causal clustering state

### Screenshot
<img width="2131" alt="Screenshot 2019-11-25 at 13 51 06" src="https://user-images.githubusercontent.com/52443771/69542065-e9c31080-0f8a-11ea-92b5-7ecf6c65ea46.png">
