### PR TITLE
Call config procedure and store state of its availability + fix E2E when run tests over HTTPS

### DIFF
--- a/e2e_tests/integration/0.index.spec.js
+++ b/e2e_tests/integration/0.index.spec.js
@@ -123,8 +123,7 @@ describe('Neo4j Browser', () => {
     cy.executeCommand(':clear')
     cy.get('[data-testid="drawerDBMS"]').click()
     cy.get('[data-testid="user-details-username"]').should('contain', 'neo4j')
-    console.log('isEnterpriseEdition(): ', isEnterpriseEdition())
-    cy.get('[data-testid="user-details-roles"]').should(
+    cy.get('[data-testid="user-details-roles"]', { timeout: 30000 }).should(
       'contain',
       isAura()
         ? 'PUBLIC'

--- a/e2e_tests/integration/connect-form.spec.js
+++ b/e2e_tests/integration/connect-form.spec.js
@@ -18,7 +18,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { isAura, isEnterpriseEdition, stripScheme } from '../support/utils'
+import {
+  schemeWithEncryptionFlag,
+  schemeWithInvertedEncryptionFlag,
+  stripScheme
+} from '../support/utils'
 
 /* global Cypress, cy, test, expect, before */
 
@@ -39,7 +43,7 @@ describe('Connect form', () => {
   })
 
   it('extracts the scheme from the bolt url entered', () => {
-    const scheme = 'bolt://'
+    const scheme = schemeWithEncryptionFlag('bolt')
     const host = 'localhost:1212'
     getBoltUrlField()
       .clear()
@@ -49,20 +53,20 @@ describe('Connect form', () => {
     getBoltSchemeSelect().should('have.value', scheme)
   })
   it('extracts the scheme from the bolt url entered with encryption flag', () => {
-    const scheme = 'neo4j+s://'
-    const nonSecureScheme = 'neo4j://'
+    const input = schemeWithInvertedEncryptionFlag('neo4j')
+    const output = schemeWithEncryptionFlag('neo4j')
     const host = 'localhost:7687'
     getBoltUrlField()
       .clear()
-      .type(scheme + host)
+      .type(input + host)
 
     getBoltUrlField().should('have.value', host)
-    getBoltSchemeSelect().should('have.value', nonSecureScheme)
+    getBoltSchemeSelect().should('have.value', output)
   })
   it('aliases bolt+routing:// to neo4j://', () => {
-    getBoltSchemeSelect().select('bolt://')
+    getBoltSchemeSelect().select(schemeWithEncryptionFlag('bolt'))
     const scheme = 'bolt+routing://'
-    const aliasScheme = 'neo4j://'
+    const aliasScheme = schemeWithEncryptionFlag('neo4j')
     const host = 'localhost:7687'
     getBoltUrlField()
       .clear()
@@ -86,7 +90,7 @@ describe('Connect form', () => {
       cy.connect('neo4j', Cypress.config('password'), boltUrl, false)
       getFirstFrameStatusbar().should(
         'contain',
-        'Automatic retry using the "bolt://"'
+        `Automatic retry using the "${schemeWithEncryptionFlag('bolt')}"`
       )
       cy.wait(7000) // auto retry is in 5 secs
       getFirstFrameCommand().should('contain', ':play start')

--- a/e2e_tests/support/utils.js
+++ b/e2e_tests/support/utils.js
@@ -5,6 +5,8 @@ export const isEnterpriseEdition = () =>
 
 export const isAura = () => Cypress.config('serverEdition') === 'aura'
 
+export const isHttps = () => Cypress.config('baseUrl').startsWith('https')
+
 export const getDesktopContext = (
   config,
   connectionCredsType = 'host',
@@ -59,3 +61,8 @@ export const stripScheme = url => {
   }
   return rest.join('://')
 }
+
+export const schemeWithEncryptionFlag = scheme =>
+  `${scheme}${isHttps() ? '+s' : ''}://`
+export const schemeWithInvertedEncryptionFlag = scheme =>
+  `${scheme}${!isHttps() ? '+s' : ''}://`

--- a/src/shared/modules/dbMeta/dbMetaDuck.js
+++ b/src/shared/modules/dbMeta/dbMetaDuck.js
@@ -49,7 +49,8 @@ import {
   updateUserCapability,
   USER_CAPABILITIES,
   FEATURE_DETECTION_DONE,
-  isACausalCluster
+  isACausalCluster,
+  setClientConfig
 } from '../features/featuresDuck'
 
 export const NAME = 'meta'
@@ -461,11 +462,10 @@ export const serverConfigEpic = (some$, store) =>
           bolt
             .directTransaction(
               `CALL ${
-                hasClientConfig(store.getState())
+                hasClientConfig(store.getState()) !== false
                   ? 'dbms.clientConfig()'
                   : 'dbms.listConfig()'
               }`,
-
               {},
               {
                 useDb: supportsMultiDb ? SYSTEM_DB : '',
@@ -475,8 +475,38 @@ export const serverConfigEpic = (some$, store) =>
                 })
               }
             )
-            .then(resolve)
-            .catch(reject)
+            .then(r => {
+              // This is not set yet
+              if (hasClientConfig(store.getState()) === null) {
+                store.dispatch(setClientConfig(true))
+              }
+              resolve(r)
+            })
+            .catch(e => {
+              // Try older procedure if the new one doesn't exist
+              if (e.code === 'Neo.ClientError.Procedure.ProcedureNotFound') {
+                bolt
+                  .directTransaction(
+                    `CALL dbms.listConfig()`,
+                    {},
+                    {
+                      useDb: supportsMultiDb ? SYSTEM_DB : '',
+                      useCypherThread: shouldUseCypherThread(store.getState()),
+                      ...getBackgroundTxMetadata({
+                        hasServerSupport: canSendTxMetadata(store.getState())
+                      })
+                    }
+                  )
+                  .then(r => {
+                    // Store that dbms.clientConfig isn't available
+                    store.dispatch(setClientConfig(false))
+                    resolve(r)
+                  })
+                  .catch(reject)
+              } else {
+                reject(e)
+              }
+            })
         })
       )
         .catch(e => {

--- a/src/shared/modules/dbMeta/dbMetaDuck.js
+++ b/src/shared/modules/dbMeta/dbMetaDuck.js
@@ -485,6 +485,9 @@ export const serverConfigEpic = (some$, store) =>
             .catch(e => {
               // Try older procedure if the new one doesn't exist
               if (e.code === 'Neo.ClientError.Procedure.ProcedureNotFound') {
+                // Store that dbms.clientConfig isn't available
+                store.dispatch(setClientConfig(false))
+
                 bolt
                   .directTransaction(
                     `CALL dbms.listConfig()`,
@@ -497,11 +500,7 @@ export const serverConfigEpic = (some$, store) =>
                       })
                     }
                   )
-                  .then(r => {
-                    // Store that dbms.clientConfig isn't available
-                    store.dispatch(setClientConfig(false))
-                    resolve(r)
-                  })
+                  .then(resolve)
                   .catch(reject)
               } else {
                 reject(e)

--- a/src/shared/modules/features/featuresDuck.js
+++ b/src/shared/modules/features/featuresDuck.js
@@ -35,6 +35,7 @@ const CLEAR = 'features/CLEAR'
 export const UPDATE_ALL_FEATURES = 'features/UPDATE_ALL_FEATURES'
 export const UPDATE_USER_CAPABILITIES = 'features/UPDATE_USER_CAPABILITIES'
 export const FEATURE_DETECTION_DONE = 'features/FEATURE_DETECTION_DONE'
+export const DETECTED_CLIENT_CONFIG = 'features/DETECTED_CLIENT_CONFIG'
 
 export const getAvailableProcedures = state => state[NAME].availableProcedures
 export const isACausalCluster = state =>
@@ -43,8 +44,7 @@ export const isMultiDatabase = state =>
   getAvailableProcedures(state).includes('dbms.databases.overview')
 export const canAssignRolesToUser = state =>
   getAvailableProcedures(state).includes('dbms.security.addRoleToUser')
-export const hasClientConfig = state =>
-  getAvailableProcedures(state).includes('dbms.clientConfig')
+export const hasClientConfig = state => state[NAME].clientConfig
 export const useBrowserSync = state => !!state[NAME].browserSync
 export const getUserCapabilities = state => state[NAME].userCapabilities
 
@@ -56,6 +56,7 @@ export const USER_CAPABILITIES = {
 const initialState = {
   availableProcedures: [],
   browserSync: true,
+  clientConfig: null,
   userCapabilities: {
     [USER_CAPABILITIES.serverConfigReadable]: false,
     [USER_CAPABILITIES.proceduresReadable]: false
@@ -72,6 +73,8 @@ export default function(state = initialState, action) {
       }
     case UPDATE_ALL_FEATURES:
       return { ...state, availableProcedures: [...action.availableProcedures] }
+    case DETECTED_CLIENT_CONFIG:
+      return { ...state, clientConfig: action.isAvailable }
     case UPDATE_USER_CAPABILITIES:
       return {
         ...state,
@@ -105,6 +108,13 @@ export const updateUserCapability = (capabilityName, capabilityValue) => {
     type: UPDATE_USER_CAPABILITIES,
     capabilityName,
     capabilityValue
+  }
+}
+
+export const setClientConfig = isAvailable => {
+  return {
+    type: DETECTED_CLIENT_CONFIG,
+    isAvailable
   }
 }
 

--- a/src/shared/modules/features/featuresDuck.test.js
+++ b/src/shared/modules/features/featuresDuck.test.js
@@ -29,6 +29,7 @@ describe('features reducer', () => {
     expect(dehydrate(nextState)).toEqual({
       availableProcedures: [],
       browserSync: true,
+      clientConfig: null,
       userCapabilities: {
         proceduresReadable: false,
         serverConfigReadable: false


### PR DESCRIPTION
Don't rely on internal client config procedure to be listed in `dbms.procedures` output.
Make e2e tests work over HTTPS.
Add timeout for username to be populated in sidebar.