### PR TITLE
Parse query parameters correctly

### DIFF
--- a/e2e_tests/integration/desktop-env-url.spec.js
+++ b/e2e_tests/integration/desktop-env-url.spec.js
@@ -67,14 +67,15 @@ describe('Neo4j Desktop environment using url field', () => {
       .first()
       .should('contain', 'Connection updated')
   })
-  it('reacts to arguments changing', () => {
-    const expectedCommand = ':play reco'
+  it('reacts to arguments changing and handle different encodings', () => {
+    // Use regular expression to match multiple lines
+    const expectedCommand = /RETURN 1;[^R]*RETURN 2;/
     cy.executeCommand(':clear')
 
     cy.wait(1000).then(() => {
-      appOnAgumentsChange('cmd=play&arg=reco')
+      appOnAgumentsChange('cmd=edit&arg=RETURN+1;&arg=RETURN%202;')
     })
 
-    cy.getEditor().should('contain', expectedCommand)
+    cy.getEditor().contains(expectedCommand)
   })
 })

--- a/src/shared/modules/editor/editorDuck.js
+++ b/src/shared/modules/editor/editorDuck.js
@@ -74,8 +74,13 @@ export const populateEditorFromUrlEpic = (some$, store) => {
 
       const commandType = cmdParam[0]
       const cmdchar = getSettings(store.getState()).cmdchar
+      // Credits to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent
+      // for the "decodeURIComponent cannot be used directly to parse query parameters"
       const cmdArgs =
-        getUrlParamValue('arg', decodeURIComponent(action.url)) || []
+        getUrlParamValue(
+          'arg',
+          decodeURIComponent(action.url.replace(/\+/g, ' '))
+        ) || []
       const fullCommand = validCommandTypes[commandType](cmdchar, cmdArgs)
 
       return Rx.Observable.of({ type: SET_CONTENT, ...setContent(fullCommand) })


### PR DESCRIPTION
Desktop uses the `URL().searchParams.toString()` which encodes spaces to `+` signs when sending arguments, and browser didn't handle that correctly.
This fixes it and includes it in an E2E test to verify it works.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent has an example on how to use `decodeURIComponent` (which we already use) to do this. 
One small addition to it was all that was needed.