### PR TITLE
filter example scripts by database version

### DIFF
--- a/src/browser/modules/Sidebar/static-scripts.js
+++ b/src/browser/modules/Sidebar/static-scripts.js
@@ -18,11 +18,13 @@
 import { withBus } from 'react-suber'
 import { connect } from 'react-redux'
 import MyScripts from '@relate-by-ui/saved-scripts'
+import semver from 'semver'
 
 import * as editor from 'shared/modules/editor/editorDuck'
 import { executeCommand } from 'shared/modules/commands/commandsDuck'
 import * as favorites from '../../../shared/modules/favorites/favoritesDuck'
 import * as folders from '../../../shared/modules/favorites/foldersDuck'
+import { getVersion } from 'shared/modules/dbMeta/dbMetaDuck'
 
 import {
   mapOldFavoritesAndFolders,
@@ -30,10 +32,12 @@ import {
 } from '../../../shared/services/export-favorites'
 
 const mapFavoritesStateToProps = state => {
+  const version = semver.coerce(getVersion(state) || '0')
   const scripts = mapOldFavoritesAndFolders(
     favorites.getFavorites(state),
     folders.getFolders(state),
-    ({ isStatic }) => isStatic
+    ({ isStatic, versionRange }) =>
+      isStatic && semver.satisfies(version, versionRange)
   )
 
   return {
@@ -56,7 +60,10 @@ const mapFavoritesDispatchToProps = (dispatch, ownProps) => ({
   onRemoveFolder: Function.prototype
 })
 const Favorites = withBus(
-  connect(mapFavoritesStateToProps, mapFavoritesDispatchToProps)(MyScripts)
+  connect(
+    mapFavoritesStateToProps,
+    mapFavoritesDispatchToProps
+  )(MyScripts)
 )
 
 export default Favorites

--- a/src/browser/modules/Sidebar/static-scripts.test.js
+++ b/src/browser/modules/Sidebar/static-scripts.test.js
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { fireEvent, render } from '@testing-library/react'
+import React from 'react'
+import { Provider } from 'react-redux'
+import { createStore } from 'redux'
+
+import Favorites from './static-scripts'
+import { folders, scripts } from 'shared/modules/favorites/staticScripts'
+
+describe('<Favorites />', () => {
+  // Rename the two show meta-graph scripts so they can be distinguished from each other in DOM
+  const documents = scripts.map(script => ({
+    ...script,
+    isStatic: true,
+    content: !script.content.includes('Show meta-graph')
+      ? script.content
+      : script.versionRange === '>=3 <4'
+      ? script.content.replace('Show meta-graph', 'Show meta-graph v3')
+      : script.content.replace('Show meta-graph', 'Show meta-graph v4')
+  }))
+
+  const renderWithDBMSVersion = version => {
+    const state = {
+      documents,
+      folders,
+      meta: { server: { version } }
+    }
+
+    return render(
+      <Provider store={createStore(() => state, state)}>
+        <Favorites />
+      </Provider>
+    )
+  }
+
+  it('lists the "Connect to DBMS" example when there is no DBMS version', () => {
+    const version = null
+    const { queryByText } = renderWithDBMSVersion(version)
+
+    fireEvent.click(queryByText('Basic Queries'))
+
+    expect(queryByText('Connect to DBMS')).toBeTruthy()
+  })
+
+  it('lists only the v3 version of the "Show meta-graph" example when version is 3', () => {
+    const version = '3.5.14'
+    const { queryByText } = renderWithDBMSVersion(version)
+
+    fireEvent.click(queryByText('Common Procedures'))
+
+    expect(queryByText('Show meta-graph v3')).toBeTruthy()
+    expect(queryByText('Show meta-graph v4')).toBeFalsy()
+  })
+
+  it('lists only the v4 version of the "Show meta-graph" example when version is 4', () => {
+    const version = '4.0.3'
+    const { queryByText } = renderWithDBMSVersion(version)
+
+    fireEvent.click(queryByText('Common Procedures'))
+
+    expect(queryByText('Show meta-graph v3')).toBeFalsy()
+    expect(queryByText('Show meta-graph v4')).toBeTruthy()
+  })
+})

--- a/src/shared/modules/favorites/staticScripts.js
+++ b/src/shared/modules/favorites/staticScripts.js
@@ -21,89 +21,123 @@
 export const scripts = [
   {
     folder: 'basics',
-    content:
-      '// Hello World!\nCREATE (database:Database {name:"Neo4j"})-[r:SAYS]->(message:Message {name:"Hello World!"}) RETURN database, message, r'
+    content: '// Connect to DBMS\n:server connect',
+    versionRange: '0.0.0'
   },
   {
     folder: 'basics',
-    content: '// Get some data\nMATCH (n1)-[r]->(n2) RETURN r, n1, n2 LIMIT 25'
+    content:
+      '// Hello World!\nCREATE (database:Database {name:"Neo4j"})-[r:SAYS]->(message:Message {name:"Hello World!"}) RETURN database, message, r',
+    versionRange: '>=3'
+  },
+  {
+    folder: 'basics',
+    content: '// Get some data\nMATCH (n1)-[r]->(n2) RETURN r, n1, n2 LIMIT 25',
+    versionRange: '>=3'
   },
   {
     folder: 'basics',
     not_executable: true,
     content:
-      "// Create an index\n// Replace:\n//   'LabelName' with label to index\n//   'propertyKey' with property to be indexed\nCREATE INDEX ON :<LabelName>(<propertyKey>)"
+      "// Create an index\n// Replace:\n//   'LabelName' with label to index\n//   'propertyKey' with property to be indexed\nCREATE INDEX ON :<LabelName>(<propertyKey>)",
+    versionRange: '>=3'
   },
   {
     folder: 'basics',
     not_executable: true,
     content:
-      "// Create unique property constraint\n// Replace:\n//   'LabelName' with node label\n//   'propertyKey' with property that should be unique\nCREATE CONSTRAINT ON (n:<LabelName>) ASSERT n.<propertyKey> IS UNIQUE"
+      "// Create unique property constraint\n// Replace:\n//   'LabelName' with node label\n//   'propertyKey' with property that should be unique\nCREATE CONSTRAINT ON (n:<LabelName>) ASSERT n.<propertyKey> IS UNIQUE",
+    versionRange: '>=3'
   },
   {
     folder: 'profile',
-    content: '// Count all nodes\nMATCH (n)\nRETURN count(n)'
+    content: '// Count all nodes\nMATCH (n)\nRETURN count(n)',
+    versionRange: '>=3'
   },
   {
     folder: 'profile',
-    content: '// Count all relationships\nMATCH ()-->() RETURN count(*);'
+    content: '// Count all relationships\nMATCH ()-->() RETURN count(*);',
+    versionRange: '>=3'
   },
   {
     folder: 'profile',
     content:
-      '// What kind of nodes exist\n// Sample some nodes, reporting on property and relationship counts per node.\nMATCH (n) WHERE rand() <= 0.1\nRETURN\nDISTINCT labels(n),\ncount(*) AS SampleSize,\navg(size(keys(n))) as Avg_PropertyCount,\nmin(size(keys(n))) as Min_PropertyCount,\nmax(size(keys(n))) as Max_PropertyCount,\navg(size( (n)-[]-() ) ) as Avg_RelationshipCount,\nmin(size( (n)-[]-() ) ) as Min_RelationshipCount,\nmax(size( (n)-[]-() ) ) as Max_RelationshipCount'
+      '// What kind of nodes exist\n// Sample some nodes, reporting on property and relationship counts per node.\nMATCH (n) WHERE rand() <= 0.1\nRETURN\nDISTINCT labels(n),\ncount(*) AS SampleSize,\navg(size(keys(n))) as Avg_PropertyCount,\nmin(size(keys(n))) as Min_PropertyCount,\nmax(size(keys(n))) as Max_PropertyCount,\navg(size( (n)-[]-() ) ) as Avg_RelationshipCount,\nmin(size( (n)-[]-() ) ) as Min_RelationshipCount,\nmax(size( (n)-[]-() ) ) as Max_RelationshipCount',
+    versionRange: '>=3'
   },
   {
     folder: 'profile',
-    content: '// What is related, and how\nCALL db.schema()'
+    content: '// What is related, and how\nCALL db.schema.visualization()',
+    versionRange: '>=4'
   },
   {
     folder: 'profile',
-    content: '// List node labels\nCALL db.labels()'
+    content: '// What is related, and how\nCALL db.schema()',
+    versionRange: '>=3 <4'
   },
   {
     folder: 'profile',
-    content: '// List relationship types\nCALL db.relationshipTypes()'
+    content: '// List node labels\nCALL db.labels()',
+    versionRange: '>=3'
   },
   {
     folder: 'profile',
-    content: '// Display constraints and indexes\n:schema'
+    content: '// List relationship types\nCALL db.relationshipTypes()',
+    versionRange: '>=3'
+  },
+  {
+    folder: 'profile',
+    content: '// Display constraints and indexes\n:schema',
+    versionRange: '>=3'
   },
   {
     folder: 'graphs',
-    content: '// Movie Graph\n:play movie-graph'
+    content: '// Movie Graph\n:play movie-graph',
+    versionRange: '>=3'
   },
   {
     folder: 'graphs',
-    content: '// Northwind Graph\n:play northwind-graph'
+    content: '// Northwind Graph\n:play northwind-graph',
+    versionRange: '>=3'
   },
   {
     folder: 'procedures',
-    content: '// List procedures\nCALL dbms.procedures()'
+    content: '// List procedures\nCALL dbms.procedures()',
+    versionRange: '>=3'
   },
   {
     folder: 'procedures',
-    content: '// List functions\nCALL dbms.functions()'
+    content: '// List functions\nCALL dbms.functions()',
+    versionRange: '>=3'
   },
   {
     folder: 'procedures',
-    content: '// Show meta-graph\nCALL db.schema()'
+    content: '// Show meta-graph\nCALL db.schema.visualization()',
+    versionRange: '>=4'
   },
   {
     folder: 'procedures',
-    content: '// List running queries\nCALL dbms.listQueries()'
+    content: '// Show meta-graph\nCALL db.schema()',
+    versionRange: '>=3 <4'
+  },
+  {
+    folder: 'procedures',
+    content: '// List running queries\nCALL dbms.listQueries()',
+    versionRange: '>=3'
   },
   {
     folder: 'procedures',
     not_executable: true,
     content:
-      '// Wait for index to come online\n// E.g. db.awaitIndex(":Person(name)")\nCALL db.awaitIndex(<param>)'
+      '// Wait for index to come online\n// E.g. db.awaitIndex(":Person(name)")\nCALL db.awaitIndex(<param>)',
+    versionRange: '>=3'
   },
   {
     folder: 'procedures',
     not_executable: true,
     content:
-      '// Schedule resampling of an index\n// E.g. db.resampleIndex(":Person(name)")\nCALL db.resampleIndex(<param>)'
+      '// Schedule resampling of an index\n// E.g. db.resampleIndex(":Person(name)")\nCALL db.resampleIndex(<param>)',
+    versionRange: '>=3'
   }
 ]
 
@@ -111,21 +145,25 @@ export const folders = [
   {
     id: 'basics',
     name: 'Basic Queries',
-    isStatic: true
+    isStatic: true,
+    versionRange: ''
   },
   {
     id: 'graphs',
     name: 'Example Graphs',
-    isStatic: true
+    isStatic: true,
+    versionRange: ''
   },
   {
     id: 'profile',
     name: 'Data Profiling',
-    isStatic: true
+    isStatic: true,
+    versionRange: ''
   },
   {
     id: 'procedures',
     name: 'Common Procedures',
-    isStatic: true
+    isStatic: true,
+    versionRange: ''
   }
 ]


### PR DESCRIPTION
Fixes #1033  by adding a version range on the example queries and filtering the list by if the currently connected database is in the range.

Also added a Connect to database example for when there is no database version (when disconnected).