### PR TITLE
Fix reacting to deep links when in Neo4j Desktop environment

### DIFF
--- a/e2e_tests/integration/desktop-env-url.spec.js
+++ b/e2e_tests/integration/desktop-env-url.spec.js
@@ -22,6 +22,7 @@
 
 import { getDesktopContext } from '../support/utils'
 let appContextListener
+let appOnAgumentsChange
 
 // This file only esists to be able to test the auto connect using
 // the host field.
@@ -34,7 +35,8 @@ describe('Neo4j Desktop environment using url field', () => {
         win.neo4jDesktopApi = {
           getContext: () =>
             Promise.resolve(getDesktopContext(Cypress.config, 'url')),
-          onContextUpdate: fn => (appContextListener = fn.bind(fn))
+          onContextUpdate: fn => (appContextListener = fn.bind(fn)),
+          onArgumentsChange: fn => (appOnAgumentsChange = fn.bind(fn))
         }
       }
     })
@@ -64,5 +66,15 @@ describe('Neo4j Desktop environment using url field', () => {
     cy.get('[data-testid="frame"]', { timeout: 10000 })
       .first()
       .should('contain', 'Connection updated')
+  })
+  it('reacts to arguments changing', () => {
+    const expectedCommand = ':play reco'
+    cy.executeCommand(':clear')
+
+    cy.wait(1000).then(() => {
+      appOnAgumentsChange('cmd=play&arg=reco')
+    })
+
+    cy.getEditor().should('contain', expectedCommand)
   })
 })

--- a/e2e_tests/support/commands.js
+++ b/e2e_tests/support/commands.js
@@ -1,8 +1,11 @@
 const SubmitQueryButton = '[data-testid="submitQuery"]'
 const ClearEditorButton = '[data-testid="clearEditorContent"]'
 const Editor = '.ReactCodeMirror textarea'
+const VisibleEditor = '[data-testid="editor-wrapper"]'
 
 /* global Cypress, cy */
+
+Cypress.Commands.add('getEditor', () => cy.get(VisibleEditor))
 
 Cypress.Commands.add(
   'setInitialPassword',

--- a/src/browser/components/desktop-api/desktop-api.js
+++ b/src/browser/components/desktop-api/desktop-api.js
@@ -38,6 +38,15 @@ function DesktopApi({ integrationPoint = DEFAULT_INTEGRATION_POINT, ...rest }) {
     }
 
     function onUpdate() {
+      // Arguments change
+      if (
+        integrationPoint &&
+        integrationPoint.onArgumentsChange &&
+        rest.onArgumentsChange
+      ) {
+        integrationPoint.onArgumentsChange(rest.onArgumentsChange)
+      }
+      // Regular events
       if (integrationPoint && integrationPoint.onContextUpdate) {
         // Setup generic event listener
         integrationPoint.onContextUpdate((event, context, oldContext) => {
@@ -53,10 +62,14 @@ function DesktopApi({ integrationPoint = DEFAULT_INTEGRATION_POINT, ...rest }) {
     mountEvent()
     onUpdate()
 
-    return () =>
+    return () => {
       integrationPoint &&
-      integrationPoint.onContextUpdate &&
-      integrationPoint.onContextUpdate(null)
+        integrationPoint.onContextUpdate &&
+        integrationPoint.onContextUpdate(null)
+      integrationPoint &&
+        integrationPoint.onArgumentsChange &&
+        integrationPoint.onArgumentsChange(null)
+    }
   }, [integrationPoint])
   return null
 }

--- a/src/browser/components/desktop-api/desktop-api.test.js
+++ b/src/browser/components/desktop-api/desktop-api.test.js
@@ -139,4 +139,28 @@ describe('<DesktopApi>', () => {
       integrationPoint.getKerberosTicket
     )
   })
+  test('calls onArgumentsChange when args change', () => {
+    // Given
+    let componentOnArgumentsChange
+    const newArgsString = 'test=1&test2=2'
+    const fn = jest.fn()
+    const integrationPoint = {
+      onArgumentsChange: fn => (componentOnArgumentsChange = fn)
+    }
+
+    // When
+    render(
+      <DesktopApi integrationPoint={integrationPoint} onArgumentsChange={fn} />
+    )
+
+    // Then
+    expect(fn).toHaveBeenCalledTimes(0)
+
+    // When
+    componentOnArgumentsChange(newArgsString)
+
+    // Then
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(fn).toHaveBeenLastCalledWith(newArgsString)
+  })
 })

--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -67,7 +67,7 @@ import { getMetadata, getUserAuthStatus } from 'shared/modules/sync/syncDuck'
 import ErrorBoundary from 'browser-components/ErrorBoundary'
 import { getExperimentalFeatures } from 'shared/modules/experimentalFeatures/experimentalFeaturesDuck'
 import FeatureToggleProvider from '../FeatureToggle/FeatureToggleProvider'
-import { inWebEnv } from 'shared/modules/app/appDuck'
+import { inWebEnv, URL_ARGUMENTS_CHANGE } from 'shared/modules/app/appDuck'
 import useDerivedTheme from 'browser-hooks/useDerivedTheme'
 import FileDrop from 'browser-components/FileDrop/FileDrop'
 import DesktopApi from 'browser-components/desktop-api/desktop-api'
@@ -149,6 +149,9 @@ export function App(props) {
           getDesktopTheme(...args)
             .then(theme => setEnvironmentTheme(theme))
             .catch(setEnvironmentTheme(null))
+        }
+        onArgumentsChange={argsString =>
+          props.bus.send(URL_ARGUMENTS_CHANGE, { url: `?${argsString}` })
         }
       />
       <ThemeProvider theme={themeData}>


### PR DESCRIPTION
Fixes a regression and reacts to Desktops `onArgumentsChange` again.
Both component tests + E2E tests added.

See it in action:
![Kapture 2020-02-09 at 20 23 48-2](https://user-images.githubusercontent.com/570998/74108410-64f39600-4b7a-11ea-90d9-40e2829e8c06.gif)
