### PR TITLE
Reuse `:help` and `:play` frames by building frame stacks from internal link clicks

### DIFF
--- a/e2e_tests/integration/help-command.spec.js
+++ b/e2e_tests/integration/help-command.spec.js
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { isEnterpriseEdition } from '../support/utils'
+
+/* global Cypress, cy, test, expect, before */
+
+const getNextInStackBtn = () => cy.get('[data-testid="next-in-stack-button"]')
+const getPrevInStackBtn = () => cy.get('[data-testid="prev-in-stack-button"]')
+
+describe('Help command', () => {
+  before(function() {
+    cy.visit(Cypress.config('url'))
+      .title()
+      .should('include', 'Neo4j Browser')
+    cy.wait(3000)
+  })
+  it('can `:help` command', () => {
+    cy.executeCommand(':clear')
+    const query = ':help'
+    cy.executeCommand(query)
+
+    let frame = cy.getFrames()
+
+    // Make sure first loads
+    frame
+      .should('have.length', 1)
+      .should('contain', 'Neo4j Browser is a command shell')
+
+    // Click a help topic
+    frame.contains('help commands').click()
+
+    frame = cy.getFrames()
+
+    // Make sure it loads in same frame
+    frame
+      .should('have.length', 1)
+      .should('contain', 'In addition to composing and running Cypher queries')
+
+    // Click back in stack
+    getPrevInStackBtn().click()
+    frame = cy.getFrames()
+
+    // Make sure we're back
+    frame
+      .should('have.length', 1)
+      .should('contain', 'Neo4j Browser is a command shell')
+
+    // Click forward
+    getNextInStackBtn().click()
+    frame = cy.getFrames()
+    frame
+      .should('have.length', 1)
+      .should('contain', 'In addition to composing and running Cypher queries')
+
+    // Click new topic
+    frame.contains('help auto').click()
+    frame = cy.getFrames()
+
+    frame
+      .should('have.length', 1)
+      .should(
+        'contain',
+        'Execute a Cypher query within an auto-committing transaction'
+      )
+
+    // Then click back twice
+    getPrevInStackBtn().click()
+    getPrevInStackBtn().click()
+    frame = cy.getFrames()
+
+    // And we should be back
+    frame
+      .should('have.length', 1)
+      .should('contain', 'Neo4j Browser is a command shell')
+
+    // Click something else
+    frame.contains('play concepts').click()
+
+    // We should now have two frames
+    cy.getFrames().should('have.length', 2)
+  })
+})

--- a/e2e_tests/integration/play-command.spec.js
+++ b/e2e_tests/integration/play-command.spec.js
@@ -20,7 +20,9 @@
 
 /* global Cypress, cy, test, expect, before */
 
-describe('Help command', () => {
+const nextSlideBtn = () => cy.get('[data-testid="nextSlide"]')
+
+describe('Play command', () => {
   before(function() {
     cy.visit(Cypress.config('url'))
       .title()
@@ -29,67 +31,68 @@ describe('Help command', () => {
   })
   it('can `:help` command', () => {
     cy.executeCommand(':clear')
-    const query = ':help'
+    const query = ':play start'
     cy.executeCommand(query)
 
     let frame = cy.getFrames()
 
     // Make sure first loads
-    frame
-      .should('have.length', 1)
-      .should('contain', 'Neo4j Browser is a command shell')
+    frame.should('have.length', 1).should('contain', 'Learn about Neo4j')
 
-    // Click a help topic
-    frame.contains('help commands').click()
+    // Click a guide button
+    frame.contains('Start Learning').click()
 
     frame = cy.getFrames()
 
     // Make sure it loads in same frame
-    frame
-      .should('have.length', 1)
-      .should('contain', 'In addition to composing and running Cypher queries')
+    frame.should('have.length', 1).should('contain', 'Graph Fundamentals')
 
     // Click back in stack
     cy.getPrevInFrameStackBtn().click()
     frame = cy.getFrames()
 
     // Make sure we're back
-    frame
-      .should('have.length', 1)
-      .should('contain', 'Neo4j Browser is a command shell')
+    frame.should('have.length', 1).should('contain', 'Learn about Neo4j')
 
-    // Click forward
+    // Go to next again
+    cy.getNextInFrameStackBtn().click()
+
+    // Click forward 7 times (to last slide)
+    nextSlideBtn().click()
+    nextSlideBtn().click()
+    nextSlideBtn().click()
+    nextSlideBtn().click()
+    nextSlideBtn().click()
+    nextSlideBtn().click()
+
+    frame = cy.getFrames()
+
+    frame.should('have.length', 1).should('contain', 'Keep getting started')
+
+    // Click new guide
+    frame.contains('The Movie Graph').click()
+    frame = cy.getFrames()
+
+    frame.should('have.length', 1).should('contain', 'Pop-cultural connections')
+
+    // Then click back in stack once
+    cy.getPrevInFrameStackBtn().click()
+    // Click to last slide again
+    nextSlideBtn().click()
+    nextSlideBtn().click()
+    nextSlideBtn().click()
+    nextSlideBtn().click()
+    nextSlideBtn().click()
+    nextSlideBtn().click()
+
+    frame = cy.getFrames()
+    frame.should('have.length', 1).should('contain', 'Keep getting started')
+
+    // Click next in stack
     cy.getNextInFrameStackBtn().click()
     frame = cy.getFrames()
-    frame
-      .should('have.length', 1)
-      .should('contain', 'In addition to composing and running Cypher queries')
 
-    // Click new topic
-    frame.contains('help auto').click()
-    frame = cy.getFrames()
-
-    frame
-      .should('have.length', 1)
-      .should(
-        'contain',
-        'Execute a Cypher query within an auto-committing transaction'
-      )
-
-    // Then click back twice
-    cy.getPrevInFrameStackBtn().click()
-    cy.getPrevInFrameStackBtn().click()
-    frame = cy.getFrames()
-
-    // And we should be back
-    frame
-      .should('have.length', 1)
-      .should('contain', 'Neo4j Browser is a command shell')
-
-    // Click something else
-    frame.contains('play concepts').click()
-
-    // We should now have two frames
-    cy.getFrames().should('have.length', 2)
+    // And we should be back on the movie
+    frame.should('have.length', 1).should('contain', 'Pop-cultural connections')
   })
 })

--- a/e2e_tests/integration/play-command.spec.js
+++ b/e2e_tests/integration/play-command.spec.js
@@ -29,7 +29,7 @@ describe('Play command', () => {
       .should('include', 'Neo4j Browser')
     cy.wait(3000)
   })
-  it('can `:help` command', () => {
+  it('can stack `:play` commands', () => {
     cy.executeCommand(':clear')
     const query = ':play start'
     cy.executeCommand(query)
@@ -94,5 +94,57 @@ describe('Play command', () => {
 
     // And we should be back on the movie
     frame.should('have.length', 1).should('contain', 'Pop-cultural connections')
+  })
+  it('can execute remote types of `:play`', () => {
+    cy.executeCommand(':clear')
+
+    // Existing guide
+    cy.executeCommand(':play reco')
+    cy.getFrames().should(
+      'contain',
+      'Welcome to the Neo4j recommendations training'
+    )
+
+    // Next slide
+    nextSlideBtn().click()
+
+    // Click link to new guide
+    cy.contains('Procedures').click()
+
+    // Assert
+    cy.getFrames()
+      .should('have.length', 1)
+      .should('contain', 'Procedures are a new feature in')
+
+    // Click back in stack
+    cy.getPrevInFrameStackBtn().click()
+
+    // Assert
+    cy.getFrames()
+      .should('have.length', 1)
+      .should('contain', 'Welcome to the Neo4j recommendations training')
+  })
+  it('handles not found guides', () => {
+    cy.executeCommand(':clear')
+    cy.executeCommand(':play not-found-guide-anywhere')
+
+    cy.getFrames()
+      .should('have.length', 1)
+      .should('contain', 'Not found')
+  })
+  it('populates editor on code click', () => {
+    cy.executeCommand(':clear')
+    cy.executeCommand(':play movies')
+
+    // Goto slide 2
+    nextSlideBtn().click()
+
+    // Click code
+    cy.getFrames()
+      .get('.runnable')
+      .click()
+
+    // Assert
+    cy.getEditor().should('contain', 'CREATE')
   })
 })

--- a/e2e_tests/support/commands.js
+++ b/e2e_tests/support/commands.js
@@ -2,12 +2,17 @@ const SubmitQueryButton = '[data-testid="submitQuery"]'
 const ClearEditorButton = '[data-testid="clearEditorContent"]'
 const Editor = '.ReactCodeMirror textarea'
 const VisibleEditor = '[data-testid="editor-wrapper"]'
-const Frames = '[data-testid="frame"]'
 
 /* global Cypress, cy */
 
 Cypress.Commands.add('getEditor', () => cy.get(VisibleEditor))
-Cypress.Commands.add('getFrames', () => cy.get(Frames))
+Cypress.Commands.add('getFrames', () => cy.get('[data-testid="frame"]'))
+Cypress.Commands.add('getPrevInFrameStackBtn', () =>
+  cy.get('[data-testid="prev-in-stack-button"]')
+)
+Cypress.Commands.add('getNextInFrameStackBtn', () =>
+  cy.get('[data-testid="next-in-stack-button"]')
+)
 
 Cypress.Commands.add(
   'setInitialPassword',

--- a/e2e_tests/support/commands.js
+++ b/e2e_tests/support/commands.js
@@ -2,10 +2,12 @@ const SubmitQueryButton = '[data-testid="submitQuery"]'
 const ClearEditorButton = '[data-testid="clearEditorContent"]'
 const Editor = '.ReactCodeMirror textarea'
 const VisibleEditor = '[data-testid="editor-wrapper"]'
+const Frames = '[data-testid="frame"]'
 
 /* global Cypress, cy */
 
 Cypress.Commands.add('getEditor', () => cy.get(VisibleEditor))
+Cypress.Commands.add('getFrames', () => cy.get(Frames))
 
 Cypress.Commands.add(
   'setInitialPassword',

--- a/src/browser/components/Directives.jsx
+++ b/src/browser/components/Directives.jsx
@@ -109,7 +109,8 @@ export const Directives = props => {
             addClass(e, 'clicked')
             return props.onItemClick(
               directive.valueExtractor(e),
-              directive.autoExec
+              directive.autoExec,
+              props.originFrameId
             )
           }
         })
@@ -122,10 +123,10 @@ export const Directives = props => {
 
 const mapDispatchToProps = (dispatch, ownProps) => {
   return {
-    onItemClick: (cmd, autoExec) => {
+    onItemClick: (cmd, autoExec, id) => {
       if (!cmd.endsWith(' null') && !cmd.endsWith(':null')) {
         if (autoExec) {
-          const action = executeCommand(cmd)
+          const action = executeCommand(cmd, { id })
           ownProps.bus.send(action.type, action)
         } else {
           ownProps.bus.send(editor.SET_CONTENT, editor.setContent(cmd))
@@ -135,4 +136,9 @@ const mapDispatchToProps = (dispatch, ownProps) => {
   }
 }
 
-export default withBus(connect(null, mapDispatchToProps)(Directives))
+export default withBus(
+  connect(
+    null,
+    mapDispatchToProps
+  )(Directives)
+)

--- a/src/browser/components/Directives.test.js
+++ b/src/browser/components/Directives.test.js
@@ -42,7 +42,7 @@ describe('Directives', () => {
 
     // Then
     expect(clickEvent).toHaveBeenCalled()
-    expect(clickEvent).toHaveBeenCalledWith(':play hello', true)
+    expect(clickEvent).toHaveBeenCalledWith(':play hello', true, undefined)
     expect(container).toMatchSnapshot()
   })
   test('should attach help topic directive when contents has a play-topic attribute', () => {
@@ -64,7 +64,7 @@ describe('Directives', () => {
 
     // Then
     expect(clickEvent).toHaveBeenCalled()
-    expect(clickEvent).toHaveBeenCalledWith(':help hello', true)
+    expect(clickEvent).toHaveBeenCalledWith(':help hello', true, undefined)
     expect(container).toMatchSnapshot()
   })
   test('should attach runnable directive when element has a tag of `pre.runnable`', () => {
@@ -86,7 +86,7 @@ describe('Directives', () => {
 
     // Then
     expect(clickEvent).toHaveBeenCalled()
-    expect(clickEvent).toHaveBeenCalledWith('my code', false)
+    expect(clickEvent).toHaveBeenCalledWith('my code', false, undefined)
     expect(container).toMatchSnapshot()
   })
   test('should attach runnable directive when element has a class name of `.runnable pre`', () => {
@@ -112,7 +112,7 @@ describe('Directives', () => {
 
     // Then
     expect(clickEvent).toHaveBeenCalled()
-    expect(clickEvent).toHaveBeenCalledWith('my code', false)
+    expect(clickEvent).toHaveBeenCalledWith('my code', false, undefined)
     expect(container).toMatchSnapshot()
   })
   test('should attach all directives when contents has both attributes in different elements', () => {
@@ -146,8 +146,8 @@ describe('Directives', () => {
 
     // Then
     expect(clickEvent).toHaveBeenCalledTimes(2)
-    expect(clickEvent).toHaveBeenCalledWith(':help help', true)
-    expect(clickEvent).toHaveBeenCalledWith(':play play', true)
+    expect(clickEvent).toHaveBeenCalledWith(':help help', true, undefined)
+    expect(clickEvent).toHaveBeenCalledWith(':play play', true, undefined)
     expect(container).toMatchSnapshot()
   })
   test('should not attach any directives when contents does not have any directive attributes', () => {

--- a/src/browser/components/Directives.test.js
+++ b/src/browser/components/Directives.test.js
@@ -117,6 +117,7 @@ describe('Directives', () => {
   })
   test('should attach all directives when contents has both attributes in different elements', () => {
     // Given
+    const FRAME_ID = 'FRAME_ID'
     const clickEvent = jest.fn()
     const html = (
       <div>
@@ -127,7 +128,11 @@ describe('Directives', () => {
 
     // When
     const { container, getByText } = render(
-      <DirectivesComponent content={html} onItemClick={clickEvent} />
+      <DirectivesComponent
+        originFrameId={FRAME_ID}
+        content={html}
+        onItemClick={clickEvent}
+      />
     )
     fireEvent(
       getByText('help'),
@@ -146,8 +151,8 @@ describe('Directives', () => {
 
     // Then
     expect(clickEvent).toHaveBeenCalledTimes(2)
-    expect(clickEvent).toHaveBeenCalledWith(':help help', true, undefined)
-    expect(clickEvent).toHaveBeenCalledWith(':play play', true, undefined)
+    expect(clickEvent).toHaveBeenCalledWith(':help help', true, FRAME_ID)
+    expect(clickEvent).toHaveBeenCalledWith(':play play', true, FRAME_ID)
     expect(container).toMatchSnapshot()
   })
   test('should not attach any directives when contents does not have any directive attributes', () => {

--- a/src/browser/components/buttons/index.jsx
+++ b/src/browser/components/buttons/index.jsx
@@ -342,6 +342,7 @@ export const ActionButton = props => {
 }
 
 const BaseCarouselButton = styled.button`
+  color: ${props => props.theme.secondaryButtonText};
   background-color: transparent;
   display: flex;
   justify-content: center;

--- a/src/browser/components/icons/Icons.jsx
+++ b/src/browser/components/icons/Icons.jsx
@@ -39,6 +39,7 @@ import Text201 from 'icons/Text2-01.svg'
 import appWindowCode from 'icons/app-window-code.svg'
 import arrowLeft1 from 'icons/arrow-left-1.svg'
 import arrowRight1 from 'icons/arrow-right-1.svg'
+import skipPrev from 'icons/skip-prev.svg'
 
 const inactive = `
   color: #797979;
@@ -187,6 +188,16 @@ export const SlidePreviousIcon = () => (
 )
 export const SlideNextIcon = () => (
   <IconContainer icon={arrowRight1} width={20} />
+)
+export const StackPreviousIcon = () => (
+  <IconContainer icon={skipPrev} width={12} />
+)
+export const StackNextIcon = () => (
+  <IconContainer
+    icon={skipPrev}
+    style={{ transform: 'rotate(180deg)' }}
+    width={12}
+  />
 )
 export const TableIcon = () => (
   <IconContainer icon={table01} text="Table" width={20} />

--- a/src/browser/documentation/guides/concepts.jsx
+++ b/src/browser/documentation/guides/concepts.jsx
@@ -206,8 +206,4 @@ const slides = [
   </Slide>
 ]
 
-const content = (
-  <Carousel className="deck container-fluid" slides={slides} withDirectives />
-)
-
-export default { title, category, content }
+export default { title, category, slides }

--- a/src/browser/documentation/guides/cypher.jsx
+++ b/src/browser/documentation/guides/cypher.jsx
@@ -290,8 +290,4 @@ RETURN DISTINCT surfer`}
   </Slide>
 ]
 
-const content = (
-  <Carousel className="deck container-fluid" slides={slides} withDirectives />
-)
-
-export default { title, category, content }
+export default { title, category, slides }

--- a/src/browser/documentation/guides/intro.jsx
+++ b/src/browser/documentation/guides/intro.jsx
@@ -172,13 +172,4 @@ const slides = [
   </Slide>
 ]
 
-const content = (
-  <Carousel
-    className="deck container-fluid"
-    slides={slides}
-    showIntro
-    withDirectives
-  />
-)
-
-export default { title, content }
+export default { title, slides, showIntro: true }

--- a/src/browser/documentation/guides/learn.jsx
+++ b/src/browser/documentation/guides/learn.jsx
@@ -207,8 +207,4 @@ const slides = [
   </Slide>
 ]
 
-const content = (
-  <Carousel className="deck container-fluid" slides={slides} withDirectives />
-)
-
-export default { title, category, content }
+export default { title, category, slides }

--- a/src/browser/documentation/guides/movie-graph.jsx
+++ b/src/browser/documentation/guides/movie-graph.jsx
@@ -839,8 +839,4 @@ RETURN tom, m, coActors, m2, cruise`}
   </Slide>
 ]
 
-const content = (
-  <Carousel className="deck container-fluid" slides={slides} withDirectives />
-)
-
-export default { title, category, content }
+export default { title, category, slides }

--- a/src/browser/documentation/guides/northwind-graph.jsx
+++ b/src/browser/documentation/guides/northwind-graph.jsx
@@ -358,8 +358,4 @@ RETURN DISTINCT cust.contactName as CustomerName, SUM(o.quantity) AS TotalProduc
   </Slide>
 ]
 
-const content = (
-  <Carousel className="deck container-fluid" slides={slides} withDirectives />
-)
-
-export default { title, category, content }
+export default { title, category, slides }

--- a/src/browser/icons/skip-prev.svg
+++ b/src/browser/icons/skip-prev.svg
@@ -1,6 +1,6 @@
 <svg width="13px" height="13px" viewBox="0 0 13 13" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <g id="Artboard" stroke="currentColor" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-        <polyline id="Path-2-Copy-2" transform="translate(8.728909, 6.752389) rotate(-180.000000) translate(-8.728909, -6.752389) " points="6.1051035 1.50477886 11.3527141 6.75238943 6.1051035 12"></polyline>
+    <g stroke="currentColor" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <polyline transform="translate(8.728909, 6.752389) rotate(-180.000000) translate(-8.728909, -6.752389) " points="6.1051035 1.50477886 11.3527141 6.75238943 6.1051035 12"></polyline>
         <line x1="2.5" y1="1.5" x2="2.5" y2="11.5" id="Line-Copy"></line>
     </g>
 </svg>

--- a/src/browser/icons/skip-prev.svg
+++ b/src/browser/icons/skip-prev.svg
@@ -1,0 +1,6 @@
+<svg width="13px" height="13px" viewBox="0 0 13 13" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <g id="Artboard" stroke="currentColor" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
+        <polyline id="Path-2-Copy-2" transform="translate(8.728909, 6.752389) rotate(-180.000000) translate(-8.728909, -6.752389) " points="6.1051035 1.50477886 11.3527141 6.75238943 6.1051035 12"></polyline>
+        <line x1="2.5" y1="1.5" x2="2.5" y2="11.5" id="Line-Copy"></line>
+    </g>
+</svg>

--- a/src/browser/modules/Carousel/Carousel.jsx
+++ b/src/browser/modules/Carousel/Carousel.jsx
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { Component } from 'react'
+import React from 'react'
 import Directives from 'browser-components/Directives'
 import { CarouselButton } from 'browser-components/buttons'
 import {

--- a/src/browser/modules/Carousel/Carousel.jsx
+++ b/src/browser/modules/Carousel/Carousel.jsx
@@ -35,120 +35,139 @@ import {
   StyledCarouselIntroAnimated,
   StyledCarouselIntro
 } from './styled'
+import { useState } from 'react'
+import { useRef } from 'react'
+import { useEffect } from 'react'
 
-export default class Carousel extends Component {
-  state = {
-    visibleSlide: 0,
-    wasClicked: false
-  }
+export default function Carousel({
+  onSlide,
+  showIntro,
+  withDirectives,
+  originFrameId,
+  initialSlide = 1,
+  slides = []
+}) {
+  const [visibleSlide, setVisibleSlide] = useState(() => {
+    if (initialSlide <= slides.length) {
+      return initialSlide - 1
+    }
+    return 0
+  })
+  const [wasClicked, setWasClicked] = useState(false)
+  const myRef = useRef()
 
-  constructor(props) {
-    super(props)
-    this.slides = this.props.slides || []
-    this.myRef = React.createRef()
+  useEffect(() => {
+    setVisibleSlide(0)
+  }, [slides])
 
-    if (props.initialSlide && props.initialSlide <= this.slides.length) {
-      this.state.visibleSlide = props.initialSlide - 1
+  useEffect(() => {
+    if (onSlide) {
+      onSlide({
+        slideIndex: visibleSlide,
+        hasNext: visibleSlide < slides.length - 1,
+        hasPrev: visibleSlide > 0
+      })
+    }
+  }, [visibleSlide])
+
+  const onKeyDown = ev => {
+    if (ev.keyCode === 37 && visibleSlide !== 0) {
+      prev()
+    }
+    if (ev.keyCode === 39 && visibleSlide !== slides.length - 1) {
+      next()
     }
   }
 
-  onKeyDown(ev) {
-    if (ev.keyCode === 37 && this.state.visibleSlide !== 0) {
-      this.prev()
-    }
-    if (
-      ev.keyCode === 39 &&
-      this.state.visibleSlide !== this.slides.length - 1
-    ) {
-      this.next()
-    }
+  const next = () => {
+    const slide = visibleSlide + 1
+    setVisibleSlide(slide)
+    setWasClicked(true)
+    myRef.current.scrollTo(0, 0)
   }
 
-  next() {
-    this.setState({ visibleSlide: this.state.visibleSlide + 1 })
-    this.setState({ wasClicked: true })
-    this.myRef.current.scrollTo(0, 0)
+  const prev = () => {
+    const slide = visibleSlide - 1
+    setVisibleSlide(slide)
+    myRef.current.scrollTo(0, 0)
   }
 
-  prev() {
-    this.setState({ visibleSlide: this.state.visibleSlide - 1 })
-    this.myRef.current.scrollTo(0, 0)
+  const getSlide = slideNumber => {
+    return slides[slideNumber]
   }
 
-  getSlide(slideNumber) {
-    return this.slides[slideNumber]
+  const goToSlide = slideNumber => {
+    setVisibleSlide(slideNumber)
   }
 
-  goToSlide(slideNumber) {
-    this.setState({ visibleSlide: slideNumber })
-  }
-
-  render() {
-    const { showIntro, withDirectives } = this.props
-    return (
-      <StyledCarousel
-        data-testid="carousel"
-        onKeyDown={e => this.onKeyDown(e)}
-        tabIndex="0"
-      >
+  return (
+    <StyledCarousel
+      data-testid="carousel"
+      onKeyUp={e => onKeyDown(e)}
+      tabIndex="0"
+    >
+      {visibleSlide > 0 && (
         <CarouselButton
           className="previous-slide  rounded"
           data-testid="previousSlide"
-          disabled={this.state.visibleSlide === 0}
-          onClick={this.prev.bind(this)}
+          onClick={prev}
         >
           <SlidePreviousIcon />
         </CarouselButton>
-        <StyledCarouselButtonContainer>
-          {showIntro && !this.state.wasClicked && (
-            <StyledCarouselIntroAnimated className="carousel-intro-animation">
-              <StyledCarouselIntro>
-                <span>Use the navigation to get started</span>
-                <span>{'->'}</span>
-              </StyledCarouselIntro>
-            </StyledCarouselIntroAnimated>
-          )}
-          <StyledCarouselButtonContainerInner>
-            <StyledCarouselCount>
-              {`${this.state.visibleSlide + 1} / ${this.slides.length}`}
-            </StyledCarouselCount>
-            <CarouselButton
-              className="previous-slide"
-              disabled={this.state.visibleSlide === 0}
-              onClick={this.prev.bind(this)}
-            >
-              <SlidePreviousIcon />
-            </CarouselButton>
-            <CarouselSlidePicker
-              slides={this.slides}
-              visibleSlide={this.state.visibleSlide}
-              onClickEvent={slideNumber => this.goToSlide(slideNumber)}
-            />
-            <CarouselButton
-              className="next-slide"
-              disabled={this.state.visibleSlide === this.slides.length - 1}
-              onClick={this.next.bind(this)}
-            >
-              <SlideNextIcon />
-            </CarouselButton>
-          </StyledCarouselButtonContainerInner>
-        </StyledCarouselButtonContainer>
-        <SlideContainer ref={this.myRef}>
-          {withDirectives ? (
-            <Directives content={this.getSlide(this.state.visibleSlide)} />
-          ) : (
-            this.getSlide(this.state.visibleSlide)
-          )}
-        </SlideContainer>
+      )}
+      <StyledCarouselButtonContainer>
+        {showIntro && !wasClicked && (
+          <StyledCarouselIntroAnimated className="carousel-intro-animation">
+            <StyledCarouselIntro>
+              <span>Use the navigation to get started</span>
+              <span>{'->'}</span>
+            </StyledCarouselIntro>
+          </StyledCarouselIntroAnimated>
+        )}
+        <StyledCarouselButtonContainerInner>
+          <StyledCarouselCount>
+            {`${visibleSlide + 1} / ${slides.length}`}
+          </StyledCarouselCount>
+          <CarouselButton
+            className="previous-slide"
+            disabled={visibleSlide === 0}
+            onClick={prev}
+          >
+            <SlidePreviousIcon />
+          </CarouselButton>
+          <CarouselSlidePicker
+            slides={slides}
+            visibleSlide={visibleSlide}
+            onClickEvent={slideNumber => goToSlide(slideNumber)}
+          />
+          <CarouselButton
+            className="next-slide"
+            disabled={visibleSlide === slides.length - 1}
+            onClick={next}
+          >
+            <SlideNextIcon />
+          </CarouselButton>
+        </StyledCarouselButtonContainerInner>
+      </StyledCarouselButtonContainer>
+      <SlideContainer ref={myRef}>
+        {withDirectives ? (
+          <Directives
+            originFrameId={originFrameId}
+            content={getSlide(visibleSlide)}
+          />
+        ) : (
+          getSlide(visibleSlide)
+        )}
+      </SlideContainer>
+      {visibleSlide < slides.length - 1 && (
         <CarouselButton
           className="next-slide rounded"
           data-testid="nextSlide"
-          disabled={this.state.visibleSlide === this.slides.length - 1}
-          onClick={this.next.bind(this)}
+          onClick={next}
         >
           <SlideNextIcon />
         </CarouselButton>
-      </StyledCarousel>
-    )
-  }
+      )}
+    </StyledCarousel>
+  )
 }

--- a/src/browser/modules/Docs/Docs.jsx
+++ b/src/browser/modules/Docs/Docs.jsx
@@ -18,71 +18,67 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { Component } from 'react'
+import React, { useState, useEffect } from 'react'
 import uuid from 'uuid'
 import Directives from 'browser-components/Directives'
 import Carousel from '../Carousel/Carousel'
 import Slide from '../Carousel/Slide'
 
-export default class Docs extends Component {
-  constructor(props) {
-    super(props)
-    this.ref = React.createRef()
-    this.state = { slides: null, firstRender: true }
-  }
+export default function Docs({
+  slides,
+  content,
+  html,
+  withDirectives,
+  initialSlide,
+  onSlide,
+  originFrameId
+}) {
+  const [stateSlides, setStateSlides] = useState([])
 
-  componentDidMount() {
-    if (!this.ref) return
-    if (!this.ref.current) return
-    const slides = this.ref.current.getElementsByTagName('slide')
-    let reactSlides = this
-    if (slides.length > 0) {
-      reactSlides = Array.from(slides).map(slide => {
-        return {
-          html: slide
-        }
-      })
+  useEffect(() => {
+    if (slides && slides.length) {
+      setStateSlides(slides)
+      return
     }
-    this.setState({ slides: reactSlides, firstRender: false })
-  }
-
-  render() {
-    const {
-      content,
-      html,
-      withDirectives,
-      initialSlide,
-      hasCarouselComponent
-    } = this.props
-
-    if (hasCarouselComponent) {
-      return content
-    }
-
-    if (this.state.slides && Array.isArray(this.state.slides)) {
-      const ListOfSlides = this.state.slides.map(slide => {
-        return <Slide key={uuid.v4()} html={slide.html.innerHTML} />
-      })
-      return (
-        <Carousel
-          slides={ListOfSlides}
-          initialSlide={initialSlide}
-          withDirectives={withDirectives}
-        />
-      )
-    }
-
-    let slide = <Slide ref={this.ref} html="" />
+    let slide = <Slide html="" />
     if (content) {
-      slide = <Slide ref={this.ref} content={content} />
+      slide = <Slide content={content} />
     } else if (html) {
-      slide = <Slide ref={this.ref} html={html} />
+      const tmpDiv = document.createElement('div')
+      tmpDiv.innerHTML = html
+      const htmlSlides = tmpDiv.getElementsByTagName('slide')
+      if (htmlSlides && htmlSlides.length) {
+        const reactSlides = Array.from(htmlSlides).map(slide => {
+          return <Slide key={uuid.v4()} html={slide.innerHTML} />
+        })
+        setStateSlides(reactSlides)
+        return
+      }
+      slide = <Slide html={html} />
     }
 
     if (withDirectives) {
-      return <Directives content={slide} />
-    } else {
-      return slide
+      slide = <Directives originFrameId={originFrameId} content={slide} />
     }
+    setStateSlides([slide])
+
+    if (onSlide) {
+      onSlide({ hasPrev: false, hasNext: false, slideIndex: 0 })
+    }
+  }, [slides, content, html, withDirectives])
+
+  if (stateSlides.length > 1) {
+    return (
+      <Carousel
+        onSlide={onSlide}
+        slides={stateSlides}
+        initialSlide={initialSlide}
+        withDirectives={withDirectives}
+        originFrameId={originFrameId}
+      />
+    )
+  } else if (stateSlides.length) {
+    return stateSlides[0]
   }
+  return null
 }

--- a/src/browser/modules/Frame/styled.jsx
+++ b/src/browser/modules/Frame/styled.jsx
@@ -65,7 +65,8 @@ export const StyledFrameBody = styled.div`
   width: 100%;
   padding: 30px;
 
-  .has-carousel & {
+  .has-carousel,
+  .has-stack & {
     position: relative;
     padding-bottom: 40px;
     padding-left: 40px;

--- a/src/browser/modules/Frame/styled.jsx
+++ b/src/browser/modules/Frame/styled.jsx
@@ -65,7 +65,7 @@ export const StyledFrameBody = styled.div`
   width: 100%;
   padding: 30px;
 
-  .has-carousel,
+  .has-carousel &,
   .has-stack & {
     position: relative;
     padding-bottom: 40px;

--- a/src/browser/modules/Stream/CypherScriptFrame/CypherScriptFrame.jsx
+++ b/src/browser/modules/Stream/CypherScriptFrame/CypherScriptFrame.jsx
@@ -31,6 +31,7 @@ import Accordion from 'browser-components/Accordion/Accordion'
 import { getCmdChar } from 'shared/modules/settings/settingsDuck'
 import { Summary, CypherSummary } from './Summary'
 import { Icon } from './Icon'
+import { getLatestFromFrameStack } from '../stream.utils'
 
 const isCypher = (str, cmdchar) => !str.startsWith(cmdchar)
 
@@ -106,7 +107,7 @@ class CypherScriptFrame extends Component {
 const mapStateToProps = (state, ownProps) => {
   if (!ownProps.frame.statements) return {}
   const frames = ownProps.frame.statements
-    .map(id => getFrame(state, id))
+    .map(id => getLatestFromFrameStack(getFrame(state, id)))
     .reduce((all, curr) => {
       all[curr.id] = curr
       return all

--- a/src/browser/modules/Stream/HelpFrame.jsx
+++ b/src/browser/modules/Stream/HelpFrame.jsx
@@ -45,7 +45,7 @@ const HelpFrame = ({ frame, stack = [] }) => {
   const prevBtn =
     currentFrameIndex === stack.length - 1 ? null : (
       <CarouselButton
-        className="previous-slide  rounded"
+        className="previous-slide rounded"
         data-testid="prev-in-stack-button"
         onClick={() => setCurrentFrameIndex(currentFrameIndex + 1)}
       >

--- a/src/browser/modules/Stream/HelpFrame.jsx
+++ b/src/browser/modules/Stream/HelpFrame.jsx
@@ -60,7 +60,7 @@ const HelpFrame = ({ frame }) => {
       className="helpFrame help"
       header={frame}
       aside={aside}
-      contents={<Directives content={ret} />}
+      contents={<Directives originFrameId={frame.id} content={ret} />}
     />
   )
 }

--- a/src/browser/modules/Stream/HelpFrame.jsx
+++ b/src/browser/modules/Stream/HelpFrame.jsx
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import Docs from '../Docs/Docs'
 import docs from '../../documentation'
 import Directives from 'browser-components/Directives'
@@ -25,39 +25,62 @@ import FrameTemplate from '../Frame/FrameTemplate'
 import FrameAside from '../Frame/FrameAside'
 import { transformCommandToHelpTopic } from 'services/commandUtils'
 import { DynamicTopics } from '../../documentation/templates/DynamicTopics'
-import Carousel from '../Carousel/Carousel'
-import Slide from '../Carousel/Slide'
+import { CarouselButton } from 'browser-components/buttons/index'
+import {
+  SlideNextIcon,
+  SlidePreviousIcon
+} from 'browser-components/icons/Icons'
 
 const HelpFrame = ({ frame, stack = [] }) => {
-  const { aside, main } = generateContent(frame)
+  const [currentFrameIndex, setCurrentFrameIndex] = useState(0)
+  const currentFrame = stack[currentFrameIndex]
 
-  console.log('stack: ', stack)
+  // When we get a new frame, go to it
+  useEffect(() => {
+    setCurrentFrameIndex(0)
+  }, [stack.length])
+
+  const { aside, main } = generateContent(currentFrame)
+
+  const prevBtn = (
+    <CarouselButton
+      className="previous-slide  rounded"
+      data-testid="previousSlide"
+      disabled={currentFrameIndex === stack.length - 1}
+      onClick={() => setCurrentFrameIndex(currentFrameIndex + 1)}
+    >
+      <SlidePreviousIcon />
+    </CarouselButton>
+  )
+
+  const nextBtn = (
+    <CarouselButton
+      className="next-slide rounded"
+      data-testid="nextSlide"
+      disabled={currentFrameIndex === 0}
+      onClick={() => setCurrentFrameIndex(currentFrameIndex - 1)}
+    >
+      <SlideNextIcon />
+    </CarouselButton>
+  )
+
   const contents =
     stack.length > 1 ? (
-      <Carousel
-        className="deck container-fluid"
-        slides={stack.map(generateDirective).reverse()}
-        initialSlide={stack.length}
-      />
+      <React.Fragment>
+        {prevBtn}
+        <Directives originFrameId={frame.id} content={main} />
+        {nextBtn}
+      </React.Fragment>
     ) : (
       <Directives originFrameId={frame.id} content={main} />
     )
   return (
     <FrameTemplate
-      className="helpFrame has-carousel"
-      header={frame}
+      className="helpFrame has-stack"
+      header={currentFrame}
       aside={aside}
       contents={contents}
     />
-  )
-}
-
-function generateDirective(frame, i) {
-  const { aside, main } = generateContent(frame)
-  return (
-    <Slide key={`${frame.id}-${i}`}>
-      <Directives originFrameId={frame.id} content={main} />
-    </Slide>
   )
 }
 

--- a/src/browser/modules/Stream/HelpFrame.jsx
+++ b/src/browser/modules/Stream/HelpFrame.jsx
@@ -68,11 +68,11 @@ const HelpFrame = ({ frame, stack = [] }) => {
     stack.length > 1 ? (
       <React.Fragment>
         {prevBtn}
-        <Directives originFrameId={frame.id} content={main} />
+        {main}
         {nextBtn}
       </React.Fragment>
     ) : (
-      <Directives originFrameId={frame.id} content={main} />
+      main
     )
   return (
     <FrameTemplate
@@ -96,7 +96,7 @@ function generateContent(frame) {
   let aside
 
   if (frame.result) {
-    main = <Docs html={frame.result} />
+    main = <Docs withDirectives originFrameId={frame.id} html={frame.result} />
   } else {
     const helpTopic = transformCommandToHelpTopic(frame.cmd)
     if (helpTopic !== '') {
@@ -111,7 +111,7 @@ function generateContent(frame) {
       }
 
       aside = title ? <FrameAside title={title} subtitle={subtitle} /> : null
-      main = <Docs content={content} />
+      main = <Docs withDirectives originFrameId={frame.id} content={content} />
     }
   }
   return { aside, main }

--- a/src/browser/modules/Stream/HelpFrame.jsx
+++ b/src/browser/modules/Stream/HelpFrame.jsx
@@ -27,8 +27,8 @@ import { transformCommandToHelpTopic } from 'services/commandUtils'
 import { DynamicTopics } from '../../documentation/templates/DynamicTopics'
 import { CarouselButton } from 'browser-components/buttons/index'
 import {
-  SlideNextIcon,
-  SlidePreviousIcon
+  StackNextIcon,
+  StackPreviousIcon
 } from 'browser-components/icons/Icons'
 
 const HelpFrame = ({ frame, stack = [] }) => {
@@ -42,27 +42,27 @@ const HelpFrame = ({ frame, stack = [] }) => {
 
   const { aside, main } = generateContent(currentFrame)
 
-  const prevBtn = (
-    <CarouselButton
-      className="previous-slide  rounded"
-      data-testid="previousSlide"
-      disabled={currentFrameIndex === stack.length - 1}
-      onClick={() => setCurrentFrameIndex(currentFrameIndex + 1)}
-    >
-      <SlidePreviousIcon />
-    </CarouselButton>
-  )
+  const prevBtn =
+    currentFrameIndex === stack.length - 1 ? null : (
+      <CarouselButton
+        className="previous-slide  rounded"
+        data-testid="previousSlide"
+        onClick={() => setCurrentFrameIndex(currentFrameIndex + 1)}
+      >
+        <StackPreviousIcon />
+      </CarouselButton>
+    )
 
-  const nextBtn = (
-    <CarouselButton
-      className="next-slide rounded"
-      data-testid="nextSlide"
-      disabled={currentFrameIndex === 0}
-      onClick={() => setCurrentFrameIndex(currentFrameIndex - 1)}
-    >
-      <SlideNextIcon />
-    </CarouselButton>
-  )
+  const nextBtn =
+    currentFrameIndex === 0 ? null : (
+      <CarouselButton
+        className="next-slide rounded"
+        data-testid="nextSlide"
+        onClick={() => setCurrentFrameIndex(currentFrameIndex - 1)}
+      >
+        <StackNextIcon />
+      </CarouselButton>
+    )
 
   const contents =
     stack.length > 1 ? (

--- a/src/browser/modules/Stream/HelpFrame.jsx
+++ b/src/browser/modules/Stream/HelpFrame.jsx
@@ -46,7 +46,7 @@ const HelpFrame = ({ frame, stack = [] }) => {
     currentFrameIndex === stack.length - 1 ? null : (
       <CarouselButton
         className="previous-slide  rounded"
-        data-testid="previousSlide"
+        data-testid="prev-in-stack-button"
         onClick={() => setCurrentFrameIndex(currentFrameIndex + 1)}
       >
         <StackPreviousIcon />
@@ -57,7 +57,7 @@ const HelpFrame = ({ frame, stack = [] }) => {
     currentFrameIndex === 0 ? null : (
       <CarouselButton
         className="next-slide rounded"
-        data-testid="nextSlide"
+        data-testid="next-in-stack-button"
         onClick={() => setCurrentFrameIndex(currentFrameIndex - 1)}
       >
         <StackNextIcon />

--- a/src/browser/modules/Stream/HelpFrame.jsx
+++ b/src/browser/modules/Stream/HelpFrame.jsx
@@ -25,8 +25,43 @@ import FrameTemplate from '../Frame/FrameTemplate'
 import FrameAside from '../Frame/FrameAside'
 import { transformCommandToHelpTopic } from 'services/commandUtils'
 import { DynamicTopics } from '../../documentation/templates/DynamicTopics'
+import Carousel from '../Carousel/Carousel'
+import Slide from '../Carousel/Slide'
 
-const HelpFrame = ({ frame }) => {
+const HelpFrame = ({ frame, stack = [] }) => {
+  const { aside, main } = generateContent(frame)
+
+  console.log('stack: ', stack)
+  const contents =
+    stack.length > 1 ? (
+      <Carousel
+        className="deck container-fluid"
+        slides={stack.map(generateDirective).reverse()}
+        initialSlide={stack.length}
+      />
+    ) : (
+      <Directives originFrameId={frame.id} content={main} />
+    )
+  return (
+    <FrameTemplate
+      className="helpFrame has-carousel"
+      header={frame}
+      aside={aside}
+      contents={contents}
+    />
+  )
+}
+
+function generateDirective(frame, i) {
+  const { aside, main } = generateContent(frame)
+  return (
+    <Slide key={`${frame.id}-${i}`}>
+      <Directives originFrameId={frame.id} content={main} />
+    </Slide>
+  )
+}
+
+function generateContent(frame) {
   const { help, cypher, bolt } = docs
   const chapters = {
     ...help.chapters,
@@ -34,10 +69,11 @@ const HelpFrame = ({ frame }) => {
     ...bolt.chapters
   }
 
-  let ret = 'Help topic not specified'
+  let main = 'Help topic not specified'
   let aside
+
   if (frame.result) {
-    ret = <Docs html={frame.result} />
+    main = <Docs html={frame.result} />
   } else {
     const helpTopic = transformCommandToHelpTopic(frame.cmd)
     if (helpTopic !== '') {
@@ -52,16 +88,10 @@ const HelpFrame = ({ frame }) => {
       }
 
       aside = title ? <FrameAside title={title} subtitle={subtitle} /> : null
-      ret = <Docs content={content} />
+      main = <Docs content={content} />
     }
   }
-  return (
-    <FrameTemplate
-      className="helpFrame help"
-      header={frame}
-      aside={aside}
-      contents={<Directives originFrameId={frame.id} content={ret} />}
-    />
-  )
+  return { aside, main }
 }
+
 export default HelpFrame

--- a/src/browser/modules/Stream/PlayFrame.jsx
+++ b/src/browser/modules/Stream/PlayFrame.jsx
@@ -91,7 +91,7 @@ export function PlayFrame({ stack, bus }) {
   const prevBtn =
     stackIndex === stack.length - 1 || !atSlideStart ? null : (
       <CarouselButton
-        className="previous-slide  rounded"
+        className="previous-slide rounded"
         data-testid="prev-in-stack-button"
         onClick={prevGuide}
       >
@@ -198,14 +198,14 @@ function generateContent(stackFrame, bus, onSlide) {
   const guide = chapters[guideName] || {}
   // Check if content exists locally
   if (Object.keys(guide).length) {
-    const { content, title, subtitle, slides } = guide
+    const { content, title, subtitle, slides = null } = guide
     return {
       guide: (
         <Docs
           originFrameId={stackFrame.id}
           withDirectives
-          content={!!slides ? null : content}
-          slides={!!slides ? slides : null}
+          content={slides ? null : content}
+          slides={slides ? slides : null}
           onSlide={onSlide}
         />
       ),

--- a/src/browser/modules/Stream/PlayFrame.jsx
+++ b/src/browser/modules/Stream/PlayFrame.jsx
@@ -230,7 +230,7 @@ function generateContent(stackFrame, bus, onSlide) {
       bus.self(action.type, action, res => {
         if (!res.success) {
           // No luck
-          return resolve(unfound(chapters.unfound))
+          return resolve(unfound(stackFrame, chapters.unfound, onSlide))
         }
         // Found remote guide
         return resolve({

--- a/src/browser/modules/Stream/PlayFrame.jsx
+++ b/src/browser/modules/Stream/PlayFrame.jsx
@@ -43,11 +43,6 @@ const {
   play: { chapters }
 } = docs
 
-const useForceUpdate = () => {
-  const [, updateState] = useState()
-  return useCallback(() => updateState({}), [])
-}
-
 const checkHtmlForSlides = html => {
   const el = document.createElement('html')
   el.innerHTML = html

--- a/src/browser/modules/Stream/PlayFrame.jsx
+++ b/src/browser/modules/Stream/PlayFrame.jsx
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { Component } from 'react'
+import React from 'react'
 import { withBus } from 'react-suber'
 import { fetchGuideFromWhitelistAction } from 'shared/modules/commands/commandsDuck'
 
@@ -31,10 +31,22 @@ import {
   transformCommandToHelpTopic
 } from 'services/commandUtils'
 import { ErrorsView } from './CypherFrame/ErrorsView'
+import { useState } from 'react'
+import { useEffect } from 'react'
+import { CarouselButton } from 'browser-components/buttons/index'
+import {
+  StackPreviousIcon,
+  StackNextIcon
+} from 'browser-components/icons/Icons'
 
 const {
   play: { chapters }
 } = docs
+
+const useForceUpdate = () => {
+  const [, updateState] = useState()
+  return useCallback(() => updateState({}), [])
+}
 
 const checkHtmlForSlides = html => {
   const el = document.createElement('html')
@@ -43,145 +55,218 @@ const checkHtmlForSlides = html => {
   return !!slides.length
 }
 
-export class PlayFrame extends Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      guide: null,
-      aside: null,
-      hasCarousel: false,
-      isRemote: false
+export function PlayFrame({ stack, bus }) {
+  const [stackIndex, setStackIndex] = useState(0)
+  const [atSlideStart, setAtSlideStart] = useState(null)
+  const [atSlideEnd, setAtSlideEnd] = useState(null)
+  const [guideObj, setGuideObj] = useState({})
+  const currentFrame = stack[stackIndex]
+
+  const onSlide = ({ hasPrev, hasNext }) => {
+    setAtSlideStart(!hasPrev)
+    setAtSlideEnd(!hasNext)
+  }
+
+  useEffect(() => {
+    async function generate() {
+      const { guide, aside, hasCarousel, isRemote } = await generateContent(
+        currentFrame,
+        bus,
+        onSlide
+      )
+      setGuideObj({ guide, aside, hasCarousel, isRemote })
+    }
+    generate()
+  }, [currentFrame])
+
+  const { guide, aside, hasCarousel, isRemote } = guideObj
+
+  const prevGuide = () => {
+    setStackIndex(stackIndex + 1)
+    // useForceUpdate()
+  }
+
+  const nextGuide = () => {
+    setStackIndex(stackIndex - 1)
+    // useForceUpdate()
+  }
+
+  useEffect(() => {
+    setStackIndex(0)
+  }, [stack.length])
+
+  const prevBtn =
+    stackIndex === stack.length - 1 || !atSlideStart ? null : (
+      <CarouselButton
+        className="previous-slide  rounded"
+        data-testid="previousSlide"
+        onClick={prevGuide}
+      >
+        <StackPreviousIcon />
+      </CarouselButton>
+    )
+
+  const nextBtn =
+    stackIndex === 0 || !atSlideEnd ? null : (
+      <CarouselButton
+        className="next-slide rounded"
+        data-testid="nextSlide"
+        onClick={nextGuide}
+      >
+        <StackNextIcon />
+      </CarouselButton>
+    )
+
+  const classNames = ['playFrame']
+  if (hasCarousel || stack.length > 1) {
+    classNames.push('has-carousel')
+  }
+  if (isRemote) {
+    classNames.push('is-remote')
+  }
+
+  let guideAndNav = guide
+  if (stack.length > 1) {
+    guideAndNav = (
+      <React.Fragment>
+        {prevBtn}
+        <div>{guide}</div>
+        {nextBtn}
+      </React.Fragment>
+    )
+  }
+  return (
+    <FrameTemplate
+      className={classNames.join(' ')}
+      header={stack[stackIndex]}
+      aside={aside}
+      contents={guideAndNav}
+    />
+  )
+}
+
+function generateContent(stackFrame, bus, onSlide) {
+  // Not found
+  if (stackFrame.response && stackFrame.response.status === 404) {
+    return unfound(stackFrame, chapters.unfound, onSlide)
+  }
+
+  // Found a remote guide
+  if (stackFrame.result) {
+    return {
+      guide: (
+        <Docs
+          originFrameId={stackFrame.id}
+          withDirectives
+          initialSlide={stackFrame.initialSlide || 1}
+          html={stackFrame.result}
+          onSlide={onSlide}
+        />
+      ),
+      hasCarousel: checkHtmlForSlides(stackFrame.result),
+      isRemote: true
     }
   }
 
-  componentDidMount() {
-    if (this.props.frame.result) {
-      const { initialSlide } = this.props.frame
-
-      // Found remote guide
-      this.setState({
-        guide: (
-          <Docs
-            withDirectives
-            initialSlide={initialSlide}
-            html={this.props.frame.result}
-          />
-        ),
-        hasCarousel: checkHtmlForSlides(this.props.frame.result),
-        isRemote: true
-      })
-      return
+  // Request error
+  if (stackFrame.response && stackFrame.error && stackFrame.error.error) {
+    return {
+      guide: (
+        <ErrorsView
+          result={{
+            message:
+              'Error: The remote server responded with the following error: ' +
+              stackFrame.response.status,
+            code: 'Remote guide error'
+          }}
+          onSlide={onSlide}
+        />
+      )
     }
-    if (
-      this.props.frame.response &&
-      this.props.frame.error &&
-      this.props.frame.error.error
-    ) {
-      // Not found remotely (or other error)
-      if (this.props.frame.response.status === 404) {
-        return this.unfound(chapters.unfound)
-      }
-      return this.setState({
-        guide: (
-          <ErrorsView
-            result={{
-              message:
-                'Error: The remote server responded with the following error: ' +
-                this.props.frame.response.status,
-              code: 'Remote guide error'
-            }}
-          />
-        )
-      })
-    }
-    if (this.props.frame.error && this.props.frame.error.error) {
-      // Some other error. Whitelist error etc.
-      return this.setState({
-        guide: (
-          <ErrorsView
-            result={{
-              message: this.props.frame.error.error,
-              code: 'Remote guide error'
-            }}
-          />
-        )
-      })
-    }
+  }
 
-    const guideName = transformCommandToHelpTopic(
-      this.props.frame.cmd || 'start'
-    )
-    const guide = chapters[guideName] || {}
-
-    // Check if content exists
-    if (Object.keys(guide).length) {
-      const { content, title, subtitle } = guide
-      const hasCarousel = !!content.props.slides
-      this.setState({
-        guide: (
-          <Docs
-            withDirectives
-            hasCarouselComponent={hasCarousel}
-            content={content}
-          />
-        ),
-        aside:
-          title && !hasCarousel ? (
-            <FrameAside title={title} subtitle={subtitle} />
-          ) : null,
-        hasCarousel
-      })
-      return
+  // Some other error. Whitelist error etc.
+  if (stackFrame.error && stackFrame.error.error) {
+    return {
+      guide: (
+        <ErrorsView
+          result={{
+            message: stackFrame.error.error,
+            code: 'Remote guide error'
+          }}
+          onSlide={onSlide}
+        />
+      )
     }
+  }
 
-    // Not found remotely or locally
-    // Try to find it remotely by name
-    if (this.props.bus) {
-      const topicInput = (
-        splitStringOnFirst(this.props.frame.cmd, ' ')[1] || ''
-      ).trim()
-      const action = fetchGuideFromWhitelistAction(topicInput)
-      this.props.bus.self(action.type, action, res => {
+  // Local guides
+  const guideName = transformCommandToHelpTopic(stackFrame.cmd || 'start')
+  const guide = chapters[guideName] || {}
+  // Check if content exists locally
+  if (Object.keys(guide).length) {
+    const { content, title, subtitle, slides } = guide
+    return {
+      guide: (
+        <Docs
+          originFrameId={stackFrame.id}
+          withDirectives
+          content={!!slides ? null : content}
+          slides={!!slides ? slides : null}
+          onSlide={onSlide}
+        />
+      ),
+      aside:
+        !slides && title ? (
+          <FrameAside title={title} subtitle={subtitle} />
+        ) : null,
+      hasCarousel: !!slides
+    }
+  }
+
+  // Check whitelisted remote URLs for name matches
+  if (bus) {
+    const topicInput = (splitStringOnFirst(stackFrame.cmd, ' ')[1] || '').trim()
+    const action = fetchGuideFromWhitelistAction(topicInput)
+    return new Promise(resolve => {
+      bus.self(action.type, action, res => {
         if (!res.success) {
           // No luck
-          return this.unfound(chapters.unfound)
+          return resolve(unfound(chapters.unfound))
         }
         // Found remote guide
-        this.setState({
-          guide: <Docs withDirectives html={res.result} />,
+        return resolve({
+          guide: (
+            <Docs
+              originFrameId={stackFrame.id}
+              withDirectives
+              html={res.result}
+              onSlide={onSlide}
+            />
+          ),
           hasCarousel: checkHtmlForSlides(res.result)
         })
       })
-    } else {
-      // No bus. Give up
-      return this.unfound(chapters.unfound)
-    }
-  }
-
-  unfound({ content, title, subtitle }) {
-    this.setState({
-      guide: <Docs withDirectives content={content} />,
-      aside: <FrameAside title={title} subtitle={subtitle} />
     })
+  } else {
+    // No bus. Give up
+    return unfound(stackFrame, chapters.unfound, onSlide)
   }
+}
 
-  render() {
-    const classNames = ['playFrame']
-    if (this.state.hasCarousel) {
-      classNames.push('has-carousel')
-    }
-    if (this.state.isRemote) {
-      classNames.push('is-remote')
-    }
-
-    return (
-      <FrameTemplate
-        className={classNames.join(' ')}
-        header={this.props.frame}
-        aside={this.state.aside}
-        contents={this.state.guide}
+const unfound = (frame, { content, title, subtitle }, onSlide) => {
+  return {
+    guide: (
+      <Docs
+        originFrameId={frame.id}
+        withDirectives
+        content={content}
+        onSlide={onSlide}
       />
-    )
+    ),
+    aside: <FrameAside title={title} subtitle={subtitle} />,
+    isRemote: false,
+    hasCarousel: false
   }
 }
 

--- a/src/browser/modules/Stream/PlayFrame.jsx
+++ b/src/browser/modules/Stream/PlayFrame.jsx
@@ -83,12 +83,10 @@ export function PlayFrame({ stack, bus }) {
 
   const prevGuide = () => {
     setStackIndex(stackIndex + 1)
-    // useForceUpdate()
   }
 
   const nextGuide = () => {
     setStackIndex(stackIndex - 1)
-    // useForceUpdate()
   }
 
   useEffect(() => {

--- a/src/browser/modules/Stream/PlayFrame.jsx
+++ b/src/browser/modules/Stream/PlayFrame.jsx
@@ -97,7 +97,7 @@ export function PlayFrame({ stack, bus }) {
     stackIndex === stack.length - 1 || !atSlideStart ? null : (
       <CarouselButton
         className="previous-slide  rounded"
-        data-testid="previousSlide"
+        data-testid="prev-in-stack-button"
         onClick={prevGuide}
       >
         <StackPreviousIcon />
@@ -108,7 +108,7 @@ export function PlayFrame({ stack, bus }) {
     stackIndex === 0 || !atSlideEnd ? null : (
       <CarouselButton
         className="next-slide rounded"
-        data-testid="nextSlide"
+        data-testid="next-in-stack-button"
         onClick={nextGuide}
       >
         <StackNextIcon />

--- a/src/browser/modules/Stream/Stream.jsx
+++ b/src/browser/modules/Stream/Stream.jsx
@@ -47,6 +47,7 @@ import { getFrames } from 'shared/modules/stream/streamDuck'
 import { getActiveConnectionData } from 'shared/modules/connections/connectionsDuck'
 import { getScrollToTop } from 'shared/modules/settings/settingsDuck'
 import DbsFrame from './Auth/DbsFrame'
+import { getLatestFromFrameStack } from './stream.utils'
 
 const getFrame = type => {
   const trans = {
@@ -100,9 +101,10 @@ class Stream extends PureComponent {
   render() {
     return (
       <StyledStream ref={this.base}>
-        {this.props.frames.map(frame => {
+        {this.props.frames.map(frameObject => {
+          const frame = getLatestFromFrameStack(frameObject)
           const frameProps = {
-            frame,
+            frame: { ...frame, isPinned: frameObject.isPinned },
             activeConnectionData: this.props.activeConnectionData
           }
           let MyFrame = getFrame(frame.type)

--- a/src/browser/modules/Stream/Stream.jsx
+++ b/src/browser/modules/Stream/Stream.jsx
@@ -105,7 +105,8 @@ class Stream extends PureComponent {
           const frame = getLatestFromFrameStack(frameObject)
           const frameProps = {
             frame: { ...frame, isPinned: frameObject.isPinned },
-            activeConnectionData: this.props.activeConnectionData
+            activeConnectionData: this.props.activeConnectionData,
+            stack: frameObject.stack
           }
           let MyFrame = getFrame(frame.type)
           if (frame.type === 'error') {

--- a/src/browser/modules/Stream/stream.utils.js
+++ b/src/browser/modules/Stream/stream.utils.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export function getLatestFromFrameStack(frameObj) {
+  if (!frameObj.stack) {
+    return null
+  }
+  return frameObj.stack[0]
+}

--- a/src/shared/modules/stream/__snapshots__/streamDuck.test.js.snap
+++ b/src/shared/modules/stream/__snapshots__/streamDuck.test.js.snap
@@ -9,7 +9,11 @@ Array [
 exports[`streamDuck cuts the number of frames when config is set 2`] = `
 Object {
   "1": Object {
-    "id": 1,
+    "stack": Array [
+      Object {
+        "id": 1,
+      },
+    ],
   },
 }
 `;
@@ -25,9 +29,15 @@ exports[`streamDuck dont remove pinned frames when cutting frames 2`] = `
 Object {
   "1": Object {
     "isPinned": 1,
+    "stack": Array [
+      Object {},
+    ],
   },
   "2": Object {
     "isPinned": 1,
+    "stack": Array [
+      Object {},
+    ],
   },
 }
 `;

--- a/src/shared/modules/stream/streamDuck.js
+++ b/src/shared/modules/stream/streamDuck.js
@@ -69,14 +69,19 @@ function addFrame(state, newState) {
   let allIds = [].concat(state.allIds)
 
   if (newState.parentId) {
-    const currentStatements = byId[newState.parentId].statements || []
+    const currentStatements = byId[newState.parentId].stack[0].statements || []
     // Need to add this id to parent's list of statements
     if (!currentStatements.includes(newState.id)) {
       byId = {
         ...byId,
         [newState.parentId]: {
           ...byId[newState.parentId],
-          statements: currentStatements.concat(newState.id)
+          stack: [
+            {
+              ...byId[newState.parentId].stack[0],
+              statements: currentStatements.concat(newState.id)
+            }
+          ]
         }
       }
     }

--- a/src/shared/modules/stream/streamDuck.js
+++ b/src/shared/modules/stream/streamDuck.js
@@ -62,7 +62,10 @@ function addFrame(state, newState) {
     // No parent
     return state
   }
-  let byId = Object.assign({}, state.byId, { [newState.id]: newState })
+
+  let frameObject = state.byId[newState.id] || { stack: [], isPinned: false }
+  frameObject.stack.unshift(newState)
+  let byId = Object.assign({}, state.byId, { [newState.id]: frameObject })
   let allIds = [].concat(state.allIds)
 
   if (newState.parentId) {

--- a/src/shared/modules/stream/streamDuck.test.js
+++ b/src/shared/modules/stream/streamDuck.test.js
@@ -45,7 +45,7 @@ describe('streamDuck', () => {
       ...initialState,
       maxFrames: 2,
       allIds: [1, 2],
-      byId: { 1: { id: 1 }, 2: { id: 2 } }
+      byId: { 1: { stack: [{ id: 1 }] }, 2: { stack: [{ id: 2 }] } }
     }
     const action = { type: SET_MAX_FRAMES, maxFrames: 1 }
 
@@ -59,7 +59,10 @@ describe('streamDuck', () => {
   })
   test('dont remove pinned frames when cutting frames', () => {
     // Given
-    const byId = { 1: { isPinned: 1 }, 2: { isPinned: 1 } }
+    const byId = {
+      1: { stack: [{}], isPinned: 1 },
+      2: { stack: [{}], isPinned: 1 }
+    }
     const init = { ...initialState, maxFrames: 2, allIds: [1, 2], byId }
     const action = { type: SET_MAX_FRAMES, maxFrames: 1 }
 
@@ -70,5 +73,56 @@ describe('streamDuck', () => {
     expect(newState.allIds.length).toBe(2)
     expect(newState.allIds).toMatchSnapshot()
     expect(newState.byId).toMatchSnapshot()
+  })
+  test('saves a stack of same ids', () => {
+    const ID = 'test-id'
+    const BEFORE = 'before'
+    const AFTER = 'after'
+    const byId = { [ID]: { stack: [{ type: BEFORE }] }, 2: { stack: [{}] } }
+    const init = { ...initialState, allIds: [ID, 2], byId }
+    const action = add({ id: ID, type: AFTER })
+
+    // Then
+    expect(init.byId).toMatchInlineSnapshot(`
+      Object {
+        "2": Object {
+          "stack": Array [
+            Object {},
+          ],
+        },
+        "test-id": Object {
+          "stack": Array [
+            Object {
+              "type": "before",
+            },
+          ],
+        },
+      }
+    `)
+    // When
+    const newState = reducer(init, action)
+
+    // Then
+    expect(newState.allIds.length).toBe(2)
+    expect(newState.byId).toMatchInlineSnapshot(`
+      Object {
+        "2": Object {
+          "stack": Array [
+            Object {},
+          ],
+        },
+        "test-id": Object {
+          "stack": Array [
+            Object {
+              "id": "test-id",
+              "type": "after",
+            },
+            Object {
+              "type": "before",
+            },
+          ],
+        },
+      }
+    `)
   })
 })

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -94,6 +94,7 @@ import {
   tryGetRemoteInitialSlideFromUrl
 } from './commandUtils'
 import { unescapeCypherIdentifier } from './utils'
+import { getLatestFromFrameStack } from 'browser/modules/Stream/stream.utils'
 
 const availableCommands = [
   {
@@ -536,8 +537,11 @@ const availableCommands = [
       if (action.id) {
         const originFrame = frames.getFrame(store.getState(), action.id)
         // Only replace when the origin is a help frame
-        if (originFrame && originFrame.type === HELP_FRAME_TYPE) {
-          id = action.id
+        if (originFrame) {
+          const latest = getLatestFromFrameStack(originFrame)
+          if (latest && latest.type === HELP_FRAME_TYPE) {
+            id = action.id
+          }
         } else {
           // New id === new frame
           id = v4()

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -529,10 +529,25 @@ const availableCommands = [
     name: 'help',
     match: cmd => /^(help|\?)(\s|$)/.test(cmd),
     exec: function(action, cmdchar, put, store) {
+      const HELP_FRAME_TYPE = 'help'
+      let id
+
+      // We have a frame that generated this command
+      if (action.id) {
+        const originFrame = frames.getFrame(store.getState(), action.id)
+        // Only replace when the origin is a help frame
+        if (originFrame && originFrame.type === HELP_FRAME_TYPE) {
+          id = action.id
+        } else {
+          // New id === new frame
+          id = v4()
+        }
+      }
       put(
         frames.add({
           useDb: getUseDb(store.getState()),
           ...action,
+          id,
           type: 'help'
         })
       )


### PR DESCRIPTION
The stream becomes cluttered quite quickly when clicking on help topics from within help topics.
This PR enables frame stacks, so if a user clicks a help topic from within a help topic, the same frame is reused and the user can navigate back and forth through out the stack.

The same goes for guides.

Frames are only reused within their own category, so clicking a guide topic from within a help topic will generate a new frame in the stream.

Demo guides:  
![Mar-24-2020 18-49-30](https://user-images.githubusercontent.com/570998/77459613-467eec80-6e00-11ea-8652-cef1dadd8c10.gif)

Demo help:
![Mar-24-2020 19-26-46](https://user-images.githubusercontent.com/570998/77463265-a035e580-6e05-11ea-9c4e-80868cb587b8.gif)
