### PR TITLE
Deprecated lifecycles

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To run on an existing server (with a password already set), you can use any of t
 `yarn e2e-local-open --env server=3.4`  
 The latter just opens Cypress runner so you can see the tests being executed and run only some of them. Very useful when writing tests.
 
-There are also e2e tests that covers import from CSV files. To run thise, copy the `e2e_tests/files/import.csv` to the `import/` directory of the database you want to run the tests on and then start the e2e tests with the `--env include-import-tests=true` flag.
+There are also e2e tests that cover import from CSV files. To run these, copy the `e2e_tests/files/import.csv` to the `import/` directory of the database you want to run the tests on and then start the e2e tests with the `--env include-import-tests=true` flag.
 Example: `yarn e2e-local-open --env server=3.4,include-import-tests=true`
 
 Here are the available options / env variables:

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -5,6 +5,7 @@
     "allowSyntheticDefaultImports": true,
     "baseUrl": "src/",
     "checkJs": false,
+    "jsx": "react",
     "paths": {
       "services/*": ["shared/services/*"],
       "browser-services/*": ["browser/services/*"],

--- a/src/browser/components/Display.jsx
+++ b/src/browser/components/Display.jsx
@@ -31,10 +31,11 @@ export default class Display extends PureComponent {
     }
   }
 
-  componentWillReceiveProps(props) {
-    if (this.state.mounted === false && props.if) {
-      this.setState({ mounted: true })
+  static getDerivedStateFromProps(props, state) {
+    if (state.mounted === false && props.if) {
+      return { mounted: true }
     }
+    return null
   }
 
   render() {

--- a/src/browser/components/TabNavigation/Navigation.jsx
+++ b/src/browser/components/TabNavigation/Navigation.jsx
@@ -49,22 +49,22 @@ class Navigation extends Component {
     })
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.openDrawer !== this.props.openDrawer) {
+  componentDidUpdate(prevProps, prevState) {
+    if (prevProps.openDrawer !== this.props.openDrawer) {
       var newState = {}
-      if (nextProps.openDrawer) {
-        newState.drawerContent = nextProps.openDrawer
+      if (this.props.openDrawer) {
+        newState.drawerContent = this.props.openDrawer
         if (
-          this.state.transitionState === Closed ||
-          this.state.transitionState === Closing
+          prevState.transitionState === Closed ||
+          prevState.transitionState === Closing
         ) {
           newState.transitionState = Opening
         }
       } else {
         newState.drawerContent = ''
         if (
-          this.state.transitionState === Open ||
-          this.state.transitionState === Opening
+          prevState.transitionState === Open ||
+          prevState.transitionState === Opening
         ) {
           newState.transitionState = Closing
         }

--- a/src/browser/components/TabNavigation/Navigation.test.js
+++ b/src/browser/components/TabNavigation/Navigation.test.js
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react'
+
+import Navigation from './Navigation'
+
+describe('<Navigation />', () => {
+  const div = testid => () => <div data-testid={testid}></div>
+
+  const topNavItems = [
+    {
+      name: 'Documents',
+      title: 'Documentation',
+      icon: div('documents-icon'),
+      content: div('documents-content')
+    },
+    {
+      name: 'DBMS',
+      title: 'DBMS',
+      icon: div('dbms-icon'),
+      content: div('dbms-content')
+    }
+  ]
+
+  // recreation of reducer logic
+  const toggleDrawer = (current, clicked) =>
+    clicked && clicked !== current ? clicked : null
+
+  it('should open drawer when button is clicked on closed drawer', () => {
+    let openDrawer = ''
+    const onNavClick = clickedDrawer => {
+      openDrawer = toggleDrawer(openDrawer, clickedDrawer)
+    }
+
+    // render with closed drawer
+    const { getByTestId, queryByTestId, rerender } = render(
+      <Navigation
+        onNavClick={onNavClick}
+        openDrawer={openDrawer}
+        topNavItems={topNavItems}
+      />
+    )
+
+    // click documents button
+    fireEvent.click(getByTestId('documents-icon'))
+
+    // rerender with updated openDrawer value
+    rerender(
+      <Navigation
+        onNavClick={onNavClick}
+        openDrawer={openDrawer}
+        topNavItems={topNavItems}
+      />
+    )
+
+    // expect documents drawer to be open
+    expect(queryByTestId('documents-content')).toBeTruthy()
+  })
+
+  it('should close drawer when button is clicked on open drawer', () => {
+    let openDrawer = 'documents'
+    const onNavClick = clickedDrawer => {
+      openDrawer = toggleDrawer(openDrawer, clickedDrawer)
+    }
+
+    // render with documents drawer open
+    const { getByTestId, queryByTestId, rerender } = render(
+      <Navigation
+        onNavClick={onNavClick}
+        openDrawer={openDrawer}
+        topNavItems={topNavItems}
+      />
+    )
+
+    // click documents button
+    fireEvent.click(getByTestId('documents-icon'))
+
+    // rerender with updated openDrawer value
+    rerender(
+      <Navigation
+        onNavClick={onNavClick}
+        openDrawer={openDrawer}
+        topNavItems={topNavItems}
+      />
+    )
+
+    // expect drawer to be closed
+    expect(queryByTestId('documents-content')).toBeNull()
+    expect(queryByTestId('dbms-content')).toBeNull()
+  })
+
+  it('should switch drawer when different button is clicked than currently open', () => {
+    let openDrawer = 'documents'
+    const onNavClick = clickedDrawer => {
+      openDrawer = toggleDrawer(openDrawer, clickedDrawer)
+    }
+
+    // render with documents drawer open
+    const { getByTestId, queryByTestId, rerender } = render(
+      <Navigation
+        onNavClick={onNavClick}
+        openDrawer={openDrawer}
+        topNavItems={topNavItems}
+      />
+    )
+
+    // click DBMS button
+    fireEvent.click(getByTestId('dbms-icon'))
+
+    // rerender with updated openDrawer value
+    rerender(
+      <Navigation
+        onNavClick={onNavClick}
+        openDrawer={openDrawer}
+        topNavItems={topNavItems}
+      />
+    )
+
+    // expect DBMS drawer to be open
+    expect(queryByTestId('dbms-content')).toBeTruthy()
+    expect(queryByTestId('documents-content')).toBeNull()
+  })
+})

--- a/src/browser/components/buttons/ConfirmationButton.jsx
+++ b/src/browser/components/buttons/ConfirmationButton.jsx
@@ -42,9 +42,7 @@ export class ConfirmationButton extends Component {
     this.state = {
       requested: false
     }
-  }
 
-  componentWillMount() {
     this.confirmIcon = this.props.confirmIcon || <RightArrowIcon />
     this.cancelIcon = this.props.cancelIcon || <CancelIcon />
     this.requestIcon = this.props.requestIcon || <MinusIcon />

--- a/src/browser/modules/D3Visualization/components/Explorer.jsx
+++ b/src/browser/modules/D3Visualization/components/Explorer.jsx
@@ -143,10 +143,13 @@ export class ExplorerComponent extends Component {
     })
   }
 
-  componentWillReceiveProps(props) {
-    if (!deepEquals(props.graphStyleData, this.props.graphStyleData)) {
-      if (props.graphStyleData) {
-        const rebasedStyle = deepmerge(this.defaultStyle, props.graphStyleData)
+  componentDidUpdate(prevProps) {
+    if (!deepEquals(prevProps.graphStyleData, this.props.graphStyleData)) {
+      if (this.props.graphStyleData) {
+        const rebasedStyle = deepmerge(
+          this.defaultStyle,
+          this.props.graphStyleData
+        )
         this.state.graphStyle.loadRules(rebasedStyle)
         this.setState({
           graphStyle: this.state.graphStyle,

--- a/src/browser/modules/D3Visualization/components/Graph.jsx
+++ b/src/browser/modules/D3Visualization/components/Graph.jsx
@@ -30,8 +30,7 @@ import graphView from '../lib/visualization/components/graphView'
 export class GraphComponent extends Component {
   state = {
     zoomInLimitReached: true,
-    zoomOutLimitReached: false,
-    shouldResize: false
+    zoomOutLimitReached: false
   }
 
   graphInit(el) {
@@ -115,22 +114,14 @@ export class GraphComponent extends Component {
     }
   }
 
-  componentWillReceiveProps(props) {
-    if (props.styleVersion !== this.props.styleVersion) {
+  componentDidUpdate(prevProps) {
+    if (prevProps.styleVersion !== this.props.styleVersion) {
       this.graphView.update()
     }
     if (
-      this.props.fullscreen !== props.fullscreen ||
-      this.props.frameHeight !== props.frameHeight
+      this.props.fullscreen !== prevProps.fullscreen ||
+      this.props.frameHeight !== prevProps.frameHeight
     ) {
-      this.setState({ shouldResize: true })
-    } else {
-      this.setState({ shouldResize: false })
-    }
-  }
-
-  componentDidUpdate() {
-    if (this.state.shouldResize) {
       this.graphView.resize()
     }
   }

--- a/src/browser/modules/D3Visualization/components/GrassEditor.jsx
+++ b/src/browser/modules/D3Visualization/components/GrassEditor.jsx
@@ -303,12 +303,12 @@ export class GrassEditorComponent extends Component {
     )
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate(prevProps) {
     if (
-      nextProps.graphStyleData &&
-      nextProps.graphStyleData !== this.props.graphStyleData
+      this.props.graphStyleData &&
+      prevProps.graphStyleData !== this.props.graphStyleData
     ) {
-      this.graphStyle.loadRules(nextProps.graphStyleData)
+      this.graphStyle.loadRules(this.props.graphStyleData)
     }
   }
 

--- a/src/browser/modules/D3Visualization/components/GrassEditor.test.js
+++ b/src/browser/modules/D3Visualization/components/GrassEditor.test.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react'
+import { Provider } from 'react-redux'
+import { combineReducers, createStore } from 'redux'
+import { render } from '@testing-library/react'
+
+import { GrassEditor } from './GrassEditor'
+import reducers from 'shared/rootReducer'
+
+describe('<GrassEditor />', () => {
+  it('loads style rules on style option click', () => {
+    const reducer = combineReducers({ ...reducers })
+    const store = createStore(reducer)
+    const { container, rerender } = render(
+      <Provider store={store}>
+        <GrassEditor
+          selectedLabel={{
+            label: 'foo',
+            propertyKeys: []
+          }}
+        />
+      </Provider>
+    )
+
+    // No test ID on options so grab last one in list through DOM
+    const largestSizeOption = container.querySelector(
+      '.style-picker .size-picker li:last-of-type a'
+    )
+
+    // Click style option to trigger redux action resulting in new graphStyleData
+    largestSizeOption.click()
+
+    // Expect clicked size option to be active
+    expect(largestSizeOption.classList.contains('active')).toBe(true)
+  })
+})

--- a/src/browser/modules/D3Visualization/components/Inspector.jsx
+++ b/src/browser/modules/D3Visualization/components/Inspector.jsx
@@ -246,8 +246,8 @@ export class InspectorComponent extends Component {
     })
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (!deepEquals(this.props.selectedItem, nextProps.selectedItem)) {
+  componentDidUpdate(prevProps) {
+    if (!deepEquals(this.props.selectedItem, prevProps.selectedItem)) {
       this.setState({ contracted: true })
       this.props.onExpandToggled && this.props.onExpandToggled(true, 0)
     }

--- a/src/browser/modules/Editor/Codemirror.jsx
+++ b/src/browser/modules/Editor/Codemirror.jsx
@@ -29,11 +29,6 @@ import 'codemirror/addon/lint/lint.css'
 import 'cypher-codemirror/dist/cypher-codemirror-syntax.css'
 import { debounce } from 'services/utils'
 
-function normalizeLineEndings(str) {
-  if (!str) return str
-  return str.replace(/\r\n|\r/g, '\n')
-}
-
 export default class CodeMirror extends Component {
   lastChange = null
   constructor(props) {
@@ -75,33 +70,16 @@ export default class CodeMirror extends Component {
     }
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (
-      this.codeMirror &&
-      nextProps.value !== undefined &&
-      normalizeLineEndings(this.codeMirror.getValue()) !==
-        normalizeLineEndings(nextProps.value)
-    ) {
-      if (this.props.preserveScrollPosition) {
-        const prevScrollPosition = this.codeMirror.getScrollInfo()
-        this.codeMirror.setValue(nextProps.value)
-        this.codeMirror.scrollTo(
-          prevScrollPosition.left,
-          prevScrollPosition.top
-        )
-      } else {
-        this.codeMirror.setValue(nextProps.value)
-      }
-    }
-    if (typeof nextProps.options === 'object') {
-      for (const optionName in nextProps.options) {
-        if (nextProps.options.hasOwnProperty(optionName)) {
-          this.codeMirror.setOption(optionName, nextProps.options[optionName])
+  componentDidUpdate(prevProps) {
+    if (typeof this.props.options === 'object') {
+      for (const optionName in this.props.options) {
+        if (this.props.options.hasOwnProperty(optionName)) {
+          this.codeMirror.setOption(optionName, this.props.options[optionName])
         }
       }
     }
-    if (nextProps.schema) {
-      this.editorSupport.setSchema(this.props.schema)
+    if (this.props.schema) {
+      this.editorSupport.setSchema(prevProps.schema)
     }
   }
 

--- a/src/browser/modules/Editor/Editor.jsx
+++ b/src/browser/modules/Editor/Editor.jsx
@@ -83,6 +83,19 @@ export class Editor extends Component {
       contentId: null,
       editorHeight: 0
     }
+
+    if (this.props.bus) {
+      this.props.bus.take(SET_CONTENT, msg => {
+        this.setContentId(null)
+        this.setEditorValue(msg.message)
+      })
+      this.props.bus.take(EDIT_CONTENT, msg => {
+        this.setContentId(msg.id)
+        this.setEditorValue(msg.message)
+      })
+      this.props.bus.take(FOCUS, this.focusEditor.bind(this))
+      this.props.bus.take(EXPAND, this.expandEditorToggle.bind(this))
+    }
   }
 
   shouldComponentUpdate(nextProps, nextState) {
@@ -210,21 +223,6 @@ export class Editor extends Component {
       try {
         cm.execCommand('autocomplete')
       } catch (e) {}
-    }
-  }
-
-  componentWillMount() {
-    if (this.props.bus) {
-      this.props.bus.take(SET_CONTENT, msg => {
-        this.setContentId(null)
-        this.setEditorValue(msg.message)
-      })
-      this.props.bus.take(EDIT_CONTENT, msg => {
-        this.setContentId(msg.id)
-        this.setEditorValue(msg.message)
-      })
-      this.props.bus.take(FOCUS, this.focusEditor.bind(this))
-      this.props.bus.take(EXPAND, this.expandEditorToggle.bind(this))
     }
   }
 
@@ -509,4 +507,9 @@ const mapStateToProps = state => {
   }
 }
 
-export default withBus(connect(mapStateToProps, mapDispatchToProps)(Editor))
+export default withBus(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(Editor)
+)

--- a/src/browser/modules/Editor/Editor.test.js
+++ b/src/browser/modules/Editor/Editor.test.js
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react'
+import { render } from '@testing-library/react'
+import { createBus } from 'suber'
+import { Editor } from './Editor'
+import {
+  FOCUS,
+  editContent,
+  setContent
+} from 'shared/modules/editor/editorDuck'
+
+describe('<Editor /> ', () => {
+  describe('Bus listener setup', () => {
+    window.focus = jest.fn()
+    const SET_STRING = 'SET FROM TEST'
+    const EDIT_STRING = 'EDIT FROM TEST'
+    const props = {
+      useDb: null,
+      enableEditorAutocomplete: false,
+      enableEditorLint: false,
+      history: [],
+      cmdchar: ':',
+      schema: {}
+    }
+
+    it('should setup on mount', async () => {
+      // Given bus is provided
+      const bus = createBus()
+      const { findByText } = render(<Editor {...props} bus={bus} />)
+
+      // The SET_CONTENT action
+      // When
+      const setAction = setContent(SET_STRING)
+      bus.send(setAction.type, setAction)
+
+      // Then
+      const setTextElement = await findByText(SET_STRING)
+      expect(setTextElement).toBeDefined()
+
+      // The EDIT_CONTENT action
+      // When
+      const editAction = editContent('x', EDIT_STRING)
+      bus.send(editAction.type, editAction)
+
+      // Then
+      const editTextElement = await findByText(EDIT_STRING)
+      expect(editTextElement).toBeDefined()
+
+      // FOCUS action
+      // Reset because it has already been called a few times when loaded
+      window.focus.mockClear()
+      // When
+      bus.send(FOCUS)
+
+      // Then
+      expect(window.focus).toHaveBeenCalledTimes(1)
+    })
+
+    it('should not setup listeners if not provided a bus', async () => {
+      // Given no bus is provided
+      const bus = createBus()
+      const { queryByText } = render(<Editor {...props} bus={null} />)
+
+      // The SET_CONTENT action
+      // When
+      const setAction = setContent(SET_STRING)
+      bus.send(setAction.type, setAction)
+
+      // Then
+      const setTextElement = await queryByText(SET_STRING)
+      expect(setTextElement).toBeNull()
+
+      // The EDIT_CONTENT action
+      // When
+      const editAction = editContent('x', EDIT_STRING)
+      bus.send(editAction.type, editAction)
+
+      // Then
+      const editTextElement = await queryByText(EDIT_STRING)
+      expect(editTextElement).toBeNull()
+
+      // FOCUS action
+      // Reset because it has already been called a few times when loaded
+      window.focus.mockClear()
+      // When
+      bus.send(FOCUS)
+
+      // Then
+      expect(window.focus).toHaveBeenCalledTimes(0)
+    })
+  })
+})

--- a/src/browser/modules/Intercom/index.jsx
+++ b/src/browser/modules/Intercom/index.jsx
@@ -54,13 +54,13 @@ export class Intercom extends Component {
     updateData({ ...otherProps, app_id: appID })
   }
 
-  componentWillReceiveProps(nextProps) {
+  componentDidUpdate() {
     const {
       appID,
       updateData,
       children, // eslint-disable-line
       ...otherProps
-    } = nextProps
+    } = this.props
     if (!canUseDOM()) return
     updateData({ ...otherProps, app_id: appID })
   }
@@ -85,4 +85,7 @@ const mapDispatchToProps = dispatch => {
     updateData: data => dispatch(updateData(data))
   }
 }
-export default connect(null, mapDispatchToProps)(Intercom)
+export default connect(
+  null,
+  mapDispatchToProps
+)(Intercom)

--- a/src/browser/modules/Stream/Auth/ConnectionForm.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectionForm.jsx
@@ -147,7 +147,7 @@ export class ConnectionForm extends Component {
       {
         host: this.state.host,
         username: this.state.username,
-        password: this.props.oldPassword || this.state.password,
+        password: this.state.password,
         encrypted: getEncryptionMode(this.state),
         newPassword
       },
@@ -209,15 +209,15 @@ export class ConnectionForm extends Component {
     })
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (nextProps.oldPassword) {
-      this.setState({ oldPassword: nextProps.oldPassword })
+  static getDerivedStateFromProps(props, state) {
+    if (props.activeConnection && props.activeConnectionData) {
+      if (!state.isConnected) {
+        return { isConnected: true }
+      }
+    } else if (state.isConnected) {
+      return { isConnected: false }
     }
-    if (nextProps.activeConnection && nextProps.activeConnectionData) {
-      this.setState({ isConnected: true })
-    } else {
-      this.setState({ isConnected: false })
-    }
+    return null
   }
 
   render() {
@@ -305,5 +305,9 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
 }
 
 export default withBus(
-  connect(mapStateToProps, mapDispatchToProps, mergeProps)(ConnectionForm)
+  connect(
+    mapStateToProps,
+    mapDispatchToProps,
+    mergeProps
+  )(ConnectionForm)
 )

--- a/src/browser/modules/Stream/CypherFrame/AsciiView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/AsciiView.jsx
@@ -49,9 +49,9 @@ export class AsciiView extends Component {
     this.makeState(this.props)
   }
 
-  componentWillReceiveProps(props) {
-    if (!this.equalProps(props)) {
-      this.makeState(props)
+  componentDidUpdate(prevProps) {
+    if (!this.equalProps(prevProps)) {
+      this.makeState(this.props)
     }
   }
 
@@ -118,8 +118,8 @@ export class AsciiStatusbar extends Component {
     statusBarMessage: ''
   }
 
-  componentWillReceiveProps(props) {
-    this.makeState(props)
+  componentDidUpdate() {
+    this.makeState(this.props)
   }
 
   makeState(props) {

--- a/src/browser/modules/Stream/CypherFrame/PlanView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/PlanView.jsx
@@ -48,18 +48,19 @@ export class PlanView extends Component {
       .catch(e => {})
   }
 
-  componentWillReceiveProps(props) {
-    if (props.updated !== this.props.updated) {
-      return this.extractPlan(props.result || {})
+  componentDidUpdate(prevProps) {
+    if (prevProps.updated !== this.props.updated) {
+      return this.extractPlan(this.props.result || {})
         .then(() => {
-          this.ensureToggleExpand(props)
+          this.ensureToggleExpand(prevProps)
         })
         .catch(e => {
           console.log(e)
         })
     }
-    this.ensureToggleExpand(props)
-    props.assignVisElement && props.assignVisElement(this.el, this.plan)
+    this.ensureToggleExpand(prevProps)
+    this.props.assignVisElement &&
+      this.props.assignVisElement(this.el, this.plan)
   }
 
   shouldComponentUpdate(props, state) {
@@ -95,9 +96,12 @@ export class PlanView extends Component {
     }
   }
 
-  ensureToggleExpand(props) {
-    if (props._planExpand && props._planExpand !== this.props._planExpand) {
-      switch (props._planExpand) {
+  ensureToggleExpand(prevProps) {
+    if (
+      this.props._planExpand &&
+      this.props._planExpand !== prevProps._planExpand
+    ) {
+      switch (this.props._planExpand) {
         case 'COLLAPSE': {
           this.toggleExpanded(false)
           break
@@ -151,13 +155,13 @@ export class PlanStatusbar extends Component {
     if (extractedPlan) this.setState({ extractedPlan })
   }
 
-  componentWillReceiveProps(props) {
-    if (props.result === undefined) return
+  componentDidUpdate(prevProps) {
+    if (this.props.result === undefined) return
     if (
-      this.props.result === undefined ||
-      !deepEquals(props.result.summary, this.props.result.summary)
+      prevProps.result === undefined ||
+      !deepEquals(this.props.result.summary, prevProps.result.summary)
     ) {
-      const extractedPlan = bolt.extractPlan(props.result, true)
+      const extractedPlan = bolt.extractPlan(this.props.result, true)
       this.setState({ extractedPlan })
     }
   }

--- a/src/browser/modules/Stream/CypherFrame/TableView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/TableView.jsx
@@ -107,16 +107,16 @@ export class TableView extends Component {
   }
 
   componentDidMount() {
-    this.makeState(this.props)
+    this.makeState()
   }
 
-  componentWillReceiveProps(props) {
+  componentDidUpdate(prevProps) {
     if (
       this.props === undefined ||
       this.props.result === undefined ||
-      this.props.updated !== props.updated
+      this.props.updated !== prevProps.updated
     ) {
-      this.makeState(props)
+      this.makeState()
     }
   }
 
@@ -126,14 +126,17 @@ export class TableView extends Component {
     )
   }
 
-  makeState(props) {
-    const records = getRecordsToDisplayInTable(props.result, props.maxRows)
+  makeState() {
+    const records = getRecordsToDisplayInTable(
+      this.props.result,
+      this.props.maxRows
+    )
     const table = transformResultRecordsToResultArray(records) || []
     const data = table ? table.slice() : []
     const columns = data.length > 0 ? data.shift() : []
     const { bodyMessage } = getBodyAndStatusBarMessages(
-      props.result,
-      props.maxRows
+      this.props.result,
+      this.props.maxRows
     )
     this.setState({ data, columns, bodyMessage })
   }
@@ -173,11 +176,11 @@ export class TableStatusbar extends Component {
   }
 
   componentDidMount() {
-    this.makeState(this.props)
+    this.makeState()
   }
 
-  componentWillReceiveProps(props) {
-    this.makeState(props)
+  componentDidUpdate() {
+    this.makeState()
   }
 
   shouldComponentUpdate(props, state) {
@@ -185,10 +188,10 @@ export class TableStatusbar extends Component {
     return false
   }
 
-  makeState(props) {
+  makeState() {
     const { statusBarMessage } = getBodyAndStatusBarMessages(
-      props.result,
-      props.maxRows
+      this.props.result,
+      this.props.maxRows
     )
     if (statusBarMessage !== undefined) this.setState({ statusBarMessage })
   }

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView.jsx
@@ -53,12 +53,12 @@ export class Visualization extends Component {
     )
   }
 
-  componentWillReceiveProps(props) {
+  componentDidUpdate(prevProps) {
     if (
-      this.props.updated !== props.updated ||
-      this.props.autoComplete !== props.autoComplete
+      this.props.updated !== prevProps.updated ||
+      this.props.autoComplete !== prevProps.autoComplete
     ) {
-      this.populateDataToStateFromProps(props)
+      this.populateDataToStateFromProps(this.props)
     }
   }
 
@@ -205,5 +205,8 @@ const mapDispatchToProps = dispatch => {
 }
 
 export const VisualizationConnectedBus = withBus(
-  connect(mapStateToProps, mapDispatchToProps)(Visualization)
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(Visualization)
 )

--- a/src/browser/modules/User/UserAdd.jsx
+++ b/src/browser/modules/User/UserAdd.jsx
@@ -68,9 +68,7 @@ export class UserAdd extends Component {
       success: null,
       isLoading: false
     }
-  }
 
-  componentWillMount() {
     this.getRoles()
   }
 
@@ -404,4 +402,9 @@ const mapStateToProps = state => {
   }
 }
 
-export default withBus(connect(mapStateToProps, null)(UserAdd))
+export default withBus(
+  connect(
+    mapStateToProps,
+    null
+  )(UserAdd)
+)

--- a/src/browser/modules/User/UserAdd.test.js
+++ b/src/browser/modules/User/UserAdd.test.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { render } from '@testing-library/react'
+import React from 'react'
+import { createBus } from 'suber'
+
+import { UserAdd } from './UserAdd'
+import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
+import { listRolesQuery } from 'shared/modules/cypher/boltUserHelper'
+
+// Stubbing out title bar as it depends on store
+jest.mock('browser/modules/Frame/FrameTitlebar', () => () => null)
+
+describe('<UserAdd />', () => {
+  it('should send a Cypher request to list user roles when mounted', () => {
+    const bus = createBus()
+    const useSystemDb = true
+    const props = {
+      bus,
+      frame: {},
+      isEnterpriseEdition: true,
+      useSystemDb
+    }
+
+    const busCallback = jest.fn()
+    bus.one(CYPHER_REQUEST, busCallback)
+
+    render(<UserAdd {...props} />)
+
+    expect(busCallback).toHaveBeenCalledTimes(1)
+    expect(busCallback).toHaveBeenCalledWith(
+      expect.objectContaining({ query: listRolesQuery(useSystemDb) })
+    )
+  })
+})

--- a/src/browser/modules/User/UserList.jsx
+++ b/src/browser/modules/User/UserList.jsx
@@ -50,6 +50,11 @@ export class UserList extends Component {
       userList: this.props.users || [],
       listRoles: this.props.roles || []
     }
+
+    if (this.props.isEnterpriseEdition) {
+      this.getUserList()
+      this.getRoles()
+    }
   }
 
   extractUserNameAndRolesFromBolt(result) {
@@ -175,13 +180,6 @@ export class UserList extends Component {
     this.props.bus.send(action.type, action)
   }
 
-  componentWillMount() {
-    if (this.props.isEnterpriseEdition) {
-      this.getUserList()
-      this.getRoles()
-    }
-  }
-
   render() {
     let aside = null
     let frameContents
@@ -218,4 +216,9 @@ const mapStateToProps = state => {
   }
 }
 
-export default withBus(connect(mapStateToProps, null)(UserList))
+export default withBus(
+  connect(
+    mapStateToProps,
+    null
+  )(UserList)
+)

--- a/src/browser/modules/User/UserList.test.js
+++ b/src/browser/modules/User/UserList.test.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { render } from '@testing-library/react'
+import React from 'react'
+import { createBus } from 'suber'
+
+import { UserList } from './UserList'
+import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
+import {
+  listRolesQuery,
+  listUsersQuery
+} from 'shared/modules/cypher/boltUserHelper'
+
+// Stubbing out title bar as it depends on store
+jest.mock('browser/modules/Frame/FrameTitlebar', () => () => null)
+
+describe('<UserList />', () => {
+  it('should list users and user roles when enterprise edition is mounted', () => {
+    const bus = createBus()
+    const useSystemDb = true
+    const props = {
+      bus,
+      frame: {},
+      isEnterpriseEdition: true,
+      useSystemDb
+    }
+
+    const busCallback = jest.fn()
+    bus.take(CYPHER_REQUEST, busCallback)
+
+    render(<UserList {...props} />)
+
+    expect(busCallback).toHaveBeenCalledTimes(2)
+    expect(busCallback).toHaveBeenCalledWith(
+      expect.objectContaining({ query: listRolesQuery(useSystemDb) })
+    )
+    expect(busCallback).toHaveBeenCalledWith(
+      expect.objectContaining({ query: listUsersQuery(useSystemDb) })
+    )
+  })
+
+  it('should not list users or user roles when non enterprise edition is mounted', () => {
+    const bus = createBus()
+    const useSystemDb = true
+    const props = {
+      bus,
+      frame: {},
+      isEnterpriseEdition: false,
+      useSystemDb
+    }
+
+    const busCallback = jest.fn()
+    bus.take(CYPHER_REQUEST, busCallback)
+
+    render(<UserList {...props} />)
+
+    expect(busCallback).toHaveBeenCalledTimes(0)
+  })
+})

--- a/src/shared/services/utils.js
+++ b/src/shared/services/utils.js
@@ -94,6 +94,9 @@ export const deepEquals = (x, y) => {
     if (Object.keys(x).length !== Object.keys(y).length) return false
     return Object.keys(x).every(key => deepEquals(x[key], y[key]))
   }
+  if (typeof x === 'function' && typeof y === 'function') {
+    return x.toString() === y.toString()
+  }
   return x === y
 }
 

--- a/src/shared/services/utils.test.js
+++ b/src/shared/services/utils.test.js
@@ -131,6 +131,14 @@ describe('utils', () => {
     expect(utils.deepEquals(o1, o3)).toBeFalsy()
     expect(utils.deepEquals(o4, o5)).toBeTruthy()
   })
+  test('deepEquals compares object methods by source instead of by reference', () => {
+    const foo1 = { someMethod: () => 'foo' }
+    const foo2 = { someMethod: () => 'foo' }
+    const bar = { someMethod: () => 'bar' }
+
+    expect(utils.deepEquals(foo1, foo2)).toBeTruthy()
+    expect(utils.deepEquals(foo1, bar)).toBeFalsy()
+  })
   test('can shallowEquals compare objects', () => {
     // Given
     const o1 = { a: 1, b: 2, c: 'hello' }

--- a/test_utils/setupTests.js
+++ b/test_utils/setupTests.js
@@ -24,6 +24,7 @@ global.document.createRange = () => {
   return {
     setEnd: () => {},
     setStart: () => {},
-    getBoundingClientRect: () => {}
+    getBoundingClientRect: () => {},
+    getClientRects: () => []
   }
 }


### PR DESCRIPTION
Rename deprecated lifecycles to current name to clear lint warnings.
Add jsx flag in jsconfig to enable "Go to Definition" and "Find All References" in VS Code.