### PR TITLE
Update UX on :style usage

### DIFF
--- a/src/shared/modules/commands/commandsDuck.js
+++ b/src/shared/modules/commands/commandsDuck.js
@@ -161,7 +161,13 @@ export const handleCommandEpic = (action$, store) =>
       store.dispatch(clearErrorMessage())
       const maxHistory = getMaxHistory(store.getState())
       store.dispatch(addHistory(action.cmd, maxHistory))
-      const statements = shouldEnableMultiStatementMode(store.getState())
+
+      // Semicolons in :style grass break parsing of multiline statements from codemirror.
+      const useMultiLine =
+        !action.cmd.startsWith(':style') &&
+        shouldEnableMultiStatementMode(store.getState())
+
+      const statements = useMultiLine
         ? extractStatementsFromString(action.cmd)
         : [action.cmd]
 

--- a/src/shared/modules/commands/commandsDuck.js
+++ b/src/shared/modules/commands/commandsDuck.js
@@ -163,11 +163,11 @@ export const handleCommandEpic = (action$, store) =>
       store.dispatch(addHistory(action.cmd, maxHistory))
 
       // Semicolons in :style grass break parsing of multiline statements from codemirror.
-      const useMultiLine =
+      const useMultiStatement =
         !action.cmd.startsWith(':style') &&
         shouldEnableMultiStatementMode(store.getState())
 
-      const statements = useMultiLine
+      const statements = useMultiStatement
         ? extractStatementsFromString(action.cmd)
         : [action.cmd]
 

--- a/src/shared/services/exceptionMessages.js
+++ b/src/shared/services/exceptionMessages.js
@@ -30,3 +30,4 @@ export const FetchURLError =
   'Could not fetch URL: "#error#". This could be due to the remote server policy. See your web browsers error console for more information.'
 export const UnsupportedError = '#message#'
 export const NotFoundError = '#message#'
+export const InvalidGrassError = '#message#'

--- a/src/shared/services/exceptions.js
+++ b/src/shared/services/exceptions.js
@@ -115,3 +115,11 @@ export function NotFoundError(message) {
   }
 }
 errorFunctions.NotFoundError = NotFoundError
+
+export function InvalidGrassError(message) {
+  return {
+    type: 'InvalidGrassError',
+    message
+  }
+}
+errorFunctions.InvalidGrassError = InvalidGrassError

--- a/src/shared/services/grassUtils.js
+++ b/src/shared/services/grassUtils.js
@@ -102,7 +102,6 @@ function parseGrassCSS(string) {
 
 export const objToCss = obj => {
   if (typeof obj !== 'object') {
-    console.error('Need a object but got ', typeof obj, obj)
     return false
   }
   let output = ''


### PR DESCRIPTION
Fixes this problem where semicolons break style when using multiline.
<img width="673" alt="image" src="https://user-images.githubusercontent.com/10564538/87552303-cc75ba80-c6b1-11ea-8d81-988833bb2d24.png">

There's some behaviour changes, they are outlined as comments.