### PR TITLE
Fix huge SVG icons in inspector

### DIFF
--- a/src/browser/modules/D3Visualization/components/Inspector.jsx
+++ b/src/browser/modules/D3Visualization/components/Inspector.jsx
@@ -132,7 +132,7 @@ export class InspectorComponent extends Component {
                 'token' + ' ' + 'token-context-menu-key' + ' ' + 'token-label'
               }
             >
-              <SVGInline svg={item.label} width="12" />
+              <SVGInline svg={item.label} width="12px" />
             </StyledTokenContextMenuKey>
             <StyledInspectorFooterRowListPair key="pair" className="pair">
               <StyledInspectorFooterRowListValue className="value">


### PR DESCRIPTION
Steps to reproduce: 
- Run any query returning a graph
- Click on a node
- Hover the icons around it, or click the dismiss icon
- The icon showing in the footer of the card will be huge and scrollable

**Note:** this issue was happening only on Firefox. 

Before:
![before](https://user-images.githubusercontent.com/13448636/71353486-7b697200-2579-11ea-8e31-52d04229b7c4.png)

After:
![after](https://user-images.githubusercontent.com/13448636/71353484-79071800-2579-11ea-8142-85a104272da3.png)