### PR TITLE
Add initalSwitchConnectionFailEpic to rootEpic

### DIFF
--- a/e2e_tests/integration/desktop-env.spec.js
+++ b/e2e_tests/integration/desktop-env.spec.js
@@ -61,4 +61,26 @@ describe('Neo4j Desktop environment', () => {
       .first()
       .should('contain', 'Connection updated')
   })
+
+  it('displays disconnected banner and connection failed frame when initial state is INACTIVE', () => {
+    cy.visit(Cypress.config('url'), {
+      onBeforeLoad: win => {
+        win.neo4jDesktopApi = {
+          getContext: () =>
+            Promise.resolve(
+              getDesktopContext(Cypress.config, 'host', 'INACTIVE')
+            )
+        }
+      }
+    })
+
+    const frames = cy.get('[data-testid="frameCommand"]', { timeout: 10000 })
+    frames.should('have.length', 1)
+
+    frames.first().should('contain', ':server switch fail')
+
+    cy.get('[data-testid="disconnectedBanner"]', { timeout: 10000 })
+      .first()
+      .should('contain', 'Database access not available.')
+  })
 })

--- a/e2e_tests/support/utils.js
+++ b/e2e_tests/support/utils.js
@@ -3,12 +3,16 @@
 export const isEnterpriseEdition = () =>
   Cypress.config('serverEdition') === 'enterprise'
 
-export const getDesktopContext = (config, connectionCredsType = 'host') => ({
+export const getDesktopContext = (
+  config,
+  connectionCredsType = 'host',
+  status = 'ACTIVE'
+) => ({
   projects: [
     {
       graphs: [
         {
-          status: 'ACTIVE',
+          status,
           connection: {
             type: 'REMOTE',
             configuration: {

--- a/src/shared/rootEpic.js
+++ b/src/shared/rootEpic.js
@@ -39,6 +39,7 @@ import {
   switchConnectionEpic,
   switchConnectionSuccessEpic,
   switchConnectionFailEpic,
+  initialSwitchConnectionFailEpic,
   silentDisconnectEpic,
   useDbEpic
 } from './modules/connections/connectionsDuck'
@@ -95,6 +96,7 @@ export default combineEpics(
   switchConnectionEpic,
   switchConnectionSuccessEpic,
   switchConnectionFailEpic,
+  initialSwitchConnectionFailEpic,
   retainCredentialsSettingsEpic,
   connectEpic,
   disconnectEpic,


### PR DESCRIPTION
In the [autorun play commands PR](https://github.com/neo4j/neo4j-browser/pull/1072) I added the initialSwitchConnectionFailEpic epic, but forgot to combine it in the root epic so it was never active. This created the bug that the server switch fail frame was not displayed when starting browser from neo4j desktop without a started database. This PR adds the epic to rootEpic to fix this bug and adds an E2E test to verify that the server switch fail frame is displayed as intended.