### PR TITLE
Add memory allocation to plan output if provided by Neo4j

### DIFF
--- a/e2e_tests/integration/plan.spec.js
+++ b/e2e_tests/integration/plan.spec.js
@@ -69,6 +69,18 @@ describe('Plan output', () => {
       el.should('contain', 'Ordered by n.age ASC')
     })
   }
+  if (Cypress.config('serverVersion') >= 4.1) {
+    it('print total memory in PROFILE', () => {
+      cy.executeCommand(':clear')
+      cy.executeCommand('CREATE INDEX ON :Person(age)')
+      cy.executeCommand(
+        'PROFILE MATCH (n:Person) WHERE n.age > 18 RETURN n.name ORDER BY n.age'
+      )
+      cy.get('[data-testid="planExpandButton"]', { timeout: 10000 }).click()
+      const el = cy.get('[data-testid="planSvg"]', { timeout: 10000 })
+      el.should('contain', 'total memory')
+    })
+  }
   if (
     Cypress.config('serverVersion') >= 3.4 &&
     Cypress.config('serverVersion') < 4.0 &&

--- a/e2e_tests/integration/plan.spec.js
+++ b/e2e_tests/integration/plan.spec.js
@@ -29,13 +29,11 @@ describe('Plan output', () => {
       .should('include', 'Neo4j Browser')
     cy.wait(3000)
     cy.disableEditorAutocomplete()
+    const password = Cypress.config('password')
+    cy.connect('neo4j', password)
   })
   after(function() {
     cy.enableEditorAutocomplete()
-  })
-  it('can connect', () => {
-    const password = Cypress.config('password')
-    cy.connect('neo4j', password)
   })
   it('displays the expanded details by default and displays/hides details when clicking the plan expand/collapse buttons respectively', () => {
     cy.executeCommand(':clear')
@@ -77,8 +75,8 @@ describe('Plan output', () => {
         'PROFILE MATCH (n:Person) WHERE n.age > 18 RETURN n.name ORDER BY n.age'
       )
       cy.get('[data-testid="planExpandButton"]', { timeout: 10000 }).click()
-      const el = cy.get('[data-testid="planSvg"]', { timeout: 10000 })
-      el.should('contain', 'total memory')
+      cy.get('.global-memory').should('contain', 'total memory (bytes)')
+      cy.get('.operator-memory').should('contain', 'memory (bytes)')
     })
   }
   if (

--- a/src/browser/modules/D3Visualization/lib/visualization/components/queryPlan.js
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/queryPlan.js
@@ -25,7 +25,7 @@ function queryPlan(element) {
   const maxComparableRows = 1000000 // link widths are comparable between plans if all operators are below this row count
   const maxComparableDbHits = 1000000 // db hits are comparable between plans if all operators are below this db hit count
 
-  const operatorWidth = 180
+  const operatorWidth = 220
   const operatorCornerRadius = 4
   const operatorHeaderHeight = 18
   const operatorHeaderFontSize = 11
@@ -183,6 +183,13 @@ function queryPlan(element) {
     if (operator.Order) {
       wordWrap(`Ordered by ${operator.Order}`, 'order')
       details.push({ className: 'padding' })
+    }
+    if (operator.GlobalMemory) {
+      details.push({
+        className: 'global-memory',
+        key: 'total memory (bytes)',
+        value: formatNumber(operator.GlobalMemory)
+      })
     }
 
     if (operator.PageCacheHits || operator.PageCacheMisses) {

--- a/src/browser/modules/D3Visualization/lib/visualization/components/queryPlan.js
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/queryPlan.js
@@ -191,6 +191,13 @@ function queryPlan(element) {
         value: formatNumber(operator.GlobalMemory)
       })
     }
+    if (operator.Memory) {
+      details.push({
+        className: 'operator-memory',
+        key: 'memory (bytes)',
+        value: formatNumber(operator.Memory)
+      })
+    }
 
     if (operator.PageCacheHits || operator.PageCacheMisses) {
       details.push({


### PR DESCRIPTION
Add output for `GlobalMemory` and `Memory` where it exists.
`GlobalMemory` should normally only be available on the last `Produce Result` and `Memory` can be on some of the other operators.
The query `PROFILE MATCH(n) RETURN 1` should have operators that displays both variants.

See screenshot below for how it's rendered.
I also widened the operator boxes a little bit to make it fit and in general make the plan less tall.
And added E2E tests to make sure they don't disappear.

<img width="337" alt="Screenshot 2020-06-01 11 09 15" src="https://user-images.githubusercontent.com/570998/83394357-bd37f780-a3f8-11ea-860a-83510bc4173c.png">
