### PR TITLE
Show graph items properties in table view, not the metadata (id, labels, types etc)

### DIFF
--- a/src/browser/modules/Sidebar/Settings.jsx
+++ b/src/browser/modules/Sidebar/Settings.jsx
@@ -138,7 +138,7 @@ const visualSettings = [
       {
         showRawTableResults: {
           displayName: 'Show raw results in tables',
-          tooltip: 'If this is checked, relationships are shown raw in tables.',
+          tooltip: 'If this is checked, results are shown raw in tables.',
           type: 'checkbox'
         }
       }

--- a/src/browser/modules/Sidebar/Settings.jsx
+++ b/src/browser/modules/Sidebar/Settings.jsx
@@ -134,13 +134,6 @@ const visualSettings = [
           tooltip: 'Automatically scroll stream to top on new frames.',
           type: 'checkbox'
         }
-      },
-      {
-        showRawTableResults: {
-          displayName: 'Show raw results in tables',
-          tooltip: 'If this is checked, results are shown raw in tables.',
-          type: 'checkbox'
-        }
       }
     ]
   },

--- a/src/browser/modules/Sidebar/Settings.jsx
+++ b/src/browser/modules/Sidebar/Settings.jsx
@@ -134,6 +134,13 @@ const visualSettings = [
           tooltip: 'Automatically scroll stream to top on new frames.',
           type: 'checkbox'
         }
+      },
+      {
+        showRawTableResults: {
+          displayName: 'Show raw results in tables',
+          tooltip: 'If this is checked, relationships are shown raw in tables.',
+          type: 'checkbox'
+        }
       }
     ]
   },

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/relatable-view.test.js.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/relatable-view.test.js.snap
@@ -17,7 +17,7 @@ exports[`RelatableViews RelatableView displays bodyMessage if no rows 1`] = `
 exports[`RelatableViews RelatableView does not display bodyMessage if rows, and escapes HTML 1`] = `
 <div>
   <div
-    class="relatable-viewstyled__RelatableStyleWrapper-sc-4f9z7m-0 fgUNnb"
+    class="relatable-viewstyled__RelatableStyleWrapper-sc-4f9z7m-0 bbriTa"
   >
     <div
       class="relatable css-1dne9dv"

--- a/src/browser/modules/Stream/CypherFrame/helpers.js
+++ b/src/browser/modules/Stream/CypherFrame/helpers.js
@@ -366,7 +366,7 @@ export function recordToJSONMapper(record) {
 
       return {
         ...agg,
-        [key]: mapNeo4jValuesToPlainValues(field)
+        [key]: mapNeo4jValuesToPlainValues(field, true)
       }
     },
     {}
@@ -404,7 +404,7 @@ export function mapNeo4jValuesToPlainValues(values, showRawEntities) {
     )
   }
 
-  if (elementType === 'path segment') {
+  if (!showRawEntities && elementType === 'path segment') {
     return mapNeo4jValuesToPlainValues(
       [values.start, values.relationship, values.end],
       showRawEntities
@@ -414,10 +414,13 @@ export function mapNeo4jValuesToPlainValues(values, showRawEntities) {
   if (includes(['relationship', 'node'], elementType)) {
     const all = { ...values }
 
-    return mapNeo4jValuesToPlainValues(
-      showRawEntities ? all : get(all, 'properties', {}),
-      showRawEntities
-    )
+    return {
+      elementType,
+      ...mapNeo4jValuesToPlainValues(
+        showRawEntities ? all : get(all, 'properties', {}),
+        showRawEntities
+      )
+    }
   }
 
   return reduce(

--- a/src/browser/modules/Stream/CypherFrame/helpers.js
+++ b/src/browser/modules/Stream/CypherFrame/helpers.js
@@ -397,15 +397,27 @@ export function mapNeo4jValuesToPlainValues(values, showRawEntities) {
   // could be a Node or Relationship
   const elementType = lowerCase(get(values, 'constructor.name', ''))
 
+  if (elementType === 'path') {
+    return mapNeo4jValuesToPlainValues(
+      showRawEntities ? { ...values } : [...values.segments],
+      showRawEntities
+    )
+  }
+
+  if (elementType === 'path segment') {
+    return mapNeo4jValuesToPlainValues(
+      [values.start, values.relationship, values.end],
+      showRawEntities
+    )
+  }
+
   if (includes(['relationship', 'node'], elementType)) {
     const all = { ...values }
 
-    return {
-      ...mapNeo4jValuesToPlainValues(
-        showRawEntities ? all : get(all, 'properties', {}),
-        showRawEntities
-      )
-    }
+    return mapNeo4jValuesToPlainValues(
+      showRawEntities ? all : get(all, 'properties', {}),
+      showRawEntities
+    )
   }
 
   return reduce(

--- a/src/browser/modules/Stream/CypherFrame/relatable-view.jsx
+++ b/src/browser/modules/Stream/CypherFrame/relatable-view.jsx
@@ -39,7 +39,8 @@ import {
 import arrayHasItems from 'shared/utils/array-has-items'
 import {
   getMaxFieldItems,
-  getMaxRows
+  getMaxRows,
+  getShowRawTableResults
 } from 'shared/modules/settings/settingsDuck'
 
 import ClickableUrls, {
@@ -52,7 +53,8 @@ import { isPoint, isInt } from 'neo4j-driver'
 
 const RelatableView = connect(state => ({
   maxRows: getMaxRows(state),
-  maxFieldItems: getMaxFieldItems(state)
+  maxFieldItems: getMaxFieldItems(state),
+  showEntityMeta: getShowRawTableResults(state)
 }))(RelatableViewComponent)
 
 export default RelatableView
@@ -92,19 +94,25 @@ function getColumns(records, maxFieldItems) {
   }))
 }
 
-function CypherCell({ cell }) {
+const CypherCell = connect(state => ({
+  showRawTableResults: getShowRawTableResults(state)
+}))(CypherCellComponent)
+
+function CypherCellComponent({ cell, showRawTableResults }) {
   const { value } = cell
   const mapper = useCallback(
     value => {
       const memo = memoize(mapNeo4jValuesToPlainValues, value => {
         const { elementType, identity } = value || {}
 
-        return elementType ? `${elementType}:${identity}` : identity
+        const key = elementType ? `${elementType}:${identity}` : identity
+
+        return showRawTableResults ? `meta-${key}` : key
       })
 
-      return memo(value)
+      return memo(value, showRawTableResults)
     },
-    [memoize, mapNeo4jValuesToPlainValues]
+    [memoize, mapNeo4jValuesToPlainValues, showRawTableResults]
   )
   const mapped = mapper(value)
 

--- a/src/browser/modules/Stream/CypherFrame/relatable-view.jsx
+++ b/src/browser/modules/Stream/CypherFrame/relatable-view.jsx
@@ -98,7 +98,7 @@ const CypherCell = connect(state => ({
   showRawTableResults: getShowRawTableResults(state)
 }))(CypherCellComponent)
 
-function CypherCellComponent({ cell, showRawTableResults }) {
+export function CypherCellComponent({ cell, showRawTableResults }) {
   const { value } = cell
   const mapper = useCallback(
     value => {

--- a/src/browser/modules/Stream/CypherFrame/relatable-view.styled.js
+++ b/src/browser/modules/Stream/CypherFrame/relatable-view.styled.js
@@ -35,6 +35,7 @@ export const RelatableStyleWrapper = styled.div`
   }
   .relatable__table-body-row .relatable__table-cell {
     border-top: ${props => props.theme.inFrameBorder};
+    vertical-align: top;
   }
 `
 
@@ -47,6 +48,6 @@ export const StyledJsonPre = styled.pre`
   color: ${props => props.theme.preText};
   line-height: 26px;
   padding: 2px 10px;
-  max-width: 320px;
+  max-width: 500px;
   white-space: pre-wrap;
 `

--- a/src/browser/modules/Stream/CypherFrame/relatable-view.test.js
+++ b/src/browser/modules/Stream/CypherFrame/relatable-view.test.js
@@ -21,11 +21,19 @@
 import React from 'react'
 import { render } from '@testing-library/react'
 import neo4j from 'neo4j-driver'
+import { createStore } from 'redux'
+import { Provider } from 'react-redux'
 
 import {
   RelatableViewComponent as RelatableView,
   RelatableStatusbarComponent as RelatableStatusbar
 } from './relatable-view'
+
+const initialState = { settings: {} }
+const store = createStore(() => initialState, initialState)
+function renderWithRedux(ui) {
+  return render(<Provider store={store}>{ui}</Provider>)
+}
 
 describe('RelatableViews', () => {
   describe('RelatableView', () => {
@@ -42,7 +50,7 @@ describe('RelatableViews', () => {
       }
 
       // When
-      const { container } = render(
+      const { container } = renderWithRedux(
         <RelatableView {...props} maxFieldItems={1000} maxRows={1000} />
       )
 
@@ -60,7 +68,7 @@ describe('RelatableViews', () => {
       }
 
       // When
-      const { container } = render(
+      const { container } = renderWithRedux(
         <RelatableView result={result} maxFieldItems={1000} maxRows={1000} />
       )
 
@@ -74,7 +82,7 @@ describe('RelatableViews', () => {
       const props = { result: {}, maxRows: 0 }
 
       // When
-      const { container } = render(
+      const { container } = renderWithRedux(
         <RelatableStatusbar {...props} maxFieldItems={1000} maxRows={1000} />
       )
 
@@ -97,7 +105,7 @@ describe('RelatableViews', () => {
       }
 
       // When
-      const { container } = render(
+      const { container } = renderWithRedux(
         <RelatableStatusbar {...props} maxFieldItems={1000} maxRows={1000} />
       )
 

--- a/src/shared/modules/settings/__snapshots__/settingsDuck.test.js.snap
+++ b/src/shared/modules/settings/__snapshots__/settingsDuck.test.js.snap
@@ -21,6 +21,7 @@ Object {
   "playImplicitInitCommands": true,
   "scrollToTop": true,
   "shouldReportUdc": true,
+  "showRawTableResults": false,
   "showSampleScripts": true,
   "theme": "auto",
   "useCypherThread": true,

--- a/src/shared/modules/settings/settingsDuck.js
+++ b/src/shared/modules/settings/settingsDuck.js
@@ -52,6 +52,8 @@ export const getMaxNeighbours = state =>
 export const getMaxRows = state => state[NAME].maxRows || initialState.maxRows
 export const getMaxFieldItems = state =>
   get(state, [NAME, 'maxFieldItems'], initialState.maxFieldItems)
+export const getShowRawTableResults = state =>
+  get(state, [NAME, 'showRawTableResults'], initialState.showRawTableResults)
 export const getInitialNodeDisplay = state =>
   state[NAME].initialNodeDisplay || initialState.initialNodeDisplay
 export const getScrollToTop = state => state[NAME].scrollToTop
@@ -93,6 +95,7 @@ const initialState = {
   browserSyncDebugServer: null,
   maxRows: 1000,
   maxFieldItems: 500,
+  showRawTableResults: false,
   shouldReportUdc: true,
   autoComplete: true,
   scrollToTop: true,


### PR DESCRIPTION
This PR makes showing raw results in tables an opt-in setting, restoring previous display behaviour.

### Screenshots
disabled
<img width="981" alt="Screenshot 2020-06-11 at 11 33 55" src="https://user-images.githubusercontent.com/52443771/84369800-ad2dce00-abd7-11ea-8057-5243b02fb431.png">

enabled
<img width="996" alt="Screenshot 2020-06-11 at 11 33 48" src="https://user-images.githubusercontent.com/52443771/84369815-b28b1880-abd7-11ea-98e9-07ddb23bed9a.png">

Paths
<img width="953" alt="Screenshot 2020-06-11 at 12 55 05" src="https://user-images.githubusercontent.com/52443771/84377403-d0aa4600-abe2-11ea-8aff-4c65fd20a9d9.png">
