### PR TITLE
Update change password form to avoid overlap with password manager icons

### DIFF
--- a/src/browser/modules/Stream/Auth/ChangePasswordForm.jsx
+++ b/src/browser/modules/Stream/Auth/ChangePasswordForm.jsx
@@ -146,7 +146,7 @@ export default class ChangePasswordForm extends Component {
                       disabled: isLoading
                     })}
                   />
-                  &nbsp;OR&nbsp;
+                  &nbsp;OR&nbsp;&nbsp;
                   <FormButton tabIndex="-1" onClick={this.onSuggestPassword}>
                     Generate
                   </FormButton>

--- a/src/browser/modules/Stream/Auth/styled.jsx
+++ b/src/browser/modules/Stream/Auth/styled.jsx
@@ -96,25 +96,24 @@ export const StyledSegmentedConnectionTextInput = styled(StyledInput)`
 export const StyledRevealablePasswordWrapper = styled.div`
   position: relative;
   display: inline-block;
-  width: 44%;
+  width: calc(44% + 30px);
   min-width: 200px;
 
   > input {
-    padding-right: 30px;
-    width: 100%;
+    width: calc(100% - 30px);
   }
 
   > .icon {
+    display: inline-block;
+    width: 25px;
+    color: ${props => props.theme.primaryText};
     position: absolute;
     user-select: none;
     right: 0;
-    top: 6px;
+    top: 5px;
     height: auto;
-    width: auto;
     padding: 3px;
     cursor: pointer;
-    color: #333333;
-    opacity: 0.5;
   }
 `
 


### PR DESCRIPTION
If you have a password manager that adds an icon inside password input fields, the eye icon that reveals password will be covered by the password manager icon:
![neo4j@neo4j___localhost_7687_neo4j - Neo4j Browser - Mozilla Firefox 7_9_2020 10_52_05 AM](https://user-images.githubusercontent.com/939458/87019062-7052f800-c1d2-11ea-8ce8-7c2ee4a749fd.png)

This change moves the reveal icons out of the inputs to make room for any password manager icon:
![neo4j@neo4j___localhost_7687_neo4j - Neo4j Browser - Mozilla Firefox 7_9_2020 10_53_11 AM](https://user-images.githubusercontent.com/939458/87019074-72b55200-c1d2-11ea-9eb6-f52c08a4f8ac.png)

Alignment was adjusted slightly as well.