### PR TITLE
Update help cards to point to the cypher manual

### DIFF
--- a/src/browser/components/ManualLink.jsx
+++ b/src/browser/components/ManualLink.jsx
@@ -25,6 +25,27 @@ import semver from 'semver'
 import { getVersion } from 'shared/modules/dbMeta/dbMetaDuck'
 import { formatDocVersion } from 'browser/modules/Sidebar/Documents'
 
+const movedPages = {
+  '/administration/indexes-for-search-performance/': {
+    oldPage: 'schema/index/',
+    oldContent: 'Schema indexes'
+  },
+  '/administration/constraints/': {
+    oldPage: 'schema/constraints/',
+    oldContent: 'Schema constraints'
+  },
+  '/administration/': {
+    oldPage: 'schema/',
+    oldContent: 'Cypher Schema'
+  }
+}
+
+const isPageMoved = (chapter, page, neo4jVersion) =>
+  chapter === 'cypher-manual' &&
+  movedPages[page] &&
+  neo4jVersion &&
+  semver.satisfies(neo4jVersion, '<4.0.0-alpha.1')
+
 export function ManualLink({
   chapter,
   page,
@@ -32,7 +53,12 @@ export function ManualLink({
   neo4jVersion,
   minVersion
 }) {
-  const cleanPage = page.replace(/^\//, '')
+  let cleanPage = page.replace(/^\//, '')
+  let content = children
+  if (isPageMoved(chapter, page, neo4jVersion)) {
+    cleanPage = movedPages[page].oldPage
+    content = movedPages[page].oldContent
+  }
 
   let version = formatDocVersion(neo4jVersion)
   if (
@@ -46,7 +72,7 @@ export function ManualLink({
 
   return (
     <a href={url} target="_blank">
-      {children}
+      {content}
     </a>
   )
 }

--- a/src/browser/components/ManualLink.test.js
+++ b/src/browser/components/ManualLink.test.js
@@ -72,3 +72,40 @@ test.each(tests)('Render correct url for props %o', (props, expected) => {
   const url = getByText('link to manual').getAttribute('href')
   expect(url).toEqual(expected)
 })
+
+const movedPages = [
+  [
+    { neo4jVersion: '3.5.0', page: '/administration/' },
+    {
+      text: 'Cypher Schema',
+      url: 'https://neo4j.com/docs/cypher-manual/3.5/schema/'
+    }
+  ],
+  [
+    { neo4jVersion: '4.0.0', page: '/administration/' },
+    {
+      text: 'link to manual',
+      url: 'https://neo4j.com/docs/cypher-manual/4.0/administration/'
+    }
+  ],
+  [
+    { page: '/administration/' },
+    {
+      text: 'link to manual',
+      url: 'https://neo4j.com/docs/cypher-manual/current/administration/'
+    }
+  ]
+]
+
+test.each(movedPages)(
+  'Render correct url for moved page %o',
+  (props, expected) => {
+    const { getByText } = render(
+      <ManualLink chapter="cypher-manual" {...props}>
+        link to manual
+      </ManualLink>
+    )
+    const url = getByText(expected.text).getAttribute('href')
+    expect(url).toEqual(expected.url)
+  }
+)

--- a/src/browser/documentation/dynamic/cypher.jsx
+++ b/src/browser/documentation/dynamic/cypher.jsx
@@ -40,7 +40,7 @@ const description = (
       <div className="link">
         <p className="title">Reference</p>
         <p className="content">
-          <ManualLink chapter="developer-manual" page="/cypher/">
+          <ManualLink chapter="cypher-manual" page="/">
             Cypher introduction
           </ManualLink>
         </p>

--- a/src/browser/documentation/guides/concepts.jsx
+++ b/src/browser/documentation/guides/concepts.jsx
@@ -189,8 +189,8 @@ const slides = [
           <a play-topic="cypher">Cypher</a> - query language
         </li>
         <li>
-          <ManualLink chapter="developer-manual" page="/">
-            Neo4j Developer Manual
+          <ManualLink chapter="cypher-manual" page="/">
+            Neo4j Cypher Manual
           </ManualLink>
         </li>
       </ul>

--- a/src/browser/documentation/guides/cypher.jsx
+++ b/src/browser/documentation/guides/cypher.jsx
@@ -280,7 +280,7 @@ RETURN DISTINCT surfer`}
           </ManualLink>
         </li>
         <li>
-          <ManualLink manual="developer-manual" page="/cypher/">
+          <ManualLink chapter="cypher-manual" page="/">
             The Cypher chapter
           </ManualLink>{' '}
           of the Neo4j Developer Manual

--- a/src/browser/documentation/guides/learn.jsx
+++ b/src/browser/documentation/guides/learn.jsx
@@ -190,8 +190,8 @@ const slides = [
           <a play-topic="cypher">Cypher</a> - query language
         </li>
         <li>
-          <ManualLink chapter="developer-manual" page="/">
-            Neo4j Developer Manual
+          <ManualLink chapter="cypher-manual" page="/">
+            Neo4j Cypher Manual
           </ManualLink>
         </li>
       </ul>

--- a/src/browser/documentation/guides/movie-graph.jsx
+++ b/src/browser/documentation/guides/movie-graph.jsx
@@ -830,8 +830,8 @@ RETURN tom, m, coActors, m2, cruise`}
           </a>
         </li>
         <li>
-          <ManualLink chapter="developer-manual" page="/">
-            Neo4j Developer Manual
+          <ManualLink chapter="cypher-manual" page="/">
+            Neo4j Cypher Manual
           </ManualLink>
         </li>
       </ul>

--- a/src/browser/documentation/guides/northwind-graph.jsx
+++ b/src/browser/documentation/guides/northwind-graph.jsx
@@ -349,8 +349,8 @@ RETURN DISTINCT cust.contactName as CustomerName, SUM(o.quantity) AS TotalProduc
           </a>
         </li>
         <li>
-          <ManualLink chapter="developer-manual" page="/">
-            Neo4j Developer Manual
+          <ManualLink chapter="cypher-manual" page="/">
+            Neo4j Cypher Manual
           </ManualLink>
         </li>
       </ul>

--- a/src/browser/documentation/help/contains.jsx
+++ b/src/browser/documentation/help/contains.jsx
@@ -34,8 +34,8 @@ const content = (
         <p className="title">Reference</p>
         <p className="content">
           <ManualLink
-            chapter="developer-manual"
-            page="/cypher/clauses/where/#query-where-string"
+            chapter="cypher-manual"
+            page="/clauses/where/#query-where-string"
           >
             WHERE
           </ManualLink>{' '}

--- a/src/browser/documentation/help/create-constraint-on.jsx
+++ b/src/browser/documentation/help/create-constraint-on.jsx
@@ -19,6 +19,7 @@
  */
 
 import React from 'react'
+import ManualLink from 'browser-components/ManualLink'
 const title = 'CREATE CONSTRAINT ON'
 const subtitle =
   'Create a property constraint on a node label or relationship type'
@@ -33,22 +34,28 @@ const content = (
       The <code>IS UNIQUE</code> property constraint will create an accompanying
       index.
     </p>
-    <table className="table-condensed table-help">
-      <tbody>
-        {/* <tr>
-        <th>Reference:</th>
-        <td><code><a href='{{ neo4j.version | neo4jDeveloperDoc }}/cypher/#query-constraints'>schema constraints</a></code> manual page</td>
-      </tr> */}
-        <tr>
-          <th>Related:</th>
-          <td>
-            <a help-topic="drop-constraint-on">:help DROP CONSTRAINT ON</a>{' '}
-            <a help-topic="schema">:help Schema</a>{' '}
-            <a help-topic="cypher">:help Cypher</a>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <div className="links">
+      <div className="link">
+        <p className="title">Reference</p>
+        <p className="content">
+          <ManualLink
+            chapter="cypher-manual"
+            page="/administration/constraints/"
+          >
+            Constraints
+          </ManualLink>{' '}
+          manual page
+        </p>
+      </div>
+      <div className="link">
+        <div className="title">Related</div>
+        <div className="content">
+          <a help-topic="drop-constraint-on">:help DROP CONSTRAINT ON</a>{' '}
+          <a help-topic="schema">:help Schema</a>{' '}
+          <a help-topic="cypher">:help Cypher</a>
+        </div>
+      </div>
+    </div>
     <section className="example">
       <figure>
         <pre className="code runnable standalone-example">

--- a/src/browser/documentation/help/create-index-on.jsx
+++ b/src/browser/documentation/help/create-index-on.jsx
@@ -33,7 +33,7 @@ const content = (
       <div className="link">
         <p className="title">Reference</p>
         <p className="content">
-          <ManualLink chapter="developer-manual" page="/cypher/schema/index/">
+          <ManualLink chapter="cypher-manual" page="/schema/index/">
             schema indexes
           </ManualLink>{' '}
           manual page

--- a/src/browser/documentation/help/create-index-on.jsx
+++ b/src/browser/documentation/help/create-index-on.jsx
@@ -33,8 +33,11 @@ const content = (
       <div className="link">
         <p className="title">Reference</p>
         <p className="content">
-          <ManualLink chapter="cypher-manual" page="/schema/index/">
-            schema indexes
+          <ManualLink
+            chapter="cypher-manual"
+            page="/administration/indexes-for-search-performance/"
+          >
+            Indexes for search performance
           </ManualLink>{' '}
           manual page
         </p>

--- a/src/browser/documentation/help/create.jsx
+++ b/src/browser/documentation/help/create.jsx
@@ -40,7 +40,7 @@ const content = (
       <div className="link">
         <p className="title">Reference</p>
         <p className="content">
-          <ManualLink chapter="developer-manual" page="/cypher/clauses/create/">
+          <ManualLink chapter="cypher-manual" page="/clauses/create/">
             CREATE
           </ManualLink>{' '}
           manual page

--- a/src/browser/documentation/help/delete.jsx
+++ b/src/browser/documentation/help/delete.jsx
@@ -35,7 +35,7 @@ const content = (
       <div className="link">
         <p className="title">Reference</p>
         <p className="content">
-          <ManualLink chapter="developer-manual" page="/cypher/clauses/delete/">
+          <ManualLink chapter="cypher-manual" page="/clauses/delete/">
             DELETE
           </ManualLink>{' '}
           manual page

--- a/src/browser/documentation/help/detach-delete.jsx
+++ b/src/browser/documentation/help/detach-delete.jsx
@@ -33,7 +33,7 @@ const content = (
       <div className="link">
         <p className="title">Reference</p>
         <p className="content">
-          <ManualLink chapter="developer-manual" page="/cypher/clauses/delete/">
+          <ManualLink chapter="cypher-manual" page="/clauses/delete/">
             DELETE
           </ManualLink>{' '}
           manual page

--- a/src/browser/documentation/help/drop-constraint-on.jsx
+++ b/src/browser/documentation/help/drop-constraint-on.jsx
@@ -19,6 +19,7 @@
  */
 
 import React from 'react'
+import ManualLink from 'browser-components/ManualLink'
 const title = 'DROP CONSTRAINT ON'
 const subtitle =
   'Drops a property constraint on a node label or relationship type'
@@ -29,22 +30,28 @@ const content = (
       The <code>DROP CONSTRAINT ON</code> clause will delete a property
       constraint
     </p>
-    <table className="table-condensed table-help">
-      <tbody>
-        {/* <tr>
-        <th>Reference:</th>
-        <td><code><a href='{{ neo4j.version | neo4jDeveloperDoc }}/cypher/#query-constraints'>schema constraints</a></code> manual page</td>
-      </tr> */}
-        <tr>
-          <th>Related:</th>
-          <td>
-            <a help-topic="drop-constraint-on">:help CREATE CONSTRAINT ON</a>{' '}
-            <a help-topic="schema">:help Schema</a>{' '}
-            <a help-topic="cypher">:help Cypher</a>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+    <div className="links">
+      <div className="link">
+        <p className="title">Reference</p>
+        <p className="content">
+          <ManualLink
+            chapter="cypher-manual"
+            page="/administration/constraints/"
+          >
+            Constraints
+          </ManualLink>{' '}
+          manual page
+        </p>
+      </div>
+      <div className="link">
+        <p className="title">Related</p>
+        <p className="content">
+          <a help-topic="drop-constraint-on">:help CREATE CONSTRAINT ON</a>{' '}
+          <a help-topic="schema">:help Schema</a>{' '}
+          <a help-topic="cypher">:help Cypher</a>
+        </p>
+      </div>
+    </div>
     <section className="example">
       <figure>
         <pre className="code runnable standalone-example">

--- a/src/browser/documentation/help/drop-index-on.jsx
+++ b/src/browser/documentation/help/drop-index-on.jsx
@@ -33,7 +33,7 @@ const content = (
       <div className="link">
         <p className="title">Reference</p>
         <p className="content">
-          <ManualLink chapter="developer-manual" page="/cypher/schema/index/">
+          <ManualLink chapter="cypher-manual" page="/schema/index/">
             schema indexes
           </ManualLink>{' '}
           manual page

--- a/src/browser/documentation/help/drop-index-on.jsx
+++ b/src/browser/documentation/help/drop-index-on.jsx
@@ -33,8 +33,11 @@ const content = (
       <div className="link">
         <p className="title">Reference</p>
         <p className="content">
-          <ManualLink chapter="cypher-manual" page="/schema/index/">
-            schema indexes
+          <ManualLink
+            chapter="cypher-manual"
+            page="/administration/indexes-for-search-performance/"
+          >
+            Indexes for search performance
           </ManualLink>{' '}
           manual page
         </p>

--- a/src/browser/documentation/help/ends-with.jsx
+++ b/src/browser/documentation/help/ends-with.jsx
@@ -33,7 +33,7 @@ const content = (
       <div className="link">
         <p className="title">Reference</p>
         <p className="content">
-          <ManualLink chapter="developer-manual" page="/cypher/clauses/where/">
+          <ManualLink chapter="cypher-manual" page="/clauses/where/">
             WHERE
           </ManualLink>{' '}
           manual page

--- a/src/browser/documentation/help/foreach.jsx
+++ b/src/browser/documentation/help/foreach.jsx
@@ -33,10 +33,7 @@ const content = (
       <div className="link">
         <p className="title">Reference</p>
         <p className="content">
-          <ManualLink
-            chapter="developer-manual"
-            page="/cypher/clauses/foreach/"
-          >
+          <ManualLink chapter="cypher-manual" page="/clauses/foreach/">
             FOREACH
           </ManualLink>{' '}
           manual page

--- a/src/browser/documentation/help/load-csv.jsx
+++ b/src/browser/documentation/help/load-csv.jsx
@@ -37,17 +37,14 @@ const content = (
       <div className="link">
         <p className="title">Reference</p>
         <p className="content">
-          <ManualLink
-            chapter="developer-manual"
-            page="/cypher/clauses/load-csv/"
-          >
+          <ManualLink chapter="cypher-manual" page="/clauses/load-csv/">
             LOAD CSV
           </ManualLink>{' '}
           manual page
           <br />
           <ManualLink
-            chapter="developer-manual"
-            page="/cypher/query-tuning/using/#query-using-periodic-commit-hint"
+            chapter="cypher-manual"
+            page="/query-tuning/using/#query-using-periodic-commit-hint"
           >
             USING PERIODIC COMMIT
           </ManualLink>{' '}

--- a/src/browser/documentation/help/match.jsx
+++ b/src/browser/documentation/help/match.jsx
@@ -38,7 +38,7 @@ const content = (
       <div className="link">
         <p className="title">Reference</p>
         <p className="content">
-          <ManualLink chapter="developer-manual" page="/cypher/clauses/match/">
+          <ManualLink chapter="cypher-manual" page="/clauses/match/">
             MATCH
           </ManualLink>{' '}
           manual page

--- a/src/browser/documentation/help/merge.jsx
+++ b/src/browser/documentation/help/merge.jsx
@@ -34,14 +34,14 @@ const content = (
       <div className="link">
         <p className="title">Reference</p>
         <p className="content">
-          <ManualLink chapter="developer-manual" page="/cypher/clauses/merge/">
+          <ManualLink chapter="cypher-manual" page="/clauses/merge/">
             MERGE
           </ManualLink>{' '}
           manual page
           <br />
           <ManualLink
-            chapter="developer-manual"
-            page="/cypher/clauses/merge/#query-merge-on-create-on-match"
+            chapter="cypher-manual"
+            page="/clauses/merge/#query-merge-on-create-on-match"
           >
             ON CREATE and ON MATCH
           </ManualLink>{' '}

--- a/src/browser/documentation/help/profile.jsx
+++ b/src/browser/documentation/help/profile.jsx
@@ -38,10 +38,7 @@ const content = (
       <div className="link">
         <p className="title">Reference:</p>
         <p className="content">
-          <ManualLink
-            chapter="developer-manual"
-            page="/cypher/execution-plans/"
-          >
+          <ManualLink chapter="cypher-manual" page="/execution-plans/">
             Execution Plans
           </ManualLink>{' '}
           manual page

--- a/src/browser/documentation/help/query-plan.jsx
+++ b/src/browser/documentation/help/query-plan.jsx
@@ -59,7 +59,7 @@ const content = (
       <p>
         Each Operator is displayed as a rectangle with its name in the top-left
         corner. See the{' '}
-        <ManualLink chapter="developer-manual" page="/cypher/execution-plans/">
+        <ManualLink chapter="cypher-manual" page="/execution-plans/">
           operators manual page
         </ManualLink>{' '}
         for a description of what each operator does.
@@ -155,10 +155,7 @@ const content = (
           <tr>
             <th>Reference:</th>
             <td>
-              <ManualLink
-                chapter="developer-manual"
-                page="/cypher/execution-plans/"
-              >
+              <ManualLink chapter="cypher-manual" page="/execution-plans/">
                 Execution Plans
               </ManualLink>{' '}
               manual page

--- a/src/browser/documentation/help/remove.jsx
+++ b/src/browser/documentation/help/remove.jsx
@@ -33,7 +33,7 @@ const content = (
       <div className="link">
         <p className="title">Reference</p>
         <p className="content">
-          <ManualLink chapter="developer-manual" page="/cypher/clauses/remove/">
+          <ManualLink chapter="cypher-manual" page="/clauses/remove/">
             REMOVE
           </ManualLink>{' '}
           manual page

--- a/src/browser/documentation/help/return.jsx
+++ b/src/browser/documentation/help/return.jsx
@@ -33,7 +33,7 @@ const content = (
       <div className="link">
         <p className="title">Reference</p>
         <p className="content">
-          <ManualLink chapter="developer-manual" page="/cypher/clauses/return/">
+          <ManualLink chapter="cypher-manual" page="/clauses/return/">
             RETURN
           </ManualLink>{' '}
           manual page

--- a/src/browser/documentation/help/schema.jsx
+++ b/src/browser/documentation/help/schema.jsx
@@ -30,7 +30,7 @@ const content = (
       <div className="link">
         <p className="title">Reference</p>
         <p className="content">
-          <ManualLink chapter="developer-manual" page="/cypher/schema/">
+          <ManualLink chapter="cypher-manual" page="/schema/">
             Cypher Schema
           </ManualLink>
         </p>

--- a/src/browser/documentation/help/schema.jsx
+++ b/src/browser/documentation/help/schema.jsx
@@ -30,8 +30,8 @@ const content = (
       <div className="link">
         <p className="title">Reference</p>
         <p className="content">
-          <ManualLink chapter="cypher-manual" page="/schema/">
-            Cypher Schema
+          <ManualLink chapter="cypher-manual" page="/administration/">
+            Neo4j Database Administration
           </ManualLink>
         </p>
       </div>

--- a/src/browser/documentation/help/set.jsx
+++ b/src/browser/documentation/help/set.jsx
@@ -32,7 +32,7 @@ const content = (
       <div className="link">
         <p className="title">Reference</p>
         <p className="content">
-          <ManualLink chapter="developer-manual" page="/cypher/clauses/set/">
+          <ManualLink chapter="cypher-manual" page="/clauses/set/">
             SET
           </ManualLink>{' '}
           manual page

--- a/src/browser/documentation/help/starts-with.jsx
+++ b/src/browser/documentation/help/starts-with.jsx
@@ -33,7 +33,7 @@ const content = (
       <div className="link">
         <p className="title">Reference</p>
         <p className="content">
-          <ManualLink chapter="developer-manual" page="/cypher/clauses/where/">
+          <ManualLink chapter="cypher-manual" page="/clauses/where/">
             WHERE
           </ManualLink>{' '}
           manual page

--- a/src/browser/documentation/help/template.jsx
+++ b/src/browser/documentation/help/template.jsx
@@ -39,7 +39,7 @@ const content = (
       <div className="link">
         <p className="title">Reference</p>
         <p className="content">
-          <ManualLink chapter="developer-manual" page="/cypher/">
+          <ManualLink chapter="cypher-manual" page="/">
             Cypher introduction
           </ManualLink>
         </p>

--- a/src/browser/documentation/help/unwind.jsx
+++ b/src/browser/documentation/help/unwind.jsx
@@ -33,7 +33,7 @@ const content = (
       <div className="link">
         <p className="title">Reference</p>
         <p className="content">
-          <ManualLink chapter="developer-manual" page="/cypher/clauses/unwind/">
+          <ManualLink chapter="cypher-manual" page="/clauses/unwind/">
             UNWIND
           </ManualLink>{' '}
           manual page

--- a/src/browser/documentation/help/where.jsx
+++ b/src/browser/documentation/help/where.jsx
@@ -38,7 +38,7 @@ const content = (
       <div className="link">
         <p className="title">Reference</p>
         <p className="content">
-          <ManualLink chapter="developer-manual" page="/cypher/clauses/where/">
+          <ManualLink chapter="cypher-manual" page="/clauses/where/">
             WHERE
           </ManualLink>{' '}
           manual page

--- a/src/browser/documentation/help/with.jsx
+++ b/src/browser/documentation/help/with.jsx
@@ -34,7 +34,7 @@ const content = (
       <div className="link">
         <p className="title">Reference</p>
         <p className="content">
-          <ManualLink chapter="developer-manual" page="/cypher/clauses/with/">
+          <ManualLink chapter="cypher-manual" page="/clauses/with/">
             WITH
           </ManualLink>{' '}
           manual page

--- a/src/browser/modules/Editor/cypher/functions.js
+++ b/src/browser/modules/Editor/cypher/functions.js
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// https://neo4j.com/docs/developer-manual/current/cypher/functions/
+// https://neo4j.com/docs/cypher-manual/current/functions/
 /**
  * Signature syntax examples:
  * - (name :: TYPE?, name = default :: INTEGER?) :: VOID


### PR DESCRIPTION
The developer manual has been removed in version 3.5, and the cypher manual should be used going forward. I updated all the URLs to point to the correct version, so that we don't have any broken links (which is currently the case for 4.0). 

This change in the URL structure is backwards compatible. I tested all links with 4.0 and 3.4.

The `/schema` section has been moved to `/administration` in 4.0, and the last commit is to make sure the correct path is rendered depending on the version. 