### PR TITLE
Fix unsubscribe bug

### DIFF
--- a/e2e_tests/support/commands.js
+++ b/e2e_tests/support/commands.js
@@ -151,12 +151,14 @@ Cypress.Commands.add('addUser', (userName, password, role, force) => {
 })
 Cypress.Commands.add('enableMultiStatement', () => {
   cy.get('[data-testid="drawerSettings"]').click()
-  cy.get('[data-testid="enableMultiStatementMode"]').check()
+  cy.get('[data-testid="enableMultiStatementMode"]', { timeout: 30000 }).check()
   cy.get('[data-testid="drawerSettings"]').click()
 })
 Cypress.Commands.add('disableMultiStatement', () => {
   cy.get('[data-testid="drawerSettings"]').click()
-  cy.get('[data-testid="enableMultiStatementMode"]').uncheck()
+  cy.get('[data-testid="enableMultiStatementMode"]', {
+    timeout: 30000
+  }).uncheck()
   cy.get('[data-testid="drawerSettings"]').click()
 })
 Cypress.Commands.add('createUser', (username, password, forceChangePw) => {

--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -109,8 +109,8 @@ export function App(props) {
           eventMetricsCallback.current &&
           eventMetricsCallback.current({ category, label, data })
       })
-    return unsub
-  })
+    return () => unsub && unsub()
+  }, [])
 
   const focusEditorOnSlash = e => {
     if (['INPUT', 'TEXTAREA'].indexOf(e.target.tagName) > -1) return


### PR DESCRIPTION
Only subscribe to metrics once, on app mount.
`unsub` can be false and `useEffect` expects a function to be returned.