### PR TITLE
Neo4j-Browser becomes unresponsive with large query results

### DIFF
--- a/src/browser/modules/D3Visualization/components/Explorer.jsx
+++ b/src/browser/modules/D3Visualization/components/Explorer.jsx
@@ -26,6 +26,8 @@ import neoGraphStyle from '../graphStyle'
 import { InspectorComponent } from './Inspector'
 import { LegendComponent } from './Legend'
 import { StyledFullSizeContainer } from './styled'
+import { getMaxFieldItems } from 'shared/modules/settings/settingsDuck'
+import { connect } from 'react-redux'
 
 const deduplicateNodes = nodes => {
   return nodes.reduce(
@@ -231,6 +233,7 @@ export class ExplorerComponent extends Component {
           setGraph={this.props.setGraph}
         />
         <InspectorComponent
+          hasTruncatedFields={this.props.hasTruncatedFields}
           fullscreen={this.props.fullscreen}
           hoveredItem={this.state.hoveredItem}
           selectedItem={this.state.selectedItem}
@@ -241,4 +244,6 @@ export class ExplorerComponent extends Component {
     )
   }
 }
-export const Explorer = ExplorerComponent
+export const Explorer = connect(state => ({
+  maxFieldItems: getMaxFieldItems(state)
+}))(ExplorerComponent)

--- a/src/browser/modules/D3Visualization/components/Inspector.jsx
+++ b/src/browser/modules/D3Visualization/components/Inspector.jsx
@@ -40,6 +40,9 @@ import { GrassEditor } from './GrassEditor'
 import { RowExpandToggleComponent } from './RowExpandToggle'
 import ClickableUrls from '../../../components/clickable-urls'
 import numberToUSLocale from 'shared/utils/number-to-US-locale'
+import { StyledTruncatedMessage } from 'browser/modules/Stream/styled'
+import { Icon } from 'semantic-ui-react'
+import Ellipsis from 'browser-components/Ellipsis'
 
 const mapItemProperties = itemProperties =>
   itemProperties
@@ -149,6 +152,12 @@ export class InspectorComponent extends Component {
           <StyledInlineList className="list-inline">
             <StyledInspectorFooterRowListPair className="pair" key="pair">
               <StyledInspectorFooterRowListValue className="value">
+                {this.props.hasTruncatedFields && (
+                  <StyledTruncatedMessage>
+                    <Icon name="warning sign" /> Result fields have been
+                    truncated.&nbsp;
+                  </StyledTruncatedMessage>
+                )}
                 {description}
               </StyledInspectorFooterRowListValue>
             </StyledInspectorFooterRowListPair>

--- a/src/browser/modules/D3Visualization/components/Inspector.jsx
+++ b/src/browser/modules/D3Visualization/components/Inspector.jsx
@@ -154,7 +154,7 @@ export class InspectorComponent extends Component {
               <StyledInspectorFooterRowListValue className="value">
                 {this.props.hasTruncatedFields && (
                   <StyledTruncatedMessage>
-                    <Icon name="warning sign" /> Result fields have been
+                    <Icon name="warning sign" /> Record fields have been
                     truncated.&nbsp;
                   </StyledTruncatedMessage>
                 )}

--- a/src/browser/modules/Sidebar/Settings.jsx
+++ b/src/browser/modules/Sidebar/Settings.jsx
@@ -161,9 +161,9 @@ const visualSettings = [
       },
       {
         maxFieldItems: {
-          displayName: 'Property item limit',
+          displayName: 'Record field limit',
           tooltip:
-            'Max amount of items shown for list properties. When reached, lists get truncated.'
+            'Max number of items in a field per record being handled. When reached, items get truncated.'
         }
       },
       {

--- a/src/browser/modules/Sidebar/Settings.jsx
+++ b/src/browser/modules/Sidebar/Settings.jsx
@@ -161,9 +161,9 @@ const visualSettings = [
       },
       {
         maxFieldItems: {
-          displayName: 'Max field items',
+          displayName: 'Property item limit',
           tooltip:
-            'Max items of result fields shown. When reached, fields get truncated.'
+            'Max amount of items shown for list properties. When reached, lists get truncated.'
         }
       },
       {

--- a/src/browser/modules/Sidebar/Settings.jsx
+++ b/src/browser/modules/Sidebar/Settings.jsx
@@ -160,6 +160,13 @@ const visualSettings = [
         }
       },
       {
+        maxFieldItems: {
+          displayName: 'Max field items',
+          tooltip:
+            'Max items of result fields shown. When reached, fields get truncated.'
+        }
+      },
+      {
         autoComplete: {
           displayName: 'Connect result nodes',
           tooltip:

--- a/src/browser/modules/Stream/CypherFrame/AsciiView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/AsciiView.jsx
@@ -38,8 +38,10 @@ import {
   stringifyResultArray
 } from './helpers'
 import { stringModifier } from 'services/bolt/cypherTypesFormatting'
+import { getMaxFieldItems } from 'shared/modules/settings/settingsDuck'
+import { connect } from 'react-redux'
 
-export class AsciiView extends Component {
+export class AsciiViewComponent extends Component {
   state = {
     serializedRows: [],
     bodyMessage: ''
@@ -72,8 +74,8 @@ export class AsciiView extends Component {
     return !this.equalProps(props) || !shallowEquals(state, this.state)
   }
 
-  makeState(props) {
-    const { result, maxRows } = props
+  makeState (props) {
+    const { result, maxRows, maxFieldItems } = props
     const { bodyMessage = null } =
       getBodyAndStatusBarMessages(result, maxRows) || {}
     this.setState({ bodyMessage })
@@ -82,7 +84,7 @@ export class AsciiView extends Component {
     const serializedRows =
       stringifyResultArray(
         stringModifier,
-        transformResultRecordsToResultArray(records)
+        transformResultRecordsToResultArray(records, maxFieldItems)
       ) || []
     this.setState({ serializedRows })
     const maxColWidth = asciitable.maxColumnWidth(serializedRows)
@@ -109,6 +111,10 @@ export class AsciiView extends Component {
     return <PaddedDiv>{contents}</PaddedDiv>
   }
 }
+
+export const AsciiView = connect(state => ({
+  maxFieldItems: getMaxFieldItems(state)
+}))(AsciiViewComponent)
 
 export class AsciiStatusbar extends Component {
   state = {

--- a/src/browser/modules/Stream/CypherFrame/AsciiView.test.js
+++ b/src/browser/modules/Stream/CypherFrame/AsciiView.test.js
@@ -22,7 +22,7 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import neo4j from 'neo4j-driver'
 
-import { AsciiView, AsciiStatusbar } from './AsciiView'
+import { AsciiViewComponent as AsciiView, AsciiStatusbar } from './AsciiView'
 
 describe('AsciiViews', () => {
   describe('AsciiView', () => {

--- a/src/browser/modules/Stream/CypherFrame/CodeView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/CodeView.jsx
@@ -29,7 +29,7 @@ import {
   StyledTd,
   StyledExpandable
 } from '../styled'
-import { TableStatusbar } from './TableView'
+import { TableStatusbar, TableStatusbarComponent } from './TableView'
 import { getMaxFieldItems } from 'shared/modules/settings/settingsDuck'
 import { connect } from 'react-redux'
 import { map, take } from 'lodash-es'
@@ -121,4 +121,5 @@ export const CodeView = connect(state => ({
   maxFieldItems: getMaxFieldItems(state)
 }))(CodeViewComponent)
 
+export const CodeStatusbarComponent = TableStatusbarComponent
 export const CodeStatusbar = TableStatusbar

--- a/src/browser/modules/Stream/CypherFrame/CodeView.test.js
+++ b/src/browser/modules/Stream/CypherFrame/CodeView.test.js
@@ -22,7 +22,10 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import neo4j from 'neo4j-driver'
 
-import { CodeViewComponent as CodeView, CodeStatusbar } from './CodeView'
+import {
+  CodeViewComponent as CodeView,
+  CodeStatusbarComponent as CodeStatusbar
+} from './CodeView'
 
 describe('CodeViews', () => {
   describe('CodeView', () => {

--- a/src/browser/modules/Stream/CypherFrame/CodeView.test.js
+++ b/src/browser/modules/Stream/CypherFrame/CodeView.test.js
@@ -22,7 +22,7 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import neo4j from 'neo4j-driver'
 
-import { CodeView, CodeStatusbar } from './CodeView'
+import { CodeViewComponent as CodeView, CodeStatusbar } from './CodeView'
 
 describe('CodeViews', () => {
   describe('CodeView', () => {

--- a/src/browser/modules/Stream/CypherFrame/TableView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/TableView.jsx
@@ -26,7 +26,8 @@ import { HTMLEntities } from 'services/santize.utils'
 import {
   StyledStatsBar,
   PaddedTableViewDiv,
-  StyledBodyMessage
+  StyledBodyMessage,
+  StyledTruncatedMessage
 } from '../styled'
 import Ellipsis from 'browser-components/Ellipsis'
 import {
@@ -40,7 +41,8 @@ import { shallowEquals, stringifyMod } from 'services/utils'
 import {
   getBodyAndStatusBarMessages,
   getRecordsToDisplayInTable,
-  transformResultRecordsToResultArray
+  transformResultRecordsToResultArray,
+  resultHasTruncatedFields
 } from './helpers'
 import { stringModifier } from 'services/bolt/cypherTypesFormatting'
 import ClickableUrls, {
@@ -48,6 +50,7 @@ import ClickableUrls, {
 } from '../../../components/clickable-urls'
 import { getMaxFieldItems } from 'shared/modules/settings/settingsDuck'
 import { connect } from 'react-redux'
+import { Icon } from 'semantic-ui-react'
 
 const renderCell = (entry, maxFieldItems) => {
   if (Array.isArray(entry)) {
@@ -178,7 +181,7 @@ export const TableView = connect(state => ({
   maxFieldItems: getMaxFieldItems(state)
 }))(TableViewComponent)
 
-export class TableStatusbar extends Component {
+export class TableStatusbarComponent extends Component {
   state = {
     statusBarMessage: ''
   }
@@ -201,14 +204,30 @@ export class TableStatusbar extends Component {
       this.props.result,
       this.props.maxRows
     )
-    if (statusBarMessage !== undefined) this.setState({ statusBarMessage })
+    const hasTruncatedFields = resultHasTruncatedFields(
+      props.result,
+      props.maxFieldItems
+    )
+    if (statusBarMessage !== undefined) { this.setState({ statusBarMessage, hasTruncatedFields }) }
   }
 
   render() {
     return (
       <StyledStatsBar>
-        <Ellipsis>{this.state.statusBarMessage}</Ellipsis>
+        <Ellipsis>
+          {this.state.hasTruncatedFields && (
+            <StyledTruncatedMessage>
+              <Icon name='warning sign' /> Result fields have been
+              truncated.&nbsp;
+            </StyledTruncatedMessage>
+          )}
+          {this.state.statusBarMessage}
+        </Ellipsis>
       </StyledStatsBar>
     )
   }
 }
+
+export const TableStatusbar = connect(state => ({
+  maxFieldItems: getMaxFieldItems(state)
+}))(TableStatusbarComponent)

--- a/src/browser/modules/Stream/CypherFrame/TableView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/TableView.jsx
@@ -46,12 +46,14 @@ import { stringModifier } from 'services/bolt/cypherTypesFormatting'
 import ClickableUrls, {
   convertUrlsToHrefTags
 } from '../../../components/clickable-urls'
+import { getMaxFieldItems } from 'shared/modules/settings/settingsDuck'
+import { connect } from 'react-redux'
 
-const renderCell = entry => {
+const renderCell = (entry, maxFieldItems) => {
   if (Array.isArray(entry)) {
-    const children = entry.map((item, index) => (
+    const children = entry.slice(0, maxFieldItems).map((item, index) => (
       <span key={index}>
-        {renderCell(item)}
+        {renderCell(item, maxFieldItems)}
         {index === entry.length - 1 ? null : ', '}
       </span>
     ))
@@ -75,12 +77,12 @@ export const renderObject = entry => {
     />
   )
 }
-const buildData = entries => {
+const buildData = (entries, maxFieldItems) => {
   return entries.map(entry => {
     if (entry !== null) {
       return (
-        <StyledTd className="table-properties" key={v4()}>
-          {renderCell(entry)}
+        <StyledTd className='table-properties' key={v4()}>
+          {renderCell(entry, maxFieldItems)}
         </StyledTd>
       )
     }
@@ -91,15 +93,15 @@ const buildData = entries => {
     )
   })
 }
-const buildRow = item => {
+const buildRow = (item, maxFieldItems) => {
   return (
-    <StyledBodyTr className="table-row" key={v4()}>
-      {buildData(item)}
+    <StyledBodyTr className='table-row' key={v4()}>
+      {buildData(item, maxFieldItems)}
     </StyledBodyTr>
   )
 }
 
-export class TableView extends Component {
+export class TableViewComponent extends Component {
   state = {
     columns: [],
     data: [],
@@ -155,7 +157,9 @@ export class TableView extends Component {
       </StyledTh>
     ))
     const tableBody = (
-      <tbody>{this.state.data.map(item => buildRow(item))}</tbody>
+      <tbody>
+        {this.state.data.map(item => buildRow(item, this.props.maxFieldItems))}
+      </tbody>
     )
     return (
       <PaddedTableViewDiv>
@@ -169,6 +173,10 @@ export class TableView extends Component {
     )
   }
 }
+
+export const TableView = connect(state => ({
+  maxFieldItems: getMaxFieldItems(state)
+}))(TableViewComponent)
 
 export class TableStatusbar extends Component {
   state = {

--- a/src/browser/modules/Stream/CypherFrame/TableView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/TableView.jsx
@@ -54,9 +54,10 @@ import { Icon } from 'semantic-ui-react'
 
 const renderCell = (entry, maxFieldItems) => {
   if (Array.isArray(entry)) {
-    const children = entry.slice(0, maxFieldItems).map((item, index) => (
+    const entryToUse = maxFieldItems ? entry.slice(0, maxFieldItems) : entry
+    const children = entryToUse.map((item, index) => (
       <span key={index}>
-        {renderCell(item, maxFieldItems)}
+        {renderCell(item)}
         {index === entry.length - 1 ? null : ', '}
       </span>
     ))
@@ -84,7 +85,7 @@ const buildData = (entries, maxFieldItems) => {
   return entries.map(entry => {
     if (entry !== null) {
       return (
-        <StyledTd className='table-properties' key={v4()}>
+        <StyledTd className="table-properties" key={v4()}>
           {renderCell(entry, maxFieldItems)}
         </StyledTd>
       )
@@ -98,7 +99,7 @@ const buildData = (entries, maxFieldItems) => {
 }
 const buildRow = (item, maxFieldItems) => {
   return (
-    <StyledBodyTr className='table-row' key={v4()}>
+    <StyledBodyTr className="table-row" key={v4()}>
       {buildData(item, maxFieldItems)}
     </StyledBodyTr>
   )
@@ -208,7 +209,9 @@ export class TableStatusbarComponent extends Component {
       props.result,
       props.maxFieldItems
     )
-    if (statusBarMessage !== undefined) { this.setState({ statusBarMessage, hasTruncatedFields }) }
+    if (statusBarMessage !== undefined) {
+      this.setState({ statusBarMessage, hasTruncatedFields })
+    }
   }
 
   render() {
@@ -217,7 +220,7 @@ export class TableStatusbarComponent extends Component {
         <Ellipsis>
           {this.state.hasTruncatedFields && (
             <StyledTruncatedMessage>
-              <Icon name='warning sign' /> Result fields have been
+              <Icon name="warning sign" /> Result fields have been
               truncated.&nbsp;
             </StyledTruncatedMessage>
           )}

--- a/src/browser/modules/Stream/CypherFrame/TableView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/TableView.jsx
@@ -220,7 +220,7 @@ export class TableStatusbarComponent extends Component {
         <Ellipsis>
           {this.state.hasTruncatedFields && (
             <StyledTruncatedMessage>
-              <Icon name="warning sign" /> Result fields have been
+              <Icon name="warning sign" /> Record fields have been
               truncated.&nbsp;
             </StyledTruncatedMessage>
           )}

--- a/src/browser/modules/Stream/CypherFrame/TableView.test.js
+++ b/src/browser/modules/Stream/CypherFrame/TableView.test.js
@@ -24,7 +24,7 @@ import neo4j from 'neo4j-driver'
 
 import {
   TableViewComponent as TableView,
-  TableStatusbar,
+  TableStatusbarComponent as TableStatusbar,
   renderObject
 } from './TableView'
 

--- a/src/browser/modules/Stream/CypherFrame/TableView.test.js
+++ b/src/browser/modules/Stream/CypherFrame/TableView.test.js
@@ -22,7 +22,11 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import neo4j from 'neo4j-driver'
 
-import { TableView, TableStatusbar, renderObject } from './TableView'
+import {
+  TableViewComponent as TableView,
+  TableStatusbar,
+  renderObject
+} from './TableView'
 
 describe('TableViews', () => {
   describe('TableView', () => {

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView.jsx
@@ -30,6 +30,7 @@ import { StyledVisContainer } from './VisualizationView.styled'
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
 import { NEO4J_BROWSER_USER_ACTION_QUERY } from 'services/bolt/txMetadata'
 import { getMaxFieldItems } from 'shared/modules/settings/settingsDuck'
+import { resultHasTruncatedFields } from 'browser/modules/Stream/CypherFrame/helpers'
 
 export class Visualization extends Component {
   state = {
@@ -72,9 +73,14 @@ export class Visualization extends Component {
       true,
       props.maxFieldItems
     )
+    const hasTruncatedFields = resultHasTruncatedFields(
+      props.result,
+      props.maxFieldItems
+    )
     this.setState({
       nodes,
       relationships,
+      hasTruncatedFields,
       updated: new Date().getTime()
     })
   }
@@ -176,6 +182,7 @@ export class Visualization extends Component {
       <StyledVisContainer fullscreen={this.props.fullscreen}>
         <ExplorerComponent
           maxNeighbours={this.props.maxNeighbours}
+          hasTruncatedFields={this.state.hasTruncatedFields}
           initialNodeDisplay={this.props.initialNodeDisplay}
           graphStyleData={this.props.graphStyleData}
           updateStyle={this.props.updateStyle}

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView.jsx
@@ -29,6 +29,7 @@ import { StyledVisContainer } from './VisualizationView.styled'
 
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
 import { NEO4J_BROWSER_USER_ACTION_QUERY } from 'services/bolt/txMetadata'
+import { getMaxFieldItems } from 'shared/modules/settings/settingsDuck'
 
 export class Visualization extends Component {
   state = {
@@ -67,7 +68,9 @@ export class Visualization extends Component {
       nodes,
       relationships
     } = bolt.extractNodesAndRelationshipsFromRecordsForOldVis(
-      props.result.records
+      props.result.records,
+      true,
+      props.maxFieldItems
     )
     this.setState({
       nodes,
@@ -115,7 +118,8 @@ export class Visualization extends Component {
                   : 0
               const resultGraph = bolt.extractNodesAndRelationshipsFromRecordsForOldVis(
                 response.result.records,
-                false
+                false,
+                this.props.maxFieldItems
               )
               this.autoCompleteRelationships(
                 this.graph._nodes,
@@ -150,7 +154,8 @@ export class Visualization extends Component {
               resolve({
                 ...bolt.extractNodesAndRelationshipsFromRecordsForOldVis(
                   response.result.records,
-                  false
+                  false,
+                  this.props.maxFieldItems
                 )
               })
             }
@@ -192,7 +197,8 @@ export class Visualization extends Component {
 
 const mapStateToProps = state => {
   return {
-    graphStyleData: grassActions.getGraphStyleData(state)
+    graphStyleData: grassActions.getGraphStyleData(state),
+    maxFieldItems: getMaxFieldItems(state)
   }
 }
 

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/AsciiView.test.js.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/AsciiView.test.js.snap
@@ -20,14 +20,14 @@ exports[`AsciiViews AsciiStatusbar displays statusBarMessage if no rows 2`] = `
     class="styled__StyledStatsBar-sc-1dtvgs1-23 gWjkIU"
   >
     <div
-      class="styled__StyledRightPartial-sc-1dtvgs1-32 ghhzbn"
+      class="styled__StyledRightPartial-sc-1dtvgs1-33 kITufN"
     >
       <div
-        class="styled__StyledWidthSliderContainer-sc-1dtvgs1-34 idlnPl"
+        class="styled__StyledWidthSliderContainer-sc-1dtvgs1-35 hsuISq"
       >
         Max column width:
         <input
-          class="styled__StyledWidthSlider-sc-1dtvgs1-35 kvIxBa"
+          class="styled__StyledWidthSlider-sc-1dtvgs1-36 cgzxFB"
           max="3"
           min="3"
           type="range"
@@ -45,7 +45,7 @@ exports[`AsciiViews AsciiView displays bodyMessage if no rows 1`] = `
     class="styled__PaddedDiv-sc-1dtvgs1-1 kyHRpW"
   >
     <div
-      class="styled__StyledBodyMessage-sc-1dtvgs1-26 gpPoTU"
+      class="styled__StyledBodyMessage-sc-1dtvgs1-27 hpwxul"
     >
       (no changes, no records)
     </div>

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/CodeView.test.js.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/CodeView.test.js.snap
@@ -7,7 +7,9 @@ exports[`CodeViews CodeStatusbar displays no statusBarMessage 1`] = `
   >
     <div
       class="Ellipsis-sc-1dn9bou-0 gzqRPC"
-    />
+    >
+      
+    </div>
   </div>
 </div>
 `;
@@ -34,85 +36,85 @@ exports[`CodeViews CodeView displays request and response info if successful que
     class="styled__PaddedDiv-sc-1dtvgs1-1 kyHRpW"
   >
     <table
-      class="styled__StyledTable-sc-1dtvgs1-36 bXcmxT"
+      class="styled__StyledTable-sc-1dtvgs1-37 hQXYgT"
     >
       <tbody
-        class="styled__StyledTBody-sc-1dtvgs1-37 gZUxwp"
+        class="styled__StyledTBody-sc-1dtvgs1-38 kGUkAE"
       >
         <tr
-          class="styled__StyledAlteringTr-sc-1dtvgs1-39 dFJTjq"
+          class="styled__StyledAlteringTr-sc-1dtvgs1-40 iAVdiN"
         >
           <td
-            class="styled__StyledStrongTd-sc-1dtvgs1-40 fXHrSd"
+            class="styled__StyledStrongTd-sc-1dtvgs1-41 gkKCBY"
           >
             Server version
           </td>
           <td
-            class="styled__StyledTd-sc-1dtvgs1-41 fJfBGu"
+            class="styled__StyledTd-sc-1dtvgs1-42 dGNdSM"
           >
             xx1
           </td>
         </tr>
         <tr
-          class="styled__StyledAlteringTr-sc-1dtvgs1-39 dFJTjq"
+          class="styled__StyledAlteringTr-sc-1dtvgs1-40 iAVdiN"
         >
           <td
-            class="styled__StyledStrongTd-sc-1dtvgs1-40 fXHrSd"
+            class="styled__StyledStrongTd-sc-1dtvgs1-41 gkKCBY"
           >
             Server address
           </td>
           <td
-            class="styled__StyledTd-sc-1dtvgs1-41 fJfBGu"
+            class="styled__StyledTd-sc-1dtvgs1-42 dGNdSM"
           >
             xx2
           </td>
         </tr>
         <tr
-          class="styled__StyledAlteringTr-sc-1dtvgs1-39 dFJTjq"
+          class="styled__StyledAlteringTr-sc-1dtvgs1-40 iAVdiN"
         >
           <td
-            class="styled__StyledStrongTd-sc-1dtvgs1-40 fXHrSd"
+            class="styled__StyledStrongTd-sc-1dtvgs1-41 gkKCBY"
           >
             Query
           </td>
           <td
-            class="styled__StyledTd-sc-1dtvgs1-41 fJfBGu"
+            class="styled__StyledTd-sc-1dtvgs1-42 dGNdSM"
           >
             MATCH xx0
           </td>
         </tr>
         <tr
-          class="styled__StyledAlteringTr-sc-1dtvgs1-39 dFJTjq"
+          class="styled__StyledAlteringTr-sc-1dtvgs1-40 iAVdiN"
         >
           <td
-            class="styled__StyledStrongTd-sc-1dtvgs1-40 fXHrSd"
+            class="styled__StyledStrongTd-sc-1dtvgs1-41 gkKCBY"
           >
             Summary
             <div
-              class="styled__StyledExpandable-sc-1dtvgs1-38 dMVSiX fa fa-caret-right"
+              class="styled__StyledExpandable-sc-1dtvgs1-39 dxftfv fa fa-caret-right"
               title="Expand section"
             />
           </td>
           <td
-            class="styled__StyledTd-sc-1dtvgs1-41 fJfBGu"
+            class="styled__StyledTd-sc-1dtvgs1-42 dGNdSM"
           >
             {,  "server": {,    "version": "xx1", ...
           </td>
         </tr>
         <tr
-          class="styled__StyledAlteringTr-sc-1dtvgs1-39 dFJTjq"
+          class="styled__StyledAlteringTr-sc-1dtvgs1-40 iAVdiN"
         >
           <td
-            class="styled__StyledStrongTd-sc-1dtvgs1-40 fXHrSd"
+            class="styled__StyledStrongTd-sc-1dtvgs1-41 gkKCBY"
           >
             Response
             <div
-              class="styled__StyledExpandable-sc-1dtvgs1-38 dMVSiX fa fa-caret-right"
+              class="styled__StyledExpandable-sc-1dtvgs1-39 dxftfv fa fa-caret-right"
               title="Expand section"
             />
           </td>
           <td
-            class="styled__StyledTd-sc-1dtvgs1-41 fJfBGu"
+            class="styled__StyledTd-sc-1dtvgs1-42 dGNdSM"
           >
             [,  {,    "res": "xx3" ...
           </td>

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/TableView.test.js.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/TableView.test.js.snap
@@ -7,7 +7,9 @@ exports[`TableViews TableStatusbar displays no statusBarMessage 1`] = `
   >
     <div
       class="Ellipsis-sc-1dn9bou-0 gzqRPC"
-    />
+    >
+      
+    </div>
   </div>
 </div>
 `;
@@ -32,7 +34,7 @@ exports[`TableViews TableView displays bodyMessage if no rows 1`] = `
     class="styled__PaddedDiv-sc-1dtvgs1-1 styled__PaddedTableViewDiv-sc-1dtvgs1-2 clXnC"
   >
     <div
-      class="styled__StyledBodyMessage-sc-1dtvgs1-26 gpPoTU"
+      class="styled__StyledBodyMessage-sc-1dtvgs1-27 hpwxul"
     >
       (no changes, no records)
     </div>

--- a/src/browser/modules/Stream/CypherFrame/helpers.js
+++ b/src/browser/modules/Stream/CypherFrame/helpers.js
@@ -53,9 +53,11 @@ export const resultHasTruncatedFields = (result, maxFieldItems) => {
   }
 
   return some(result.records, record =>
-    some(record.keys, key =>
-      Array.isArray(record.get(key) && record.get(key).length > maxFieldItems)
-    )
+    some(record.keys, key => {
+      const val = record.get(key)
+
+      return Array.isArray(val) && val.length > maxFieldItems
+    })
   )
 }
 

--- a/src/browser/modules/Stream/CypherFrame/helpers.js
+++ b/src/browser/modules/Stream/CypherFrame/helpers.js
@@ -61,7 +61,7 @@ export const resultHasTruncatedFields = (result, maxFieldItems) => {
   )
 }
 
-export function getBodyAndStatusBarMessages (result, maxRows) {
+export function getBodyAndStatusBarMessages(result, maxRows) {
   if (!result || !result.summary || !result.summary.resultAvailableAfter) {
     return {}
   }
@@ -118,7 +118,7 @@ export const getRecordsToDisplayInTable = (result, maxRows) => {
     : result.records
 }
 
-export const flattenArray = arr => {
+export const flattenArrayDeep = arr => {
   let toFlatten = arr
   let result = []
 
@@ -140,7 +140,7 @@ export const resultHasNodes = (request, types = bolt.neo4j.types) => {
   for (let i = 0; i < records.length; i++) {
     const graphItems = keys.map(key => records[i].get(key))
     const items = recursivelyExtractGraphItems(types, graphItems)
-    const flat = flattenArray(items)
+    const flat = flattenArrayDeep(items)
     const nodes = flat.filter(
       item => item instanceof types.Node || item instanceof types.Path
     )
@@ -236,10 +236,10 @@ export const stringifyResultArray = (formatter = stringModifier, arr = []) => {
 export const transformResultRecordsToResultArray = (records, maxFieldItems) => {
   return records && records.length
     ? [records]
-      .map(recs => extractRecordsToResultArray(recs, maxFieldItems))
-      .map(
-        flattenGraphItemsInResultArray.bind(null, neo4j.types, neo4j.isInt)
-      )[0]
+        .map(recs => extractRecordsToResultArray(recs, maxFieldItems))
+        .map(
+          flattenGraphItemsInResultArray.bind(null, neo4j.types, neo4j.isInt)
+        )[0]
     : undefined
 }
 

--- a/src/browser/modules/Stream/__snapshots__/HistoryRow.test.js.snap
+++ b/src/browser/modules/Stream/__snapshots__/HistoryRow.test.js.snap
@@ -3,7 +3,7 @@
 exports[`HistoryRow triggers function on click 1`] = `
 <div>
   <li
-    class="styled__StyledHistoryRow-sc-1dtvgs1-43 keUkVP"
+    class="styled__StyledHistoryRow-sc-1dtvgs1-44 whMxP"
   >
     :clear
   </li>

--- a/src/browser/modules/Stream/styled.jsx
+++ b/src/browser/modules/Stream/styled.jsx
@@ -177,6 +177,9 @@ export const StyledStatsBar = styled.div`
   padding-left: 24px;
   width: 100%;
 `
+export const StyledTruncatedMessage = styled.span`
+  color: orange;
+`
 
 export const StyledOneRowStatsBar = styled(StyledStatsBar)`
   height: 39px;

--- a/src/shared/modules/settings/__snapshots__/settingsDuck.test.js.snap
+++ b/src/shared/modules/settings/__snapshots__/settingsDuck.test.js.snap
@@ -12,6 +12,7 @@ Object {
   "enableMultiStatementMode": false,
   "initCmd": ":play start",
   "initialNodeDisplay": 300,
+  "maxFieldItems": 500,
   "maxFrames": 30,
   "maxHistory": 30,
   "maxNeighbours": 100,

--- a/src/shared/modules/settings/settingsDuck.js
+++ b/src/shared/modules/settings/settingsDuck.js
@@ -17,6 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { get } from 'lodash-es'
 
 import { APP_START, USER_CLEAR } from 'shared/modules/app/appDuck'
 
@@ -49,6 +50,8 @@ export const getBrowserSyncConfig = (
 export const getMaxNeighbours = state =>
   state[NAME].maxNeighbours || initialState.maxNeighbours
 export const getMaxRows = state => state[NAME].maxRows || initialState.maxRows
+export const getMaxFieldItems = state =>
+  get(state, [NAME, 'maxFieldItems'], initialState.maxFieldItems)
 export const getInitialNodeDisplay = state =>
   state[NAME].initialNodeDisplay || initialState.initialNodeDisplay
 export const getScrollToTop = state => state[NAME].scrollToTop
@@ -89,6 +92,7 @@ const initialState = {
   showSampleScripts: true,
   browserSyncDebugServer: null,
   maxRows: 1000,
+  maxFieldItems: 500,
   shouldReportUdc: true,
   autoComplete: true,
   scrollToTop: true,

--- a/src/shared/services/bolt/bolt.js
+++ b/src/shared/services/bolt/bolt.js
@@ -243,18 +243,21 @@ export default {
       objectConverter: mappings.extractFromNeoObjects
     })
   },
-  extractNodesAndRelationshipsFromRecords: records => {
+  extractNodesAndRelationshipsFromRecords: (records, maxFieldItems) => {
     return mappings.extractNodesAndRelationshipsFromRecords(
       records,
-      neo4j.types
+      neo4j.types,
+      maxFieldItems
     )
   },
   extractNodesAndRelationshipsFromRecordsForOldVis: (
     records,
-    filterRels = true
+    filterRels = true,
+    maxFieldItems
   ) => {
     const intChecker = neo4j.isInt
     const intConverter = val => val.toString()
+
     return mappings.extractNodesAndRelationshipsFromRecordsForOldVis(
       records,
       neo4j.types,
@@ -263,7 +266,8 @@ export default {
         intChecker,
         intConverter,
         objectConverter: mappings.extractFromNeoObjects
-      }
+      },
+      maxFieldItems
     )
   },
   extractPlan: (result, calculateTotalDbHits) => {

--- a/src/shared/services/bolt/boltMappings.js
+++ b/src/shared/services/bolt/boltMappings.js
@@ -19,7 +19,7 @@
  */
 
 import updateStatsFields from './updateStatisticsFields'
-import { flatten, take } from 'lodash-es'
+import { flatten, map, take } from 'lodash-es'
 import neo4j from 'neo4j-driver'
 import { stringModifier } from 'services/bolt/cypherTypesFormatting'
 import {
@@ -229,7 +229,7 @@ export const recursivelyExtractGraphItems = (types, item) => {
   return item
 }
 
-export function extractRawNodesAndRelationShipsFromRecords (
+export function extractRawNodesAndRelationShipsFromRecords(
   records,
   types = neo4j.types,
   maxFieldItems
@@ -246,9 +246,11 @@ export function extractRawNodesAndRelationShipsFromRecords (
     }
   }
 
-  const flatTruncatedItems = maxFieldItems
-    ? take(flatten([...items]), maxFieldItems)
-    : flatten([...items])
+  const flatTruncatedItems = flatten(
+    map([...items], item =>
+      maxFieldItems && Array.isArray(item) ? take(item, maxFieldItems) : item
+    )
+  )
 
   for (const item of flatTruncatedItems) {
     if (item instanceof types.Relationship) {

--- a/src/shared/services/bolt/boltMappings.test.js
+++ b/src/shared/services/bolt/boltMappings.test.js
@@ -414,7 +414,7 @@ describe('boltMappings', () => {
       // Then
       expect(out.nodes.length).toEqual(4)
     })
-    test('should find items in paths with segments', () => {
+    test('should find items in paths with segments, and only return unique items', () => {
       // Given
       const converters = {
         intChecker: () => false,
@@ -448,7 +448,7 @@ describe('boltMappings', () => {
       )
 
       // Then
-      expect(out.nodes.length).toEqual(4)
+      expect(out.nodes.length).toEqual(3)
     })
     test('should find items in paths zero segments', () => {
       // Given

--- a/src/shared/services/bolt/boltMappings.test.js
+++ b/src/shared/services/bolt/boltMappings.test.js
@@ -204,6 +204,31 @@ describe('boltMappings', () => {
       expect(relationships[0].properties).toEqual({})
     })
 
+    test('should truncate field items when told to do so', () => {
+      let startNode = new neo4j.types.Node('1', ['Person'], {
+        prop1: 'prop1'
+      })
+      let endNode = new neo4j.types.Node('2', ['Movie'], {
+        prop2: 'prop2'
+      })
+      let boltRecord = {
+        keys: ['p'],
+        get: key => [startNode, endNode]
+      }
+
+      let { nodes, relationships } = extractNodesAndRelationshipsFromRecords(
+        [boltRecord],
+        neo4j.types,
+        1
+      )
+      expect(nodes.length).toBe(1)
+      expect(relationships.length).toBe(0)
+      let graphNode = nodes[0]
+      expect(graphNode).toBeDefined()
+      expect(graphNode.labels).toEqual(['Person'])
+      expect(graphNode.properties).toEqual({ prop1: 'prop1' })
+    })
+
     test('should map bolt nodes and relationships to graph nodes and relationships', () => {
       const startNode = new neo4j.types.Node('1', ['Person'], {
         prop1: 'prop1'


### PR DESCRIPTION
This PR introduces a new configuration option in browser for truncating max field length before they are passed to rendering layers. The reason for this is that certain queries can produce a single result with a lot of values in a given field, which we had yet to account for.

### Screenshot
<img width="1192" alt="Screenshot 2019-12-12 at 13 01 29" src="https://user-images.githubusercontent.com/52443771/70712645-85bb7e80-1ce4-11ea-85d7-e9f5dc35290b.png">
<img width="1635" alt="Screenshot 2020-01-07 at 12 30 25" src="https://user-images.githubusercontent.com/52443771/71892843-50bb1400-314a-11ea-9b91-2d94054027a5.png">
