### PR TITLE
Update example and use normal dots in example data

### DIFF
--- a/src/browser/documentation/guides/movie-graph.jsx
+++ b/src/browser/documentation/guides/movie-graph.jsx
@@ -20,7 +20,6 @@
 
 import React from 'react'
 import ManualLink from 'browser-components/ManualLink'
-import Carousel from '../../modules/Carousel/Carousel'
 import Slide from '../../modules/Carousel/Slide'
 
 const title = 'Movie Graph'
@@ -540,7 +539,7 @@ CREATE
 (PhilipH)-[:ACTED_IN {roles:['Gust Avrakotos']}]->(CharlieWilsonsWar),
 (MikeN)-[:DIRECTED]->(CharlieWilsonsWar)
 
-CREATE (ThePolarExpress:Movie {title:'The Polar Express', released:2004, tagline:'This Holiday Season… Believe'})
+CREATE (ThePolarExpress:Movie {title:'The Polar Express', released:2004, tagline:'This Holiday Season... Believe'})
 CREATE
 (TomH)-[:ACTED_IN {roles:['Hero Boy', 'Father', 'Conductor', 'Hobo', 'Scrooge', 'Santa Claus']}]->(ThePolarExpress),
 (RobertZ)-[:DIRECTED]->(ThePolarExpress)

--- a/src/browser/documentation/help/create.jsx
+++ b/src/browser/documentation/help/create.jsx
@@ -64,8 +64,8 @@ const content = (
     <section className="example">
       <figure>
         <pre className="code runnable">
-          {`CREATE (le:Person {name: Euler }),
-  (db:Person {name: Bernoulli }),
+          {`CREATE (le:Person {name: "Euler" }),
+  (db:Person {name: "Bernoulli" }),
   (le)-[:KNOWS {since:1768}]->(db)
   RETURN le, db`}
         </pre>


### PR DESCRIPTION
The create query was not runnable without quotes. Also changed some characters to close #1079.