### PR TITLE
skip generate button when tabbing through change password form

### DIFF
--- a/src/browser/modules/Stream/Auth/ChangePasswordForm.jsx
+++ b/src/browser/modules/Stream/Auth/ChangePasswordForm.jsx
@@ -147,7 +147,7 @@ export default class ChangePasswordForm extends Component {
                     })}
                   />
                   &nbsp;OR&nbsp;
-                  <FormButton onClick={this.onSuggestPassword}>
+                  <FormButton tabIndex="-1" onClick={this.onSuggestPassword}>
                     Generate
                   </FormButton>
                 </StyledConnectionFormEntry>


### PR DESCRIPTION
Slight quality of life improvement when changing password
Before:
![tabindex before](https://user-images.githubusercontent.com/939458/73346711-a5076e80-4286-11ea-9c57-6212d63665a3.gif)
After:
![tabindex after](https://user-images.githubusercontent.com/939458/73346816-ca947800-4286-11ea-92df-e30ac714e1fa.gif)
