### PR TITLE
Fix row key issue on :sysinfo table when connected to a cluster

### DIFF
--- a/src/browser/components/Tables.jsx
+++ b/src/browser/components/Tables.jsx
@@ -93,11 +93,11 @@ export const SysInfoTableEntry = ({
   if (values) {
     return (
       <StyledTr key="values-row">
-        {values.map(value => {
+        {values.map((value, rowIndex) => {
           const mappedValue = getValue(value, mapper)
           const val = mappedValue || missingValuePlaceholder
           return mappedValue || !optional ? (
-            <StyledTd key={toKeyString(val)}>{val}</StyledTd>
+            <StyledTd key={toKeyString(`${val}${rowIndex}`)}>{val}</StyledTd>
           ) : null
         })}
       </StyledTr>


### PR DESCRIPTION
See console, throws error before this fix.