### PR TITLE
Set background color on editor container

### DIFF
--- a/src/browser/modules/Editor/styled.jsx
+++ b/src/browser/modules/Editor/styled.jsx
@@ -24,6 +24,7 @@ import { dim } from 'browser-styles/constants'
 const editorPadding = 10
 
 export const BaseBar = styled.div`
+  background-color: ${props => props.theme.primaryBackground};
   display: flex;
   flex-direction: row;
   align-items: middle;


### PR DESCRIPTION
The transparent background looks broken when the editor is in full-screen:
![editor transparent background](https://user-images.githubusercontent.com/939458/86577294-4dc6a200-bf7a-11ea-864f-29330467a0cc.gif)

With primary background color:
![editor primary background](https://user-images.githubusercontent.com/939458/86577316-54551980-bf7a-11ea-86ad-d23b8ae913c1.gif)
