### PR TITLE
Deeplink to slide in remote guides

### DIFF
--- a/src/browser/modules/Carousel/Carousel.jsx
+++ b/src/browser/modules/Carousel/Carousel.jsx
@@ -46,6 +46,10 @@ export default class Carousel extends Component {
     super(props)
     this.slides = this.props.slides || []
     this.myRef = React.createRef()
+
+    if (props.initialSlide && props.initialSlide <= this.slides.length) {
+      this.state.visibleSlide = props.initialSlide - 1
+    }
   }
 
   onKeyDown(ev) {

--- a/src/browser/modules/Docs/Docs.jsx
+++ b/src/browser/modules/Docs/Docs.jsx
@@ -47,7 +47,13 @@ export default class Docs extends Component {
   }
 
   render() {
-    const { content, html, withDirectives, hasCarouselComponent } = this.props
+    const {
+      content,
+      html,
+      withDirectives,
+      initialSlide,
+      hasCarouselComponent
+    } = this.props
 
     if (hasCarouselComponent) {
       return content
@@ -57,7 +63,13 @@ export default class Docs extends Component {
       const ListOfSlides = this.state.slides.map(slide => {
         return <Slide key={uuid.v4()} html={slide.html.innerHTML} />
       })
-      return <Carousel slides={ListOfSlides} withDirectives={withDirectives} />
+      return (
+        <Carousel
+          slides={ListOfSlides}
+          initialSlide={initialSlide}
+          withDirectives={withDirectives}
+        />
+      )
     }
 
     let slide = <Slide ref={this.ref} html="" />

--- a/src/browser/modules/Stream/PlayFrame.jsx
+++ b/src/browser/modules/Stream/PlayFrame.jsx
@@ -56,14 +56,14 @@ export class PlayFrame extends Component {
 
   componentDidMount() {
     if (this.props.frame.result) {
-      const { slideIndex } = this.props.frame
+      const { initialSlide } = this.props.frame
 
       // Found remote guide
       this.setState({
         guide: (
           <Docs
             withDirectives
-            initialSlide={slideIndex}
+            initialSlide={initialSlide}
             html={this.props.frame.result}
           />
         ),

--- a/src/browser/modules/Stream/PlayFrame.jsx
+++ b/src/browser/modules/Stream/PlayFrame.jsx
@@ -56,9 +56,17 @@ export class PlayFrame extends Component {
 
   componentDidMount() {
     if (this.props.frame.result) {
+      const { slideIndex } = this.props.frame
+
       // Found remote guide
       this.setState({
-        guide: <Docs withDirectives html={this.props.frame.result} />,
+        guide: (
+          <Docs
+            withDirectives
+            initialSlide={slideIndex}
+            html={this.props.frame.result}
+          />
+        ),
         hasCarousel: checkHtmlForSlides(this.props.frame.result),
         isRemote: true
       })

--- a/src/shared/modules/commands/commandsDuck.js
+++ b/src/shared/modules/commands/commandsDuck.js
@@ -274,6 +274,7 @@ export const fetchGuideFromWhitelistEpic = (some$, store) =>
     )
     const urlWhitelist = addProtocolsToUrlList(resolvedWildcardWhitelist)
     const guidesUrls = urlWhitelist.map(url => url + '/' + action.url)
+
     return firstSuccessPromise(guidesUrls, url => {
       // Get first successful fetch
       return fetchRemoteGuide(url, whitelistStr).then(r => ({

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -87,7 +87,7 @@ import {
 } from 'shared/services/bolt/txMetadata'
 import {
   getCommandAndParam,
-  tryGetRemoteSlideIndexFromUrl
+  tryGetRemoteInitialSlideFromUrl
 } from './commandUtils'
 
 const availableCommands = [
@@ -420,7 +420,7 @@ const availableCommands = [
               useDb: getUseDb(store.getState()),
               ...action,
               type: 'play-remote',
-              slideIndex: tryGetRemoteSlideIndexFromUrl(url),
+              initialSlide: tryGetRemoteInitialSlideFromUrl(url),
               result: r
             })
           )
@@ -432,7 +432,7 @@ const availableCommands = [
               ...action,
               type: 'play-remote',
               response: e.response || null,
-              slideIndex: tryGetRemoteSlideIndexFromUrl(url),
+              initialSlide: tryGetRemoteInitialSlideFromUrl(url),
               error: CouldNotFetchRemoteGuideError({
                 error: e.name + ': ' + e.message
               })

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -85,7 +85,10 @@ import {
   getUserDirectTxMetadata,
   getBackgroundTxMetadata
 } from 'shared/services/bolt/txMetadata'
-import { getCommandAndParam } from './commandUtils'
+import {
+  getCommandAndParam,
+  tryGetRemoteSlideIndexFromUrl
+} from './commandUtils'
 
 const availableCommands = [
   {
@@ -417,6 +420,7 @@ const availableCommands = [
               useDb: getUseDb(store.getState()),
               ...action,
               type: 'play-remote',
+              slideIndex: tryGetRemoteSlideIndexFromUrl(url),
               result: r
             })
           )
@@ -428,6 +432,7 @@ const availableCommands = [
               ...action,
               type: 'play-remote',
               response: e.response || null,
+              slideIndex: tryGetRemoteSlideIndexFromUrl(url),
               error: CouldNotFetchRemoteGuideError({
                 error: e.name + ': ' + e.message
               })

--- a/src/shared/services/commandUtils.js
+++ b/src/shared/services/commandUtils.js
@@ -154,7 +154,7 @@ export const getCommandAndParam = str => {
   return [serverCmd, props]
 }
 
-export function tryGetRemoteSlideIndexFromUrl(url) {
+export function tryGetRemoteInitialSlideFromUrl(url) {
   const hashBang = includes(url, '#') ? last(split(url, '#')) : ''
 
   if (!startsWith(hashBang, 'slide-')) return 0

--- a/src/shared/services/commandUtils.js
+++ b/src/shared/services/commandUtils.js
@@ -17,6 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { includes, last, split, startsWith } from 'lodash-es'
 import { extractStatements } from 'cypher-codemirror'
 
 export function cleanCommand(cmd) {
@@ -151,4 +152,14 @@ export const getCommandAndParam = str => {
     ' '
   )
   return [serverCmd, props]
+}
+
+export function tryGetRemoteSlideIndexFromUrl(url) {
+  const hashBang = includes(url, '#') ? last(split(url, '#')) : ''
+
+  if (!startsWith(hashBang, 'slide-')) return 0
+
+  const slideIndex = Number(last(split(hashBang, 'slide-')))
+
+  return !isNaN(slideIndex) ? slideIndex : 0
 }

--- a/src/shared/services/commandUtils.test.js
+++ b/src/shared/services/commandUtils.test.js
@@ -220,4 +220,29 @@ describe('commandutils', () => {
       })
     })
   })
+
+  describe('tryGetRemoteSlideIndexFromUrl', () => {
+    it('extracts slide index hashbangs from a string', () => {
+      expect(utils.tryGetRemoteSlideIndexFromUrl('foo#slide-1')).toEqual(1)
+      expect(
+        utils.tryGetRemoteSlideIndexFromUrl('http://foo.com#slide-2')
+      ).toEqual(2)
+      expect(
+        utils.tryGetRemoteSlideIndexFromUrl(
+          'http://www.google.com/yarr/#slide-21'
+        )
+      ).toEqual(21)
+    })
+    it('returns 0 when no valid hashbang found', () => {
+      expect(utils.tryGetRemoteSlideIndexFromUrl('foo')).toEqual(0)
+      expect(
+        utils.tryGetRemoteSlideIndexFromUrl('http://foo.com#sloide-2')
+      ).toEqual(0)
+      expect(
+        utils.tryGetRemoteSlideIndexFromUrl(
+          'http://www.google.com/yarr/#slide-fooo'
+        )
+      ).toEqual(0)
+    })
+  })
 })

--- a/src/shared/services/commandUtils.test.js
+++ b/src/shared/services/commandUtils.test.js
@@ -221,25 +221,25 @@ describe('commandutils', () => {
     })
   })
 
-  describe('tryGetRemoteSlideIndexFromUrl', () => {
-    it('extracts slide index hashbangs from a string', () => {
-      expect(utils.tryGetRemoteSlideIndexFromUrl('foo#slide-1')).toEqual(1)
+  describe('tryGetRemoteInitialSlideFromUrl', () => {
+    it('extracts initial slide hashbangs from a string', () => {
+      expect(utils.tryGetRemoteInitialSlideFromUrl('foo#slide-1')).toEqual(1)
       expect(
-        utils.tryGetRemoteSlideIndexFromUrl('http://foo.com#slide-2')
+        utils.tryGetRemoteInitialSlideFromUrl('http://foo.com#slide-2')
       ).toEqual(2)
       expect(
-        utils.tryGetRemoteSlideIndexFromUrl(
+        utils.tryGetRemoteInitialSlideFromUrl(
           'http://www.google.com/yarr/#slide-21'
         )
       ).toEqual(21)
     })
     it('returns 0 when no valid hashbang found', () => {
-      expect(utils.tryGetRemoteSlideIndexFromUrl('foo')).toEqual(0)
+      expect(utils.tryGetRemoteInitialSlideFromUrl('foo')).toEqual(0)
       expect(
-        utils.tryGetRemoteSlideIndexFromUrl('http://foo.com#sloide-2')
+        utils.tryGetRemoteInitialSlideFromUrl('http://foo.com#sloide-2')
       ).toEqual(0)
       expect(
-        utils.tryGetRemoteSlideIndexFromUrl(
+        utils.tryGetRemoteInitialSlideFromUrl(
           'http://www.google.com/yarr/#slide-fooo'
         )
       ).toEqual(0)


### PR DESCRIPTION
This PR adds ability to deeplink to specific slide when playing remote guide.

### STR
To deeplink to a remote guide slide, simply add an anchor link to the end of the remote URL
`http://guides.neo4j.com/how-to-guide.html#slide-2`

### Screenshot
<img width="1556" alt="Screenshot 2020-01-07 at 15 28 22" src="https://user-images.githubusercontent.com/52443771/71902712-eb275180-3162-11ea-9b01-5e0b4399db97.png">
