### PR TITLE
Fix indexes not showing on 4.0 SchemaFrame

### DIFF
--- a/e2e_tests/integration/schema-frame.spec.js
+++ b/e2e_tests/integration/schema-frame.spec.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* global Cypress, cy, before */
+
+describe('Schema Frame', () => {
+  before(function() {
+    cy.visit(Cypress.config('url'))
+      .title()
+      .should('include', 'Neo4j Browser')
+    cy.wait(3000)
+  })
+  it('can connect', () => {
+    const password = Cypress.config('password')
+    cy.connect('neo4j', password)
+  })
+  describe('renders schema', () => {
+    before(function() {
+      cy.executeCommand(
+        'CREATE (n:SchemaTest {{}prop1: "foo", prop2: "bar"{}})'
+      )
+
+      if (Cypress.config('serverVersion') >= 4.0) {
+        cy.executeCommand(
+          'CREATE INDEX compositeIndex FOR (n:SchemaTest) ON (n.prop1, n.prop2)'
+        )
+      } else {
+        cy.executeCommand('CREATE INDEX ON :SchemaTest(prop1, prop2)')
+      }
+
+      cy.executeCommand(
+        'CREATE CONSTRAINT ON (n:SchemaTest) ASSERT n.prop1 IS UNIQUE'
+      )
+    })
+    after(function() {
+      if (Cypress.config('serverVersion') >= 4.0) {
+        cy.executeCommand('DROP INDEX compositeIndex')
+      } else {
+        cy.executeCommand('DROP INDEX ON :SchemaTest(prop1, prop2)')
+      }
+
+      cy.executeCommand(
+        'DROP CONSTRAINT ON (n:SchemaTest) ASSERT n.prop1 IS UNIQUE'
+      )
+      cy.executeCommand('MATCH (n:SchemaTest ) DETACH DELETE n')
+    })
+
+    it('renders indexes correctly', () => {
+      cy.executeCommand(':clear')
+      cy.executeCommand(':schema')
+
+      // Headers
+      if (Cypress.config('serverVersion') >= 4.0) {
+        cy.get('[data-testid="frameContents"]')
+          .should('contain', 'Index Name')
+          .and('contain', 'LabelsOrTypes')
+          .and('contain', 'Properties')
+          .and('contain', 'State')
+      } else {
+        cy.get('[data-testid="frameContents"]').should('contain', 'Indexes')
+      }
+
+      // Index info
+      if (Cypress.config('serverVersion') >= 4.0) {
+        cy.get('[data-testid="frameContents"]').should(
+          'contain',
+          'compositeIndex'
+        )
+      }
+
+      cy.get('[data-testid="frameContents"]')
+        .should('contain', 'SchemaTest')
+        .and('contain', 'prop1')
+        .and('contain', 'prop2')
+    })
+
+    it('renders constraints correctly', () => {
+      cy.executeCommand(':clear')
+      cy.executeCommand(':schema')
+
+      cy.get('[data-testid="frameContents"]')
+        .should('contain', 'Constraints')
+        .and('contain', 'schematest.prop1')
+        .and('contain', 'IS UNIQUE')
+    })
+  })
+})

--- a/e2e_tests/integration/types.spec.js
+++ b/e2e_tests/integration/types.spec.js
@@ -41,7 +41,7 @@ describe('Types in Browser', () => {
       cy.resultContains('point({srid:4326, x:12.78, y:56.7})')
 
       // Go to ascii view
-      cy.get('[data-testid="cypherFrameSidebarAscii"')
+      cy.get('[data-testid="cypherFrameSidebarAscii"]')
         .first()
         .click()
       cy.resultContains('│point({srid:4326, x:12.78, y:56.7})')
@@ -55,7 +55,7 @@ describe('Types in Browser', () => {
 
       cy.resultContains('"2015-07-20T15:11:42[Europe/Stockholm]"')
       // Go to ascii view
-      cy.get('[data-testid="cypherFrameSidebarAscii"')
+      cy.get('[data-testid="cypherFrameSidebarAscii"]')
         .first()
         .click()
       cy.resultContains('│"2015-07-20T15:11:42[Europe/Stockholm]"')
@@ -69,7 +69,7 @@ describe('Types in Browser', () => {
 
       cy.resultContains('"2015-07-20T15:11:42"')
       // Go to ascii view
-      cy.get('[data-testid="cypherFrameSidebarAscii"')
+      cy.get('[data-testid="cypherFrameSidebarAscii"]')
         .first()
         .click()
       cy.resultContains('│"2015-07-20T15:11:42"')
@@ -82,7 +82,7 @@ describe('Types in Browser', () => {
 
       cy.resultContains('"2015-07-20"')
       // Go to ascii view
-      cy.get('[data-testid="cypherFrameSidebarAscii"')
+      cy.get('[data-testid="cypherFrameSidebarAscii"]')
         .first()
         .click()
       cy.resultContains('│"2015-07-20"')
@@ -96,7 +96,7 @@ describe('Types in Browser', () => {
 
       cy.resultContains('"P14M3DT14706S"')
       // Go to ascii view
-      cy.get('[data-testid="cypherFrameSidebarAscii"')
+      cy.get('[data-testid="cypherFrameSidebarAscii"]')
         .first()
         .click()
       cy.resultContains('│"P14M3DT14706S"')
@@ -110,7 +110,7 @@ describe('Types in Browser', () => {
 
       cy.resultContains('"14:03:04')
       // Go to ascii view
-      cy.get('[data-testid="cypherFrameSidebarAscii"')
+      cy.get('[data-testid="cypherFrameSidebarAscii"]')
         .first()
         .click()
       cy.resultContains('│"14:03:04')
@@ -123,7 +123,7 @@ describe('Types in Browser', () => {
 
       cy.resultContains('"14:03:04"')
       // Go to ascii view
-      cy.get('[data-testid="cypherFrameSidebarAscii"')
+      cy.get('[data-testid="cypherFrameSidebarAscii"]')
         .first()
         .click()
       cy.resultContains('│"14:03:04"')

--- a/src/browser/modules/Stream/SchemaFrame.jsx
+++ b/src/browser/modules/Stream/SchemaFrame.jsx
@@ -48,7 +48,13 @@ const Indexes = ({ indexes, neo4jVersion }) => {
       }`
     ])
 
-    return <SchemaTable header={['Indexes']} rows={rows} />
+    return (
+      <SchemaTable
+        testid="schemaFrameIndexesTable"
+        header={['Indexes']}
+        rows={rows}
+      />
+    )
   }
 
   const rows = indexes.map(index => [
@@ -71,7 +77,9 @@ const Indexes = ({ indexes, neo4jVersion }) => {
     'State'
   ]
 
-  return <SchemaTable header={header} rows={rows} />
+  return (
+    <SchemaTable testid="schemaFrameIndexesTable" header={header} rows={rows} />
+  )
 }
 
 const Constraints = ({ constraints }) => {
@@ -79,10 +87,16 @@ const Constraints = ({ constraints }) => {
     replace(constraint.description, 'CONSTRAINT', '')
   ])
 
-  return <SchemaTable header={['Constraints']} rows={rows} />
+  return (
+    <SchemaTable
+      testid="schemaFrameConstraintsTable"
+      header={['Constraints']}
+      rows={rows}
+    />
+  )
 }
 
-const SchemaTable = ({ header, rows }) => {
+const SchemaTable = ({ testid, header, rows }) => {
   const rowsOrNone =
     rows && rows.length ? rows : [header.map((_, i) => (i === 0 ? 'None' : ''))]
 
@@ -97,7 +111,7 @@ const SchemaTable = ({ header, rows }) => {
   ))
 
   return (
-    <StyledTable>
+    <StyledTable data-testid={testid}>
       <thead>
         <tr>
           {header.map(cell => (

--- a/src/browser/modules/Stream/SchemaFrame.test.js
+++ b/src/browser/modules/Stream/SchemaFrame.test.js
@@ -40,7 +40,16 @@ test('SchemaFrame renders empty', () => {
   expect(container).toMatchSnapshot()
 })
 
-test('SchemaFrame renders with result', () => {
+test('SchemaFrame renders empty for Neo4j < 4.0', () => {
+  const indexResult = { records: [] }
+  const { container } = renderWithRedux(
+    <SchemaFrame indexes={indexResult} neo4jVersion={'3.5.13'} />
+  )
+
+  expect(container).toMatchSnapshot()
+})
+
+test('SchemaFrame renders results for Neo4j < 4.0', () => {
   const indexResult = {
     success: true,
     result: {
@@ -92,7 +101,7 @@ test('SchemaFrame renders with result', () => {
     <SchemaFrame
       indexes={indexResult}
       constraints={constraintResult}
-      neo4jVersion={null}
+      neo4jVersion={'3.5.13'}
     />
   )
 

--- a/src/browser/modules/Stream/__snapshots__/SchemaFrame.test.js.snap
+++ b/src/browser/modules/Stream/__snapshots__/SchemaFrame.test.js.snap
@@ -15,6 +15,134 @@ exports[`SchemaFrame renders empty 1`] = `
           <thead>
             <tr>
               <th
+                class="DataTables__StyledTh-bf850j-2 ikUpyS table-header"
+              >
+                Index Name
+              </th>
+              <th
+                class="DataTables__StyledTh-bf850j-2 ikUpyS table-header"
+              >
+                Type
+              </th>
+              <th
+                class="DataTables__StyledTh-bf850j-2 ikUpyS table-header"
+              >
+                Uniqueness
+              </th>
+              <th
+                class="DataTables__StyledTh-bf850j-2 ikUpyS table-header"
+              >
+                EntityType
+              </th>
+              <th
+                class="DataTables__StyledTh-bf850j-2 ikUpyS table-header"
+              >
+                LabelsOrTypes
+              </th>
+              <th
+                class="DataTables__StyledTh-bf850j-2 ikUpyS table-header"
+              >
+                Properties
+              </th>
+              <th
+                class="DataTables__StyledTh-bf850j-2 ikUpyS table-header"
+              >
+                State
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              class="DataTables__StyledBodyTr-bf850j-1 iGjwRr table-row"
+            >
+              <td
+                class="DataTables__StyledTd-bf850j-3 lfnTDs table-properties"
+              >
+                None
+              </td>
+              <td
+                class="DataTables__StyledTd-bf850j-3 lfnTDs table-properties"
+              />
+              <td
+                class="DataTables__StyledTd-bf850j-3 lfnTDs table-properties"
+              />
+              <td
+                class="DataTables__StyledTd-bf850j-3 lfnTDs table-properties"
+              />
+              <td
+                class="DataTables__StyledTd-bf850j-3 lfnTDs table-properties"
+              />
+              <td
+                class="DataTables__StyledTd-bf850j-3 lfnTDs table-properties"
+              />
+              <td
+                class="DataTables__StyledTd-bf850j-3 lfnTDs table-properties"
+              />
+            </tr>
+          </tbody>
+        </table>
+        <table
+          class="DataTables__StyledTable-bf850j-0 cZayOW"
+        >
+          <thead>
+            <tr>
+              <th
+                class="DataTables__StyledTh-bf850j-2 ikUpyS table-header"
+              >
+                Constraints
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              class="DataTables__StyledBodyTr-bf850j-1 iGjwRr table-row"
+            >
+              <td
+                class="DataTables__StyledTd-bf850j-3 lfnTDs table-properties"
+              >
+                None
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <br />
+        <p
+          class="lead"
+        >
+          Execute the following command to visualize what's related, and how
+        </p>
+        <figure>
+          <pre
+            class="code runnable"
+          >
+            <i
+              class="fa fa-play-circle-o"
+              style="padding-right:4px"
+            />
+            CALL db.schema.visualization
+          </pre>
+        </figure>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SchemaFrame renders empty for Neo4j < 4.0 1`] = `
+<div>
+  <div
+    style="width: 100%;"
+  >
+    <div>
+      <div
+        class="styled__StyledSlide-sc-9xe8te-11 fPXIVT"
+      >
+        <table
+          class="DataTables__StyledTable-bf850j-0 cZayOW"
+        >
+          <thead>
+            <tr>
+              <th
                 class="table-header DataTables__StyledTh-bf850j-2 ikUpyS"
               >
                 Indexes
@@ -80,7 +208,7 @@ exports[`SchemaFrame renders empty 1`] = `
 </div>
 `;
 
-exports[`SchemaFrame renders with result 1`] = `
+exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
 <div>
   <div
     style="width: 100%;"

--- a/src/browser/modules/Stream/__snapshots__/SchemaFrame.test.js.snap
+++ b/src/browser/modules/Stream/__snapshots__/SchemaFrame.test.js.snap
@@ -11,41 +11,42 @@ exports[`SchemaFrame renders empty 1`] = `
       >
         <table
           class="DataTables__StyledTable-bf850j-0 cZayOW"
+          data-testid="schemaFrameIndexesTable"
         >
           <thead>
             <tr>
               <th
-                class="DataTables__StyledTh-bf850j-2 ikUpyS table-header"
+                class="table-header DataTables__StyledTh-bf850j-2 ikUpyS"
               >
                 Index Name
               </th>
               <th
-                class="DataTables__StyledTh-bf850j-2 ikUpyS table-header"
+                class="table-header DataTables__StyledTh-bf850j-2 ikUpyS"
               >
                 Type
               </th>
               <th
-                class="DataTables__StyledTh-bf850j-2 ikUpyS table-header"
+                class="table-header DataTables__StyledTh-bf850j-2 ikUpyS"
               >
                 Uniqueness
               </th>
               <th
-                class="DataTables__StyledTh-bf850j-2 ikUpyS table-header"
+                class="table-header DataTables__StyledTh-bf850j-2 ikUpyS"
               >
                 EntityType
               </th>
               <th
-                class="DataTables__StyledTh-bf850j-2 ikUpyS table-header"
+                class="table-header DataTables__StyledTh-bf850j-2 ikUpyS"
               >
                 LabelsOrTypes
               </th>
               <th
-                class="DataTables__StyledTh-bf850j-2 ikUpyS table-header"
+                class="table-header DataTables__StyledTh-bf850j-2 ikUpyS"
               >
                 Properties
               </th>
               <th
-                class="DataTables__StyledTh-bf850j-2 ikUpyS table-header"
+                class="table-header DataTables__StyledTh-bf850j-2 ikUpyS"
               >
                 State
               </th>
@@ -53,41 +54,42 @@ exports[`SchemaFrame renders empty 1`] = `
           </thead>
           <tbody>
             <tr
-              class="DataTables__StyledBodyTr-bf850j-1 iGjwRr table-row"
+              class="table-row DataTables__StyledBodyTr-bf850j-1 iGjwRr"
             >
               <td
-                class="DataTables__StyledTd-bf850j-3 lfnTDs table-properties"
+                class="table-properties DataTables__StyledTd-bf850j-3 lfnTDs"
               >
                 None
               </td>
               <td
-                class="DataTables__StyledTd-bf850j-3 lfnTDs table-properties"
+                class="table-properties DataTables__StyledTd-bf850j-3 lfnTDs"
               />
               <td
-                class="DataTables__StyledTd-bf850j-3 lfnTDs table-properties"
+                class="table-properties DataTables__StyledTd-bf850j-3 lfnTDs"
               />
               <td
-                class="DataTables__StyledTd-bf850j-3 lfnTDs table-properties"
+                class="table-properties DataTables__StyledTd-bf850j-3 lfnTDs"
               />
               <td
-                class="DataTables__StyledTd-bf850j-3 lfnTDs table-properties"
+                class="table-properties DataTables__StyledTd-bf850j-3 lfnTDs"
               />
               <td
-                class="DataTables__StyledTd-bf850j-3 lfnTDs table-properties"
+                class="table-properties DataTables__StyledTd-bf850j-3 lfnTDs"
               />
               <td
-                class="DataTables__StyledTd-bf850j-3 lfnTDs table-properties"
+                class="table-properties DataTables__StyledTd-bf850j-3 lfnTDs"
               />
             </tr>
           </tbody>
         </table>
         <table
           class="DataTables__StyledTable-bf850j-0 cZayOW"
+          data-testid="schemaFrameConstraintsTable"
         >
           <thead>
             <tr>
               <th
-                class="DataTables__StyledTh-bf850j-2 ikUpyS table-header"
+                class="table-header DataTables__StyledTh-bf850j-2 ikUpyS"
               >
                 Constraints
               </th>
@@ -95,10 +97,10 @@ exports[`SchemaFrame renders empty 1`] = `
           </thead>
           <tbody>
             <tr
-              class="DataTables__StyledBodyTr-bf850j-1 iGjwRr table-row"
+              class="table-row DataTables__StyledBodyTr-bf850j-1 iGjwRr"
             >
               <td
-                class="DataTables__StyledTd-bf850j-3 lfnTDs table-properties"
+                class="table-properties DataTables__StyledTd-bf850j-3 lfnTDs"
               >
                 None
               </td>
@@ -139,6 +141,7 @@ exports[`SchemaFrame renders empty for Neo4j < 4.0 1`] = `
       >
         <table
           class="DataTables__StyledTable-bf850j-0 cZayOW"
+          data-testid="schemaFrameIndexesTable"
         >
           <thead>
             <tr>
@@ -163,6 +166,7 @@ exports[`SchemaFrame renders empty for Neo4j < 4.0 1`] = `
         </table>
         <table
           class="DataTables__StyledTable-bf850j-0 cZayOW"
+          data-testid="schemaFrameConstraintsTable"
         >
           <thead>
             <tr>
@@ -219,6 +223,7 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
       >
         <table
           class="DataTables__StyledTable-bf850j-0 cZayOW"
+          data-testid="schemaFrameIndexesTable"
         >
           <thead>
             <tr>
@@ -243,6 +248,7 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
         </table>
         <table
           class="DataTables__StyledTable-bf850j-0 cZayOW"
+          data-testid="schemaFrameConstraintsTable"
         >
           <thead>
             <tr>


### PR DESCRIPTION
Indexes stopped showing up on the schema card on 4.0 due to a change on the data format returned from the driver. With these changes the description for each index is replaced by list of properties.

![image](https://user-images.githubusercontent.com/13448636/72260226-a859f380-3612-11ea-8df4-3f1af53d0dfb.png)
