### PR TITLE
Query plans view expanded by default

### DIFF
--- a/e2e_tests/integration/plan.spec.js
+++ b/e2e_tests/integration/plan.spec.js
@@ -37,6 +37,26 @@ describe('Plan output', () => {
     const password = Cypress.config('password')
     cy.connect('neo4j', password)
   })
+  it('displays the expanded details by default and displays/hides details when clicking the plan expand/collapse buttons respectively', () => {
+    cy.executeCommand(':clear')
+    cy.executeCommand(
+      'EXPLAIN MATCH (n:Person) WHERE n.age > 18 RETURN n.name ORDER BY n.age'
+    )
+
+    // initially should be expanded
+    const el1 = cy.get('[data-testid="planSvg"]', { timeout: 10000 })
+    el1.find('.detail').should('exist')
+
+    // collapse
+    cy.get('[data-testid="planCollapseButton"]', { timeout: 10000 }).click()
+    const el2 = cy.get('[data-testid="planSvg"]', { timeout: 10000 })
+    el2.find('.detail').should('not.exist')
+
+    // expand
+    cy.get('[data-testid="planExpandButton"]', { timeout: 10000 }).click()
+    const el3 = cy.get('[data-testid="planSvg"]', { timeout: 10000 })
+    el3.find('.detail').should('exist')
+  })
   if (Cypress.config('serverVersion') >= 3.5) {
     it('print Order in PROFILE', () => {
       cy.executeCommand(':clear')

--- a/src/browser/modules/Stream/CypherFrame/PlanView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/PlanView.jsx
@@ -49,10 +49,6 @@ export class PlanView extends Component {
   }
 
   componentWillReceiveProps(props) {
-    console.log(
-      '++componentWillReceiveProps 1',
-      props.updated !== this.props.updated
-    )
     if (props.updated !== this.props.updated) {
       return this.extractPlan(props.result || {})
         .then(() => {
@@ -62,16 +58,11 @@ export class PlanView extends Component {
           console.log(e)
         })
     }
-    // console.log('++componentWillReceiveProps 2', props.updated, this.props.updated)
     this.ensureToggleExpand(props)
     props.assignVisElement && props.assignVisElement(this.el, this.plan)
   }
 
   shouldComponentUpdate(props, state) {
-    console.log(
-      '++shouldComponentUpdate',
-      props._planExpand !== this.props._planExpand
-    )
     if (this.props.result === undefined) return true
     return (
       !deepEquals(props.result.summary, this.props.result.summary) ||
@@ -105,12 +96,8 @@ export class PlanView extends Component {
   }
 
   ensureToggleExpand(props) {
-    let expandvalue = props._planExpand
-    // if (!expandvalue) expandvalue = 'EXPAND'
-    // console.log('++props._planExpand', expandvalue)
-    // console.log('++this.props._planExpand', this.props._planExpand)
-    if (expandvalue !== this.props._planExpand) {
-      switch (expandvalue) {
+    if (props._planExpand && props._planExpand !== this.props._planExpand) {
+      switch (props._planExpand) {
         case 'COLLAPSE': {
           this.toggleExpanded(false)
           break
@@ -124,7 +111,6 @@ export class PlanView extends Component {
   }
 
   toggleExpanded(expanded) {
-    // console.log('++expanded', expanded)
     const visit = operator => {
       operator.expanded = expanded
       if (operator.children) {
@@ -134,8 +120,6 @@ export class PlanView extends Component {
       }
     }
     const tmpPlan = { ...this.state.extractedPlan }
-    // console.log('++tmpPlan', tmpPlan)
-    // console.log('++tmpPlan.root', tmpPlan.root)
     visit(tmpPlan.root)
     this.plan.display(tmpPlan)
   }

--- a/src/browser/modules/Stream/CypherFrame/PlanView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/PlanView.jsx
@@ -43,10 +43,16 @@ export class PlanView extends Component {
   }
 
   componentDidMount() {
-    this.extractPlan(this.props.result).catch(e => {})
+    this.extractPlan(this.props.result)
+      .then(() => this.props.setParentState({ _planExpand: 'EXPAND' }))
+      .catch(e => {})
   }
 
   componentWillReceiveProps(props) {
+    console.log(
+      '++componentWillReceiveProps 1',
+      props.updated !== this.props.updated
+    )
     if (props.updated !== this.props.updated) {
       return this.extractPlan(props.result || {})
         .then(() => {
@@ -56,11 +62,16 @@ export class PlanView extends Component {
           console.log(e)
         })
     }
+    // console.log('++componentWillReceiveProps 2', props.updated, this.props.updated)
     this.ensureToggleExpand(props)
     props.assignVisElement && props.assignVisElement(this.el, this.plan)
   }
 
   shouldComponentUpdate(props, state) {
+    console.log(
+      '++shouldComponentUpdate',
+      props._planExpand !== this.props._planExpand
+    )
     if (this.props.result === undefined) return true
     return (
       !deepEquals(props.result.summary, this.props.result.summary) ||
@@ -94,8 +105,12 @@ export class PlanView extends Component {
   }
 
   ensureToggleExpand(props) {
-    if (props._planExpand && props._planExpand !== this.props._planExpand) {
-      switch (props._planExpand) {
+    let expandvalue = props._planExpand
+    // if (!expandvalue) expandvalue = 'EXPAND'
+    // console.log('++props._planExpand', expandvalue)
+    // console.log('++this.props._planExpand', this.props._planExpand)
+    if (expandvalue !== this.props._planExpand) {
+      switch (expandvalue) {
         case 'COLLAPSE': {
           this.toggleExpanded(false)
           break
@@ -109,6 +124,7 @@ export class PlanView extends Component {
   }
 
   toggleExpanded(expanded) {
+    // console.log('++expanded', expanded)
     const visit = operator => {
       operator.expanded = expanded
       if (operator.children) {
@@ -118,6 +134,8 @@ export class PlanView extends Component {
       }
     }
     const tmpPlan = { ...this.state.extractedPlan }
+    // console.log('++tmpPlan', tmpPlan)
+    // console.log('++tmpPlan.root', tmpPlan.root)
     visit(tmpPlan.root)
     this.plan.display(tmpPlan)
   }

--- a/src/browser/modules/Stream/CypherFrame/index.jsx
+++ b/src/browser/modules/Stream/CypherFrame/index.jsx
@@ -76,6 +76,7 @@ export class CypherFrame extends Component {
     collapse: false,
     frameHeight: 472,
     hasVis: false
+    // _planExpand: 'EXPAND'
   }
 
   changeView(view) {

--- a/src/browser/modules/Stream/CypherFrame/index.jsx
+++ b/src/browser/modules/Stream/CypherFrame/index.jsx
@@ -76,7 +76,6 @@ export class CypherFrame extends Component {
     collapse: false,
     frameHeight: 472,
     hasVis: false
-    // _planExpand: 'EXPAND'
   }
 
   changeView(view) {


### PR DESCRIPTION
WIP (looking to add a test)
- Have query plans expanded by default as opposed to collapsed now
- I chained the `setParentState` after the `extractPlan` in the `PlanView` `componentDidMount` in order to make sure `this.state.extractedPlan` is set prior to `this.toggleExpanded` is called (as it required it to be set first.). The only other way I could think of doing it was to have `this.ensureToggleExpand` always expand by default when no `_planExpand` is available on the parent component state initially but the pattern of setting parent state is preferred. Any suggestions here are welcome as I couldn't quite determine the best way to do this work.

Some example queries I tested and it seems to work ok:
```
PROFILE 
MATCH p=(n:Movie)--(m:Person)--(o:Movie)
WHERE m.born > 1000
AND length(p) > 1
MATCH (mm:Person) WHERE mm.name STARTS WITH 'T'
MATCH (mmm:Person) WHERE mmm.name STARTS WITH 'E'
RETURN p, mm, mmm
```
```
PROFILE
WITH ['Action','Drama','Mystery'] AS genreNames
UNWIND genreNames AS name
MATCH (g:Genre {name:name})
WITH g ORDER BY size( (g)<-[:BELONGS_TO]-() ) ASC
WITH collect(g) AS genres
WITH head(genres) AS first, tail(genres) AS rest
MATCH (first)<-[:BELONGS_TO]-(m:Title)-[:BELONGS_TO]->(other)
WITH m, collect(other) AS movieGenres, rest
WHERE all(g IN rest WHERE g IN movieGenres)
RETURN count(m)
```

Watch this [video](https://drive.google.com/file/d/1G1OhcDjDAsK6KV1cTE-J8UiGcwRyaQTs/view ) for a quick demo.