### PR TITLE
Add re-run button to SchemaFrame

### DIFF
--- a/src/browser/modules/Frame/FrameTitlebar.jsx
+++ b/src/browser/modules/Frame/FrameTitlebar.jsx
@@ -250,7 +250,7 @@ class FrameTitlebar extends Component {
           >
             {expandCollapseIcon}
           </FrameButton>
-          <Render if={['cypher', 'style'].includes(frame.type)}>
+          <Render if={['cypher', 'style', 'schema'].includes(frame.type)}>
             <FrameButton
               data-testid='rerunFrameButton'
               title='Rerun'

--- a/src/browser/modules/Stream/SchemaFrame.jsx
+++ b/src/browser/modules/Stream/SchemaFrame.jsx
@@ -103,7 +103,7 @@ export class SchemaFrame extends Component {
       this.setState({ [name]: out })
     }
   }
-  componentDidMount () {
+  fetchData () {
     if (this.props.bus) {
       // Indexes
       this.props.bus.self(
@@ -124,11 +124,23 @@ export class SchemaFrame extends Component {
         this.responseHandler('constraints')
       )
     }
+  }
+  componentDidMount () {
+    this.fetchData()
     if (this.props.indexes) {
       this.responseHandler('indexes')(this.props.indexes)
     }
     if (this.props.constraints) {
       this.responseHandler('constraints')(this.props.constraints)
+    }
+  }
+
+  componentDidUpdate (prevProps) {
+    if (
+      this.props.frame &&
+      this.props.frame.schemaRequestId !== prevProps.frame.schemaRequestId
+    ) {
+      this.fetchData()
     }
   }
 

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -21,6 +21,7 @@ import bolt from 'services/bolt/bolt'
 import * as frames from 'shared/modules/stream/streamDuck'
 import { getHostedUrl } from 'shared/modules/app/appDuck'
 import { getHistory, clearHistory } from 'shared/modules/history/historyDuck'
+import { v4 } from 'uuid'
 import {
   update as updateQueryResult,
   REQUEST_STATUS_SUCCESS,
@@ -307,7 +308,8 @@ const availableCommands = [
         frames.add({
           useDb: getUseDb(store.getState()),
           ...action,
-          type: 'schema'
+          type: 'schema',
+          schemaRequestId: v4()
         })
       )
     }


### PR DESCRIPTION
I'm not entirely sure if this is the best approach to make the re-run button work.

The alternative would be to move the fetching logic to the `commandInterpreterHelper.js` file. This is what the Cypher and Style frames are currently doing (those are the only type of frames that have a re-run button at the moment). 

I decided against it as I think the current way is more readable. You can see right in the SchemaFrame component what kind of data it requires, and if that data needs to be changed, both the request and the rendering for that data are in the same file. 