### PR TITLE
Add `:help auto` + link to it from relevant errors and docs

### DIFF
--- a/src/browser/documentation/dynamic/cypher.jsx
+++ b/src/browser/documentation/dynamic/cypher.jsx
@@ -27,8 +27,8 @@ const filter = ['cypher']
 const description = (
   <>
     <p>
-      Cypher is Neo4j's graph query language. Working with a graph is all about
-      understanding patterns of data, which are central to Cypher queries.
+      Cypher is Neo4j&apos;s graph query language. Working with a graph is all
+      about understanding patterns of data, which are central to Cypher queries.
     </p>
     <p>
       Use

--- a/src/browser/documentation/help/auto.jsx
+++ b/src/browser/documentation/help/auto.jsx
@@ -25,11 +25,12 @@ const category = 'browserUiCommands'
 const content = (
   <>
     <p>
-      The <code>:auto</code> command will send the Cypher query after is in an
-      auto committing transaction. In general this is not recommended because of
-      the lack of support for auto retrying on leader switch errors in clusters.
+      The <code>:auto</code> command will send the Cypher query following it, in
+      an auto committing transaction. In general this is not recommended because
+      of the lack of support for auto retrying on leader switch errors in
+      clusters.
       <br />
-      Some query types does however need to be sent in auto-committing
+      Some query types do however need to be sent in auto-committing
       transactions, <code>USING PERIODIC COMMIT</code> is the most notable one.
     </p>
     <table className="table-condensed table-help">

--- a/src/browser/documentation/help/auto.jsx
+++ b/src/browser/documentation/help/auto.jsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react'
+const title = 'Auto-committing transactions'
+const subtitle = 'Execute a Cypher query within an auto-committing transaction'
+const category = 'browserUiCommands'
+const content = (
+  <>
+    <p>
+      The <code>:auto</code> command will send the Cypher query after is in an
+      auto committing transaction. In general this is not recommended because of
+      the lack of support for auto retrying on leader switch errors in clusters.
+      <br />
+      Some query types does however need to be sent in auto-committing
+      transactions, <code>USING PERIODIC COMMIT</code> is the most notable one.
+    </p>
+    <table className="table-condensed table-help">
+      <tbody>
+        <tr>
+          <th>Related:</th>
+          <td>
+            <a help-topic="load csv">:help load csv</a>
+            <a help-topic="cypher">:help cypher</a>
+            <a help-topic="commands">:help commands</a>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <section className="example">
+      <figure>
+        <pre>{`:auto USING PERIODIC COMMIT
+LOAD CSV WITH HEADER FROM ... `}</pre>
+        <figcaption>
+          Example usage of the <em>:auto</em> command.
+        </figcaption>
+      </figure>
+    </section>
+  </>
+)
+
+export default { title, subtitle, category, content }

--- a/src/browser/documentation/help/load-csv.jsx
+++ b/src/browser/documentation/help/load-csv.jsx
@@ -31,7 +31,8 @@ const content = (
       <code>CREATE</code> and <code>MERGE</code> to import tabular data into the
       graph. If you are importing a substantially sized data set, you should
       consider using <code>LOAD CSV</code> in combination with{' '}
-      <code>USING PERIODIC COMMIT</code>.
+      <code>USING PERIODIC COMMIT</code> (read{' '}
+      <a help-topic="auto">:help auto</a> if you are).
     </p>
     <div className="links">
       <div className="link">
@@ -54,6 +55,7 @@ const content = (
       <div className="link">
         <p className="title">Related</p>
         <p className="content">
+          <a help-topic="auto">:help auto</a>
           <a help-topic="create">:help CREATE</a>
           <a help-topic="merge">:help MERGE</a>
           <a help-topic="cypher">:help Cypher</a>

--- a/src/browser/documentation/index.js
+++ b/src/browser/documentation/index.js
@@ -20,6 +20,7 @@
 
 // Help
 import helpAlterUser from './help/alter-user'
+import helpAuto from './help/auto'
 import helpBolt from './dynamic/bolt'
 import helpBoltEncryption from './help/bolt-encryption'
 import helpBoltRouting from './help/bolt-routing'
@@ -106,6 +107,7 @@ export default {
   help: {
     title: 'Commands',
     chapters: {
+      auto: helpAuto,
       clear: helpClear,
       cypher: helpCypher,
       bolt: helpBolt,

--- a/src/browser/modules/Stream/CypherFrame/ErrorsView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/ErrorsView.jsx
@@ -34,7 +34,8 @@ import {
 import { listAvailableProcedures } from 'shared/modules/cypher/procedureFactory'
 import {
   isUnknownProcedureError,
-  isNoDbAccessError
+  isNoDbAccessError,
+  isPeriodicCommitError
 } from 'services/cypherErrorsHelper'
 import { errorMessageFormater } from './../errorMessageFormater'
 
@@ -91,6 +92,15 @@ export class ErrorsView extends Component {
                 <PlayIcon />
                 &nbsp;List available databases
               </StyledLink>
+            </StyledLinkContainer>
+          </Render>
+          <Render if={isPeriodicCommitError(error)}>
+            <StyledLinkContainer>
+              <StyledLink onClick={() => onItemClick(bus, `:help auto`)}>
+                <PlayIcon />
+                &nbsp;Info on the <code>:auto</code> command
+              </StyledLink>
+              &nbsp;(auto-committing transactions)
             </StyledLinkContainer>
           </Render>
         </StyledHelpContent>

--- a/src/browser/modules/Stream/CypherFrame/ErrorsView.test.js
+++ b/src/browser/modules/Stream/CypherFrame/ErrorsView.test.js
@@ -69,6 +69,25 @@ describe('ErrorsViews', () => {
       expect(container).toMatchSnapshot()
       expect(getByText('List available procedures')).not.toBeUndefined()
     })
+    test('displays procedure link if periodic commit error', () => {
+      // Given
+      const props = {
+        result: {
+          code: 'Neo.ClientError.Statement.SemanticError',
+          message:
+            'Executing queries that use periodic commit in an open transaction is not possible.'
+        }
+      }
+
+      // When
+      const { getByText } = render(<ErrorsView {...props} />)
+
+      // Then
+      // We need to split up because of the use of <code> tags in the rendered document
+      expect(getByText(/info on the/i)).not.toBeUndefined()
+      expect(getByText(':auto')).not.toBeUndefined()
+      expect(getByText('(auto-committing transactions)')).not.toBeUndefined()
+    })
   })
   describe('ErrorsStatusbar', () => {
     test('displays nothing if no error', () => {

--- a/src/shared/services/cypherErrorsHelper.js
+++ b/src/shared/services/cypherErrorsHelper.js
@@ -4,3 +4,7 @@ export const isUnknownProcedureError = ({ code }) =>
 export const isNoDbAccessError = ({ code, message }) =>
   code === 'Neo.ClientError.Security.Forbidden' &&
   /Database access is not allowed/i.test(message)
+
+export const isPeriodicCommitError = ({ code, message }) =>
+  code === 'Neo.ClientError.Statement.SemanticError' &&
+  /in an open transaction is not possible/i.test(message)


### PR DESCRIPTION
A follow-up PR for https://github.com/neo4j/neo4j-browser/pull/1048.

* Add new `auto` help page
* Add link to help page from `USING PERIODIC COMMIT` Cypher error frame
* Add links to auto help page from other relevant help pages

<img width="1054" alt="Screenshot 2020-01-30 10 49 56" src="https://user-images.githubusercontent.com/570998/73440054-ed8b5e80-4350-11ea-81ca-289025ccb142.png">
<img width="1046" alt="Screenshot 2020-01-30 10 50 01" src="https://user-images.githubusercontent.com/570998/73440074-f2e8a900-4350-11ea-9c0b-9e79c9390eca.png">
<img width="1049" alt="Screenshot 2020-01-30 10 50 07" src="https://user-images.githubusercontent.com/570998/73440093-fa0fb700-4350-11ea-9e61-8eb6bf941b61.png">
<img width="1053" alt="Screenshot 2020-01-30 10 49 50" src="https://user-images.githubusercontent.com/570998/73440109-00059800-4351-11ea-953f-8268a38f79d8.png">
