### PR TITLE
Show NaN in the table output instead of being handled displayed as null

### DIFF
--- a/src/shared/services/bolt/cypherTypesFormatting.js
+++ b/src/shared/services/bolt/cypherTypesFormatting.js
@@ -37,7 +37,7 @@ export const stringModifier = anything => {
 
 const numberFormat = anything => {
   // Exclude false positives and return early
-  if ([Infinity, -Infinity].includes(anything)) {
+  if ([Infinity, -Infinity, NaN].includes(anything)) {
     return `${anything}`
   }
   if (Math.floor(anything) === anything) {

--- a/src/shared/services/bolt/cypherTypesFormatting.test.js
+++ b/src/shared/services/bolt/cypherTypesFormatting.test.js
@@ -26,7 +26,8 @@ describe('Cypher Types Number modifier only modifies where needed', () => {
     [Number(123.1), undefined],
     [Number(-123.1), undefined],
     [Number(Infinity), 'Infinity'],
-    [Number(-Infinity), '-Infinity']
+    [Number(-Infinity), '-Infinity'],
+    [Number(NaN), 'NaN']
   ]
 
   test.each(tests)('Modifies %s correctly if needed', (input, output) => {


### PR DESCRIPTION
- Added `NaN` as a 'false positive' so we can display as it is and move on. Plus added an addition to a test.
- Currently, where we display the table output, we call `stringifyMod` with `stringModifier` as the second param (https://github.com/neo4j/neo4j-browser/blob/master/src/browser/modules/Stream/CypherFrame/TableView.jsx#L72). The issue is `stringModifier` doesn't handle `NaN` in any of the existing cases and so `undefined` is returned.
- This means we never return at this point (https://github.com/neo4j/neo4j-browser/blob/master/src/shared/services/utils.js#L371) and instead handled by this line (https://github.com/neo4j/neo4j-browser/blob/master/src/shared/services/utils.js#L375) and return 'null'

- This work is now in line with the output of cypher-shell (using queries shown on the Trello card)
<img width="570" alt="Screenshot 2019-12-20 at 14 15 09" src="https://user-images.githubusercontent.com/14161129/71263053-0a3b7c00-2339-11ea-99d7-e1e4398c3536.png">
<img width="533" alt="Screenshot 2019-12-20 at 14 16 27" src="https://user-images.githubusercontent.com/14161129/71263061-10c9f380-2339-11ea-8290-14f93e58e235.png">
