### PR TITLE
Fix reading `username` from connectURL param

### DIFF
--- a/src/shared/modules/connections/connectionsDuck.js
+++ b/src/shared/modules/connections/connectionsDuck.js
@@ -387,12 +387,10 @@ export const startupConnectEpic = (action$, store) => {
         !(connection.host && connection.username && connection.password)
       ) {
         store.dispatch(setActiveConnection(null))
-        store.dispatch(
-          discovery.updateDiscoveryConnection({ username: '', password: '' })
-        )
+        store.dispatch(discovery.updateDiscoveryConnection({ password: '' }))
         return Promise.resolve({ type: STARTUP_CONNECTION_FAILED })
       }
-      return new Promise((resolve, reject) => {
+      return new Promise(resolve => {
         // Try to connect with stored creds
         bolt
           .openConnection(

--- a/src/shared/modules/connections/connectionsDuck.test.js
+++ b/src/shared/modules/connections/connectionsDuck.test.js
@@ -201,7 +201,7 @@ describe('connectionsDucks Epics', () => {
             action,
             connections.useDb(null),
             connections.setActiveConnection(null),
-            updateDiscoveryConnection({ username: '', password: '' }),
+            updateDiscoveryConnection({ password: '' }),
             currentAction
           ])
           expect(bolt.openConnection).toHaveBeenCalledTimes(0)

--- a/src/shared/modules/discovery/discoveryDuck.js
+++ b/src/shared/modules/discovery/discoveryDuck.js
@@ -80,8 +80,10 @@ export const getBoltHost = state => {
 
 const updateDiscoveryState = (action, store) => {
   const updateObj = { host: action.forceURL }
-  if (action.username && action.password) {
+  if (action.username) {
     updateObj.username = action.username
+  }
+  if (action.password) {
     updateObj.password = action.password
   }
   if (typeof action.encrypted !== 'undefined') {


### PR DESCRIPTION
`http://localhost:7474/?connectURL=bolt://user@host.com` should populate connection field with the username as well as the bolt url.