### PR TITLE
Remove duplicates from the expandedNodeMap array

### DIFF
--- a/src/browser/modules/D3Visualization/lib/visualization/components/graph.js
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/graph.js
@@ -82,7 +82,7 @@ export default class Graph {
         this.nodeMap[eNode.id] = eNode
         this._nodes.push(eNode)
         this.expandedNodeMap[node.id] = this.expandedNodeMap[node.id]
-          ? this.expandedNodeMap[node.id].concat([eNode.id])
+          ? [...new Set(this.expandedNodeMap[node.id].concat([eNode.id]))]
           : [eNode.id]
       }
     }


### PR DESCRIPTION
fixes: #905 

- There seems to be an issue where the `expandedNodeMap` contains duplicates, so that as the code recursively loops over the `expandedNodeMap` array to remove nodes when a node is collapsed, it falls into an issue where the node is not found the second time round during the recursion and throws an error.

- I'm not sure of where to place a test for this as there didn't seem to be any e2e tests for expanding/closing nodes unless Im mistaken, so any input on that would be appreciated. The other option would be to open a unit test file but I don't want to start cluttering the code base with unnecessary unit test files if they're not needed.

**Before** - shows the duplicates in the `expandedNodeMap`:
<img width="1411" alt="Screenshot 2020-01-02 at 12 37 31" src="https://user-images.githubusercontent.com/14161129/71667416-e9bde980-2d5c-11ea-9fd7-9e2d8e3bf87e.png">

[Before Video](https://drive.google.com/file/d/1veHbQHBpT4GDvxop8McrQC5lk06pd42J/view)

**After** - shows no duplicates in the `expandedNodeMap`:

<img width="1318" alt="Screenshot 2020-01-02 at 12 38 29" src="https://user-images.githubusercontent.com/14161129/71667454-0e19c600-2d5d-11ea-9f41-4afe5019edc4.png">

[After video](https://drive.google.com/file/d/1HYt4MnB8I2bDZ5Vfia11tdZ5c9x_Uj6G/view)