### PR TITLE
Add help cards for security commands

### DIFF
--- a/src/browser/documentation/help/alter-user.jsx
+++ b/src/browser/documentation/help/alter-user.jsx
@@ -21,13 +21,14 @@
 import React from 'react'
 import ManualLink from 'browser-components/ManualLink'
 import AdminOnSystemDb from './partials/admin-on-systemdb'
-const title = 'DROP USER'
-const subtitle = 'Delete a user'
+const title = 'ALTER USER'
+const subtitle = 'Modify a user'
 const category = 'administration'
 const content = (
   <>
     <p>
-      The command <code>DROP USER</code> can be used to delete an existing user.
+      The command <code>ALTER USER</code> can be used to modify an existing
+      user.
     </p>
     <div className="links">
       <div className="link">
@@ -35,10 +36,10 @@ const content = (
         <p className="content">
           <ManualLink
             chapter="cypher-manual"
-            page="/administration/security/users-and-roles/#administration-security-users-drop"
+            page="/administration/security/users-and-roles/#administration-security-users-alter"
             minVersion="4.0.0"
           >
-            DROP USER
+            ALTER USER
           </ManualLink>{' '}
           manual page
         </p>
@@ -47,15 +48,37 @@ const content = (
         <p className="title">Related</p>
         <p className="content">
           <a help-topic="show-users">:help SHOW USERS</a>{' '}
-          <a help-topic="drop-user">:help CREATE USER</a>{' '}
-          <a help-topic="alter-user">:help ALTER USER</a>{' '}
+          <a help-topic="create-user">:help CREATE USER</a>{' '}
+          <a help-topic="drop-user">:help DROP USER</a>{' '}
           <a help-topic="cypher">:help Cypher</a>
         </p>
       </div>
     </div>
     <section className="example">
       <figure>
-        <pre className="code runnable standalone-example">DROP USER jake</pre>
+        <pre className="code runnable standalone-example">
+          ALTER USER jake SET PASSWORD 'abc123'
+          <br />
+          CHANGE NOT REQUIRED SET STATUS
+          <br />
+          ACTIVE
+        </pre>
+        <figcaption>
+          Modify the user jake with a new password and active status as well as
+          remove the requirement to change his password.
+        </figcaption>
+      </figure>
+      <figure>
+        <pre className="code runnable standalone-example">
+          ALTER CURRENT USER SET PASSWORD FROM 'abc123' TO '123xyz'
+        </pre>
+        <figcaption>
+          Users can change their own password using ALTER CURRENT USER SET
+          PASSWORD. The old password is required in addition to the new one, and
+          either or both can be a string value or a string parameter. When a
+          user executes this command it will change their password as well as
+          set the CHANGE NOT REQUIRED flag.
+        </figcaption>
       </figure>
     </section>
     <AdminOnSystemDb />

--- a/src/browser/documentation/help/alter-user.jsx
+++ b/src/browser/documentation/help/alter-user.jsx
@@ -27,7 +27,7 @@ const category = 'administration'
 const content = (
   <>
     <p>
-      The command <code>ALTER USER</code> can be used to modify an existing
+      The <code>ALTER USER</code> command can be used to modify an existing
       user.
     </p>
     <div className="links">

--- a/src/browser/documentation/help/create-role.jsx
+++ b/src/browser/documentation/help/create-role.jsx
@@ -21,13 +21,13 @@
 import React from 'react'
 import ManualLink from 'browser-components/ManualLink'
 import AdminOnSystemDb from './partials/admin-on-systemdb'
-const title = 'DROP USER'
-const subtitle = 'Delete a user'
-const category = 'administration'
+const title = 'CREATE ROLE'
+const subtitle = 'Create a new role'
+const category = 'security'
 const content = (
   <>
     <p>
-      The command <code>DROP USER</code> can be used to delete an existing user.
+      The <code>CREATE ROLE</code> command can be used to create roles.
     </p>
     <div className="links">
       <div className="link">
@@ -35,10 +35,10 @@ const content = (
         <p className="content">
           <ManualLink
             chapter="cypher-manual"
-            page="/administration/security/users-and-roles/#administration-security-users-drop"
+            page="/administration/security/users-and-roles/#administration-security-roles-create"
             minVersion="4.0.0"
           >
-            DROP USER
+            CREATE ROLE
           </ManualLink>{' '}
           manual page
         </p>
@@ -46,16 +46,27 @@ const content = (
       <div className="link">
         <p className="title">Related</p>
         <p className="content">
-          <a help-topic="show-users">:help SHOW USERS</a>{' '}
-          <a help-topic="drop-user">:help CREATE USER</a>{' '}
-          <a help-topic="alter-user">:help ALTER USER</a>{' '}
+          <a help-topic="show-roles">:help SHOW ROLES</a>{' '}
+          <a help-topic="drop-role">:help DROP ROLE</a>{' '}
+          <a help-topic="grant-role">:help GRANT ROLE</a>{' '}
+          <a help-topic="revoke-role">:help REVOKE ROLE</a>{' '}
           <a help-topic="cypher">:help Cypher</a>
         </p>
       </div>
     </div>
     <section className="example">
       <figure>
-        <pre className="code runnable standalone-example">DROP USER jake</pre>
+        <pre className="code runnable standalone-example">
+          CREATE ROLE myrole
+        </pre>
+      </figure>
+      <figure>
+        <pre className="code runnable standalone-example">
+          CREATE ROLE mysecondrole AS COPY OF myrole
+        </pre>
+        <figcaption>
+          A role can also be copied, keeping its privileges.
+        </figcaption>
       </figure>
     </section>
     <AdminOnSystemDb />

--- a/src/browser/documentation/help/create-user.jsx
+++ b/src/browser/documentation/help/create-user.jsx
@@ -47,6 +47,7 @@ const content = (
         <p className="title">Related</p>
         <p className="content">
           <a help-topic="show-users">:help SHOW USERS</a>{' '}
+          <a help-topic="alter-user">:help ALTER USER</a>{' '}
           <a help-topic="drop-user">:help DROP USER</a>{' '}
           <a help-topic="cypher">:help Cypher</a>
         </p>

--- a/src/browser/documentation/help/deny.jsx
+++ b/src/browser/documentation/help/deny.jsx
@@ -21,13 +21,14 @@
 import React from 'react'
 import ManualLink from 'browser-components/ManualLink'
 import AdminOnSystemDb from './partials/admin-on-systemdb'
-const title = 'DROP USER'
-const subtitle = 'Delete a user'
-const category = 'administration'
+const title = 'DENY'
+const subtitle = 'Deny privileges to roles'
+const category = 'security'
 const content = (
   <>
     <p>
-      The command <code>DROP USER</code> can be used to delete an existing user.
+      The <code>DENY</code> command allows an administrator to deny a privilege
+      to a role in order to prevent access to an entity.
     </p>
     <div className="links">
       <div className="link">
@@ -35,10 +36,19 @@ const content = (
         <p className="content">
           <ManualLink
             chapter="cypher-manual"
-            page="/administration/security/users-and-roles/#administration-security-users-drop"
+            page="/administration/security/subgraph/#administration-security-subgraph-introduction"
             minVersion="4.0.0"
           >
-            DROP USER
+            Subgraph security
+          </ManualLink>{' '}
+          manual page
+          <br />
+          <ManualLink
+            chapter="cypher-manual"
+            page="/administration/security/administration/#administration-security-administration-database-privileges"
+            minVersion="4.0.0"
+          >
+            Database administration
           </ManualLink>{' '}
           manual page
         </p>
@@ -46,16 +56,30 @@ const content = (
       <div className="link">
         <p className="title">Related</p>
         <p className="content">
-          <a help-topic="show-users">:help SHOW USERS</a>{' '}
-          <a help-topic="drop-user">:help CREATE USER</a>{' '}
-          <a help-topic="alter-user">:help ALTER USER</a>{' '}
+          <a help-topic="show-privileges">:help SHOW PRIVILEGES</a>{' '}
+          <a help-topic="grant">:help GRANT</a>{' '}
+          <a help-topic="revoke">:help REVOKE</a>{' '}
           <a help-topic="cypher">:help Cypher</a>
         </p>
       </div>
     </div>
     <section className="example">
       <figure>
-        <pre className="code runnable standalone-example">DROP USER jake</pre>
+        <pre className="code runnable standalone-example">
+          DENY graph-privilege ON GRAPH dbname entity TO role
+        </pre>
+        <figcaption>
+          Deny a subgraph privilege to a role (eg. write nodes/relationships).
+        </figcaption>
+      </figure>
+      <figure>
+        <pre className="code runnable standalone-example">
+          DENY database-privilege ON DATABASE dbname TO role
+        </pre>
+        <figcaption>
+          Deny a database administrative privilege to a role (eg. create index
+          or start/stop database).
+        </figcaption>
       </figure>
     </section>
     <AdminOnSystemDb />

--- a/src/browser/documentation/help/drop-role.jsx
+++ b/src/browser/documentation/help/drop-role.jsx
@@ -21,13 +21,13 @@
 import React from 'react'
 import ManualLink from 'browser-components/ManualLink'
 import AdminOnSystemDb from './partials/admin-on-systemdb'
-const title = 'DROP USER'
-const subtitle = 'Delete a user'
-const category = 'administration'
+const title = 'DROP ROLE'
+const subtitle = 'Delete a role'
+const category = 'security'
 const content = (
   <>
     <p>
-      The command <code>DROP USER</code> can be used to delete an existing user.
+      The <code>DROP ROLE</code> command can be used to delete roles.
     </p>
     <div className="links">
       <div className="link">
@@ -35,10 +35,10 @@ const content = (
         <p className="content">
           <ManualLink
             chapter="cypher-manual"
-            page="/administration/security/users-and-roles/#administration-security-users-drop"
+            page="/administration/security/users-and-roles/#administration-security-roles-drop"
             minVersion="4.0.0"
           >
-            DROP USER
+            DROP ROLE
           </ManualLink>{' '}
           manual page
         </p>
@@ -46,16 +46,17 @@ const content = (
       <div className="link">
         <p className="title">Related</p>
         <p className="content">
-          <a help-topic="show-users">:help SHOW USERS</a>{' '}
-          <a help-topic="drop-user">:help CREATE USER</a>{' '}
-          <a help-topic="alter-user">:help ALTER USER</a>{' '}
+          <a help-topic="show-roles">:help SHOW ROLES</a>{' '}
+          <a help-topic="create-role">:help CREATE ROLE</a>{' '}
+          <a help-topic="grant-role">:help GRANT ROLE</a>{' '}
+          <a help-topic="revoke-role">:help REVOKE ROLE</a>{' '}
           <a help-topic="cypher">:help Cypher</a>
         </p>
       </div>
     </div>
     <section className="example">
       <figure>
-        <pre className="code runnable standalone-example">DROP USER jake</pre>
+        <pre className="code runnable standalone-example">DROP ROLE myrole</pre>
       </figure>
     </section>
     <AdminOnSystemDb />

--- a/src/browser/documentation/help/grant-role.jsx
+++ b/src/browser/documentation/help/grant-role.jsx
@@ -21,13 +21,14 @@
 import React from 'react'
 import ManualLink from 'browser-components/ManualLink'
 import AdminOnSystemDb from './partials/admin-on-systemdb'
-const title = 'DROP USER'
-const subtitle = 'Delete a user'
-const category = 'administration'
+const title = 'GRANT ROLE'
+const subtitle = 'Assign roles to users'
+const category = 'security'
 const content = (
   <>
     <p>
-      The command <code>DROP USER</code> can be used to delete an existing user.
+      The <code>GRANT ROLE</code> command can be used to assign roles to users,
+      giving them access rights.
     </p>
     <div className="links">
       <div className="link">
@@ -35,10 +36,10 @@ const content = (
         <p className="content">
           <ManualLink
             chapter="cypher-manual"
-            page="/administration/security/users-and-roles/#administration-security-users-drop"
+            page="/administration/security/users-and-roles/#administration-security-roles-grant"
             minVersion="4.0.0"
           >
-            DROP USER
+            GRANT ROLE
           </ManualLink>{' '}
           manual page
         </p>
@@ -46,16 +47,28 @@ const content = (
       <div className="link">
         <p className="title">Related</p>
         <p className="content">
-          <a help-topic="show-users">:help SHOW USERS</a>{' '}
-          <a help-topic="drop-user">:help CREATE USER</a>{' '}
-          <a help-topic="alter-user">:help ALTER USER</a>{' '}
+          <a help-topic="show-roles">:help SHOW ROLES</a>{' '}
+          <a help-topic="create-role">:help CREATE ROLE</a>{' '}
+          <a help-topic="drop-role">:help DROP ROLE</a>{' '}
+          <a help-topic="revoke-role">:help REVOKE ROLE</a>{' '}
           <a help-topic="cypher">:help Cypher</a>
         </p>
       </div>
     </div>
     <section className="example">
       <figure>
-        <pre className="code runnable standalone-example">DROP USER jake</pre>
+        <pre className="code runnable standalone-example">
+          GRANT ROLE myrole TO jake
+        </pre>
+      </figure>
+      <figure>
+        <pre className="code runnable standalone-example">
+          GRANT ROLES role1, role2 TO user1, user2, user3
+        </pre>
+        <figcaption>
+          It is possible to assign multiple roles to multiple users in one
+          command.
+        </figcaption>
       </figure>
     </section>
     <AdminOnSystemDb />

--- a/src/browser/documentation/help/grant.jsx
+++ b/src/browser/documentation/help/grant.jsx
@@ -21,13 +21,14 @@
 import React from 'react'
 import ManualLink from 'browser-components/ManualLink'
 import AdminOnSystemDb from './partials/admin-on-systemdb'
-const title = 'DROP USER'
-const subtitle = 'Delete a user'
-const category = 'administration'
+const title = 'GRANT'
+const subtitle = 'Grant privileges to roles'
+const category = 'security'
 const content = (
   <>
     <p>
-      The command <code>DROP USER</code> can be used to delete an existing user.
+      The <code>GRANT</code> command allows an administrator to grant a
+      privilege to a role in order to access an entity.
     </p>
     <div className="links">
       <div className="link">
@@ -35,10 +36,19 @@ const content = (
         <p className="content">
           <ManualLink
             chapter="cypher-manual"
-            page="/administration/security/users-and-roles/#administration-security-users-drop"
+            page="/administration/security/subgraph/#administration-security-subgraph-introduction"
             minVersion="4.0.0"
           >
-            DROP USER
+            Subgraph security
+          </ManualLink>{' '}
+          manual page
+          <br />
+          <ManualLink
+            chapter="cypher-manual"
+            page="/administration/security/administration/#administration-security-administration-database-privileges"
+            minVersion="4.0.0"
+          >
+            Database administration
           </ManualLink>{' '}
           manual page
         </p>
@@ -46,16 +56,30 @@ const content = (
       <div className="link">
         <p className="title">Related</p>
         <p className="content">
-          <a help-topic="show-users">:help SHOW USERS</a>{' '}
-          <a help-topic="drop-user">:help CREATE USER</a>{' '}
-          <a help-topic="alter-user">:help ALTER USER</a>{' '}
+          <a help-topic="show-privileges">:help SHOW PRIVILEGES</a>{' '}
+          <a help-topic="revoke">:help REVOKE</a>{' '}
+          <a help-topic="deny">:help DENY</a>{' '}
           <a help-topic="cypher">:help Cypher</a>
         </p>
       </div>
     </div>
     <section className="example">
       <figure>
-        <pre className="code runnable standalone-example">DROP USER jake</pre>
+        <pre className="code runnable standalone-example">
+          GRANT graph-privilege ON GRAPH dbname entity TO role
+        </pre>
+        <figcaption>
+          Grant a subgraph privilege to a role (eg. write nodes/relationships).
+        </figcaption>
+      </figure>
+      <figure>
+        <pre className="code runnable standalone-example">
+          GRANT database-privilege ON DATABASE dbname TO role
+        </pre>
+        <figcaption>
+          Grant a database administrative privilege to a role (eg. create index
+          or start/stop database).
+        </figcaption>
       </figure>
     </section>
     <AdminOnSystemDb />

--- a/src/browser/documentation/help/revoke-role.jsx
+++ b/src/browser/documentation/help/revoke-role.jsx
@@ -21,13 +21,14 @@
 import React from 'react'
 import ManualLink from 'browser-components/ManualLink'
 import AdminOnSystemDb from './partials/admin-on-systemdb'
-const title = 'DROP USER'
-const subtitle = 'Delete a user'
-const category = 'administration'
+const title = 'REVOKE ROLE'
+const subtitle = 'Revoke roles from users'
+const category = 'security'
 const content = (
   <>
     <p>
-      The command <code>DROP USER</code> can be used to delete an existing user.
+      The <code>REVOKE ROLE</code> command can be used to revoke roles from
+      users, removing access rights from them.
     </p>
     <div className="links">
       <div className="link">
@@ -35,10 +36,10 @@ const content = (
         <p className="content">
           <ManualLink
             chapter="cypher-manual"
-            page="/administration/security/users-and-roles/#administration-security-users-drop"
+            page="/administration/security/users-and-roles/#administration-security-roles-revoke"
             minVersion="4.0.0"
           >
-            DROP USER
+            REVOKE ROLE
           </ManualLink>{' '}
           manual page
         </p>
@@ -46,16 +47,28 @@ const content = (
       <div className="link">
         <p className="title">Related</p>
         <p className="content">
-          <a help-topic="show-users">:help SHOW USERS</a>{' '}
-          <a help-topic="drop-user">:help CREATE USER</a>{' '}
-          <a help-topic="alter-user">:help ALTER USER</a>{' '}
+          <a help-topic="show-roles">:help SHOW ROLES</a>{' '}
+          <a help-topic="create-role">:help CREATE ROLE</a>{' '}
+          <a help-topic="drop-role">:help DROP ROLE</a>{' '}
+          <a help-topic="grant-role">:help GRANT ROLE</a>{' '}
           <a help-topic="cypher">:help Cypher</a>
         </p>
       </div>
     </div>
     <section className="example">
       <figure>
-        <pre className="code runnable standalone-example">DROP USER jake</pre>
+        <pre className="code runnable standalone-example">
+          REVOKE ROLE myrole FROM jake
+        </pre>
+      </figure>
+      <figure>
+        <pre className="code runnable standalone-example">
+          REVOKE ROLES role1, role2 TO user1, user2, user3
+        </pre>
+        <figcaption>
+          It is possible to revoke multiple roles from multiple users in one
+          command.
+        </figcaption>
       </figure>
     </section>
     <AdminOnSystemDb />

--- a/src/browser/documentation/help/revoke.jsx
+++ b/src/browser/documentation/help/revoke.jsx
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2002-2019 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react'
+import ManualLink from 'browser-components/ManualLink'
+import AdminOnSystemDb from './partials/admin-on-systemdb'
+const title = 'REVOKE'
+const subtitle = 'Revoke granted or denied privileges'
+const category = 'security'
+const content = (
+  <>
+    <p>
+      The <code>REVOKE</code> command allows an administrator to remove a
+      previously granted or denied privilege.
+    </p>
+    <div className="links">
+      <div className="link">
+        <p className="title">Reference</p>
+        <p className="content">
+          <ManualLink
+            chapter="cypher-manual"
+            page="/administration/security/subgraph/#administration-security-subgraph-introduction"
+            minVersion="4.0.0"
+          >
+            Subgraph security
+          </ManualLink>{' '}
+          manual page
+          <br />
+          <ManualLink
+            chapter="cypher-manual"
+            page="/administration/security/administration/#administration-security-administration-database-privileges"
+            minVersion="4.0.0"
+          >
+            Database administration
+          </ManualLink>{' '}
+          manual page
+        </p>
+      </div>
+      <div className="link">
+        <p className="title">Related</p>
+        <p className="content">
+          <a help-topic="show-privileges">:help SHOW PRIVILEGES</a>{' '}
+          <a help-topic="grant">:help GRANT</a>{' '}
+          <a help-topic="deny">:help DENY</a>{' '}
+          <a help-topic="cypher">:help Cypher</a>
+        </p>
+      </div>
+    </div>
+    <section className="example">
+      <figure>
+        <pre className="code runnable standalone-example">
+          REVOKE GRANT graph-privilege ON GRAPH dbname entity TO role
+        </pre>
+        <figcaption>
+          Revoke a granted subgraph privilege from a role (eg. write
+          nodes/relationships).
+        </figcaption>
+      </figure>
+      <figure>
+        <pre className="code runnable standalone-example">
+          REVOKE DENY graph-privilege ON GRAPH dbname entity TO role
+        </pre>
+        <figcaption>Revoke a denied subgraph privilege from a role.</figcaption>
+      </figure>
+      <figure>
+        <pre className="code runnable standalone-example">
+          REVOKE graph-privilege ON GRAPH dbname entity TO role
+        </pre>
+        <figcaption>
+          Revoke a granted or denied subgraph privilege from a role.
+        </figcaption>
+      </figure>
+      <figure>
+        <pre className="code runnable standalone-example">
+          REVOKE GRANT database-privilege ON DATABASE dbname TO role
+        </pre>
+        <figcaption>
+          Revoke a granted database administrative privilege from a role (eg.
+          create index or start/stop database).
+        </figcaption>
+      </figure>
+    </section>
+    <AdminOnSystemDb />
+  </>
+)
+export default { title, subtitle, category, content }

--- a/src/browser/documentation/help/show-privileges.jsx
+++ b/src/browser/documentation/help/show-privileges.jsx
@@ -21,13 +21,14 @@
 import React from 'react'
 import ManualLink from 'browser-components/ManualLink'
 import AdminOnSystemDb from './partials/admin-on-systemdb'
-const title = 'DROP USER'
-const subtitle = 'Delete a user'
-const category = 'administration'
+const title = 'SHOW PRIVILEGES'
+const subtitle = 'List available privileges'
+const category = 'security'
 const content = (
   <>
     <p>
-      The command <code>DROP USER</code> can be used to delete an existing user.
+      The <code>SHOW PRIVILEGES</code> command can be used to list available
+      privileges for all roles.
     </p>
     <div className="links">
       <div className="link">
@@ -35,10 +36,10 @@ const content = (
         <p className="content">
           <ManualLink
             chapter="cypher-manual"
-            page="/administration/security/users-and-roles/#administration-security-users-drop"
+            page="/administration/security/subgraph/#administration-security-subgraph-show"
             minVersion="4.0.0"
           >
-            DROP USER
+            SHOW PRIVILEGES
           </ManualLink>{' '}
           manual page
         </p>
@@ -46,16 +47,16 @@ const content = (
       <div className="link">
         <p className="title">Related</p>
         <p className="content">
-          <a help-topic="show-users">:help SHOW USERS</a>{' '}
-          <a help-topic="drop-user">:help CREATE USER</a>{' '}
-          <a help-topic="alter-user">:help ALTER USER</a>{' '}
+          <a help-topic="grant">:help GRANT</a>{' '}
+          <a help-topic="deny">:help DENY</a>{' '}
+          <a help-topic="revoke">:help REVOKE</a>{' '}
           <a help-topic="cypher">:help Cypher</a>
         </p>
       </div>
     </div>
     <section className="example">
       <figure>
-        <pre className="code runnable standalone-example">DROP USER jake</pre>
+        <pre className="code runnable standalone-example">SHOW PRIVILEGES</pre>
       </figure>
     </section>
     <AdminOnSystemDb />

--- a/src/browser/documentation/help/show-roles.jsx
+++ b/src/browser/documentation/help/show-roles.jsx
@@ -21,13 +21,13 @@
 import React from 'react'
 import ManualLink from 'browser-components/ManualLink'
 import AdminOnSystemDb from './partials/admin-on-systemdb'
-const title = 'DROP USER'
-const subtitle = 'Delete a user'
-const category = 'administration'
+const title = 'SHOW ROLES'
+const subtitle = 'List available roles'
+const category = 'security'
 const content = (
   <>
     <p>
-      The command <code>DROP USER</code> can be used to delete an existing user.
+      The <code>SHOW ROLES</code> command can be used to list available roles.
     </p>
     <div className="links">
       <div className="link">
@@ -35,10 +35,10 @@ const content = (
         <p className="content">
           <ManualLink
             chapter="cypher-manual"
-            page="/administration/security/users-and-roles/#administration-security-users-drop"
+            page="/administration/security/users-and-roles/#administration-security-roles-show"
             minVersion="4.0.0"
           >
-            DROP USER
+            SHOW ROLES
           </ManualLink>{' '}
           manual page
         </p>
@@ -46,16 +46,17 @@ const content = (
       <div className="link">
         <p className="title">Related</p>
         <p className="content">
-          <a help-topic="show-users">:help SHOW USERS</a>{' '}
-          <a help-topic="drop-user">:help CREATE USER</a>{' '}
-          <a help-topic="alter-user">:help ALTER USER</a>{' '}
+          <a help-topic="create-role">:help CREATE ROLE</a>{' '}
+          <a help-topic="drop-role">:help DROP ROLE</a>{' '}
+          <a help-topic="grant-roles">:help GRANT ROLE</a>{' '}
+          <a help-topic="revoke-role">:help REVOKE ROLE</a>{' '}
           <a help-topic="cypher">:help Cypher</a>
         </p>
       </div>
     </div>
     <section className="example">
       <figure>
-        <pre className="code runnable standalone-example">DROP USER jake</pre>
+        <pre className="code runnable standalone-example">SHOW ROLES</pre>
       </figure>
     </section>
     <AdminOnSystemDb />

--- a/src/browser/documentation/help/show-users.jsx
+++ b/src/browser/documentation/help/show-users.jsx
@@ -48,6 +48,7 @@ const content = (
         <p className="title">Related</p>
         <p className="content">
           <a help-topic="create-user">:help CREATE USER</a>{' '}
+          <a help-topic="alter-user">:help ALTER USER</a>{' '}
           <a help-topic="drop-user">:help DROP USER</a>{' '}
           <a help-topic="cypher">:help Cypher</a>
         </p>

--- a/src/browser/documentation/index.js
+++ b/src/browser/documentation/index.js
@@ -19,6 +19,7 @@
  */
 
 // Help
+import helpAlterUser from './help/alter-user'
 import helpBolt from './dynamic/bolt'
 import helpBoltEncryption from './help/bolt-encryption'
 import helpBoltRouting from './help/bolt-routing'
@@ -27,17 +28,22 @@ import helpContains from './help/contains'
 import helpCreateConstraintOn from './help/create-constraint-on'
 import helpCreateDatabase from './help/create-database'
 import helpCreateIndexOn from './help/create-index-on'
+import helpCreateRole from './help/create-role'
 import helpCreateUser from './help/create-user'
 import helpCreate from './help/create'
 import helpDelete from './help/delete'
+import helpDeny from './help/deny'
 import helpDropConstraintOn from './help/drop-constraint-on'
 import helpDropDatabase from './help/drop-database'
 import helpDropIndexOn from './help/drop-index-on'
+import helpDropRole from './help/drop-role'
 import helpDropUser from './help/drop-user'
 import helpDetachDelete from './help/detach-delete'
 import helpEndsWith from './help/ends-with'
 import helpExplain from './help/explain'
 import helpForeach from './help/foreach'
+import helpGrant from './help/grant'
+import helpGrantRole from './help/grant-role'
 import helpHistory from './help/history'
 import helpHistoryClear from './help/history-clear'
 import helpKeys from './help/keys'
@@ -56,11 +62,15 @@ import helpRestGet from './help/rest-get'
 import helpRestPost from './help/rest-post'
 import helpRestPut from './help/rest-put'
 import helpReturn from './help/return'
+import helpRevoke from './help/revoke'
+import helpRevokeRole from './help/revoke-role'
 import helpSchema from './help/schema'
 import helpServer from './help/server'
 import helpServerUser from './help/server-user'
 import helpSet from './help/set'
 import helpShowDatabases from './help/show-databases'
+import helpShowPrivileges from './help/show-privileges'
+import helpShowRoles from './help/show-roles'
 import helpShowUsers from './help/show-users'
 import helpStartsWith from './help/starts-with'
 import helpStyle from './help/style'
@@ -117,21 +127,27 @@ export default {
   cypher: {
     title: 'Cypher',
     chapters: {
+      alterUser: helpAlterUser,
       contains: helpContains,
       createConstraintOn: helpCreateConstraintOn,
       createDatabase: helpCreateDatabase,
       createIndexOn: helpCreateIndexOn,
+      createRole: helpCreateRole,
       createUser: helpCreateUser,
       create: helpCreate,
       delete: helpDelete,
+      deny: helpDeny,
       detachDelete: helpDetachDelete,
       dropConstraintOn: helpDropConstraintOn,
       dropDatabase: helpDropDatabase,
       dropIndexOn: helpDropIndexOn,
+      dropRole: helpDropRole,
       dropUser: helpDropUser,
       endsWith: helpEndsWith,
       explain: helpExplain,
       foreach: helpForeach,
+      grant: helpGrant,
+      grantRole: helpGrantRole,
       loadCsv: helpLoadCsv,
       match: helpMatch,
       merge: helpMerge,
@@ -146,9 +162,13 @@ export default {
       restPost: helpRestPost,
       restPut: helpRestPut,
       return: helpReturn,
+      revoke: helpRevoke,
+      revokeRole: helpRevokeRole,
       schema: helpSchema,
       set: helpSet,
       showDatabases: helpShowDatabases,
+      showPrivileges: helpShowPrivileges,
+      showRoles: helpShowRoles,
       showUsers: helpShowUsers,
       startsWith: helpStartsWith,
       template: helpTemplate,

--- a/src/browser/documentation/templates/DynamicTopics.jsx
+++ b/src/browser/documentation/templates/DynamicTopics.jsx
@@ -40,6 +40,7 @@ const categorize = commands => {
     cypherHelp: { title: 'Cypher Help' },
     schemaClauses: { title: 'Schema Clauses' },
     administration: { title: 'Administration' },
+    security: { title: 'Security' },
     cypherPredicates: { title: 'Cypher Predicates' },
     restApiCommands: { title: 'Rest API Commands' },
     guides: { title: 'Guides' },


### PR DESCRIPTION
Adds help cards for the following commands:

- ALTER USER
- SHOW ROLES
- [CREATE|GRANT|REVOKE|DROP] ROLE
- SHOW PRIVILEGES
- GRANT
- DENY
- REVOKE

Links to the help cards are also added into a new section of the `:help cypher` result card.

![image](https://user-images.githubusercontent.com/13448636/71352412-91c1fe80-2576-11ea-959a-05f253a8d364.png)
