### PR TITLE
Fix comment filtering on command

### DIFF
--- a/src/browser/components/TabNavigation/Navigation.jsx
+++ b/src/browser/components/TabNavigation/Navigation.jsx
@@ -51,7 +51,7 @@ class Navigation extends Component {
 
   componentDidUpdate(prevProps, prevState) {
     if (prevProps.openDrawer !== this.props.openDrawer) {
-      var newState = {}
+      const newState = {}
       if (this.props.openDrawer) {
         newState.drawerContent = this.props.openDrawer
         if (
@@ -90,8 +90,8 @@ class Navigation extends Component {
   render() {
     const { onNavClick, topNavItems, bottomNavItems = [] } = this.props
 
-    const buildNavList = (list, selected) => {
-      return list.map((item, index) => {
+    const buildNavList = (list, selected) =>
+      list.map(item => {
         const isOpen = item.name.toLowerCase() === selected
         return (
           <NavigationButtonContainer
@@ -107,12 +107,12 @@ class Navigation extends Component {
           </NavigationButtonContainer>
         )
       })
-    }
+
     const getContentToShow = openDrawer => {
       if (openDrawer) {
-        const filteredList = topNavItems.concat(bottomNavItems).filter(item => {
-          return item.name.toLowerCase() === openDrawer
-        })
+        const filteredList = topNavItems
+          .concat(bottomNavItems)
+          .filter(item => item.name.toLowerCase() === openDrawer)
         const TabContent = filteredList[0].content
         return <TabContent />
       }

--- a/src/browser/modules/Sidebar/DocumentItems.jsx
+++ b/src/browser/modules/Sidebar/DocumentItems.jsx
@@ -64,7 +64,7 @@ export const DocumentItems = ({ header, items, onItemClick = null }) => {
   )
 }
 
-const mapDispatchToProps = (dispatch, ownProps) => {
+const mapDispatchToProps = (_dispatch, ownProps) => {
   return {
     onItemClick: cmd => {
       ownProps.bus.send(SET_CONTENT, setContent(cmd))

--- a/src/browser/modules/Sidebar/Documents.jsx
+++ b/src/browser/modules/Sidebar/Documents.jsx
@@ -86,12 +86,11 @@ const getReferences = (version, v) => {
       command: `https://neo4j.com/docs/operations-manual/${v}/`,
       type: 'link'
     },
-    // Drivers manual needs to wait for the page to be published
-    // {
-    //   name: 'Drivers Manual',
-    //   command: `https://neo4j.com/docs/driver-manual/current/`,
-    //   type: 'link'
-    // },
+    {
+      name: 'Drivers Manual',
+      command: `https://neo4j.com/docs/driver-manual/current/`,
+      type: 'link'
+    },
     {
       name: 'Cypher Refcard',
       command: `https://neo4j.com/docs/cypher-refcard/${v}/`,

--- a/src/browser/modules/Sidebar/DragItemTypes.js
+++ b/src/browser/modules/Sidebar/DragItemTypes.js
@@ -1,3 +1,0 @@
-export default {
-  FAVORITE: 'favorite'
-}

--- a/src/shared/services/commandUtils.js
+++ b/src/shared/services/commandUtils.js
@@ -35,7 +35,10 @@ export function stripEmptyCommandLines(str) {
 }
 
 export function stripCommandComments(str) {
-  return str.replace(/((^|\n)\/\/[^\n$]+\n?)/g, '')
+  return str
+    .split('\n')
+    .filter(line => !line.trim().startsWith('//'))
+    .join('\n')
 }
 
 export function splitStringOnFirst(str, delimiter) {
@@ -141,7 +144,8 @@ export const mapParamToCypherStatement = (key, param) => {
 }
 
 export const extractStatementsFromString = str => {
-  const parsed = extractStatements(str)
+  const cleanCmd = cleanCommand(str)
+  const parsed = extractStatements(cleanCmd)
   const { statements } = parsed.referencesListener
   return statements[0]
     .raw()

--- a/src/shared/services/commandUtils.test.js
+++ b/src/shared/services/commandUtils.test.js
@@ -23,12 +23,30 @@ import * as utils from './commandUtils'
 describe('commandutils', () => {
   test('stripCommandComments should remove lines starting with a comment ', () => {
     const testStrs = [
-      '//This is a comment\nRETURN 1',
-      '// Another comment\nRETURN 1',
-      '// Another comment\nRETURN 1\n//Next comment'
+      { str: '//This is a comment\nRETURN 1', expect: 'RETURN 1' },
+      { str: '// Another comment\nRETURN 1', expect: 'RETURN 1' },
+      {
+        str: '// Another comment\nRETURN 1\n//Next comment',
+        expect: 'RETURN 1'
+      },
+      {
+        str: `RETURN 1
+;
+
+// comment 1
+// comment 2
+// comment 3
+RETURN 2
+;`,
+        expect: `RETURN 1
+;
+
+RETURN 2
+;`
+      }
     ]
-    testStrs.forEach(str => {
-      expect(utils.stripCommandComments(str)).toEqual('RETURN 1')
+    testStrs.forEach(item => {
+      expect(utils.stripCommandComments(item.str)).toEqual(item.expect)
     })
   })
 
@@ -211,6 +229,23 @@ describe('commandutils', () => {
         {
           stmt: ':history; RETURN 1;\nMATCH (n)\nRETURN n',
           expect: [':history', 'RETURN 1', 'MATCH (n)\nRETURN n']
+        },
+        {
+          stmt: 'RETURN 1\n;\n\n// comment 1\n//comment 2\nRETURN 2\n;',
+          expect: ['RETURN 1', 'RETURN 2']
+        },
+        {
+          stmt: `MATCH (n) return n LIMIT 1;
+MATCH (n)
+UNWIND range(0, 5) as x
+// Return n
+RETURN n`,
+          expect: [
+            'MATCH (n) return n LIMIT 1',
+            `MATCH (n)
+UNWIND range(0, 5) as x
+RETURN n`
+          ]
         }
       ]
 


### PR DESCRIPTION
Replaced the comment regex with a filter that easier to understand and doesn't have this issue:
<img width="549" alt="image" src="https://user-images.githubusercontent.com/10564538/87423623-e1334f00-c5da-11ea-940d-055089c5cc63.png">

However. This is an edge-case but could happen:
<img width="471" alt="image" src="https://user-images.githubusercontent.com/10564538/87423351-6ff39c00-c5da-11ea-94d4-e1de3d5275ce.png">
It seems to me from https://neo4j.com/docs/2.2.2/cypher-comments.html that cypher supports comments, any reason why we need to "clean the command"? Could it not simply be removed (perhaps some version stuff with cypher?).

From some initial looks this
<img width="230" alt="image" src="https://user-images.githubusercontent.com/10564538/87423940-70d8fd80-c5db-11ea-87a3-683e8d245d5a.png">
Doesn't work if we let cypher handle the comments because then the second statement is evaluated as cypher instead of a command. So perhaps leaving the cleaning as it is is preferable? The current implementation has that awkward edgecase but at least the syntax highlighting indicates the something might be wrong.
