### PR TITLE
Fix scroll to top bug when a frame was deleted

### DIFF
--- a/src/browser/modules/Stream/Stream.jsx
+++ b/src/browser/modules/Stream/Stream.jsx
@@ -86,8 +86,9 @@ class Stream extends PureComponent {
   }
 
   componentDidUpdate(prevProps) {
+    // If we want to scroll to top when a new frame is added
     if (
-      prevProps.framesSignature !== this.props.framesSignature &&
+      prevProps.frames.length < this.props.frames.length &&
       this.props.scrollToTop &&
       this.base &&
       this.base.current
@@ -125,9 +126,6 @@ class Stream extends PureComponent {
 const mapStateToProps = state => {
   const frames = getFrames(state)
   return {
-    framesSignature: frames
-      .map(frame => frame.id + (frame.requestId || ''))
-      .join(''),
     frames,
     activeConnectionData: getActiveConnectionData(state),
     scrollToTop: getScrollToTop(state)


### PR DESCRIPTION
Before: Browser scrolled to top when a frame was deleted in the stream.
Now: Only scroll to top when a frame is added to the stream.

Not sure how to easily test this though.

![Kapture 2020-03-06 at 11 54 43](https://user-images.githubusercontent.com/570998/76077752-9dcc3280-5fa1-11ea-9351-73d8ba6c89b8.gif)
