### PR TITLE
e2e test added for export options

### DIFF
--- a/e2e_tests/integration/data-export.spec.js
+++ b/e2e_tests/integration/data-export.spec.js
@@ -31,69 +31,49 @@ describe('Data export', () => {
     const password = Cypress.config('password')
     cy.connect('neo4j', password)
   })
-  it('shows the correct export buttons', () => {
-    cy.executeCommand(':clear')
-    cy.executeCommand('CREATE (n:ExportTest) RETURN n')
-
-    cy.get('[data-testid="frame"]', { timeout: 10000 }).should('have.length', 1)
-
-    // viz
-    cy.get('[data-testid="frame-export-dropdown"]').trigger('mouseover')
-    cy.get('[data-testid="frame-export-dropdown"]', { timeout: 10000 }).within(
-      () => {
-        cy.get('a').then(exportButtonsList => {
-          expect(exportButtonsList).to.have.length(4)
-          expect(exportButtonsList.eq(0)).to.contain('Export CSV')
-          expect(exportButtonsList.eq(1)).to.contain('Export JSON')
-          expect(exportButtonsList.eq(2)).to.contain('Export PNG')
-          expect(exportButtonsList.eq(3)).to.contain('Export SVG')
-        })
+  context('export options', () => {
+    before(function() {
+      cy.executeCommand(':clear')
+      cy.executeCommand('CREATE (n:ExportTest) RETURN n')
+      cy.get('[data-testid="frame"]', { timeout: 10000 }).should(
+        'have.length',
+        1
+      )
+    })
+    after(function() {
+      cy.executeCommand('MATCH (n:ExportTest) DETACH DELETE n')
+    })
+    const exportOptionsConfig = [
+      {
+        names: ['Visualization'],
+        order: ['CSV', 'JSON', 'PNG', 'SVG']
+      },
+      {
+        names: ['Table', 'Ascii', 'Code'],
+        order: ['CSV', 'JSON']
       }
-    )
-
-    // table
-    cy.get('[data-testid="cypherFrameSidebarTable"]', {
-      timeout: 10000
-    }).click()
-    cy.get('[data-testid="frame-export-dropdown"]').trigger('mouseover')
-    cy.get('[data-testid="frame-export-dropdown"]', { timeout: 10000 }).within(
-      () => {
-        cy.get('a').then(exportButtonsList => {
-          expect(exportButtonsList).to.have.length(2)
-          expect(exportButtonsList.eq(0)).to.contain('Export CSV')
-          expect(exportButtonsList.eq(1)).to.contain('Export JSON')
+    ]
+    exportOptionsConfig.forEach(config => {
+      config.names.forEach(name => {
+        it(`shows the correct export buttons for ${name} view`, () => {
+          cy.get(`[data-testid="cypherFrameSidebar${name}"]`, {
+            timeout: 10000
+          }).click()
+          cy.get('[data-testid="frame-export-dropdown"]').trigger('mouseover')
+          cy.get('[data-testid="frame-export-dropdown"]', {
+            timeout: 10000
+          }).within(() => {
+            cy.get('a').then(exportButtonsList => {
+              expect(exportButtonsList).to.have.length(config.order.length)
+              config.order.forEach((exportType, index) => {
+                expect(exportButtonsList.eq(index)).to.contain(
+                  `Export ${exportType}`
+                )
+              })
+            })
+          })
         })
-      }
-    )
-
-    // text
-    cy.get('[data-testid="cypherFrameSidebarAscii"]', {
-      timeout: 10000
-    }).click()
-    cy.get('[data-testid="frame-export-dropdown"]').trigger('mouseover')
-    cy.get('[data-testid="frame-export-dropdown"]', { timeout: 10000 }).within(
-      () => {
-        cy.get('a').then(exportButtonsList => {
-          expect(exportButtonsList).to.have.length(2)
-          expect(exportButtonsList.eq(0)).to.contain('Export CSV')
-          expect(exportButtonsList.eq(1)).to.contain('Export JSON')
-        })
-      }
-    )
-
-    // code
-    cy.get('[data-testid="cypherFrameSidebarCode"]', { timeout: 10000 }).click()
-    cy.get('[data-testid="frame-export-dropdown"]').trigger('mouseover')
-    cy.get('[data-testid="frame-export-dropdown"]', { timeout: 10000 }).within(
-      () => {
-        cy.get('a').then(exportButtonsList => {
-          expect(exportButtonsList).to.have.length(2)
-          expect(exportButtonsList.eq(0)).to.contain('Export CSV')
-          expect(exportButtonsList.eq(1)).to.contain('Export JSON')
-        })
-      }
-    )
-
-    cy.executeCommand('MATCH (n:ExportTest) DETACH DELETE n')
+      })
+    })
   })
 })

--- a/e2e_tests/integration/data-export.spec.js
+++ b/e2e_tests/integration/data-export.spec.js
@@ -34,7 +34,7 @@ describe('Data export', () => {
   context('export options', () => {
     before(function() {
       cy.executeCommand(':clear')
-      cy.executeCommand('CREATE (n:ExportTest) RETURN n')
+      cy.executeCommand('PROFILE CREATE (n:ExportTest) RETURN n')
       cy.get('[data-testid="frame"]', { timeout: 10000 }).should(
         'have.length',
         1

--- a/e2e_tests/integration/data-export.spec.js
+++ b/e2e_tests/integration/data-export.spec.js
@@ -45,7 +45,7 @@ describe('Data export', () => {
     })
     const exportOptionsConfig = [
       {
-        names: ['Visualization'],
+        names: ['Plan', 'Visualization'],
         order: ['CSV', 'JSON', 'PNG', 'SVG']
       },
       {

--- a/e2e_tests/integration/data-export.spec.js
+++ b/e2e_tests/integration/data-export.spec.js
@@ -43,10 +43,10 @@ describe('Data export', () => {
       () => {
         cy.get('a').then(exportButtonsList => {
           expect(exportButtonsList).to.have.length(4)
-          expect(exportButtonsList.eq(0)).to.contain('Export PNG')
-          expect(exportButtonsList.eq(1)).to.contain('Export SVG')
-          expect(exportButtonsList.eq(2)).to.contain('Export CSV')
-          expect(exportButtonsList.eq(3)).to.contain('Export JSON')
+          expect(exportButtonsList.eq(0)).to.contain('Export CSV')
+          expect(exportButtonsList.eq(1)).to.contain('Export JSON')
+          expect(exportButtonsList.eq(2)).to.contain('Export PNG')
+          expect(exportButtonsList.eq(3)).to.contain('Export SVG')
         })
       }
     )

--- a/e2e_tests/integration/data-export.spec.js
+++ b/e2e_tests/integration/data-export.spec.js
@@ -31,17 +31,68 @@ describe('Data export', () => {
     const password = Cypress.config('password')
     cy.connect('neo4j', password)
   })
-  it('shows export buttons on viz load', () => {
+  it('shows the correct export buttons', () => {
     cy.executeCommand(':clear')
     cy.executeCommand('CREATE (n:ExportTest) RETURN n')
 
     cy.get('[data-testid="frame"]', { timeout: 10000 }).should('have.length', 1)
-    cy.get('[data-testid="frame-export-dropdown"]')
-      .first()
-      .trigger('mouseover')
-    cy.get('[data-testid="frame-export-dropdown"]')
-      .first()
-      .should('contain', 'Export PNG')
+
+    // viz
+    cy.get('[data-testid="frame-export-dropdown"]').trigger('mouseover')
+    cy.get('[data-testid="frame-export-dropdown"]', { timeout: 10000 }).within(
+      () => {
+        cy.get('a').then(exportButtonsList => {
+          expect(exportButtonsList).to.have.length(4)
+          expect(exportButtonsList.eq(0)).to.contain('Export PNG')
+          expect(exportButtonsList.eq(1)).to.contain('Export SVG')
+          expect(exportButtonsList.eq(2)).to.contain('Export CSV')
+          expect(exportButtonsList.eq(3)).to.contain('Export JSON')
+        })
+      }
+    )
+
+    // table
+    cy.get('[data-testid="cypherFrameSidebarTable"]', {
+      timeout: 10000
+    }).click()
+    cy.get('[data-testid="frame-export-dropdown"]').trigger('mouseover')
+    cy.get('[data-testid="frame-export-dropdown"]', { timeout: 10000 }).within(
+      () => {
+        cy.get('a').then(exportButtonsList => {
+          expect(exportButtonsList).to.have.length(2)
+          expect(exportButtonsList.eq(0)).to.contain('Export CSV')
+          expect(exportButtonsList.eq(1)).to.contain('Export JSON')
+        })
+      }
+    )
+
+    // text
+    cy.get('[data-testid="cypherFrameSidebarAscii"]', {
+      timeout: 10000
+    }).click()
+    cy.get('[data-testid="frame-export-dropdown"]').trigger('mouseover')
+    cy.get('[data-testid="frame-export-dropdown"]', { timeout: 10000 }).within(
+      () => {
+        cy.get('a').then(exportButtonsList => {
+          expect(exportButtonsList).to.have.length(2)
+          expect(exportButtonsList.eq(0)).to.contain('Export CSV')
+          expect(exportButtonsList.eq(1)).to.contain('Export JSON')
+        })
+      }
+    )
+
+    // code
+    cy.get('[data-testid="cypherFrameSidebarCode"]', { timeout: 10000 }).click()
+    cy.get('[data-testid="frame-export-dropdown"]').trigger('mouseover')
+    cy.get('[data-testid="frame-export-dropdown"]', { timeout: 10000 }).within(
+      () => {
+        cy.get('a').then(exportButtonsList => {
+          expect(exportButtonsList).to.have.length(2)
+          expect(exportButtonsList.eq(0)).to.contain('Export CSV')
+          expect(exportButtonsList.eq(1)).to.contain('Export JSON')
+        })
+      }
+    )
 
     cy.executeCommand('MATCH (n:ExportTest) DETACH DELETE n')
   })

--- a/src/browser/modules/Frame/FrameTitlebar.jsx
+++ b/src/browser/modules/Frame/FrameTitlebar.jsx
@@ -184,14 +184,12 @@ class FrameTitlebar extends Component {
               <DropdownList>
                 <DropdownContent>
                   <Render if={props.visElement}>
-                    <span>
-                      <DropdownItem onClick={() => this.exportPNG()}>
-                        Export PNG
-                      </DropdownItem>
-                      <DropdownItem onClick={() => this.exportSVG()}>
-                        Export SVG
-                      </DropdownItem>
-                    </span>
+                    <DropdownItem onClick={() => this.exportPNG()}>
+                      Export PNG
+                    </DropdownItem>
+                    <DropdownItem onClick={() => this.exportSVG()}>
+                      Export SVG
+                    </DropdownItem>
                   </Render>
                   <Render if={this.hasData() && frame.type === 'cypher'}>
                     <DropdownItem

--- a/src/browser/modules/Frame/FrameTitlebar.jsx
+++ b/src/browser/modules/Frame/FrameTitlebar.jsx
@@ -183,14 +183,6 @@ class FrameTitlebar extends Component {
               <DownloadIcon />
               <DropdownList>
                 <DropdownContent>
-                  <Render if={props.visElement}>
-                    <DropdownItem onClick={() => this.exportPNG()}>
-                      Export PNG
-                    </DropdownItem>
-                    <DropdownItem onClick={() => this.exportSVG()}>
-                      Export SVG
-                    </DropdownItem>
-                  </Render>
                   <Render if={this.hasData() && frame.type === 'cypher'}>
                     <DropdownItem
                       onClick={() => this.exportCSV(props.getRecords())}
@@ -201,6 +193,14 @@ class FrameTitlebar extends Component {
                       onClick={() => this.exportJSON(props.getRecords())}
                     >
                       Export JSON
+                    </DropdownItem>
+                  </Render>
+                  <Render if={props.visElement}>
+                    <DropdownItem onClick={() => this.exportPNG()}>
+                      Export PNG
+                    </DropdownItem>
+                    <DropdownItem onClick={() => this.exportSVG()}>
+                      Export SVG
                     </DropdownItem>
                   </Render>
                   <Render if={this.canExportTXT()}>

--- a/src/browser/modules/Stream/CypherFrame/index.jsx
+++ b/src/browser/modules/Stream/CypherFrame/index.jsx
@@ -205,6 +205,7 @@ export class CypherFrame extends Component {
         </Render>
         <Render if={!resultIsError(this.props.request)}>
           <CypherFrameButton
+            data-testid="cypherFrameSidebarCode"
             selected={this.state.openView === viewTypes.CODE}
             onClick={() => {
               this.changeView(viewTypes.CODE)

--- a/src/browser/modules/Stream/CypherFrame/index.jsx
+++ b/src/browser/modules/Stream/CypherFrame/index.jsx
@@ -140,6 +140,7 @@ export class CypherFrame extends Component {
       <FrameSidebar>
         <Render if={resultHasNodes(this.props.request) && !this.state.errors}>
           <CypherFrameButton
+            data-testid="cypherFrameSidebarVisualization"
             selected={this.state.openView === viewTypes.VISUALIZATION}
             onClick={() => {
               this.changeView(viewTypes.VISUALIZATION)

--- a/src/browser/modules/Stream/CypherFrame/index.jsx
+++ b/src/browser/modules/Stream/CypherFrame/index.jsx
@@ -178,6 +178,7 @@ export class CypherFrame extends Component {
         </Render>
         <Render if={resultHasPlan(this.props.request)}>
           <CypherFrameButton
+            data-testid="cypherFrameSidebarPlan"
             selected={this.state.openView === viewTypes.PLAN}
             onClick={() => this.changeView(viewTypes.PLAN)}
           >


### PR DESCRIPTION
- Add e2e tests for the correct export options to appear dependent on the Cypher frame view

- I question the need for alphabetical order mainly for the viz view, as it seems to be logical/better UX to me to have the PNG and SVG options first. It's a trivial change in any case and will be quick to implement once we decide on what to do (edit: after speaking with UX, it was deemed better to put in alphabetical order since in this case CSV/JSON will always be at the top and likely a better UX experience)