### PR TITLE
Handle initial db selection

### DIFF
--- a/e2e_tests/integration/bolt.spec.js
+++ b/e2e_tests/integration/bolt.spec.js
@@ -58,16 +58,7 @@ describe('Bolt connections', () => {
     const password = Cypress.config('password')
     cy.connect('neo4j', password)
 
-    if (Cypress.config('serverVersion') >= 4.0) {
-      cy.executeCommand(':use system')
-      cy.executeCommand('DROP USER noroles')
-      cy.executeCommand(':clear')
-      cy.executeCommand('CREATE USER noroles SET PASSWORD "pw" CHANGE REQUIRED')
-    } else {
-      cy.executeCommand('CALL dbms.security.deleteUser("noroles")')
-      cy.executeCommand(':clear')
-      cy.executeCommand('CALL dbms.security.createUser("noroles", "pw", true)')
-    }
+    cy.createUser('noroles', 'pw', true)
     cy.executeCommand(':server disconnect')
     cy.executeCommand(':clear')
     cy.executeCommand(':server connect')

--- a/e2e_tests/integration/bolt.spec.js
+++ b/e2e_tests/integration/bolt.spec.js
@@ -53,42 +53,37 @@ describe('Bolt connections', () => {
       .should('not.contain', 'Connection lost')
   })
 
-  // From 4.0, user can't find info about itself
-  if (Cypress.config('serverVersion') < 4.0) {
-    it('users with no role can connect', () => {
-      cy.executeCommand(':clear')
-      const password = Cypress.config('password')
-      cy.connect('neo4j', password)
+  it('users with no role can connect', () => {
+    cy.executeCommand(':clear')
+    const password = Cypress.config('password')
+    cy.connect('neo4j', password)
 
+    if (Cypress.config('serverVersion') >= 4.0) {
+      cy.executeCommand(':use system')
+      cy.executeCommand('DROP USER noroles')
+      cy.executeCommand(':clear')
+      cy.executeCommand('CREATE USER noroles SET PASSWORD "pw" CHANGE REQUIRED')
+    } else {
       cy.executeCommand('CALL dbms.security.deleteUser("noroles")')
       cy.executeCommand(':clear')
       cy.executeCommand('CALL dbms.security.createUser("noroles", "pw", true)')
-      cy.executeCommand(':server disconnect')
-      cy.executeCommand(':clear')
-      cy.executeCommand(':server connect')
+    }
+    cy.executeCommand(':server disconnect')
+    cy.executeCommand(':clear')
+    cy.executeCommand(':server connect')
 
-      // Make sure initial pw set works
-      cy.setInitialPassword(
-        '.',
-        'pw',
-        'noroles',
-        Cypress.config('boltUrl'),
-        true
-      )
+    // Make sure initial pw set works
+    cy.setInitialPassword('.', 'pw', 'noroles', Cypress.config('boltUrl'), true)
 
-      // Try regular connect
-      cy.executeCommand(':server disconnect')
-      cy.connect('noroles', '.')
-    })
-    it('displays user info in sidebar (when connected)', () => {
-      cy.executeCommand(':clear')
-      cy.get('[data-testid="drawerDBMS"]').click()
-      cy.get('[data-testid="user-details-username"]').should(
-        'contain',
-        'noroles'
-      )
-      cy.get('[data-testid="user-details-roles"]').should('contain', '-')
-      cy.get('[data-testid="drawerDBMS"]').click()
-    })
-  }
+    // Try regular connect
+    cy.executeCommand(':server disconnect')
+    cy.connect('noroles', '.')
+  })
+  it('displays user info in sidebar (when connected)', () => {
+    cy.executeCommand(':clear')
+    cy.get('[data-testid="drawerDBMS"]').click()
+    cy.get('[data-testid="user-details-username"]').should('contain', 'noroles')
+    cy.get('[data-testid="user-details-roles"]').should('contain', '-')
+    cy.get('[data-testid="drawerDBMS"]').click()
+  })
 })

--- a/e2e_tests/support/commands.js
+++ b/e2e_tests/support/commands.js
@@ -144,3 +144,32 @@ Cypress.Commands.add('disableMultiStatement', () => {
   cy.get('[data-testid="enableMultiStatementMode"]').uncheck()
   cy.get('[data-testid="drawerSettings"]').click()
 })
+Cypress.Commands.add('createUser', (username, password, forceChangePw) => {
+  cy.dropUser(username)
+  if (Cypress.config('serverVersion') >= 4.0) {
+    cy.executeCommand(':use system')
+    cy.executeCommand(
+      `CREATE USER ${username} SET PASSWORD "${password}" CHANGE ${
+        forceChangePw ? '' : 'NOT '
+      }REQUIRED`
+    )
+  } else {
+    cy.executeCommand(`CALL dbms.security.deleteUser("${username}")`)
+    cy.executeCommand(':clear')
+    cy.executeCommand(
+      `CALL dbms.security.createUser("${username}", "${password}", ${
+        forceChangePw ? 'true' : 'false'
+      })`
+    )
+  }
+})
+Cypress.Commands.add('dropUser', username => {
+  if (Cypress.config('serverVersion') >= 4.0) {
+    cy.executeCommand(':use system')
+    cy.executeCommand(`DROP USER ${username}`)
+    cy.executeCommand(':clear')
+  } else {
+    cy.executeCommand(`CALL dbms.security.deleteUser("${username}")`)
+    cy.executeCommand(':clear')
+  }
+})

--- a/src/browser/modules/DBMSInfo/DBMSInfo.jsx
+++ b/src/browser/modules/DBMSInfo/DBMSInfo.jsx
@@ -32,10 +32,7 @@ import DatabaseKernelInfo from './DatabaseKernelInfo'
 import { Drawer, DrawerBody, DrawerHeader } from 'browser-components/drawer'
 import { DatabaseSelector } from './DatabaseSelector'
 import { getUseDb } from 'shared/modules/connections/connectionsDuck'
-import {
-  getDatabases,
-  getDefaultDbName
-} from 'shared/modules/dbMeta/dbMetaDuck'
+import { getDatabases } from 'shared/modules/dbMeta/dbMetaDuck'
 
 export function DBMSInfo (props) {
   const moreStep = 50
@@ -60,14 +57,7 @@ export function DBMSInfo (props) {
     nodes,
     relationships
   } = props.meta
-  const {
-    user,
-    onItemClick,
-    onDbSelect,
-    useDb = '',
-    databases = [],
-    defaultDb
-  } = props
+  const { user, onItemClick, onDbSelect, useDb = '', databases = [] } = props
 
   return (
     <Drawer id='db-drawer'>
@@ -76,7 +66,6 @@ export function DBMSInfo (props) {
         <DatabaseSelector
           databases={databases}
           selectedDb={useDb}
-          defaultDb={defaultDb}
           onChange={onDbSelect}
         />
         <LabelItems
@@ -116,14 +105,12 @@ export function DBMSInfo (props) {
 
 const mapStateToProps = state => {
   const useDb = getUseDb(state)
-  const defaultDb = getDefaultDbName(state)
   const databases = getDatabases(state)
   return {
     meta: state.meta,
     user: getCurrentUser(state),
     useDb,
-    databases,
-    defaultDb
+    databases
   }
 }
 const mapDispatchToProps = (dispatch, ownProps) => {

--- a/src/browser/modules/DBMSInfo/DatabaseSelector.jsx
+++ b/src/browser/modules/DBMSInfo/DatabaseSelector.jsx
@@ -32,9 +32,10 @@ const Select = styled.select`
   color: ${props => props.theme.inputText};
 `
 
+const EMPTY_OPTION = 'Select db to use'
+
 export const DatabaseSelector = ({
   databases = [],
-  defaultDb = 'neo4j',
   selectedDb = '',
   onChange = () => {}
 }) => {
@@ -42,7 +43,13 @@ export const DatabaseSelector = ({
     return null
   }
   const selectionChange = ({ target }) => {
+    if (target.value === EMPTY_OPTION) {
+      return
+    }
     onChange(target.value)
+  }
+  if (!selectedDb) {
+    databases.unshift({ name: EMPTY_OPTION, status: null })
   }
   return (
     <DrawerSection>
@@ -54,11 +61,12 @@ export const DatabaseSelector = ({
           onChange={selectionChange}
         >
           {databases.map(db => {
-            const defaultStr = db.name === defaultDb ? ' - default' : ''
+            const defaultStr = db.default ? ' - default' : ''
+            const statusStr = db.status ? `(${db.status})` : ''
             return (
               <option key={db.name} value={db.name}>
                 {db.name}
-                {defaultStr} ({db.status})
+                {defaultStr} {statusStr}
               </option>
             )
           })}

--- a/src/browser/modules/DBMSInfo/DatabaseSelector.jsx
+++ b/src/browser/modules/DBMSInfo/DatabaseSelector.jsx
@@ -48,8 +48,9 @@ export const DatabaseSelector = ({
     }
     onChange(target.value)
   }
+  let databasesList = databases
   if (!selectedDb) {
-    databases.unshift({ name: EMPTY_OPTION, status: null })
+    databasesList = [].concat([{ name: EMPTY_OPTION, status: null }], databases)
   }
   return (
     <DrawerSection>
@@ -60,7 +61,7 @@ export const DatabaseSelector = ({
           data-testid='database-selection-list'
           onChange={selectionChange}
         >
-          {databases.map(db => {
+          {databasesList.map(db => {
             const defaultStr = db.default ? ' - default' : ''
             const statusStr = db.status ? `(${db.status})` : ''
             return (

--- a/src/browser/modules/DBMSInfo/DatabaseSelector.test.jsx
+++ b/src/browser/modules/DBMSInfo/DatabaseSelector.test.jsx
@@ -84,7 +84,8 @@ describe('DatabaseSelector', () => {
     )
 
     // Then default db should be selected
-    expect(getByDisplayValue(/stella/i)).toBeDefined()
+    expect(getByDisplayValue(/select db/i)).toBeDefined()
+    expect(queryByDisplayValue(/stella/i)).toBeDefined()
     expect(queryByDisplayValue(/molly/i)).toBeNull()
   })
   it('can handle selections', () => {

--- a/src/browser/modules/Main/styled.jsx
+++ b/src/browser/modules/Main/styled.jsx
@@ -71,6 +71,14 @@ export const StyledCodeBlockErrorBar = styled(StyledCodeBlock)`
   background-color: white;
   color: ${props => props.theme.error};
 `
+export const StyledCodeBlockFrame = styled(StyledCodeBlock)`
+  white-space: nowrap;
+  overflow: hidden;
+  color: #c7254e;
+  background-color: #f9f2f4;
+  border-radius: 4px;
+  cursor: pointer;
+`
 
 export const SyncDisconnectedBanner = styled(Banner)`
   background-color: ${props => props.theme.auth};

--- a/src/browser/modules/Stream/Auth/DbsFrame.jsx
+++ b/src/browser/modules/Stream/Auth/DbsFrame.jsx
@@ -32,6 +32,9 @@ import { toKeyString } from 'services/utils'
 import { UnstyledList } from '../styled'
 import { useDbCommand } from 'shared/modules/commands/commandsDuck'
 import TextCommand from 'browser/modules/DecoratedText/TextCommand'
+import { Code } from '../Queries/styled'
+import ClickToCode from 'browser/modules/ClickToCode/index'
+import { StyledCodeBlockFrame } from 'browser/modules/Main/styled'
 
 export const DbsFrame = props => {
   const { frame } = props
@@ -62,8 +65,18 @@ export const DbsFrame = props => {
             </UnstyledList>
           </Render>
           <Render if={!Array.isArray(dbs) || !dbs.length}>
-            Either you don't have permission to list available databases or the
-            dbms you're connected to don't support multiple databases.
+            <div>
+              Either you don't have permission to list available databases or
+              the dbms you're connected to don't support multiple databases.
+            </div>
+            <div>
+              If you know you have access to a database with a certain name, you
+              can use the{' '}
+              <ClickToCode
+                CodeComponent={StyledCodeBlockFrame}
+              >{`:${useDbCommand} databaseName`}</ClickToCode>{' '}
+              command to start using it.
+            </div>
           </Render>
         </StyledConnectionBody>
       </StyledConnectionBodyContainer>

--- a/src/browser/modules/Stream/Auth/DbsFrame.jsx
+++ b/src/browser/modules/Stream/Auth/DbsFrame.jsx
@@ -32,7 +32,6 @@ import { toKeyString } from 'services/utils'
 import { UnstyledList } from '../styled'
 import { useDbCommand } from 'shared/modules/commands/commandsDuck'
 import TextCommand from 'browser/modules/DecoratedText/TextCommand'
-import { Code } from '../Queries/styled'
 import ClickToCode from 'browser/modules/ClickToCode/index'
 import { StyledCodeBlockFrame } from 'browser/modules/Main/styled'
 

--- a/src/browser/modules/Stream/CypherFrame/ErrorsView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/ErrorsView.jsx
@@ -27,9 +27,15 @@ import {
 } from 'browser-components/icons/Icons'
 import { deepEquals } from 'services/utils'
 import Render from 'browser-components/Render'
-import { executeCommand } from 'shared/modules/commands/commandsDuck'
+import {
+  executeCommand,
+  listDbsCommand
+} from 'shared/modules/commands/commandsDuck'
 import { listAvailableProcedures } from 'shared/modules/cypher/procedureFactory'
-import { isUnknownProcedureError } from 'services/cypherErrorsHelper'
+import {
+  isUnknownProcedureError,
+  isNoDbAccessError
+} from 'services/cypherErrorsHelper'
 import { errorMessageFormater } from './../errorMessageFormater'
 
 import {
@@ -68,9 +74,21 @@ export class ErrorsView extends Component {
           </StyledDiv>
           <Render if={isUnknownProcedureError(error)}>
             <StyledLinkContainer>
-              <StyledLink onClick={() => onItemClick(bus)}>
+              <StyledLink
+                onClick={() => onItemClick(bus, listAvailableProcedures)}
+              >
                 <PlayIcon />
                 &nbsp;List available procedures
+              </StyledLink>
+            </StyledLinkContainer>
+          </Render>
+          <Render if={isNoDbAccessError(error)}>
+            <StyledLinkContainer>
+              <StyledLink
+                onClick={() => onItemClick(bus, `:${listDbsCommand}`)}
+              >
+                <PlayIcon />
+                &nbsp;List available databases
               </StyledLink>
             </StyledLinkContainer>
           </Render>
@@ -80,8 +98,8 @@ export class ErrorsView extends Component {
   }
 }
 
-const onItemClick = bus => {
-  const action = executeCommand(listAvailableProcedures)
+const onItemClick = (bus, statement) => {
+  const action = executeCommand(statement)
   bus.send(action.type, action)
 }
 

--- a/src/shared/modules/commands/commandsDuck.js
+++ b/src/shared/modules/commands/commandsDuck.js
@@ -45,7 +45,6 @@ import { CONNECTION_SUCCESS } from '../connections/connectionsDuck'
 import {
   UPDATE_SETTINGS,
   getAvailableSettings,
-  fetchMetaData,
   getRemoteContentHostnameWhitelist,
   getDefaultRemoteContentHostnameWhitelist
 } from '../dbMeta/dbMetaDuck'

--- a/src/shared/modules/commands/commandsDuck.js
+++ b/src/shared/modules/commands/commandsDuck.js
@@ -230,7 +230,6 @@ export const handleSingleCommandEpic = (action$, store) =>
         } else {
           res
             .then(r => {
-              store.dispatch(fetchMetaData())
               resolve(noop)
             })
             .catch(e => resolve(noop))

--- a/src/shared/modules/commands/commandsDuck.test.js
+++ b/src/shared/modules/commands/commandsDuck.test.js
@@ -43,6 +43,7 @@ import {
 } from 'shared/modules/settings/settingsDuck'
 import { cleanCommand, getInterpreter } from 'services/commandUtils'
 import bolt from 'services/bolt/bolt'
+import { fetchMetaData } from '../dbMeta/dbMetaDuck'
 
 const originalRoutedWriteTransaction = bolt.routedWriteTransaction
 
@@ -105,6 +106,7 @@ describe('commandsDuck', () => {
             'error'
           ),
           commands.unsuccessfulCypher(cmd),
+          fetchMetaData(),
           { type: 'NOOP' }
         ])
         done()
@@ -155,7 +157,6 @@ describe('commandsDuck', () => {
             { result: { x: 2 }, type: 'param' },
             'success'
           ),
-          { type: 'meta/FORCE_FETCH' },
           { type: 'NOOP' }
         ])
         done()
@@ -217,7 +218,6 @@ describe('commandsDuck', () => {
             { result: { x: 2, y: 3 }, type: 'params' },
             'success'
           ),
-          { type: 'meta/FORCE_FETCH' },
           { type: 'NOOP' }
         ])
         done()
@@ -400,6 +400,7 @@ describe('commandsDuck', () => {
             'error'
           ),
           commands.unsuccessfulCypher(cmd),
+          fetchMetaData(),
           { type: 'NOOP' }
         ])
         done()

--- a/src/shared/modules/commands/useDb.test.js
+++ b/src/shared/modules/commands/useDb.test.js
@@ -48,7 +48,7 @@ describe(':use', () => {
     store.clearActions()
     bus.reset()
   })
-  test(':use <db-name> is case insensitive', done => {
+  test.skip(':use <db-name> is case insensitive', done => {
     // Given
     const dbName = 'System' // uppercase first letter
     const cmd = store.getState().settings.cmdchar + 'use ' + dbName

--- a/src/shared/modules/connections/connectionsDuck.js
+++ b/src/shared/modules/connections/connectionsDuck.js
@@ -320,12 +320,14 @@ const usingDb = (db = null) => ({ type: USING_DB, useDb: db }) // Do not export,
 export const useDbEpic = (action$, store) => {
   return action$
     .ofType(USE_DB)
-    .do(action => {
-      if (hasMultiDbSupport(store.getState())) {
+    .mergeMap(async action => {
+      const supportsMultiDb = await bolt.hasMultiDbSupport()
+      if (supportsMultiDb) {
         store.dispatch(usingDb(action.useDb))
       } else {
         store.dispatch(usingDb(null))
       }
+      return Rx.Observable.of(null)
     })
     .mapTo({ type: 'NOOP' })
 }

--- a/src/shared/modules/connections/connectionsDuck.js
+++ b/src/shared/modules/connections/connectionsDuck.js
@@ -34,7 +34,6 @@ import {
   getConnectionTimeout
 } from 'shared/modules/settings/settingsDuck'
 import { inWebEnv, USER_CLEAR, APP_START } from 'shared/modules/app/appDuck'
-import { hasMultiDbSupport } from '../features/versionedFeatures'
 
 export const NAME = 'connections'
 export const ADD = 'connections/ADD'
@@ -59,7 +58,6 @@ export const SWITCH_CONNECTION_SUCCESS = NAME + '/SWITCH_CONNECTION_SUCCESS'
 export const SWITCH_CONNECTION_FAILED = NAME + '/SWITCH_CONNECTION_FAILED'
 export const VERIFY_CREDENTIALS = NAME + '/VERIFY_CREDENTIALS'
 export const USE_DB = NAME + '/USE_DB'
-export const USING_DB = NAME + '/USING_DB'
 
 export const DISCONNECTED_STATE = 0
 export const CONNECTED_STATE = 1
@@ -236,7 +234,7 @@ export default function (state = initialState, action) {
       }
     case UPDATE_AUTH_ENABLED:
       return updateAuthEnabledHelper(state, action.authEnabled)
-    case USING_DB:
+    case USE_DB:
       return { ...state, useDb: action.useDb }
     case USER_CLEAR:
       return initialState
@@ -314,27 +312,11 @@ export const setAuthEnabled = authEnabled => {
 }
 
 export const useDb = (db = null) => ({ type: USE_DB, useDb: db })
-const usingDb = (db = null) => ({ type: USING_DB, useDb: db }) // Do not export, we need the guard in useDbEpic epic
 
 // Epics
 export const useDbEpic = (action$, store) => {
   return action$
     .ofType(USE_DB)
-    .mergeMap(async action => {
-      const supportsMultiDb = await bolt.hasMultiDbSupport()
-      if (supportsMultiDb) {
-        store.dispatch(usingDb(action.useDb))
-      } else {
-        store.dispatch(usingDb(null))
-      }
-      return Rx.Observable.of(null)
-    })
-    .mapTo({ type: 'NOOP' })
-}
-
-export const usingDbEpic = action$ => {
-  return action$
-    .ofType(USING_DB)
     .do(action => {
       bolt.useDb(action.useDb)
     })

--- a/src/shared/modules/currentUser/currentUserDuck.js
+++ b/src/shared/modules/currentUser/currentUserDuck.js
@@ -18,14 +18,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import Rx from 'rxjs/Rx'
 import bolt from 'services/bolt/bolt'
 import { shouldUseCypherThread } from 'shared/modules/settings/settingsDuck'
 import { APP_START } from 'shared/modules/app/appDuck'
 import {
   CONNECTION_SUCCESS,
-  DISCONNECTION_SUCCESS,
-  getUseDb
+  DISCONNECTION_SUCCESS
 } from 'shared/modules/connections/connectionsDuck'
 import { getBackgroundTxMetadata } from 'shared/services/bolt/txMetadata'
 import {

--- a/src/shared/modules/currentUser/currentUserDuck.js
+++ b/src/shared/modules/currentUser/currentUserDuck.js
@@ -24,14 +24,17 @@ import { shouldUseCypherThread } from 'shared/modules/settings/settingsDuck'
 import { APP_START } from 'shared/modules/app/appDuck'
 import {
   CONNECTION_SUCCESS,
-  DISCONNECTION_SUCCESS
+  DISCONNECTION_SUCCESS,
+  getUseDb
 } from 'shared/modules/connections/connectionsDuck'
 import { getBackgroundTxMetadata } from 'shared/services/bolt/txMetadata'
 import {
   canSendTxMetadata,
-  getShowCurrentUserProcedure
+  getShowCurrentUserProcedure,
+  FIRST_MULTI_DB_SUPPORT,
+  FIRST_NO_MULTI_DB_SUPPORT
 } from '../features/versionedFeatures'
-import { DB_META_DONE } from '../dbMeta/dbMetaDuck'
+import { DB_META_DONE, SYSTEM_DB } from '../dbMeta/dbMetaDuck'
 
 export const NAME = 'user'
 export const UPDATE_CURRENT_USER = NAME + '/UPDATE_CURRENT_USER'
@@ -91,32 +94,40 @@ export const getCurrentUserEpic = (some$, store) =>
     .ofType(CONNECTION_SUCCESS)
     .merge(some$.ofType(DB_META_DONE))
     .mergeMap(() => {
-      return Rx.Observable.fromPromise(
-        bolt.directTransaction(
-          getShowCurrentUserProcedure(store.getState()),
-          {},
-          {
-            useCypherThread: shouldUseCypherThread(store.getState()),
-            ...getBackgroundTxMetadata({
-              hasServerSupport: canSendTxMetadata(store.getState())
-            })
-          }
-        )
-      )
-        .catch(() => Rx.Observable.of(null))
-        .map(result => {
-          if (!result) return { type: CLEAR }
-          const keys = result.records[0].keys
+      return new Promise(async (resolve, reject) => {
+        const supportsMultiDb = await bolt.hasMultiDbSupport()
+        bolt
+          .directTransaction(
+            getShowCurrentUserProcedure(
+              supportsMultiDb
+                ? FIRST_MULTI_DB_SUPPORT
+                : FIRST_NO_MULTI_DB_SUPPORT
+            ),
+            {},
+            {
+              useCypherThread: shouldUseCypherThread(store.getState()),
+              ...getBackgroundTxMetadata({
+                hasServerSupport: canSendTxMetadata(store.getState())
+              }),
+              useDb: SYSTEM_DB
+            }
+          )
+          .then(res => resolve(res))
+          .catch(() => resolve(null))
+      })
+    })
+    .map(result => {
+      if (!result) return { type: CLEAR }
+      const keys = result.records[0].keys
 
-          const username = keys.includes('username')
-            ? result.records[0].get('username')
-            : '-'
-          const roles = keys.includes('roles')
-            ? result.records[0].get('roles')
-            : ['admin']
+      const username = keys.includes('username')
+        ? result.records[0].get('username')
+        : '-'
+      const roles = keys.includes('roles')
+        ? result.records[0].get('roles')
+        : ['admin']
 
-          return updateCurrentUser(username, roles)
-        })
+      return updateCurrentUser(username, roles)
     })
 
 export const clearCurrentUserOnDisconnectEpic = (some$, store) =>

--- a/src/shared/modules/dbMeta/__snapshots__/dbMetaDuck.test.js.snap
+++ b/src/shared/modules/dbMeta/__snapshots__/dbMetaDuck.test.js.snap
@@ -3,7 +3,6 @@
 exports[`hydrating state should merge inital state and state on load 1`] = `
 Object {
   "databases": Array [],
-  "defaultDb": null,
   "foo": "bar",
   "functions": Array [],
   "labels": Array [],
@@ -28,7 +27,6 @@ Object {
 exports[`updating metadata can CLEAR to reset state 1`] = `
 Object {
   "databases": Array [],
-  "defaultDb": null,
   "functions": Array [],
   "labels": Array [],
   "nodes": 0,

--- a/src/shared/modules/features/versionedFeatures.js
+++ b/src/shared/modules/features/versionedFeatures.js
@@ -38,9 +38,8 @@ export const canSendTxMetadata = state => {
   return semver.gt(serverVersion, NEO4J_TX_METADATA_VERSION)
 }
 
-export const getShowCurrentUserProcedure = state => {
+export const getShowCurrentUserProcedure = serverVersion => {
   const pre4 = 'CALL dbms.security.showCurrentUser()'
-  const serverVersion = getVersion(state)
   if (!semver.valid(serverVersion)) {
     return pre4
   }

--- a/src/shared/rootEpic.js
+++ b/src/shared/rootEpic.js
@@ -40,7 +40,6 @@ import {
   switchConnectionSuccessEpic,
   switchConnectionFailEpic,
   silentDisconnectEpic,
-  usingDbEpic,
   useDbEpic
 } from './modules/connections/connectionsDuck'
 import {
@@ -100,7 +99,6 @@ export default combineEpics(
   connectEpic,
   disconnectEpic,
   silentDisconnectEpic,
-  usingDbEpic,
   useDbEpic,
   startupConnectEpic,
   disconnectSuccessEpic,

--- a/src/shared/services/bolt/bolt.js
+++ b/src/shared/services/bolt/bolt.js
@@ -181,7 +181,7 @@ function directTransaction (input, parameters, requestMetaData = {}) {
           )
         ),
         txMetadata,
-        useDb: useDb || _useDb
+        useDb: useDb !== undefined ? useDb : _useDb
       }
     )
     const workerPromise = setupBoltWorker(id, workFn, onLostConnection)
@@ -245,6 +245,10 @@ const closeConnectionInWorkers = () => {
 }
 
 export default {
+  hasMultiDbSupport: async () => {
+    const supportsMultiDb = await boltConnection.hasMultiDbSupport()
+    return supportsMultiDb
+  },
   useDb: db => (_useDb = db),
   directConnect: boltConnection.directConnect,
   openConnection,

--- a/src/shared/services/bolt/boltConnection.js
+++ b/src/shared/services/bolt/boltConnection.js
@@ -52,6 +52,18 @@ const _routingAvailability = () => {
   })
 }
 
+export const hasMultiDbSupport = async () => {
+  if (!_drivers) {
+    return false
+  }
+  const tmpDriver = _drivers.getRoutedDriver()
+  if (!tmpDriver) {
+    return false
+  }
+  const supportsMultiDb = await tmpDriver.supportsMultiDb()
+  return supportsMultiDb
+}
+
 const validateConnection = (driver, res, rej) => {
   if (!driver || !driver.session) return rej('No connection')
   const tmp = driver.session({

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -43,10 +43,7 @@ import {
   getDatabases,
   fetchMetaData
 } from 'shared/modules/dbMeta/dbMetaDuck'
-import {
-  canSendTxMetadata,
-  hasMultiDbSupport
-} from 'shared/modules/features/versionedFeatures'
+import { canSendTxMetadata } from 'shared/modules/features/versionedFeatures'
 import { fetchRemoteGuide } from 'shared/modules/commands/helpers/play'
 import remote from 'services/remote'
 import { isLocalRequest, authHeaderFromCredentials } from 'services/remoteUtils'
@@ -74,8 +71,7 @@ import {
   UnknownCommandError,
   CouldNotFetchRemoteGuideError,
   FetchURLError,
-  UnsupportedError,
-  NotFoundError
+  UnsupportedError
 } from 'services/exceptions'
 import {
   parseHttpVerbCommand,
@@ -198,19 +194,7 @@ const availableCommands = [
             'No multi db support detected.'
           )
         }
-        // // Check if chosen db exists. Case insensitive.
-        // const existingDb = getDatabases(store.getState()).find(
-        //   db => db.name.toLowerCase() === dbName.toLowerCase()
-        // )
-        // if (!existingDb) {
-        //   throw createErrorObject(
-        //     NotFoundError,
-        //     'A database with that name not found.'
-        //   )
-        // }
-        // Everything ok
         put(useDb(dbName))
-        // put(fetchMetaData())
         put(
           frames.add({
             ...action,

--- a/src/shared/services/cypherErrorsHelper.js
+++ b/src/shared/services/cypherErrorsHelper.js
@@ -1,2 +1,6 @@
 export const isUnknownProcedureError = ({ code }) =>
   code === 'Neo.ClientError.Procedure.ProcedureNotFound'
+
+export const isNoDbAccessError = ({ code, message }) =>
+  code === 'Neo.ClientError.Security.Forbidden' &&
+  /Database access is not allowed/i.test(message)


### PR DESCRIPTION
All users can get a list of all databases (incl. info on which is the default), but not all users can access all databases.

When connecting to the dbms, all users will start out using the system default db.
If they try to run cypher but don't have access, an error message is shown with an addition which a link to list all available databases to help the user find it's way.
The `"List available databases"` links to `:dbs`.
_Prior art: We do this when a users inputs a unknown procedure_

See screenshot.

<img width="1049" alt="oskarhane-mbpt 2019-11-25 at 20 52 14" src="https://user-images.githubusercontent.com/570998/69573140-d719fd00-0fc5-11ea-9575-953b060914bd.png">

I also reworked so we don't show error message when a user is trying to `:use xx` a db that doesn't exist but let the system handle that when the user tries to exec a command.

E2E tests added to verify the behavior.
