### PR TITLE
Use new plan field ‘Details’ to plan visualization

### DIFF
--- a/src/browser/modules/D3Visualization/lib/visualization/components/queryPlan.js
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/queryPlan.js
@@ -162,7 +162,7 @@ function queryPlan(element) {
       (expression =
         (left =
           (left1 =
-            operator.Details !== null
+            operator.Details != null
               ? operator.Details
               : operator.Expressions != null
               ? operator.Expressions

--- a/src/browser/modules/D3Visualization/lib/visualization/components/queryPlan.js
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/queryPlan.js
@@ -162,7 +162,9 @@ function queryPlan(element) {
       (expression =
         (left =
           (left1 =
-            operator.Expressions != null
+            operator.Details !== null
+              ? operator.Details
+              : operator.Expressions != null
               ? operator.Expressions
               : operator.Expression != null
               ? operator.Expression


### PR DESCRIPTION
If `operator.Details` exists in plan object, use that (exists in 4.1).
This fixes the E2E test in 4.1.

Before  
<img width="1021" alt="Screenshot 2020-05-04 08 58 48" src="https://user-images.githubusercontent.com/570998/80942794-fd01c400-8de5-11ea-9296-37695d2f9b8a.png">

After  
<img width="1079" alt="Screenshot 2020-05-04 08 58 53" src="https://user-images.githubusercontent.com/570998/80942805-04c16880-8de6-11ea-8986-7457e018a3d8.png">
