### PR TITLE
Use correct labeling

### DIFF
--- a/src/browser/components/Form.jsx
+++ b/src/browser/components/Form.jsx
@@ -141,7 +141,7 @@ export class RadioSelector extends Component {
                   this.props.onChange(event)
                 }}
               />
-              <StyledLabel for={option}>{option}</StyledLabel>
+              <StyledLabel htmlFor={option}>{option}</StyledLabel>
             </StyledRadioEntry>
           )
         })}


### PR DESCRIPTION
Gets rid of console error, react wants htmlFor since for is keyworded.

https://reactjs.org/docs/dom-elements.html