### PR TITLE
More reliable connection status check

### DIFF
--- a/e2e_tests/integration/commands.spec.js
+++ b/e2e_tests/integration/commands.spec.js
@@ -38,6 +38,7 @@ const commands = [
   ':param x => 1',
   ':param y: 2',
   ':queries',
+  ':debug',
   ':get /',
   ':unknown',
   'RETURN 1',

--- a/e2e_tests/integration/debug-command.spec.js
+++ b/e2e_tests/integration/debug-command.spec.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/* global Cypress, cy, test, expect, before */
+
+describe(':debug command', () => {
+  before(function() {
+    cy.visit(Cypress.config('url'))
+      .title()
+      .should('include', 'Neo4j Browser')
+    cy.wait(3000)
+  })
+  it('can `:debug` command when not connected', () => {
+    cy.executeCommand(':clear')
+    const query = ':debug'
+    cy.executeCommand(query)
+
+    let frame = cy.getFrames()
+
+    frame
+      .should('have.length', 1)
+      .should('contain', 'serverConfig')
+      .should('contain', '"proceduresReadable": false')
+      .should('contain', '"serverConfigReadable": false')
+      .should('contain', '"browser.allow_outgoing_connections": false')
+  })
+  // Now connect
+  it('can connect', () => {
+    const password = Cypress.config('password')
+    cy.connect('neo4j', password)
+  })
+
+  it('can `:debug` command when connected', () => {
+    cy.executeCommand(':clear')
+    const query = ':debug'
+    cy.executeCommand(query)
+
+    let frame = cy.getFrames()
+
+    frame
+      .should('have.length', 1)
+      .should('contain', 'serverConfig')
+      .should('contain', '"proceduresReadable": true')
+      .should('contain', '"serverConfigReadable": true')
+      .should('contain', '"browser.allow_outgoing_connections": true')
+      .should('contain', '"browser.post_connect_cmd"')
+  })
+})

--- a/src/browser/modules/Stream/Auth/ConnectionForm.test.js
+++ b/src/browser/modules/Stream/Auth/ConnectionForm.test.js
@@ -50,6 +50,7 @@ test('should print correct state for retaining credentials', async () => {
       updateConnection={updateConnection}
       setActiveConnection={setActiveConnection}
       executeInitCmd={executeInitCmd}
+      isConnected={false}
     />
   )
 
@@ -78,6 +79,7 @@ test('should print correct state for retaining credentials', async () => {
       updateConnection={updateConnection}
       setActiveConnection={setActiveConnection}
       executeInitCmd={executeInitCmd}
+      isConnected={true}
     />
   )
 
@@ -100,6 +102,7 @@ test('should print correct state for retaining credentials', async () => {
       updateConnection={updateConnection}
       setActiveConnection={setActiveConnection}
       executeInitCmd={executeInitCmd}
+      isConnected={true}
     />
   )
 

--- a/src/browser/modules/Stream/Auth/ServerStatusFrame.jsx
+++ b/src/browser/modules/Stream/Auth/ServerStatusFrame.jsx
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { Component } from 'react'
+import React from 'react'
 import { connect } from 'react-redux'
 import FrameTemplate from '../../Frame/FrameTemplate'
 import {
@@ -37,68 +37,63 @@ import {
 import { shouldRetainConnectionCredentials } from 'shared/modules/dbMeta/dbMetaDuck'
 import { ClickToCode } from 'browser/modules/ClickToCode/index'
 
-class ServerStatusFrame extends Component {
-  render() {
-    const {
-      frame,
-      activeConnectionData,
-      storeCredentials,
-      isConnected
-    } = this.props
+export const ServerStatusFrame = props => {
+  const { activeConnectionData, storeCredentials, isConnected } = props
 
-    return (
-      <FrameTemplate
-        header={frame}
-        contents={
-          <>
-            <StyledConnectionAside>
-              <span>
-                <H3>Connection status</H3>
-                This is your current connection information.
-              </span>
-            </StyledConnectionAside>
-            <StyledConnectionBodyContainer>
-              <Render if={!isConnected || !activeConnectionData}>
-                <StyledConnectionBody>
-                  You are currently not connected to Neo4j.
-                  <br />
-                  Execute <ClickToCode>:server connect</ClickToCode> and enter
-                  your credentials to connect.
-                </StyledConnectionBody>
-              </Render>
-              <Render
-                if={
-                  isConnected &&
-                  activeConnectionData &&
-                  activeConnectionData.authEnabled
-                }
-              >
-                <ConnectedView
-                  username={
-                    activeConnectionData && activeConnectionData.username
-                  }
-                  showHost
-                  host={activeConnectionData && activeConnectionData.host}
-                  storeCredentials={storeCredentials}
-                />
-              </Render>
-              <Render
-                if={
-                  isConnected &&
-                  activeConnectionData &&
-                  !activeConnectionData.authEnabled
-                }
-              >
-                <StyledConnectionBody>
-                  You have a working connection and server auth is disabled.
-                </StyledConnectionBody>
-              </Render>
-            </StyledConnectionBodyContainer>
-          </>
-        }
-      />
-    )
-  }
+  return (
+    <>
+      <StyledConnectionAside>
+        <span>
+          <H3>Connection status</H3>
+          This is your current connection information.
+        </span>
+      </StyledConnectionAside>
+      <StyledConnectionBodyContainer>
+        <Render if={!isConnected || !activeConnectionData}>
+          <StyledConnectionBody>
+            You are currently not connected to Neo4j.
+            <br />
+            Execute <ClickToCode>:server connect</ClickToCode> and enter your
+            credentials to connect.
+          </StyledConnectionBody>
+        </Render>
+        <Render
+          if={
+            isConnected &&
+            activeConnectionData &&
+            activeConnectionData.authEnabled
+          }
+        >
+          <ConnectedView
+            username={activeConnectionData && activeConnectionData.username}
+            showHost
+            host={activeConnectionData && activeConnectionData.host}
+            storeCredentials={storeCredentials}
+          />
+        </Render>
+        <Render
+          if={
+            isConnected &&
+            activeConnectionData &&
+            !activeConnectionData.authEnabled
+          }
+        >
+          <StyledConnectionBody>
+            You have a working connection and server auth is disabled.
+          </StyledConnectionBody>
+        </Render>
+      </StyledConnectionBodyContainer>
+    </>
+  )
+}
+
+const Frame = props => {
+  return (
+    <FrameTemplate
+      header={props.frame}
+      contents={<ServerStatusFrame {...props} />}
+    />
+  )
 }
 
 const mapStateToProps = state => {
@@ -110,4 +105,4 @@ const mapStateToProps = state => {
   }
 }
 
-export default connect(mapStateToProps, null)(ServerStatusFrame)
+export default connect(mapStateToProps, null)(Frame)

--- a/src/browser/modules/Stream/Auth/ServerStatusFrame.jsx
+++ b/src/browser/modules/Stream/Auth/ServerStatusFrame.jsx
@@ -62,8 +62,8 @@ class ServerStatusFrame extends Component {
                 <StyledConnectionBody>
                   You are currently not connected to Neo4j.
                   <br />
-                  Execute <ClickToCode>:server connect</ClickToCode> any enter
-                  credentials to connect.
+                  Execute <ClickToCode>:server connect</ClickToCode> and enter
+                  your credentials to connect.
                 </StyledConnectionBody>
               </Render>
               <Render

--- a/src/browser/modules/Stream/Auth/ServerStatusFrame.jsx
+++ b/src/browser/modules/Stream/Auth/ServerStatusFrame.jsx
@@ -31,13 +31,20 @@ import { H3 } from 'browser-components/headers'
 import Render from 'browser-components/Render'
 import {
   getActiveConnectionData,
-  getActiveConnection
+  getActiveConnection,
+  isConnected
 } from 'shared/modules/connections/connectionsDuck'
 import { shouldRetainConnectionCredentials } from 'shared/modules/dbMeta/dbMetaDuck'
+import { ClickToCode } from 'browser/modules/ClickToCode/index'
 
 class ServerStatusFrame extends Component {
   render() {
-    const { frame, activeConnectionData, storeCredentials } = this.props
+    const {
+      frame,
+      activeConnectionData,
+      storeCredentials,
+      isConnected
+    } = this.props
 
     return (
       <FrameTemplate
@@ -51,13 +58,20 @@ class ServerStatusFrame extends Component {
               </span>
             </StyledConnectionAside>
             <StyledConnectionBodyContainer>
-              <Render if={!activeConnectionData}>
+              <Render if={!isConnected || !activeConnectionData}>
                 <StyledConnectionBody>
-                  You are not connected.
+                  You are currently not connected to Neo4j.
+                  <br />
+                  Execute <ClickToCode>:server connect</ClickToCode> any enter
+                  credentials to connect.
                 </StyledConnectionBody>
               </Render>
               <Render
-                if={activeConnectionData && activeConnectionData.authEnabled}
+                if={
+                  isConnected &&
+                  activeConnectionData &&
+                  activeConnectionData.authEnabled
+                }
               >
                 <ConnectedView
                   username={
@@ -69,7 +83,11 @@ class ServerStatusFrame extends Component {
                 />
               </Render>
               <Render
-                if={activeConnectionData && !activeConnectionData.authEnabled}
+                if={
+                  isConnected &&
+                  activeConnectionData &&
+                  !activeConnectionData.authEnabled
+                }
               >
                 <StyledConnectionBody>
                   You have a working connection and server auth is disabled.
@@ -87,7 +105,8 @@ const mapStateToProps = state => {
   return {
     activeConnection: getActiveConnection(state),
     activeConnectionData: getActiveConnectionData(state),
-    storeCredentials: shouldRetainConnectionCredentials(state)
+    storeCredentials: shouldRetainConnectionCredentials(state),
+    isConnected: isConnected(state)
   }
 }
 

--- a/src/browser/modules/Stream/Auth/ServerStatusFrame.test.js
+++ b/src/browser/modules/Stream/Auth/ServerStatusFrame.test.js
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react'
+import { render } from '@testing-library/react'
+
+import { ServerStatusFrame } from './ServerStatusFrame'
+
+test("shows friendly message on how to connect if you're not connected (empty data)", () => {
+  // Given
+  const props = {}
+
+  // When
+  const { getByText } = render(<ServerStatusFrame {...props} />)
+
+  // Then
+  expect(getByText(/You are currently not connected to Neo4j/i)).not.toBe(null)
+})
+
+test("shows friendly message on how to connect if you're not connected (populated data)", () => {
+  // Given
+  const props = {
+    activeConnectionData: {
+      host: 'test-host',
+      username: 'test-username',
+      authEnabled: true
+    }, // Data not wiped out since last connect
+    storeCredentials: true,
+    isConnected: false
+  }
+
+  // When
+  const { getByText } = render(<ServerStatusFrame {...props} />)
+
+  // Then
+  expect(getByText(/You are currently not connected to Neo4j/i)).not.toBe(null)
+})
+
+test('shows connection info when connected (retain creds)', () => {
+  // Given
+  const props = {
+    activeConnectionData: {
+      host: 'test-host',
+      username: 'test-username',
+      authEnabled: true
+    },
+    storeCredentials: true,
+    isConnected: true
+  }
+
+  // When
+  const { getByText } = render(<ServerStatusFrame {...props} />)
+
+  // Then
+  expect(getByText(/test-username/i)).not.toBe(null)
+  expect(getByText(/test-host/i)).not.toBe(null)
+  expect(
+    getByText(/Connection credentials are\s*stored in your web browser./i)
+  ).not.toBe(null)
+})
+
+test('shows connection info when connected (no retain creds)', () => {
+  // Given
+  const props = {
+    activeConnectionData: {
+      host: 'test-host',
+      username: 'test-username',
+      authEnabled: true
+    },
+    storeCredentials: false,
+    isConnected: true
+  }
+
+  // When
+  const { getByText } = render(<ServerStatusFrame {...props} />)
+
+  // Then
+  expect(getByText(/test-username/i)).not.toBe(null)
+  expect(getByText(/test-host/i)).not.toBe(null)
+  expect(
+    getByText(/Connection credentials are\s*not\s*stored in your web browser./i)
+  ).not.toBe(null)
+})

--- a/src/shared/modules/dbMeta/__snapshots__/dbMetaDuck.test.js.snap
+++ b/src/shared/modules/dbMeta/__snapshots__/dbMetaDuck.test.js.snap
@@ -20,6 +20,7 @@ Object {
   "settings": Object {
     "browser.allow_outgoing_connections": false,
     "browser.remote_content_hostname_whitelist": "guides.neo4j.com, localhost",
+    "browser.retain_connection_credentials": true,
   },
 }
 `;
@@ -43,6 +44,7 @@ Object {
   "settings": Object {
     "browser.allow_outgoing_connections": false,
     "browser.remote_content_hostname_whitelist": "guides.neo4j.com, localhost",
+    "browser.retain_connection_credentials": true,
   },
 }
 `;

--- a/src/shared/modules/dbMeta/dbMetaDuck.js
+++ b/src/shared/modules/dbMeta/dbMetaDuck.js
@@ -43,6 +43,10 @@ import {
 } from '../features/versionedFeatures'
 import { extractServerInfo } from './dbMeta.utils'
 import { assign, reduce } from 'lodash-es'
+import {
+  updateUserCapability,
+  USER_CAPABILITIES
+} from '../features/featuresDuck'
 
 export const NAME = 'meta'
 export const UPDATE = 'meta/UPDATE'
@@ -362,6 +366,12 @@ export const dbMetaEpic = (some$, store) =>
                 )
               )
                 .catch(e => {
+                  store.dispatch(
+                    updateUserCapability(
+                      USER_CAPABILITIES.serverConfigReadable,
+                      false
+                    )
+                  )
                   return Rx.Observable.of(null)
                 })
                 .do(res => {
@@ -395,6 +405,12 @@ export const dbMetaEpic = (some$, store) =>
                     all[name] = value
                     return all
                   }, {})
+                  store.dispatch(
+                    updateUserCapability(
+                      USER_CAPABILITIES.serverConfigReadable,
+                      true
+                    )
+                  )
                   store.dispatch(updateSettings(settings))
                   return Rx.Observable.of(null)
                 }),

--- a/src/shared/modules/dbMeta/dbMetaDuck.js
+++ b/src/shared/modules/dbMeta/dbMetaDuck.js
@@ -198,7 +198,8 @@ const initialState = {
   databases: [],
   settings: {
     'browser.allow_outgoing_connections': false,
-    'browser.remote_content_hostname_whitelist': 'guides.neo4j.com, localhost'
+    'browser.remote_content_hostname_whitelist': 'guides.neo4j.com, localhost',
+    'browser.retain_connection_credentials': true
   }
 }
 

--- a/src/shared/modules/features/featuresDuck.test.js
+++ b/src/shared/modules/features/featuresDuck.test.js
@@ -28,7 +28,11 @@ describe('features reducer', () => {
     const nextState = reducer(undefined, { type: '' })
     expect(dehydrate(nextState)).toEqual({
       availableProcedures: [],
-      browserSync: true
+      browserSync: true,
+      userCapabilities: {
+        proceduresReadable: false,
+        serverConfigReadable: false
+      }
     })
   })
 

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -35,6 +35,7 @@ import {
   getUseDb
 } from 'shared/modules/connections/connectionsDuck'
 import { getParams } from 'shared/modules/params/paramsDuck'
+import { getUserCapabilities } from 'shared/modules/features/featuresDuck'
 import {
   updateGraphStyleData,
   getGraphStyleData
@@ -42,7 +43,8 @@ import {
 import {
   getRemoteContentHostnameWhitelist,
   getDatabases,
-  fetchMetaData
+  fetchMetaData,
+  getAvailableSettings
 } from 'shared/modules/dbMeta/dbMetaDuck'
 import { canSendTxMetadata } from 'shared/modules/features/versionedFeatures'
 import { fetchRemoteGuide } from 'shared/modules/commands/helpers/play'
@@ -336,6 +338,24 @@ const availableCommands = [
           ...action,
           type: 'schema',
           schemaRequestId: v4()
+        })
+      )
+    }
+  },
+  {
+    name: 'client-debug',
+    match: cmd => /^debug$/.test(cmd),
+    exec: function(action, cmdchar, put, store) {
+      const out = {
+        userCapabilities: getUserCapabilities(store.getState()),
+        settings: getAvailableSettings(store.getState())
+      }
+      put(
+        frames.add({
+          useDb: getUseDb(store.getState()),
+          ...action,
+          type: 'pre',
+          contents: JSON.stringify(out, null, 2)
         })
       )
     }

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -85,7 +85,8 @@ import { fetchRemoteGrass } from 'shared/modules/commands/helpers/grass'
 import { parseGrass } from 'shared/services/grassUtils'
 import {
   shouldUseCypherThread,
-  getCmdChar
+  getCmdChar,
+  getSettings
 } from 'shared/modules/settings/settingsDuck'
 import {
   getUserDirectTxMetadata,
@@ -348,7 +349,8 @@ const availableCommands = [
     exec: function(action, cmdchar, put, store) {
       const out = {
         userCapabilities: getUserCapabilities(store.getState()),
-        settings: getAvailableSettings(store.getState())
+        serverConfig: getAvailableSettings(store.getState()),
+        browserSettings: getSettings(store.getState())
       }
       put(
         frames.add({


### PR DESCRIPTION
Main driver for this PR is the existing bug that can be reproduced like this:

1. Open Desktop (don't start a dbms)
1. Open Neo4j Browser and see the `:server switch fail` frame.
1. Type `:server connect` or `:server status` in Neo4j Browser. It say's you're connected.

The fix: Use the `isConnected` that we have in state and don't infer it from other state props.

New look of unconnected `:server status`:  
<img width="1235" alt="Screenshot 2020-05-04 15 32 54" src="https://user-images.githubusercontent.com/570998/80971115-9055ec00-8e1c-11ea-94b1-95b54ef0703e.png">


This PR also does some user capabilities checks (can user read server config + can user list server procedures).
I've also added a `:debug` command that might be helpful when coding.
This command will get more useful in the future, but this is the introduction to it. At this point only targeted at Noe4j Browser developers.

Also, target system db (if we have multi-db support) for the "read server config" and "get existing procedures".