### PR TITLE
Fix :schema E2E tests for 4.1

### DIFF
--- a/e2e_tests/integration/schema-frame.spec.js
+++ b/e2e_tests/integration/schema-frame.spec.js
@@ -95,19 +95,9 @@ describe('Schema Frame', () => {
       cy.executeCommand(':clear')
       cy.executeCommand(':schema')
 
-      if (Cypress.config('serverVersion') <= 4.0) {
-        cy.get('[data-testid="frameContents"]')
-          .should('contain', 'Constraints')
-          .and('contain', 'schematest.prop1')
-          .and('contain', 'IS UNIQUE')
-      }
-
-      if (Cypress.config('serverVersion') >= 4.1) {
-        cy.get('[data-testid="frameContents"]')
-          .should('contain', 'Constraints')
-          .and('contain', 'SchemaTest {prop1}')
-          .and('contain', "type='UNIQUENESS'")
-      }
+      cy.get('[data-testid="frameContents"]')
+        .should('contain', 'Constraints')
+        .and('contain', ':SchemaTest')
     })
   })
 })


### PR DESCRIPTION
Make assertion more loose as well, for the future.
The new assertion matches only the Constraints parts of the output, and it also matches both output versions (details and description)