### PR TITLE
Add re-run button to all frame types

### DIFF
--- a/src/browser/modules/Frame/FrameTitlebar.jsx
+++ b/src/browser/modules/Frame/FrameTitlebar.jsx
@@ -248,15 +248,13 @@ class FrameTitlebar extends Component {
           >
             {expandCollapseIcon}
           </FrameButton>
-          <Render if={['cypher', 'style', 'schema'].includes(frame.type)}>
-            <FrameButton
-              data-testid="rerunFrameButton"
-              title="Rerun"
-              onClick={() => props.onReRunClick(frame)}
-            >
-              <RefreshIcon />
-            </FrameButton>
-          </Render>
+          <FrameButton
+            data-testid="rerunFrameButton"
+            title="Rerun"
+            onClick={() => props.onReRunClick(frame)}
+          >
+            <RefreshIcon />
+          </FrameButton>
           <FrameButton
             title="Close"
             onClick={() =>
@@ -297,7 +295,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
       if (requestId) {
         dispatch(cancelRequest(requestId))
       }
-      dispatch(commands.executeCommand(cmd, { id, useDb }))
+      dispatch(commands.executeCommand(cmd, { id, useDb, isRerun: true }))
     },
     togglePinning: (id, isPinned) => {
       isPinned ? dispatch(unpin(id)) : dispatch(pin(id))
@@ -306,8 +304,5 @@ const mapDispatchToProps = (dispatch, ownProps) => {
 }
 
 export default withBus(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(FrameTitlebar)
+  connect(mapStateToProps, mapDispatchToProps)(FrameTitlebar)
 )

--- a/src/browser/modules/Stream/Queries/QueriesFrame.jsx
+++ b/src/browser/modules/Stream/Queries/QueriesFrame.jsx
@@ -55,7 +55,6 @@ import {
   StatusbarWrapper
 } from '../AutoRefresh/styled'
 import { EnterpriseOnlyFrame } from 'browser-components/EditionView'
-import { RefreshIcon } from 'browser-components/icons/Icons'
 import Render from 'browser-components/Render'
 import FrameError from '../../Frame/FrameError'
 import { NEO4J_BROWSER_USER_ACTION_QUERY } from 'services/bolt/txMetadata'
@@ -89,6 +88,12 @@ export class QueriesFrame extends Component {
       } else {
         clearInterval(this.timer)
       }
+    }
+    if (
+      this.props.frame.ts !== prevProps.frame.ts &&
+      this.props.frame.isRerun
+    ) {
+      this.getRunningQueries()
     }
   }
 
@@ -323,9 +328,6 @@ export class QueriesFrame extends Component {
           <Render if={this.state.success}>
             <StyledStatusBar>
               {this.state.success}
-              <RefreshQueriesButton onClick={() => this.getRunningQueries()}>
-                <RefreshIcon />
-              </RefreshQueriesButton>
               <AutoRefreshSpan>
                 <AutoRefreshToggle
                   checked={this.state.autoRefresh}

--- a/src/browser/modules/Stream/Queries/QueriesFrame.jsx
+++ b/src/browser/modules/Stream/Queries/QueriesFrame.jsx
@@ -50,7 +50,6 @@ import {
 import {
   StyledStatusBar,
   AutoRefreshToggle,
-  RefreshQueriesButton,
   AutoRefreshSpan,
   StatusbarWrapper
 } from '../AutoRefresh/styled'

--- a/src/browser/modules/Stream/Queries/QueriesFrame.jsx
+++ b/src/browser/modules/Stream/Queries/QueriesFrame.jsx
@@ -89,6 +89,7 @@ export class QueriesFrame extends Component {
       }
     }
     if (
+      this.props.frame &&
       this.props.frame.ts !== prevProps.frame.ts &&
       this.props.frame.isRerun
     ) {

--- a/src/browser/modules/Stream/SysInfoFrame/index.jsx
+++ b/src/browser/modules/Stream/SysInfoFrame/index.jsx
@@ -31,11 +31,9 @@ import {
 import FrameTemplate from 'browser/modules/Frame/FrameTemplate'
 import FrameError from 'browser/modules/Frame/FrameError'
 import Render from 'browser-components/Render'
-import { RefreshIcon } from 'browser-components/icons/Icons'
 import {
   StyledStatusBar,
   AutoRefreshToggle,
-  RefreshQueriesButton,
   AutoRefreshSpan,
   StatusbarWrapper
 } from '../AutoRefresh/styled'

--- a/src/browser/modules/Stream/SysInfoFrame/index.jsx
+++ b/src/browser/modules/Stream/SysInfoFrame/index.jsx
@@ -82,6 +82,12 @@ export class SysInfoFrame extends Component {
         clearInterval(this.timer)
       }
     }
+    if (
+      this.props.frame.ts !== prevProps.frame.ts &&
+      this.props.frame.isRerun
+    ) {
+      this.getSysInfo()
+    }
   }
 
   getSysInfo() {
@@ -147,9 +153,6 @@ export class SysInfoFrame extends Component {
                 {this.state.lastFetch &&
                   `Updated: ${dateFormat(this.state.lastFetch)}`}
                 {this.state.success}
-                <RefreshQueriesButton onClick={() => this.getSysInfo()}>
-                  <RefreshIcon />
-                </RefreshQueriesButton>
                 <AutoRefreshSpan>
                   <AutoRefreshToggle
                     checked={this.state.autoRefresh}

--- a/src/browser/modules/Stream/SysInfoFrame/index.jsx
+++ b/src/browser/modules/Stream/SysInfoFrame/index.jsx
@@ -81,6 +81,7 @@ export class SysInfoFrame extends Component {
       }
     }
     if (
+      this.props.frame &&
       this.props.frame.ts !== prevProps.frame.ts &&
       this.props.frame.isRerun
     ) {

--- a/src/browser/modules/Stream/auto-exec-button.test.jsx
+++ b/src/browser/modules/Stream/auto-exec-button.test.jsx
@@ -64,7 +64,8 @@ describe('AutoExecButton', function() {
       id: undefined,
       parentId: undefined,
       requestId: undefined,
-      type: 'commands/COMMAND_QUEUED'
+      type: 'commands/COMMAND_QUEUED',
+      isRerun: false
     })
   })
 
@@ -84,7 +85,8 @@ describe('AutoExecButton', function() {
       id: undefined,
       parentId: undefined,
       requestId: undefined,
-      type: 'commands/COMMAND_QUEUED'
+      type: 'commands/COMMAND_QUEUED',
+      isRerun: false
     })
   })
 })

--- a/src/browser/modules/User/UserList.jsx
+++ b/src/browser/modules/User/UserList.jsx
@@ -50,10 +50,23 @@ export class UserList extends Component {
       userList: this.props.users || [],
       listRoles: this.props.roles || []
     }
+  }
 
+  componentDidMount() {
     if (this.props.isEnterpriseEdition) {
       this.getUserList()
       this.getRoles()
+    }
+  }
+  componentDidUpdate(prevProps) {
+    if (
+      this.props.frame.ts !== prevProps.frame.ts &&
+      this.props.frame.isRerun
+    ) {
+      if (this.props.isEnterpriseEdition) {
+        this.getUserList()
+        this.getRoles()
+      }
     }
   }
 
@@ -216,9 +229,4 @@ const mapStateToProps = state => {
   }
 }
 
-export default withBus(
-  connect(
-    mapStateToProps,
-    null
-  )(UserList)
-)
+export default withBus(connect(mapStateToProps, null)(UserList))

--- a/src/shared/modules/stream/streamDuck.js
+++ b/src/shared/modules/stream/streamDuck.js
@@ -64,7 +64,11 @@ function addFrame(state, newState) {
   }
 
   let frameObject = state.byId[newState.id] || { stack: [], isPinned: false }
-  frameObject.stack.unshift(newState)
+  if (!newState.isRerun) {
+    frameObject.stack.unshift(newState)
+  } else {
+    frameObject.stack = [newState]
+  }
   let byId = {
     ...state.byId,
     [newState.id]: frameObject


### PR DESCRIPTION
Some frames that only updated on cdm needed to be adapted.

A few frames (`:sysinfo` and `:queries`) already had a re-run button in the lower status bar. These were removed to be consistent.

<img width="1078" alt="Screenshot 2020-05-25 09 28 43" src="https://user-images.githubusercontent.com/570998/82789274-4f288900-9e6a-11ea-93da-60c4f6629c83.png">
