### PR TITLE
Two Edge fixes

### DIFF
--- a/src/browser/modules/Carousel/Carousel.jsx
+++ b/src/browser/modules/Carousel/Carousel.jsx
@@ -87,13 +87,13 @@ export default function Carousel({
     const slide = visibleSlide + 1
     setVisibleSlide(slide)
     setWasClicked(true)
-    myRef.current.scrollTo(0, 0)
+    myRef.current.scrollTop = 0
   }
 
   const prev = () => {
     const slide = visibleSlide - 1
     setVisibleSlide(slide)
-    myRef.current.scrollTo(0, 0)
+    myRef.current.scrollTop = 0
   }
 
   const getSlide = slideNumber => {

--- a/src/browser/modules/Carousel/styled.jsx
+++ b/src/browser/modules/Carousel/styled.jsx
@@ -47,11 +47,10 @@ export const StyledCarouselButtonContainer = styled.div`
   align-items: center;
   justify-content: center;
   position: absolute;
-  left: 50%;
   bottom: 0;
   z-index: 10;
   border-top: ${props => props.theme.inFrameBorder};
-  transform: translateX(-50%);
+  margin-left: -40px;
   height: 39px;
   width: 100%;
 


### PR DESCRIPTION
Found two issues when testing Edge support

1. Carousel Button Container caused horizontal scroll
Before:
![buttons old](https://user-images.githubusercontent.com/939458/86450255-86b40c00-bd19-11ea-9603-df4a1ff9d361.gif)
After:
![buttons new](https://user-images.githubusercontent.com/939458/86450281-916ea100-bd19-11ea-98da-eb6b38cae189.png)

2. Scroll position was not reset when switching guide slides
Before:
![scrollpos old](https://user-images.githubusercontent.com/939458/86450344-ab0fe880-bd19-11ea-86fc-abde506eb467.gif)
After:
![scrollpos new](https://user-images.githubusercontent.com/939458/86450356-aea36f80-bd19-11ea-939a-18a13773eab9.gif)
