### PR TITLE
Fix only executing relevant background queries (auth, cluster)

### DIFF
--- a/src/shared/modules/connections/connectionsDuck.js
+++ b/src/shared/modules/connections/connectionsDuck.js
@@ -118,6 +118,12 @@ export function getActiveConnectionData(state) {
   return getConnectionData(state, state[NAME].activeConnection)
 }
 
+export function getAuthEnabled(state) {
+  if (!state[NAME].activeConnection) return null
+  const data = getConnectionData(state, state[NAME].activeConnection)
+  return data.authEnabled
+}
+
 export function getConnectionData(state, id) {
   if (typeof state[NAME].connectionsById[id] === 'undefined') return null
   const data = state[NAME].connectionsById[id]

--- a/src/shared/modules/currentUser/currentUserDuck.js
+++ b/src/shared/modules/currentUser/currentUserDuck.js
@@ -23,7 +23,8 @@ import { shouldUseCypherThread } from 'shared/modules/settings/settingsDuck'
 import { APP_START } from 'shared/modules/app/appDuck'
 import {
   CONNECTION_SUCCESS,
-  DISCONNECTION_SUCCESS
+  DISCONNECTION_SUCCESS,
+  getAuthEnabled
 } from 'shared/modules/connections/connectionsDuck'
 import { getBackgroundTxMetadata } from 'shared/services/bolt/txMetadata'
 import {
@@ -90,7 +91,11 @@ export const getCurrentUserEpic = (some$, store) =>
     .ofType(CONNECTION_SUCCESS)
     .merge(some$.ofType(DB_META_DONE))
     .mergeMap(() => {
-      return new Promise(async (resolve, reject) => {
+      return new Promise(async resolve => {
+        const authEnabled = getAuthEnabled(store.getState())
+        if (!authEnabled) {
+          return resolve(null)
+        }
         const supportsMultiDb = await bolt.hasMultiDbSupport()
         bolt
           .directTransaction(


### PR DESCRIPTION
Skip requesting for current user when auth is disabled.
Skip checking cluster role when not in a cluster.

Gotta keep them logs clean!