### PR TITLE
Display warning in UI when database is unavailable

### DIFF
--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -32,7 +32,10 @@ import {
 import { FOCUS, EXPAND } from 'shared/modules/editor/editorDuck'
 import { useBrowserSync } from 'shared/modules/features/featuresDuck'
 import { getErrorMessage } from 'shared/modules/commands/commandsDuck'
-import { allowOutgoingConnections } from 'shared/modules/dbMeta/dbMetaDuck'
+import {
+  allowOutgoingConnections,
+  getDatabases
+} from 'shared/modules/dbMeta/dbMetaDuck'
 import {
   getActiveConnection,
   getConnectionState,
@@ -42,7 +45,8 @@ import {
   getConnectionData,
   SWITCH_CONNECTION_FAILED,
   SWITCH_CONNECTION,
-  SILENT_DISCONNECT
+  SILENT_DISCONNECT,
+  getUseDb
 } from 'shared/modules/connections/connectionsDuck'
 import { toggle } from 'shared/modules/sidebar/sidebarDuck'
 import {
@@ -120,7 +124,9 @@ export function App(props) {
     experimentalFeatures,
     store,
     codeFontLigatures,
-    defaultConnectionData
+    defaultConnectionData,
+    useDb,
+    databases
   } = props
 
   const wrapperClassNames = []
@@ -183,6 +189,8 @@ export function App(props) {
                       lastConnectionUpdate={lastConnectionUpdate}
                       errorMessage={errorMessage}
                       useBrowserSync={loadSync}
+                      useDb={useDb}
+                      databases={databases}
                     />
                   </StyledMainWrapper>
                 </StyledBody>
@@ -216,7 +224,9 @@ const mapStateToProps = state => {
     browserSyncConfig: getBrowserSyncConfig(state),
     browserSyncAuthStatus: getUserAuthStatus(state),
     loadSync: useBrowserSync(state),
-    isWebEnv: inWebEnv(state)
+    isWebEnv: inWebEnv(state),
+    useDb: getUseDb(state),
+    databases: getDatabases(state)
   }
 }
 

--- a/src/browser/modules/Main/Main.jsx
+++ b/src/browser/modules/Main/Main.jsx
@@ -40,17 +40,19 @@ import AutoExecButton from '../Stream/auto-exec-button'
 
 const Main = React.memo(function Main(props) {
   const [past5Sec, past10Sec] = useSlowConnectionState(props)
+  const { databases, useDb } = props
+  const dbMeta = databases && databases.find(db => db.name === useDb)
+  const dbIsUnavailable = useDb && (!dbMeta || dbMeta.status !== 'online')
 
   return (
     <StyledMain data-testid="main">
       <ErrorBoundary>
         <Editor />
       </ErrorBoundary>
-      <Render if={props.showUnknownCommandBanner}>
+      <Render if={dbIsUnavailable}>
         <ErrorBanner>
-          Type&nbsp;
-          <AutoExecButton cmd="help commands" />
-          &nbsp;for a list of available commands.
+          Database '{useDb}' is unavailable. Run{' '}
+          <AutoExecButton cmd="sysinfo" /> for more info.
         </ErrorBanner>
       </Render>
       <Render if={props.errorMessage}>

--- a/src/browser/modules/Main/Main.test.jsx
+++ b/src/browser/modules/Main/Main.test.jsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { render, fireEvent } from '@testing-library/react'
+import React from 'react'
+import configureMockStore from 'redux-mock-store'
+
+import Main from './Main'
+
+const mockStore = configureMockStore()
+const store = mockStore({})
+
+jest.mock('../Stream/auto-exec-button', () => () => <div></div>)
+jest.mock('../Editor/Editor', () => () => <div></div>)
+jest.mock('../Stream/Stream', () => () => <div></div>)
+
+describe('<Main />', () => {
+  it('should display an ErrorBanner when useDb is not in databases list', () => {
+    const useDb = 'some database'
+    const databases = []
+
+    const { queryByText } = render(
+      <Main
+        {...{
+          databases,
+          useDb,
+          store
+        }}
+      />
+    )
+
+    expect(
+      queryByText(`Database '${useDb}' is unavailable.`, { exact: false })
+    ).toBeTruthy()
+  })
+
+  it('should display an ErrorBanner when useDb is not online in databases list', () => {
+    const useDb = 'some database'
+    const databases = [{ name: useDb, status: 'offline' }]
+
+    const { queryByText } = render(
+      <Main
+        {...{
+          databases,
+          useDb,
+          store
+        }}
+      />
+    )
+
+    expect(
+      queryByText(`Database '${useDb}' is unavailable.`, { exact: false })
+    ).toBeTruthy()
+  })
+})

--- a/src/shared/modules/dbMeta/dbMetaDuck.js
+++ b/src/shared/modules/dbMeta/dbMetaDuck.js
@@ -312,162 +312,166 @@ export const dbMetaEpic = (some$, store) =>
           .throttle(() => some$.ofType(DB_META_DONE))
           // Server version and edition
           .do(store.dispatch({ type: FETCH_SERVER_INFO }))
-          // Labels, types and propertyKeys, and server version
-          .mergeMap(() => {
-            const state = store.getState()
-            const db = getUseDb(state)
-            if (db === 'system') {
-              store.dispatch(updateMeta([]))
-              return Rx.Observable.of(null)
-            }
-
-            return Rx.Observable.fromPromise(
-              bolt.routedReadTransaction(
-                metaQuery,
-                {},
-                {
-                  useCypherThread: shouldUseCypherThread(store.getState()),
-                  onLostConnection: onLostConnection(store.dispatch),
-                  ...getBackgroundTxMetadata({
-                    hasServerSupport: canSendTxMetadata(store.getState())
-                  })
-                }
-              )
-            ).catch(e => {
-              store.dispatch(updateMeta([]))
-              return Rx.Observable.of(null)
-            })
-          })
-          .do(res => {
-            if (res) {
-              store.dispatch(updateMeta(res))
-            }
-          })
-          // Server configuration
           .mergeMap(() =>
-            Rx.Observable.fromPromise(
-              bolt.directTransaction(
-                'CALL dbms.listConfig()',
-                {},
-                {
-                  useCypherThread: shouldUseCypherThread(store.getState()),
-                  ...getBackgroundTxMetadata({
-                    hasServerSupport: canSendTxMetadata(store.getState())
-                  })
-                }
-              )
-            )
-              .catch(e => {
-                return Rx.Observable.of(null)
-              })
-              .do(res => {
-                if (!res) return Rx.Observable.of(null)
-                const settings = res.records.reduce((all, record) => {
-                  const name = record.get('name')
-                  let value = record.get('value')
-                  if (name === 'browser.retain_connection_credentials') {
-                    let retainCredentials = true
-                    // Check if we should wipe user creds from localstorage
-                    if (
-                      typeof value !== 'undefined' &&
-                      isConfigValFalsy(value)
-                    ) {
-                      retainCredentials = false
-                    }
-                    store.dispatch(setRetainCredentials(retainCredentials))
-                  } else if (name === 'browser.allow_outgoing_connections') {
-                    // Use isConfigValFalsy to cast undefined to true
-                    value = !isConfigValFalsy(value)
-                  } else if (name === 'dbms.security.auth_enabled') {
-                    let authEnabled = true
-                    if (
-                      typeof value !== 'undefined' &&
-                      isConfigValFalsy(value)
-                    ) {
-                      authEnabled = false
-                    }
-                    store.dispatch(setAuthEnabled(authEnabled))
+            Rx.Observable.forkJoin([
+              // Labels, types and propertyKeys, and server version
+              Rx.Observable.if(
+                () => {
+                  const state = store.getState()
+                  const db = getUseDb(state)
+                  const isSystem = db === 'system'
+                  if (isSystem) {
+                    store.dispatch(updateMeta([]))
                   }
-                  all[name] = value
-                  return all
-                }, {})
-                store.dispatch(updateSettings(settings))
-                return Rx.Observable.of(null)
-              })
-          )
-          // Cluster role
-          .mergeMap(() =>
-            Rx.Observable.fromPromise(
-              bolt.directTransaction(
-                getDbClusterRole(store.getState()),
-                {},
-                {
-                  useCypherThread: shouldUseCypherThread(store.getState()),
-                  ...getBackgroundTxMetadata({
-                    hasServerSupport: canSendTxMetadata(store.getState())
-                  })
-                }
-              )
-            )
-              .catch(e => {
-                return Rx.Observable.of(null)
-              })
-              .do(res => {
-                if (!res) return Rx.Observable.of(null)
-                const role = res.records[0].get(0)
-                store.dispatch(update({ role }))
-                return Rx.Observable.of(null)
-              })
-          )
-          // Database list
-          .mergeMap(() =>
-            Rx.Observable.fromPromise(
-              new Promise(async (resolve, reject) => {
-                const supportsMultiDb = await bolt.hasMultiDbSupport()
-                if (!supportsMultiDb) {
-                  return resolve(null)
-                }
-                bolt
-                  .directTransaction(
-                    'SHOW DATABASES',
+                  return isSystem
+                },
+                Rx.Observable.of(null),
+                Rx.Observable.fromPromise(
+                  bolt.routedReadTransaction(
+                    metaQuery,
                     {},
                     {
                       useCypherThread: shouldUseCypherThread(store.getState()),
+                      onLostConnection: onLostConnection(store.dispatch),
                       ...getBackgroundTxMetadata({
                         hasServerSupport: canSendTxMetadata(store.getState())
-                      }),
-                      useDb: SYSTEM_DB // System db
+                      })
                     }
                   )
-                  .then(resolve)
-                  .catch(reject)
-              })
-            )
-              .catch(e => {
-                return Rx.Observable.of(null)
-              })
-              .do(res => {
-                if (!res) return Rx.Observable.of(null)
-                const databases = res.records.map(record => ({
-                  ...reduce(
-                    record.keys,
-                    (agg, key) => assign(agg, { [key]: record.get(key) }),
-                    {}
-                  ),
-                  status: record.get('currentStatus')
-                }))
-
-                store.dispatch(update({ databases }))
-
-                // Currently not using a db
-                if (!getUseDb(store.getState())) {
-                  const defaultDb = databases.filter(db => db.default)
-                  if (defaultDb.length) {
-                    store.dispatch(useDb(defaultDb[0].name))
+                )
+                  .do(res => {
+                    if (res) {
+                      store.dispatch(updateMeta(res))
+                    }
+                  })
+                  .catch(e => {
+                    store.dispatch(updateMeta([]))
+                    return Rx.Observable.of(null)
+                  })
+              ),
+              // Server configuration
+              Rx.Observable.fromPromise(
+                bolt.directTransaction(
+                  'CALL dbms.listConfig()',
+                  {},
+                  {
+                    useCypherThread: shouldUseCypherThread(store.getState()),
+                    ...getBackgroundTxMetadata({
+                      hasServerSupport: canSendTxMetadata(store.getState())
+                    })
                   }
-                }
-                return Rx.Observable.of(null)
-              })
+                )
+              )
+                .catch(e => {
+                  return Rx.Observable.of(null)
+                })
+                .do(res => {
+                  if (!res) return Rx.Observable.of(null)
+                  const settings = res.records.reduce((all, record) => {
+                    const name = record.get('name')
+                    let value = record.get('value')
+                    if (name === 'browser.retain_connection_credentials') {
+                      let retainCredentials = true
+                      // Check if we should wipe user creds from localstorage
+                      if (
+                        typeof value !== 'undefined' &&
+                        isConfigValFalsy(value)
+                      ) {
+                        retainCredentials = false
+                      }
+                      store.dispatch(setRetainCredentials(retainCredentials))
+                    } else if (name === 'browser.allow_outgoing_connections') {
+                      // Use isConfigValFalsy to cast undefined to true
+                      value = !isConfigValFalsy(value)
+                    } else if (name === 'dbms.security.auth_enabled') {
+                      let authEnabled = true
+                      if (
+                        typeof value !== 'undefined' &&
+                        isConfigValFalsy(value)
+                      ) {
+                        authEnabled = false
+                      }
+                      store.dispatch(setAuthEnabled(authEnabled))
+                    }
+                    all[name] = value
+                    return all
+                  }, {})
+                  store.dispatch(updateSettings(settings))
+                  return Rx.Observable.of(null)
+                }),
+              // Cluster role
+              Rx.Observable.fromPromise(
+                bolt.directTransaction(
+                  getDbClusterRole(store.getState()),
+                  {},
+                  {
+                    useCypherThread: shouldUseCypherThread(store.getState()),
+                    ...getBackgroundTxMetadata({
+                      hasServerSupport: canSendTxMetadata(store.getState())
+                    })
+                  }
+                )
+              )
+                .catch(e => {
+                  return Rx.Observable.of(null)
+                })
+                .do(res => {
+                  if (!res) return Rx.Observable.of(null)
+                  const role = res.records[0].get(0)
+                  store.dispatch(update({ role }))
+                  return Rx.Observable.of(null)
+                }),
+              // Database list
+              Rx.Observable.fromPromise(
+                new Promise(async (resolve, reject) => {
+                  const supportsMultiDb = await bolt.hasMultiDbSupport()
+                  if (!supportsMultiDb) {
+                    return resolve(null)
+                  }
+                  bolt
+                    .directTransaction(
+                      'SHOW DATABASES',
+                      {},
+                      {
+                        useCypherThread: shouldUseCypherThread(
+                          store.getState()
+                        ),
+                        ...getBackgroundTxMetadata({
+                          hasServerSupport: canSendTxMetadata(store.getState())
+                        }),
+                        useDb: SYSTEM_DB // System db
+                      }
+                    )
+                    .then(resolve)
+                    .catch(reject)
+                })
+              )
+                .catch(e => {
+                  return Rx.Observable.of(null)
+                })
+                .do(res => {
+                  if (!res) return Rx.Observable.of(null)
+                  const databases = res.records.map(record => ({
+                    ...reduce(
+                      record.keys,
+                      (agg, key) => assign(agg, { [key]: record.get(key) }),
+                      {}
+                    ),
+                    status: record.get('currentStatus')
+                  }))
+
+                  store.dispatch(update({ databases }))
+
+                  // Currently not using a db
+                  if (!getUseDb(store.getState())) {
+                    const defaultDb = databases.filter(db => db.default)
+                    if (defaultDb.length) {
+                      store.dispatch(useDb(defaultDb[0].name))
+                    }
+                  }
+                  return Rx.Observable.of(null)
+                })
+            ])
           )
           .takeUntil(
             some$


### PR DESCRIPTION
Display an error banner when current database is not online
![error banner](https://user-images.githubusercontent.com/939458/76328833-160d5d80-62ec-11ea-8631-f7660977794c.gif)
I reused an existing error banner in the main component that was unused.

Also, if user tries to `:use` an unavailable database, display an error fram in same way as when trying to use a non-existing database
![error frame](https://user-images.githubusercontent.com/939458/76329102-6a184200-62ec-11ea-8e62-cafc421ca828.gif)

If the current database is not responding, queries time out after 30 seconds. This makes the dbMetaEpic slow as it has four queries running in sequence. I remove the chained mergeMaps and wrapped the queries in a forkJoin instead to run the queries in parallel.