### PR TITLE
Prefer `bolt_routing` URL from discovery if it exists

### DIFF
--- a/src/shared/modules/discovery/discoveryDuck.js
+++ b/src/shared/modules/discovery/discoveryDuck.js
@@ -136,7 +136,9 @@ export const discoveryOnStartupEpic = (some$, store) => {
           // fake discovery response
           // Promise.resolve({ bolt: 'bolt+routing://localhost:7687' })
           .then(result => {
-            const host = result && (result.bolt_direct || result.bolt)
+            const host =
+              result &&
+              (result.bolt_routing || result.bolt_direct || result.bolt)
             // Try to get info from server
             if (!host) {
               throw new Error('No bolt address found') // No bolt info from server, throw

--- a/src/shared/modules/discovery/discoveryDuck.test.js
+++ b/src/shared/modules/discovery/discoveryDuck.test.js
@@ -146,6 +146,30 @@ describe('discoveryOnStartupEpic', () => {
     // When
     store.dispatch(action)
   })
+  test('listens on APP_START and finds all of bolt_routing, bolt_direct and a bold host and dispatches an action with the found bolt_routing host', done => {
+    // Given
+    const action = { type: APP_START, env: WEB }
+    const expectedHost = 'neo4j://myhost:7777'
+    nock(getDiscoveryEndpoint())
+      .get('/')
+      .reply(200, {
+        bolt_routing: expectedHost,
+        bolt_direct: 'bolt://myhost:666',
+        bolt: 'very://bad:1337'
+      })
+    bus.take(discovery.DONE, currentAction => {
+      // Then
+      expect(store.getActions()).toEqual([
+        action,
+        discovery.updateDiscoveryConnection({ host: expectedHost }),
+        { type: discovery.DONE }
+      ])
+      done()
+    })
+
+    // When
+    store.dispatch(action)
+  })
   test('listens on APP_START and reads bolt URL from location URL and dispatches an action with the found host', done => {
     // Given
     const action = {


### PR DESCRIPTION
In coming versions of Neo4j, `bolt_routing` is preferred.

<img width="502" alt="Screenshot 2019-12-05 14 28 43" src="https://user-images.githubusercontent.com/570998/70240695-fce59580-176d-11ea-85b0-b05c734b586c.png">
