### PR TITLE
Autorun deeplinked play commands

### DIFF
--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -43,6 +43,7 @@ import {
   getActiveConnectionData,
   isConnected,
   getConnectionData,
+  INITIAL_SWITCH_CONNECTION_FAILED,
   SWITCH_CONNECTION_FAILED,
   SWITCH_CONNECTION,
   SILENT_DISCONNECT,
@@ -140,7 +141,7 @@ export function App(props) {
         onMount={(...args) => {
           buildConnectionCreds(...args, { defaultConnectionData })
             .then(creds => props.bus.send(INJECTED_DISCOVERY, creds))
-            .catch(() => props.bus.send(SWITCH_CONNECTION_FAILED))
+            .catch(() => props.bus.send(INITIAL_SWITCH_CONNECTION_FAILED))
           getDesktopTheme(...args)
             .then(theme => setEnvironmentTheme(theme))
             .catch(setEnvironmentTheme(null))

--- a/src/browser/modules/Stream/Auth/ConnectionForm.jsx
+++ b/src/browser/modules/Stream/Auth/ConnectionForm.jsx
@@ -29,7 +29,10 @@ import {
   CONNECT,
   VERIFY_CREDENTIALS
 } from 'shared/modules/connections/connectionsDuck'
-import { getInitCmd } from 'shared/modules/settings/settingsDuck'
+import {
+  getInitCmd,
+  getPlayImplicitInitCommands
+} from 'shared/modules/settings/settingsDuck'
 import { executeSystemCommand } from 'shared/modules/commands/commandsDuck'
 import { shouldRetainConnectionCredentials } from 'shared/modules/dbMeta/dbMetaDuck'
 import { FORCE_CHANGE_PASSWORD } from 'shared/modules/cypher/cypherDuck'
@@ -196,7 +199,9 @@ export class ConnectionForm extends Component {
     this.state.successCallback()
     this.saveCredentials()
     this.props.setActiveConnection(this.state.id)
-    this.props.executeInitCmd()
+    if (this.props.playImplicitInitCommands) {
+      this.props.executeInitCmd()
+    }
   }
 
   saveCredentials() {
@@ -277,6 +282,7 @@ const mapStateToProps = state => {
     initCmd: getInitCmd(state),
     activeConnection: getActiveConnection(state),
     activeConnectionData: getActiveConnectionData(state),
+    playImplicitInitCommands: getPlayImplicitInitCommands(state),
     storeCredentials: shouldRetainConnectionCredentials(state)
   }
 }
@@ -293,6 +299,7 @@ const mapDispatchToProps = dispatch => {
 
 const mergeProps = (stateProps, dispatchProps, ownProps) => {
   return {
+    playImplicitInitCommands: stateProps.playImplicitInitCommands,
     activeConnection: stateProps.activeConnection,
     activeConnectionData: stateProps.activeConnectionData,
     storeCredentials: stateProps.storeCredentials,

--- a/src/shared/modules/commands/commandsDuck.js
+++ b/src/shared/modules/commands/commandsDuck.js
@@ -38,6 +38,7 @@ import { addHistory } from '../history/historyDuck'
 import {
   getCmdChar,
   getMaxHistory,
+  getPlayImplicitInitCommands,
   shouldEnableMultiStatementMode
 } from '../settings/settingsDuck'
 import { fetchRemoteGuide } from './helpers/play'
@@ -257,7 +258,10 @@ export const postConnectCmdEpic = (some$, store) =>
           const cmds = extractPostConnectCommandsFromServerConfig(
             serverSettings['browser.post_connect_cmd']
           )
-          if (cmds !== undefined) {
+          const playImplicitInitCommands = getPlayImplicitInitCommands(
+            store.getState()
+          )
+          if (playImplicitInitCommands && cmds !== undefined) {
             cmds.forEach(cmd => {
               store.dispatch(executeSystemCommand(`${cmdchar}${cmd}`))
             })

--- a/src/shared/modules/commands/postConnectCmdEpic.test.js
+++ b/src/shared/modules/commands/postConnectCmdEpic.test.js
@@ -40,7 +40,8 @@ describe('postConnectCmdEpic', () => {
     const command = 'play hello'
     const store = mockStoreLocal({
       settings: {
-        cmdchar: ':'
+        cmdchar: ':',
+        playImplicitInitCommands: true
       },
       meta: {
         settings: {
@@ -80,7 +81,8 @@ describe('postConnectCmdEpic', () => {
     ])
     const store = mockStoreLocal({
       settings: {
-        cmdchar: ':'
+        cmdchar: ':',
+        playImplicitInitCommands: true
       },
       meta: {
         settings: {

--- a/src/shared/modules/editor/editorDuck.js
+++ b/src/shared/modules/editor/editorDuck.js
@@ -20,8 +20,12 @@
 
 import Rx from 'rxjs/Rx'
 import { getUrlParamValue } from 'services/utils'
-import { getSettings } from 'shared/modules/settings/settingsDuck'
+import {
+  getSettings,
+  DISABLE_IMPLICIT_INIT_COMMANDS
+} from 'shared/modules/settings/settingsDuck'
 import { APP_START, URL_ARGUMENTS_CHANGE } from 'shared/modules/app/appDuck'
+import { executeCommand } from 'shared/modules/commands/commandsDuck'
 
 const NAME = 'editor'
 export const SET_CONTENT = NAME + '/SET_CONTENT'
@@ -82,6 +86,15 @@ export const populateEditorFromUrlEpic = (some$, store) => {
           decodeURIComponent(action.url.replace(/\+/g, ' '))
         ) || []
       const fullCommand = validCommandTypes[commandType](cmdchar, cmdArgs)
+
+      // Play command is considered safe and can run automatically
+      // When running the explicit command, also set flag to skip any implicit init commands
+      if (commandType === 'play') {
+        return [
+          executeCommand(fullCommand),
+          { type: DISABLE_IMPLICIT_INIT_COMMANDS }
+        ]
+      }
 
       return Rx.Observable.of({ type: SET_CONTENT, ...setContent(fullCommand) })
     })

--- a/src/shared/modules/editor/editorDuck.test.js
+++ b/src/shared/modules/editor/editorDuck.test.js
@@ -27,6 +27,7 @@ import {
   NOT_SUPPORTED_URL_PARAM_COMMAND
 } from './editorDuck'
 import { APP_START, URL_ARGUMENTS_CHANGE } from '../app/appDuck'
+import { COMMAND_QUEUED, executeCommand } from '../commands/commandsDuck'
 
 describe('editorDuck Epics', () => {
   let store
@@ -47,9 +48,29 @@ describe('editorDuck Epics', () => {
     bus.reset()
     store.clearActions()
   })
-  test('Sends a SET_CONTENT event on initial url arguments', done => {
+  test('Sends a COMMAND_QUEUED event if cmd is "play"', done => {
     const cmd = 'play'
     const arg = 'test-guide'
+    const action = {
+      type: APP_START,
+      url: `http://url.com?cmd=${cmd}&arg=${arg}`
+    }
+
+    bus.take(COMMAND_QUEUED, () => {
+      // Then
+      expect(store.getActions()).toEqual([
+        action,
+        executeCommand(`:${cmd} ${arg}`)
+      ])
+      done()
+    })
+
+    // When
+    store.dispatch(action)
+  })
+  test('Sends a SET_CONTENT event on initial url arguments', done => {
+    const cmd = 'edit'
+    const arg = 'RETURN 1'
     const action = {
       type: APP_START,
       url: `http://url.com?cmd=${cmd}&arg=${arg}`
@@ -59,7 +80,7 @@ describe('editorDuck Epics', () => {
       // Then
       expect(store.getActions()).toEqual([
         action,
-        { type: SET_CONTENT, message: `:${cmd} ${arg}` }
+        { type: SET_CONTENT, message: arg }
       ])
       done()
     })
@@ -68,8 +89,8 @@ describe('editorDuck Epics', () => {
     store.dispatch(action)
   })
   test('Sends a SET_CONTENT event on url arguments change', done => {
-    const cmd = 'play'
-    const arg = 'test-guide'
+    const cmd = 'edit'
+    const arg = 'RETURN 1'
     const action = {
       type: URL_ARGUMENTS_CHANGE,
       url: `?cmd=${cmd}&arg=${arg}`
@@ -79,7 +100,7 @@ describe('editorDuck Epics', () => {
       // Then
       expect(store.getActions()).toEqual([
         action,
-        { type: SET_CONTENT, message: `:${cmd} ${arg}` }
+        { type: SET_CONTENT, message: arg }
       ])
       done()
     })

--- a/src/shared/modules/settings/__snapshots__/settingsDuck.test.js.snap
+++ b/src/shared/modules/settings/__snapshots__/settingsDuck.test.js.snap
@@ -17,6 +17,7 @@ Object {
   "maxNeighbours": 100,
   "maxRows": 1000,
   "new": "conf",
+  "playImplicitInitCommands": true,
   "scrollToTop": true,
   "shouldReportUdc": true,
   "showSampleScripts": true,

--- a/src/shared/modules/settings/settingsDuck.js
+++ b/src/shared/modules/settings/settingsDuck.js
@@ -23,6 +23,8 @@ import { APP_START, USER_CLEAR } from 'shared/modules/app/appDuck'
 export const NAME = 'settings'
 export const UPDATE = 'settings/UPDATE'
 export const REPLACE = 'settings/REPLACE'
+export const DISABLE_IMPLICIT_INIT_COMMANDS =
+  'settings/DISABLE_IMPLICIT_INIT_COMMANDS'
 
 export const AUTO_THEME = 'auto'
 export const LIGHT_THEME = 'normal'
@@ -35,6 +37,8 @@ export const getSettings = state => state[NAME]
 export const getMaxHistory = state =>
   state[NAME].maxHistory || initialState.maxHistory
 export const getInitCmd = state => (state[NAME].initCmd || '').trim()
+export const getPlayImplicitInitCommands = state =>
+  state[NAME].playImplicitInitCommands
 export const getTheme = state => state[NAME].theme || initialState.theme
 export const getUseBoltRouting = state =>
   state[NAME].useBoltRouting || initialState.useBoltRouting
@@ -79,6 +83,7 @@ const initialState = {
   maxHistory: 30,
   theme: AUTO_THEME,
   initCmd: ':play start',
+  playImplicitInitCommands: true,
   initialNodeDisplay: 300,
   maxNeighbours: 100,
   showSampleScripts: true,
@@ -108,6 +113,8 @@ export default function settings(state = initialState, action) {
       return Object.assign({}, { ...initialState }, action.state)
     case USER_CLEAR:
       return initialState
+    case DISABLE_IMPLICIT_INIT_COMMANDS:
+      return { ...state, playImplicitInitCommands: false }
     default:
       return state
   }

--- a/src/shared/modules/settings/settingsDuck.test.js
+++ b/src/shared/modules/settings/settingsDuck.test.js
@@ -19,6 +19,7 @@
  */
 
 import reducer, {
+  DISABLE_IMPLICIT_INIT_COMMANDS,
   NAME,
   UPDATE,
   REPLACE,
@@ -70,6 +71,18 @@ describe('settings reducer', () => {
     expect(nextState.greeting).toBeUndefined()
     expect(nextState.type).toBeUndefined()
     expect(nextState).toMatchSnapshot()
+  })
+
+  it('defaults playImplicitInitCommands to true', () => {
+    expect(reducer(undefined, { type: 'dummy action' })).toEqual(
+      expect.objectContaining({ playImplicitInitCommands: true })
+    )
+  })
+
+  it('sets playImplicitInitCommands to false on DISABLE_IMPLICIT_INIT_COMMANDS', () => {
+    expect(
+      reducer(undefined, { type: DISABLE_IMPLICIT_INIT_COMMANDS })
+    ).toEqual(expect.objectContaining({ playImplicitInitCommands: false }))
   })
 })
 

--- a/src/shared/services/localstorage.js
+++ b/src/shared/services/localstorage.js
@@ -50,7 +50,12 @@ export function getAll() {
   keys.forEach(key => {
     const current = getItem(key)
     if (current !== undefined) {
-      out[key] = current
+      if (key === 'settings') {
+        const { playImplicitInitCommands, ...otherSettings } = current
+        out[key] = { ...otherSettings, playImplicitInitCommands: true }
+      } else {
+        out[key] = current
+      }
     }
   })
   return out

--- a/src/shared/services/localstorage.test.js
+++ b/src/shared/services/localstorage.test.js
@@ -80,4 +80,17 @@ describe('localstorage', () => {
     // Then
     expect(response).toEqual(vals)
   })
+
+  it('returns "settings" with the playImplicitInitCommands flag set true', () => {
+    ls.applyKeys('settings')
+    ls.setStorage({
+      getItem: () => JSON.stringify({})
+    })
+
+    expect(ls.getAll()).toEqual(
+      expect.objectContaining({
+        settings: { playImplicitInitCommands: true }
+      })
+    )
+  })
 })


### PR DESCRIPTION
Autorun play commands in url parameters. The play url command is considered an explicit init command and will disable all the implicit init commands that are normally run (server status/connect frame, settings sample script and post connect command).
![disconnected](https://user-images.githubusercontent.com/939458/77524463-acfb1d80-6e87-11ea-864e-1fc70e695a99.gif)
![connected](https://user-images.githubusercontent.com/939458/77524495-b7b5b280-6e87-11ea-86d3-de36f60b3989.gif)

changelog: Auto-run `:play` commands when sent with URL params (deep-link)