### PR TITLE
Bugfix browser implicit lambda with newlines

### DIFF
--- a/e2e_tests/integration/multistatements.spec.js
+++ b/e2e_tests/integration/multistatements.spec.js
@@ -165,6 +165,7 @@ describe('Multi statements', () => {
           .should('have.length', 0)
 
         // Check sidebar for test1
+        cy.wait(5000) // Wait to ensure last meta update in finished
         cy.executeCommand(':use test1')
         cy.get('[data-testid="drawerDBMS"]').click()
         cy.contains('[data-testid="sidebarMetaItem"]', 'Test1', {
@@ -172,6 +173,7 @@ describe('Multi statements', () => {
         })
         cy.get('[data-testid="drawerDBMS"]').click()
 
+        cy.wait(5000) // Wait to ensure last meta update in finished
         cy.executeCommand(':use test2')
         cy.get('[data-testid="drawerDBMS"]').click()
         cy.contains('[data-testid="sidebarMetaItem"]', 'Test2', {

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "xml2js": "^0.4.19"
   },
   "dependencies": {
-    "@neo4j/browser-lambda-parser": "^1.0.3",
+    "@neo4j/browser-lambda-parser": "1.0.4",
     "@relate-by-ui/css": "^1.0.4",
     "@relate-by-ui/saved-scripts": "^1.0.4",
     "ascii-data-table": "^2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,10 +1228,10 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@neo4j/browser-lambda-parser@^1.0.3":
-  version "1.0.3"
-  resolved "https://registry.npmjs.org/@neo4j/browser-lambda-parser/-/browser-lambda-parser-1.0.3.tgz#d49675122aa673e0ed888e5959e4519d66cf20ff"
-  integrity sha512-+4DZ1kjyoJR9JUPzNqNKLnI/jtoTPV7I79EUe4vOE6baSoYd+fqdC+ZIWaAmZH/UCljvqTZn5ZV9jI65IFiu/g==
+"@neo4j/browser-lambda-parser@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.npmjs.org/@neo4j/browser-lambda-parser/-/browser-lambda-parser-1.0.4.tgz#d9fa3711e49d93acfec25b183adc3fd11d8e1fa4"
+  integrity sha512-8iJWtSylP73gk1rnS2pNRl+mPkNye17Uur4MagZxc8sBpNiPWoF2XJmtNLboJgq+ocwaj5Ju0E7tWXbDSmsGzA==
   dependencies:
     nearley "2.18.0"
 


### PR DESCRIPTION
bumb parser dependency

Upstream change: https://github.com/neo4j-apps/lambda-parser/pull/3

changelog: Fix `:param` when returning an implicit object with newlines