### PR TITLE
Fix integer rendering in table recursively + JSON export

### DIFF
--- a/e2e_tests/integration/types.spec.js
+++ b/e2e_tests/integration/types.spec.js
@@ -32,16 +32,18 @@ describe('Types in Browser', () => {
   if (Cypress.config('serverVersion') >= 3.4) {
     it('presents large integers correctly', () => {
       cy.executeCommand(':clear')
-      const query = 'RETURN 2467500000 AS bigNumber'
+      const query = 'RETURN 2467500000 AS bigNumber, {{}x: 9907199254740991}'
       cy.executeCommand(query)
       cy.waitForCommandResult()
       cy.resultContains('2467500000')
+      cy.resultContains('9907199254740991')
 
       // Go to ascii view
       cy.get('[data-testid="cypherFrameSidebarAscii"]')
         .first()
         .click()
       cy.resultContains('│2467500000')
+      cy.resultContains('9907199254740991')
     })
     it('presents the point type correctly', () => {
       cy.executeCommand(':clear')

--- a/src/browser/modules/Frame/FrameTitlebar.jsx
+++ b/src/browser/modules/Frame/FrameTitlebar.jsx
@@ -67,10 +67,9 @@ import {
   transformResultRecordsToResultArray,
   recordToJSONMapper
 } from 'browser/modules/Stream/CypherFrame/helpers'
-import { csvFormat } from 'services/bolt/cypherTypesFormatting'
+import { csvFormat, stringModifier } from 'services/bolt/cypherTypesFormatting'
 import arrayHasItems from 'shared/utils/array-has-items'
-
-const JSON_EXPORT_INDENT = 2
+import { stringifyMod } from 'services/utils'
 
 class FrameTitlebar extends Component {
   hasData() {
@@ -115,15 +114,11 @@ class FrameTitlebar extends Component {
   }
 
   exportJSON(records) {
-    const data = JSON.stringify(
-      map(records, recordToJSONMapper),
-      null,
-      JSON_EXPORT_INDENT
-    )
+    const exportData = map(records, recordToJSONMapper)
+    const data = stringifyMod(exportData, stringModifier, true)
     const blob = new Blob([data], {
       type: 'text/plain;charset=utf-8'
     })
-
     saveAs(blob, 'records.json')
   }
 

--- a/src/browser/modules/Stream/CypherFrame/AsciiView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/AsciiView.jsx
@@ -87,7 +87,8 @@ export class AsciiViewComponent extends Component {
     const serializedRows =
       stringifyResultArray(
         stringModifier,
-        transformResultRecordsToResultArray(records, maxFieldItems)
+        transformResultRecordsToResultArray(records, maxFieldItems),
+        true
       ) || []
     this.setState({ serializedRows })
     const maxColWidth = asciitable.maxColumnWidth(serializedRows)

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/relatable-view.test.js.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/relatable-view.test.js.snap
@@ -72,7 +72,9 @@ exports[`RelatableViews RelatableView does not display bodyMessage if rows, and 
               class="relatable__table-cell relatable__table-body-cell"
               role="cell"
             >
-              "String with HTML &lt;strong&gt;in&lt;/strong&gt; it"
+              <span>
+                "String with HTML &lt;strong&gt;in&lt;/strong&gt; it"
+              </span>
             </td>
           </tr>
         </tbody>

--- a/src/browser/modules/Stream/CypherFrame/helpers.js
+++ b/src/browser/modules/Stream/CypherFrame/helpers.js
@@ -229,13 +229,13 @@ export const initialView = (props, state = {}) => {
 export const stringifyResultArray = (
   formatter = stringModifier,
   arr = [],
-  unescapeDoulbeQuotes = false
+  unescapeDoubleQuotes = false
 ) => {
   return arr.map(col => {
     if (!col) return col
     return col.map(fVal => {
       const res = stringifyMod(fVal, formatter)
-      return unescapeDoulbeQuotes ? unescapeDoubleQuotesForDisplay(res) : res
+      return unescapeDoubleQuotes ? unescapeDoubleQuotesForDisplay(res) : res
     })
   })
 }
@@ -358,9 +358,9 @@ const arrayifyPath = (types = neo4j.types, path) => {
 
 /**
  * Converts a raw Neo4j record into a JSON friendly format, mimicking APOC output
- * Note: This preservers Neo4j integers as objects because they can't be guaranteed
+ * Note: This preserves Neo4j integers as objects because they can't be guaranteed
  * to be converted to numbers and keeping the precision.
- * It's up to the serializer to indentify those and write them as fake numbers (strings without quotes)
+ * It's up to the serializer to identify them and write them as fake numbers (strings without quotes)
  * @param     {Record}    record
  * @return    {*}
  */

--- a/src/browser/modules/Stream/CypherFrame/helpers.test.js
+++ b/src/browser/modules/Stream/CypherFrame/helpers.test.js
@@ -639,7 +639,7 @@ describe('helpers', () => {
         neo4j.isInt,
         step1
       )
-      const res = stringifyResultArray(stringModifier, step2)
+      const res = stringifyResultArray(stringModifier, step2, true)
       // Then
       expect(res).toEqual([
         ['""neoInt""', '""int""', '""any""', '""backslash""'],
@@ -713,7 +713,7 @@ describe('helpers', () => {
         neo4j.isInt,
         step1
       )
-      const res = stringifyResultArray(stringModifier, step2)
+      const res = stringifyResultArray(stringModifier, step2, true)
       // Then
       expect(res).toEqual([
         ['""x""', '""y""', '""n""'],
@@ -730,7 +730,11 @@ describe('helpers', () => {
   describe('recordToJSONMapper', () => {
     describe('Nodes', () => {
       test('handles integer values', () => {
-        const node = new neo4j.types.Node(1, ['foo'], { bar: new neo4j.int(3) })
+        const node = new neo4j.types.Node(1, ['foo'], {
+          bar: new neo4j.int(3),
+          baz: new neo4j.int(1416268800000),
+          bax: new neo4j.int(9907199254740991) // Larger than Number.MAX_SAFE_INTEGER, but still in 64 bit int range
+        })
         const record = new neo4j.types.Record(['n'], [node])
         const expected = {
           n: {
@@ -738,7 +742,9 @@ describe('helpers', () => {
             elementType: 'node',
             labels: ['foo'],
             properties: {
-              bar: 3
+              bar: new neo4j.int(3),
+              baz: new neo4j.int(1416268800000),
+              bax: new neo4j.int(9907199254740991)
             }
           }
         }
@@ -911,7 +917,7 @@ describe('helpers', () => {
             elementType: 'relationship',
             type: 'foo',
             properties: {
-              bar: 3
+              bar: new neo4j.int(3)
             }
           }
         }
@@ -1109,7 +1115,7 @@ describe('helpers', () => {
             elementType: 'node',
             labels: ['foo'],
             properties: {
-              bar: 3
+              bar: new neo4j.int(3)
             }
           },
           r1: {
@@ -1159,7 +1165,7 @@ describe('helpers', () => {
               elementType: 'node',
               labels: ['foo'],
               properties: {
-                bar: 3
+                bar: new neo4j.int(3)
               }
             },
             end: {
@@ -1177,7 +1183,7 @@ describe('helpers', () => {
                   elementType: 'node',
                   labels: ['foo'],
                   properties: {
-                    bar: 3
+                    bar: new neo4j.int(3)
                   }
                 },
                 relationship: {
@@ -1224,7 +1230,12 @@ describe('helpers', () => {
         )
         const expected = {
           foo: {
-            data: [1, 'car', { srid: 1, x: 10, y: 5, z: 15 }, '1970-01-01']
+            data: [
+              new neo4j.int(1),
+              'car',
+              { srid: 1, x: 10, y: 5, z: 15 },
+              '1970-01-01'
+            ]
           }
         }
 

--- a/src/shared/services/utils.js
+++ b/src/shared/services/utils.js
@@ -328,6 +328,10 @@ export const stringifyMod = (
   const newLine = prettyLevel ? '\n' : ''
   const indentation =
     prettyLevel && !skipOpeningIndentation ? Array(prettyLevel).join('  ') : ''
+  const nextIndentation =
+    nextPrettyLevel && !skipOpeningIndentation
+      ? Array(nextPrettyLevel).join('  ')
+      : ''
   const endIndentation = prettyLevel ? Array(prettyLevel).join('  ') : ''
   const propSpacing = prettyLevel ? ' ' : ''
   const toString = Object.prototype.toString
@@ -337,7 +341,7 @@ export const stringifyMod = (
       return toString.call(a) === '[object Array]'
     }
   const escMap = {
-    '"': '"',
+    '"': '\\"',
     '\\': '\\',
     '\b': '\b',
     '\f': '\f',
@@ -381,10 +385,8 @@ export const stringifyMod = (
       for (const k in value) {
         if (value.hasOwnProperty(k)) {
           tmp.push(
-            `${stringifyMod(
-              k,
-              modFn,
-              nextPrettyLevel
+            `${nextIndentation}${JSON.stringify(
+              k
             )}:${propSpacing}${stringifyMod(
               value[k],
               modFn,
@@ -401,6 +403,8 @@ export const stringifyMod = (
   }
   return `${indentation}"${value.toString().replace(escRE, escFunc)}"`
 }
+
+export const unescapeDoubleQuotesForDisplay = str => str.replace(/\\"/g, '"')
 
 export const safetlyAddObjectProp = (obj, prop, val) => {
   const localObj = escapeReservedProps(obj, prop)


### PR DESCRIPTION
Use the existing `stringifyMod` function to create fake numbers out of Neo4j integers (strings witout quotes).
Add tests to lock this functionality.

Can be verified with this query:

```
RETURN 9907199254740991, 1416268800000, {int: 9907199254740991, ont: 1416268800000}, [9907199254740991, 1416268800000]
```

Before:

<img width="1066" alt="Screenshot 2020-06-24 11 22 21" src="https://user-images.githubusercontent.com/570998/85529116-08ff4a80-b60d-11ea-8d31-2e8339e71f4b.png">


After:

<img width="1069" alt="Screenshot 2020-06-24 11 23 29" src="https://user-images.githubusercontent.com/570998/85529297-2fbd8100-b60d-11ea-9ba8-2d95bc01064c.png">

