### PR TITLE
User feedback running system commands

### DIFF
--- a/e2e_tests/integration/multi-db.spec.js
+++ b/e2e_tests/integration/multi-db.spec.js
@@ -38,6 +38,27 @@ describe('Multi database', () => {
     cy.connect('neo4j', password)
   })
   if (Cypress.config('serverVersion') >= 4.0) {
+    it('shows a message indicating whether system updates have occured', () => {
+      cy.executeCommand(':clear')
+
+      cy.executeCommand(':use system')
+      cy.executeCommand('CREATE DATABASE test1')
+
+      cy.wait(3000) // CREATE database can take a sec
+
+      cy.resultContains('1 system update, no records')
+
+      cy.executeCommand('STOP DATABASE test1')
+      cy.wait(1000)
+      cy.resultContains('1 system update, no records')
+
+      cy.executeCommand('STOP DATABASE test1')
+      cy.wait(1000)
+      cy.resultContains('no changes, no records')
+
+      cy.executeCommand('DROP DATABASE test1')
+      cy.executeCommand(':clear')
+    })
     it(':use command works + shows current db in editor gutter', () => {
       cy.executeCommand(':clear')
       const editor = () => cy.get('[data-testid="editor-wrapper"]')

--- a/src/browser/modules/Stream/CypherFrame/helpers.js
+++ b/src/browser/modules/Stream/CypherFrame/helpers.js
@@ -62,9 +62,7 @@ export function getBodyAndStatusBarMessages (result, maxRows) {
   let updateMessages = bolt.retrieveFormattedUpdateStatistics(result)
   let streamMessage =
     result.records.length > 0
-      ? `started streaming ${
-        result.records.length
-      } records ${resultAvailableAfter} ms and completed ${totalTimeString} ${streamMessageTail}`
+      ? `started streaming ${result.records.length} records ${resultAvailableAfter} ms and completed ${totalTimeString} ${streamMessageTail}`
       : `completed ${totalTimeString} ${streamMessageTail}`
 
   if (updateMessages && updateMessages.length > 0) {
@@ -74,10 +72,15 @@ export function getBodyAndStatusBarMessages (result, maxRows) {
     streamMessage = streamMessage[0].toUpperCase() + streamMessage.slice(1)
   }
 
+  const systemUpdatesValue = get(result, 'summary.counters._systemUpdates')
   const bodyMessage =
     (!updateMessages || updateMessages.length === 0) &&
     result.records.length === 0
-      ? '(no changes, no records)'
+      ? `(${(systemUpdatesValue > 0 &&
+          `${systemUpdatesValue} system update${(systemUpdatesValue > 1 &&
+            's') ||
+            ''}`) ||
+          'no changes'}, no records)`
       : updateMessages + `completed ${totalTimeString} ms.`
 
   return {


### PR DESCRIPTION
Adjust the messaging shown to users with regards to system updates when running system commands

- Displays `1 system update,  no records` when `_systemUpdate` = 1
- Should display `n system update, no records`, when `_systemUpdate` > 1 (not been able to figure out to get this show in practice so suggestions welcome). I can remove this if its just deemed as unnecessary.
- Displays `no changes, no records` when !`_systemUpdate` (as before)

Ive only scoped the e2e tests within the `'serverVersion') >= 4.0`...

<img width="415" alt="Screenshot 2019-12-10 at 11 34 06" src="https://user-images.githubusercontent.com/14161129/70526256-1d806780-1b41-11ea-9acb-d051987cd2a5.png">
<img width="735" alt="Screenshot 2019-12-10 at 11 33 44" src="https://user-images.githubusercontent.com/14161129/70526258-1d806780-1b41-11ea-977a-60113cf6cd5b.png">
