### PR TITLE
Use best practices driver transaction functions by default

### DIFF
--- a/e2e_tests/integration/loadcsv.spec.js
+++ b/e2e_tests/integration/loadcsv.spec.js
@@ -56,14 +56,14 @@ describe('LOAD CSV', () => {
     LOAD CSV WITH HEADERS FROM 'file:///import.csv' AS row 
     CREATE (p:Person {{}name: row.name, born: toInteger(row.born), city: row.city, comment:row.comment});`
 
-    // Let's see it fail when not using implicit tx's first
+    // Let's see it fail when not using auto-committed tx's first
     cy.executeCommand(':clear')
     cy.executeCommand(periodicQuery)
     cy.resultContains('Neo.ClientError.Statement.SemanticError')
 
     cy.executeCommand(':clear')
     cy.executeCommand('MATCH (n) DETACH DELETE n')
-    cy.executeCommand(`:implicit ${periodicQuery}`)
+    cy.executeCommand(`:auto ${periodicQuery}`)
 
     cy.resultContains('Added 3 labels, created 3 nodes, set 11 properties,')
 

--- a/e2e_tests/integration/loadcsv.spec.js
+++ b/e2e_tests/integration/loadcsv.spec.js
@@ -52,11 +52,18 @@ describe('LOAD CSV', () => {
     if (!Cypress.config('includeImportTests')) {
       return
     }
+    const periodicQuery = `USING PERIODIC COMMIT 1{shift}{enter}
+    LOAD CSV WITH HEADERS FROM 'file:///import.csv' AS row 
+    CREATE (p:Person {{}name: row.name, born: toInteger(row.born), city: row.city, comment:row.comment});`
+
+    // Let's see it fail when not using implicit tx's first
+    cy.executeCommand(':clear')
+    cy.executeCommand(periodicQuery)
+    cy.resultContains('Neo.ClientError.Statement.SemanticError')
+
     cy.executeCommand(':clear')
     cy.executeCommand('MATCH (n) DETACH DELETE n')
-    cy.executeCommand(`USING PERIODIC COMMIT 1{shift}{enter}
-    LOAD CSV WITH HEADERS FROM 'file:///import.csv' AS row 
-    CREATE (p:Person {{}name: row.name, born: toInteger(row.born), city: row.city, comment:row.comment});`)
+    cy.executeCommand(`:implicit ${periodicQuery}`)
 
     cy.resultContains('Added 3 labels, created 3 nodes, set 11 properties,')
 

--- a/src/shared/modules/commands/commandsDuck.js
+++ b/src/shared/modules/commands/commandsDuck.js
@@ -66,6 +66,7 @@ export const FETCH_GUIDE_FROM_WHITELIST = NAME + 'FETCH_GUIDE_FROM_WHITELIST'
 
 export const useDbCommand = 'use'
 export const listDbsCommand = 'dbs'
+export const implicitTxCommand = 'implicit'
 
 const initialState = {}
 export const getErrorMessage = state => state[NAME].errorMessage

--- a/src/shared/modules/commands/commandsDuck.js
+++ b/src/shared/modules/commands/commandsDuck.js
@@ -66,7 +66,7 @@ export const FETCH_GUIDE_FROM_WHITELIST = NAME + 'FETCH_GUIDE_FROM_WHITELIST'
 
 export const useDbCommand = 'use'
 export const listDbsCommand = 'dbs'
-export const implicitTxCommand = 'implicit'
+export const autoCommitTxCommand = 'auto'
 
 const initialState = {}
 export const getErrorMessage = state => state[NAME].errorMessage

--- a/src/shared/modules/commands/cypher.test.js
+++ b/src/shared/modules/commands/cypher.test.js
@@ -25,7 +25,8 @@ import { flushPromises } from 'services/utils'
 import {
   executeSystemCommand,
   executeSingleCommand,
-  handleSingleCommandEpic
+  handleSingleCommandEpic,
+  implicitTxCommand
 } from './commandsDuck'
 
 jest.mock('services/bolt/bolt', () => {
@@ -108,6 +109,54 @@ describe('tx metadata with cypher', () => {
         {},
         expect.objectContaining({
           txMetadata: { app: `neo4j-browser_v${version}`, type: 'system' }
+        })
+      )
+      done()
+    })
+  })
+})
+
+describe('Implicit vs explicit transactions', () => {
+  afterEach(() => {
+    bolt.routedWriteTransaction.mockClear()
+  })
+  test(`it sends the implicit flag = true to tx functions when using the :${implicitTxCommand} command`, done => {
+    // Given
+    const bus = createBus()
+    bus.applyReduxMiddleware(createEpicMiddleware(handleSingleCommandEpic))
+    const $$responseChannel = 'test-channel3'
+    const action = executeSingleCommand(`:${implicitTxCommand} RETURN 1`)
+    action.$$responseChannel = $$responseChannel
+
+    bus.send(action.type, action)
+    flushPromises().then(() => {
+      expect(bolt.routedWriteTransaction).toHaveBeenCalledTimes(1)
+      expect(bolt.routedWriteTransaction).toHaveBeenCalledWith(
+        'RETURN 1',
+        {},
+        expect.objectContaining({
+          implicit: true
+        })
+      )
+      done()
+    })
+  })
+  test('it sends the implicit flag = false to tx functions on regular cypher', done => {
+    // Given
+    const bus = createBus()
+    bus.applyReduxMiddleware(createEpicMiddleware(handleSingleCommandEpic))
+    const $$responseChannel = 'test-channel4'
+    const action = executeSingleCommand(`RETURN 1`)
+    action.$$responseChannel = $$responseChannel
+
+    bus.send(action.type, action)
+    flushPromises().then(() => {
+      expect(bolt.routedWriteTransaction).toHaveBeenCalledTimes(1)
+      expect(bolt.routedWriteTransaction).toHaveBeenCalledWith(
+        'RETURN 1',
+        {},
+        expect.objectContaining({
+          implicit: false
         })
       )
       done()

--- a/src/shared/modules/commands/cypher.test.js
+++ b/src/shared/modules/commands/cypher.test.js
@@ -26,7 +26,7 @@ import {
   executeSystemCommand,
   executeSingleCommand,
   handleSingleCommandEpic,
-  implicitTxCommand
+  autoCommitTxCommand
 } from './commandsDuck'
 
 jest.mock('services/bolt/bolt', () => {
@@ -120,12 +120,12 @@ describe('Implicit vs explicit transactions', () => {
   afterEach(() => {
     bolt.routedWriteTransaction.mockClear()
   })
-  test(`it sends the implicit flag = true to tx functions when using the :${implicitTxCommand} command`, done => {
+  test(`it sends the autoCommit flag = true to tx functions when using the :${autoCommitTxCommand} command`, done => {
     // Given
     const bus = createBus()
     bus.applyReduxMiddleware(createEpicMiddleware(handleSingleCommandEpic))
     const $$responseChannel = 'test-channel3'
-    const action = executeSingleCommand(`:${implicitTxCommand} RETURN 1`)
+    const action = executeSingleCommand(`:${autoCommitTxCommand} RETURN 1`)
     action.$$responseChannel = $$responseChannel
 
     bus.send(action.type, action)
@@ -135,13 +135,13 @@ describe('Implicit vs explicit transactions', () => {
         'RETURN 1',
         {},
         expect.objectContaining({
-          implicit: true
+          autoCommit: true
         })
       )
       done()
     })
   })
-  test('it sends the implicit flag = false to tx functions on regular cypher', done => {
+  test('it sends the autoCommit flag = false to tx functions on regular cypher', done => {
     // Given
     const bus = createBus()
     bus.applyReduxMiddleware(createEpicMiddleware(handleSingleCommandEpic))
@@ -156,7 +156,7 @@ describe('Implicit vs explicit transactions', () => {
         'RETURN 1',
         {},
         expect.objectContaining({
-          implicit: false
+          autoCommit: false
         })
       )
       done()

--- a/src/shared/modules/commands/helpers/cypher.js
+++ b/src/shared/modules/commands/helpers/cypher.js
@@ -29,7 +29,7 @@ export const handleCypherCommand = (
   params = {},
   shouldUseCypherThread = false,
   txMetadata = {},
-  implicit = false
+  autoCommit = false
 ) => {
   const paramsToNeo4jType = Object.keys(params).map(k => ({
     [k]: applyGraphTypes(params[k])
@@ -42,7 +42,7 @@ export const handleCypherCommand = (
       requestId: action.requestId,
       cancelable: true,
       ...txMetadata,
-      implicit
+      autoCommit
     }
   )
   put(send('cypher', id))

--- a/src/shared/modules/commands/helpers/cypher.js
+++ b/src/shared/modules/commands/helpers/cypher.js
@@ -28,19 +28,21 @@ export const handleCypherCommand = (
   put,
   params = {},
   shouldUseCypherThread = false,
-  txMetadata = {}
+  txMetadata = {},
+  implicit = false
 ) => {
   const paramsToNeo4jType = Object.keys(params).map(k => ({
     [k]: applyGraphTypes(params[k])
   }))
   const [id, request] = bolt.routedWriteTransaction(
-    action.cmd,
+    action.query,
     arrayToObject(paramsToNeo4jType),
     {
       useCypherThread: shouldUseCypherThread,
       requestId: action.requestId,
       cancelable: true,
-      ...txMetadata
+      ...txMetadata,
+      implicit
     }
   )
   put(send('cypher', id))

--- a/src/shared/services/bolt/bolt.js
+++ b/src/shared/services/bolt/bolt.js
@@ -77,7 +77,8 @@ function routedWriteTransaction(input, parameters, requestMetaData = {}) {
     requestId = null,
     cancelable = false,
     onLostConnection = () => {},
-    txMetadata = undefined
+    txMetadata = undefined,
+    implicit = false
   } = requestMetaData
   if (useCypherThread && window.Worker) {
     const id = requestId || v4()
@@ -95,7 +96,8 @@ function routedWriteTransaction(input, parameters, requestMetaData = {}) {
           )
         ),
         txMetadata,
-        useDb: _useDb
+        useDb: _useDb,
+        implicit
       }
     )
     const workerPromise = setupBoltWorker(id, workFn, onLostConnection)
@@ -107,7 +109,8 @@ function routedWriteTransaction(input, parameters, requestMetaData = {}) {
       requestId,
       cancelable,
       txMetadata,
-      _useDb
+      _useDb,
+      implicit
     )
   }
 }

--- a/src/shared/services/bolt/bolt.js
+++ b/src/shared/services/bolt/bolt.js
@@ -78,7 +78,7 @@ function routedWriteTransaction(input, parameters, requestMetaData = {}) {
     cancelable = false,
     onLostConnection = () => {},
     txMetadata = undefined,
-    implicit = false
+    autoCommit = false
   } = requestMetaData
   if (useCypherThread && window.Worker) {
     const id = requestId || v4()
@@ -97,7 +97,7 @@ function routedWriteTransaction(input, parameters, requestMetaData = {}) {
         ),
         txMetadata,
         useDb: _useDb,
-        implicit
+        autoCommit
       }
     )
     const workerPromise = setupBoltWorker(id, workFn, onLostConnection)
@@ -110,7 +110,7 @@ function routedWriteTransaction(input, parameters, requestMetaData = {}) {
       cancelable,
       txMetadata,
       _useDb,
-      implicit
+      autoCommit
     )
   }
 }

--- a/src/shared/services/bolt/boltConnection.js
+++ b/src/shared/services/bolt/boltConnection.js
@@ -224,7 +224,7 @@ function _trackedTransaction(
   session,
   requestId = null,
   txMetadata = undefined,
-  implicit = false
+  autoCommit = false
 ) {
   const id = requestId || v4()
   if (!session) {
@@ -239,12 +239,12 @@ function _trackedTransaction(
   const metadata = txMetadata ? { metadata: txMetadata } : undefined
   let queryPromise
 
-  // Explicit tx's are the norm
-  if (!implicit) {
+  // Transaction functions are the norm
+  if (!autoCommit) {
     const txFn = buildTxFunctionByMode(session)
     queryPromise = txFn(tx => tx.run(input, parameters, metadata))
   } else {
-    // Implicit transaction, only used for PERIODIC COMMIT etc.
+    // Auto-Commit transaction, only used for PERIODIC COMMIT etc.
     queryPromise = session.run(input, parameters, metadata)
   }
 
@@ -324,7 +324,7 @@ export function routedWriteTransaction(
   cancelable = false,
   txMetadata = undefined,
   useDb = undefined,
-  implicit = false
+  autoCommit = false
 ) {
   const session = _drivers
     ? _drivers
@@ -338,7 +338,7 @@ export function routedWriteTransaction(
     session,
     requestId,
     txMetadata,
-    implicit
+    autoCommit
   )
 }
 

--- a/src/shared/services/bolt/boltHelpers.js
+++ b/src/shared/services/bolt/boltHelpers.js
@@ -46,7 +46,7 @@ export const buildTxFunctionByMode = session => {
   if (!session) {
     return null
   }
-  return session && session._mode !== 'READ'
+  return session._mode !== 'READ'
     ? session.writeTransaction.bind(session)
     : session.readTransaction.bind(session)
 }

--- a/src/shared/services/bolt/boltHelpers.js
+++ b/src/shared/services/bolt/boltHelpers.js
@@ -41,3 +41,12 @@ export const isConfigValTruthy = val =>
   [true, 'true', 'yes', 1, '1'].indexOf(val) > -1
 export const isConfigValFalsy = val =>
   [false, 'false', 'no', 0, '0'].indexOf(val) > -1
+
+export const buildTxFunctionByMode = session => {
+  if (!session) {
+    return null
+  }
+  return session && session._mode !== 'READ'
+    ? session.writeTransaction.bind(session)
+    : session.readTransaction.bind(session)
+}

--- a/src/shared/services/bolt/boltHelpers.test.js
+++ b/src/shared/services/bolt/boltHelpers.test.js
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import neo4j from 'neo4j-driver'
+import { buildTxFunctionByMode } from './boltHelpers'
+
+const WRITE = 'WRITE'
+const READ = 'READ'
+
+describe('buildTxFunctionByMode', () => {
+  test('it returns WRITE tx when in WRITE mode', () => {
+    // Given
+    const fakeSession = {
+      _mode: WRITE,
+      readTransaction: jest.fn(),
+      writeTransaction: jest.fn()
+    }
+
+    // When
+    const txFn = buildTxFunctionByMode(fakeSession)
+    txFn()
+
+    // Then
+    expect(fakeSession.readTransaction).toHaveBeenCalledTimes(0)
+    expect(fakeSession.writeTransaction).toHaveBeenCalledTimes(1)
+  })
+  test('it returns READ tx when in READ mode', () => {
+    // Given
+    const fakeSession = {
+      _mode: READ,
+      readTransaction: jest.fn(),
+      writeTransaction: jest.fn()
+    }
+
+    // When
+    const txFn = buildTxFunctionByMode(fakeSession)
+    txFn()
+
+    // Then
+    expect(fakeSession.readTransaction).toHaveBeenCalledTimes(1)
+    expect(fakeSession.writeTransaction).toHaveBeenCalledTimes(0)
+  })
+  test('it by DEFAULT returns tx in WRITE mode', () => {
+    // Given
+    const fakeSession = {
+      readTransaction: jest.fn(),
+      writeTransaction: jest.fn()
+    }
+
+    // When
+    const txFn = buildTxFunctionByMode(fakeSession)
+    txFn()
+
+    // Then
+    expect(fakeSession.readTransaction).toHaveBeenCalledTimes(0)
+    expect(fakeSession.writeTransaction).toHaveBeenCalledTimes(1)
+  })
+  test('it returns null if no session passed', () => {
+    // Given
+    const fakeSession = undefined
+
+    // When
+    const txFn = buildTxFunctionByMode(fakeSession)
+
+    // Then
+    expect(txFn).toBeNull()
+  })
+})

--- a/src/shared/services/bolt/boltWorker.js
+++ b/src/shared/services/bolt/boltWorker.js
@@ -70,7 +70,7 @@ const onmessage = function(message) {
       connectionProperties
     } = message.data
     beforeWork()
-    const { txMetadata, useDb, implicit } = connectionProperties
+    const { txMetadata, useDb, autoCommit } = connectionProperties
     ensureConnection(connectionProperties, connectionProperties.opts, e => {
       self.postMessage(
         boltConnectionErrorMessage(createErrorObject(BoltConnectionError))
@@ -84,7 +84,7 @@ const onmessage = function(message) {
           cancelable,
           txMetadata,
           useDb,
-          implicit
+          autoCommit
         )
         connectionTypeMap[connectionType]
           .getPromise(res)

--- a/src/shared/services/bolt/boltWorker.js
+++ b/src/shared/services/bolt/boltWorker.js
@@ -70,7 +70,7 @@ const onmessage = function(message) {
       connectionProperties
     } = message.data
     beforeWork()
-    const { txMetadata, useDb } = connectionProperties
+    const { txMetadata, useDb, implicit } = connectionProperties
     ensureConnection(connectionProperties, connectionProperties.opts, e => {
       self.postMessage(
         boltConnectionErrorMessage(createErrorObject(BoltConnectionError))
@@ -83,7 +83,8 @@ const onmessage = function(message) {
           requestId,
           cancelable,
           txMetadata,
-          useDb
+          useDb,
+          implicit
         )
         connectionTypeMap[connectionType]
           .getPromise(res)

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -57,7 +57,8 @@ import {
   unsuccessfulCypher,
   SINGLE_COMMAND_QUEUED,
   listDbsCommand,
-  useDbCommand
+  useDbCommand,
+  implicitTxCommand
 } from 'shared/modules/commands/commandsDuck'
 import {
   getParamName,
@@ -80,7 +81,10 @@ import {
 } from 'shared/modules/commands/helpers/http'
 import { fetchRemoteGrass } from 'shared/modules/commands/helpers/grass'
 import { parseGrass } from 'shared/services/grassUtils'
-import { shouldUseCypherThread } from 'shared/modules/settings/settingsDuck'
+import {
+  shouldUseCypherThread,
+  getCmdChar
+} from 'shared/modules/settings/settingsDuck'
 import {
   getUserDirectTxMetadata,
   getBackgroundTxMetadata
@@ -337,9 +341,25 @@ const availableCommands = [
   },
   {
     name: 'cypher',
-    match: cmd => /^cypher$/.test(cmd),
+    match: cmd =>
+      /^cypher$/.test(cmd) ||
+      new RegExp(`^${implicitTxCommand}`, 'i').test(cmd),
     exec: (action, cmdchar, put, store) => {
       const state = store.getState()
+
+      // Since we now also handle queries with the :implicit prefix, we need to strip that
+      // and attach to the actions object
+      const query = action.cmd.replace(
+        getCmdChar(state) + implicitTxCommand,
+        ''
+      )
+      action.query = query.trim()
+
+      // We need to find out if this is an impllicit tx or not
+      // i.e. Did we strip something off above here?
+      const implicit = action.query.length < action.cmd.trim().length
+      action.implicit = implicit
+
       const [id, request] = handleCypherCommand(
         action,
         put,
@@ -351,7 +371,8 @@ const availableCommands = [
             })
           : getBackgroundTxMetadata({
               hasServerSupport: canSendTxMetadata(store.getState())
-            })
+            }),
+        implicit
       )
       put(cypher(action.cmd))
       put(

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -58,7 +58,7 @@ import {
   SINGLE_COMMAND_QUEUED,
   listDbsCommand,
   useDbCommand,
-  implicitTxCommand
+  autoCommitTxCommand
 } from 'shared/modules/commands/commandsDuck'
 import {
   getParamName,
@@ -343,22 +343,22 @@ const availableCommands = [
     name: 'cypher',
     match: cmd =>
       /^cypher$/.test(cmd) ||
-      new RegExp(`^${implicitTxCommand}`, 'i').test(cmd),
+      new RegExp(`^${autoCommitTxCommand}`, 'i').test(cmd),
     exec: (action, cmdchar, put, store) => {
       const state = store.getState()
 
-      // Since we now also handle queries with the :implicit prefix, we need to strip that
+      // Since we now also handle queries with the :auto prefix, we need to strip that
       // and attach to the actions object
       const query = action.cmd.replace(
-        getCmdChar(state) + implicitTxCommand,
+        getCmdChar(state) + autoCommitTxCommand,
         ''
       )
       action.query = query.trim()
 
       // We need to find out if this is an impllicit tx or not
       // i.e. Did we strip something off above here?
-      const implicit = action.query.length < action.cmd.trim().length
-      action.implicit = implicit
+      const autoCommit = action.query.length < action.cmd.trim().length
+      action.autoCommit = autoCommit
 
       const [id, request] = handleCypherCommand(
         action,
@@ -372,7 +372,7 @@ const availableCommands = [
           : getBackgroundTxMetadata({
               hasServerSupport: canSendTxMetadata(store.getState())
             }),
-        implicit
+        autoCommit
       )
       put(cypher(action.cmd))
       put(

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -355,7 +355,7 @@ const availableCommands = [
       )
       action.query = query.trim()
 
-      // We need to find out if this is an impllicit tx or not
+      // We need to find out if this is an auto-committing tx or not
       // i.e. Did we strip something off above here?
       const autoCommit = action.query.length < action.cmd.trim().length
       action.autoCommit = autoCommit


### PR DESCRIPTION
To get automatic retries in cases of leader switches in clusters we want to move away from auto-committed transactions `session.run()` to transaction functions `session.xxxTransaction(tx => tx.run())`.

However, certain Cypher commands (i.e. `USING PERIODIC COMMIT`) requires an auto-committed transaction to be able function.
That's why we introduce the opt-out of transaction functions command and instead use auto-commited transactions: `:auto`.

Just prepend it to the query:  `:auto RETURN 1` and it'll use an auto-committing transaction.