### PR TITLE
Card view

### DIFF
--- a/e2e_tests/integration/0.index.spec.js
+++ b/e2e_tests/integration/0.index.spec.js
@@ -24,8 +24,8 @@ import { isAura, isEnterpriseEdition } from '../support/utils'
 
 const Editor = '.ReactCodeMirror textarea'
 const Carousel = '[data-testid="carousel"]'
-const SubmitQueryButton = '[data-testid="submitQuery"]'
-const ClearEditorButton = '[data-testid="clearEditorContent"]'
+const SubmitQueryButton = '[data-testid="editorPlay"]'
+const ClearEditorButton = '[data-testid="editorClear"]'
 
 describe('Neo4j Browser', () => {
   before(function() {

--- a/e2e_tests/support/commands.js
+++ b/e2e_tests/support/commands.js
@@ -1,7 +1,7 @@
 import { executeCommand } from '../../src/shared/modules/commands/commandsDuck'
 
-const SubmitQueryButton = '[data-testid="submitQuery"]'
-const ClearEditorButton = '[data-testid="clearEditorContent"]'
+const SubmitQueryButton = '[data-testid="editorPlay"]'
+const ClearEditorButton = '[data-testid="editorClear"]'
 const Editor = '.ReactCodeMirror textarea'
 const VisibleEditor = '[data-testid="editor-wrapper"]'
 

--- a/src/browser/components/buttons/index.jsx
+++ b/src/browser/components/buttons/index.jsx
@@ -33,9 +33,10 @@ export const CloseButton = props => {
 }
 
 export const EditorButton = props => {
-  const { icon, title, ...rest } = props
+  const { icon, title, color, ...rest } = props
+  const overrideColor = { ...(color ? { color } : {}) }
   return (
-    <BaseButton title={title}>
+    <BaseButton title={title} style={overrideColor}>
       <SVGInline svg={icon} accessibilityLabel={title} {...rest} width="24px" />
     </BaseButton>
   )
@@ -61,10 +62,6 @@ const BaseButton = styled.span`
   cursor: pointer;
   vertical-align: middle;
   display: inline-block;
-`
-
-export const EditModeEditorButton = styled(EditorButton)`
-  color: ${props => props.theme.editModeButtonText};
 `
 
 export const StyledNavigationButton = styled.button`

--- a/src/browser/custom.d.ts
+++ b/src/browser/custom.d.ts
@@ -1,0 +1,4 @@
+declare module '*.svg' {
+  const content: string
+  export default content
+}

--- a/src/browser/modules/Editor/ActionButtons.tsx
+++ b/src/browser/modules/Editor/ActionButtons.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2002-2020 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react'
+import { ActionButtonSection } from './styled'
+import { EditorButton } from 'browser-components/buttons'
+export interface ActionButtonProps {
+  buttons: ActionButton[]
+}
+
+export interface ActionButton {
+  onClick: () => void
+  disabled: boolean
+  title: string
+  icon: string
+  iconColor?: string
+}
+
+const ActionButtons: React.FC<ActionButtonProps> = ({ buttons }) => {
+  return (
+    <ActionButtonSection width={buttons.length * 33}>
+      {buttons.map((btn: ActionButton) => (
+        <EditorButton
+          data-testid={`editor${btn.title}`}
+          onClick={btn.onClick}
+          disabled={btn.disabled}
+          title={btn.title}
+          icon={btn.icon}
+          key={`editor${btn.title}`}
+          color={btn.iconColor}
+        />
+      ))}
+    </ActionButtonSection>
+  )
+}
+
+export default ActionButtons

--- a/src/browser/modules/Editor/ActionButtons.tsx
+++ b/src/browser/modules/Editor/ActionButtons.tsx
@@ -21,11 +21,11 @@
 import React from 'react'
 import { ActionButtonSection } from './styled'
 import { EditorButton } from 'browser-components/buttons'
-export interface ActionButtonProps {
+interface ActionButtonProps {
   buttons: ActionButton[]
 }
 
-export interface ActionButton {
+interface ActionButton {
   onClick: () => void
   disabled: boolean
   title: string
@@ -33,22 +33,20 @@ export interface ActionButton {
   iconColor?: string
 }
 
-const ActionButtons: React.FC<ActionButtonProps> = ({ buttons }) => {
-  return (
-    <ActionButtonSection width={buttons.length * 33}>
-      {buttons.map((btn: ActionButton) => (
-        <EditorButton
-          data-testid={`editor${btn.title}`}
-          onClick={btn.onClick}
-          disabled={btn.disabled}
-          title={btn.title}
-          icon={btn.icon}
-          key={`editor${btn.title}`}
-          color={btn.iconColor}
-        />
-      ))}
-    </ActionButtonSection>
-  )
-}
+const ActionButtons: React.FC<ActionButtonProps> = ({ buttons }) => (
+  <ActionButtonSection containerWidth={buttons.length * 33}>
+    {buttons.map((btn: ActionButton) => (
+      <EditorButton
+        data-testid={`editor${btn.title}`}
+        onClick={btn.onClick}
+        disabled={btn.disabled}
+        title={btn.title}
+        icon={btn.icon}
+        key={`editor${btn.title}`}
+        color={btn.iconColor}
+      />
+    ))}
+  </ActionButtonSection>
+)
 
 export default ActionButtons

--- a/src/browser/modules/Editor/Editor.jsx
+++ b/src/browser/modules/Editor/Editor.jsx
@@ -70,13 +70,6 @@ const shouldCheckForHints = code =>
     .toUpperCase()
     .startsWith('PROFILE')
 
-const view = 'LINE' | 'CARD' | 'FULLSCREEN'
-// CURRENTLY. setting the card/fullscreen/line as statemachine instead of
-// demo new looks. // full screen? change it?
-// rewriting editor to be functional componen
-// pair for first rewriting to functinoal component then for typescripty
-// också. till action buttons. fixa resize uit!
-
 export class Editor extends Component {
   constructor(props) {
     super(props)
@@ -447,7 +440,7 @@ export class Editor extends Component {
 
     return (
       <Bar expanded={this.state.expanded} card={cardView}>
-        <Header card={cardView}>
+        <Header expanded={this.state.expanded} card={cardView}>
           <ActionButtons buttons={buttons} />
         </Header>
         <EditorWrapper expanded={this.state.expanded} card={cardView}>

--- a/src/browser/modules/Editor/Editor.jsx
+++ b/src/browser/modules/Editor/Editor.jsx
@@ -41,7 +41,7 @@ import {
   shouldEditorAutocomplete,
   shouldEditorLint
 } from 'shared/modules/settings/settingsDuck'
-import { Bar, ActionButtonSection, EditorWrapper } from './styled'
+import { Bar, ActionButtonSection, EditorWrapper, Header } from './styled'
 import { EditorButton, EditModeEditorButton } from 'browser-components/buttons'
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
 import { deepEquals, shallowEquals } from 'services/utils'
@@ -446,8 +446,8 @@ export class Editor extends Component {
     const cardView = this.codeMirror && this.codeMirror.lineCount() !== 1
 
     return (
-      <Bar expanded={this.state.expanded}>
-        <Header style={cardView && { width: '100%' }}>
+      <Bar expanded={this.state.expanded} card={cardView}>
+        <Header card={cardView}>
           <ActionButtons buttons={buttons} />
         </Header>
         <EditorWrapper expanded={this.state.expanded} card={cardView}>

--- a/src/browser/modules/Editor/Editor.test.js
+++ b/src/browser/modules/Editor/Editor.test.js
@@ -45,7 +45,10 @@ describe('<Editor /> ', () => {
     it('should setup on mount', async () => {
       // Given bus is provided
       const bus = createBus()
-      const { findByText } = render(<Editor {...props} bus={bus} />)
+      const mockTheme = { editModeButtonText: 'red' }
+      const { findByText } = render(
+        <Editor {...props} bus={bus} theme={mockTheme} />
+      )
 
       // The SET_CONTENT action
       // When

--- a/src/browser/modules/Editor/styled.jsx
+++ b/src/browser/modules/Editor/styled.jsx
@@ -28,7 +28,8 @@ export const BaseBar = styled.div`
   border-radius: 4px;
   margin: ${editorPadding}px 0px ${editorPadding}px 0;
   display: grid;
-  grid-template-columns: 1fr auto;
+  // minmax(0, 1fr) prevents the editor from growing the text field
+  grid-template-columns: minmax(0, 1fr) auto;
   grid-template-areas: ${props => {
     if (props.expanded || props.card) {
       return "'header' 'editor'"
@@ -40,7 +41,12 @@ export const BaseBar = styled.div`
 export const Header = styled.div`
   grid-area: header;
   border-radius: 4px 4px 0 0;
-  ${props => (props.card ? 'background-color: #F8F9FB' : '')};
+  ${props => {
+    if (props.expanded || props.card) {
+      return 'background-color: #F8F9FB'
+    }
+    return ''
+  }};
   display: flex;
   justify-content: flex-end;
 `
@@ -70,8 +76,6 @@ export const ActionButtonSection = styled.div`
 const BaseEditorWrapper = styled.div`
   font-family: 'Fira Code', Monaco, 'Courier New', Terminal, monospace;
   grid-area: editor;
-  //flex: auto;
-  //width: 0; // this makes the editor wrap lines instead of making the editor wider
 
   min-height: ${props => {
     if (props.expanded) {
@@ -103,7 +107,7 @@ export const EditorWrapper = styled(BaseEditorWrapper)`
           position: absolute;
           left: 12px;
           right: 142px;
-          top: 12px;
+          top: 42px;
           bottom: 12px;
         }
         .CodeMirror-scroll {

--- a/src/browser/modules/Editor/styled.jsx
+++ b/src/browser/modules/Editor/styled.jsx
@@ -42,11 +42,18 @@ export const Header = styled.div`
   grid-area: header;
   border-radius: 4px 4px 0 0;
   ${props => {
-    if (props.expanded || props.card) {
-      return 'background-color: #F8F9FB'
+    if (props.expanded) {
+      return `background-color: #4d4a57;
+              border-radius: 0;
+      `
+    }
+    if (props.card) {
+      return `background-color: #4d4a57;
+              transition-duration: 0.3s;`
     }
     return ''
-  }};
+  }}
+
   display: flex;
   justify-content: flex-end;
 `
@@ -87,6 +94,8 @@ const BaseEditorWrapper = styled.div`
     }
     return '0'
   }};
+
+  ${props => (props.expanded ? '' : 'transition-duration: 0.1s;')}
 
   .CodeMirror {
     color: ${props => props.theme.editorCommandColor};

--- a/src/browser/modules/Editor/styled.jsx
+++ b/src/browser/modules/Editor/styled.jsx
@@ -24,51 +24,56 @@ import { dim } from 'browser-styles/constants'
 const editorPadding = 10
 
 export const BaseBar = styled.div`
-  background-color: ${props => props.theme.primaryBackground};
-  display: flex;
-  flex-direction: row;
-  align-items: middle;
-  min-height: ${props =>
-    props.expanded
-      ? '100vh'
-      : Math.max(dim.editorbarHeight, props.minHeight + editorPadding * 2)}px;
-  overflow: hidden;
-
-  margin: 0;
+  background-color: ${props => props.theme.editorBackground};
+  border-radius: 4px;
+  margin: ${editorPadding}px 0px ${editorPadding}px 0;
+  display: grid;
 `
+
+export const Header = styled.div`
+  background-color: gray;
+`
+
 export const Bar = styled(BaseBar)`
   ${props => {
     if (props.expanded) {
-      return (
-        'position: absolute;' +
-        'height: 100vh;' +
-        'z-index: 100;' +
-        'right: 0;' +
-        'left: 0;' +
-        'bottom: 0;'
-      )
+      return `
+position: fixed;
+top: -10px;
+bottom: 0;
+left: 0;
+right: 0;
+height: 100vh;
+border-radius: 0;
+z-index: 1030;`
     }
   }};
 `
 export const ActionButtonSection = styled.div`
-  flex: 0 0 120px;
-  align-items: top;
   display: flex;
-  padding-top: 21px;
   justify-content: space-between;
+  width: ${props => props.width}px;
+  margin-top: 7px;
+  margin-right: 7px;
 `
 
 const BaseEditorWrapper = styled.div`
-  flex: auto;
-  padding: ${editorPadding}px ${editorPadding}px ${editorPadding}px 0;
   font-family: 'Fira Code', Monaco, 'Courier New', Terminal, monospace;
-  min-height: ${props =>
-    props.expanded
-      ? '100vh'
-      : Math.max(dim.editorbarHeight, props.minHeight + editorPadding * 2)}px;
-  width: 0;
+  flex: auto;
+  width: 0; // this makes the editor wrap lines instead of making the editor wider
+
+  min-height: ${props => {
+    if (props.expanded) {
+      return '100vh'
+    }
+    if (props.card) {
+      // 230 is 10 lines + 2*12px padding
+      return '254px'
+    }
+    return '0'
+  }};
+
   .CodeMirror {
-    background-color: ${props => props.theme.editorBackground} !important;
     color: ${props => props.theme.editorCommandColor};
     font-size: 17px;
   }
@@ -81,20 +86,19 @@ const BaseEditorWrapper = styled.div`
 export const EditorWrapper = styled(BaseEditorWrapper)`
   ${props => {
     if (props.expanded) {
-      return (
-        'height: 100%;' +
-        'z-index: 2;' +
-        '.CodeMirror {' +
-        '  position: absolute;' +
-        '  left: 12px;' +
-        '  right: 142px;' +
-        '  top: 12px;' +
-        '  bottom: 12px;' +
-        '}' +
-        '.CodeMirror-scroll {' +
-        '   max-height: initial !important;' +
-        '}'
-      )
+      return `height: 100%;
+        z-index: 2;
+        .CodeMirror {
+          position: absolute;
+          left: 12px;
+          right: 142px;
+          top: 12px;
+          bottom: 12px;
+        }
+        .CodeMirror-scroll {
+           max-height: initial !important;
+        }
+      `
     }
   }};
 `

--- a/src/browser/modules/Editor/styled.jsx
+++ b/src/browser/modules/Editor/styled.jsx
@@ -28,10 +28,21 @@ export const BaseBar = styled.div`
   border-radius: 4px;
   margin: ${editorPadding}px 0px ${editorPadding}px 0;
   display: grid;
+  grid-template-columns: 1fr auto;
+  grid-template-areas: ${props => {
+    if (props.expanded || props.card) {
+      return "'header' 'editor'"
+    }
+    return "'editor header'"
+  }};
 `
 
 export const Header = styled.div`
-  background-color: gray;
+  grid-area: header;
+  border-radius: 4px 4px 0 0;
+  ${props => (props.card ? 'background-color: #F8F9FB' : '')};
+  display: flex;
+  justify-content: flex-end;
 `
 
 export const Bar = styled(BaseBar)`
@@ -53,14 +64,14 @@ export const ActionButtonSection = styled.div`
   display: flex;
   justify-content: space-between;
   width: ${props => props.width}px;
-  margin-top: 7px;
-  margin-right: 7px;
+  margin: 7px;
 `
 
 const BaseEditorWrapper = styled.div`
   font-family: 'Fira Code', Monaco, 'Courier New', Terminal, monospace;
-  flex: auto;
-  width: 0; // this makes the editor wrap lines instead of making the editor wider
+  grid-area: editor;
+  //flex: auto;
+  //width: 0; // this makes the editor wrap lines instead of making the editor wider
 
   min-height: ${props => {
     if (props.expanded) {

--- a/src/browser/modules/Editor/styled.tsx
+++ b/src/browser/modules/Editor/styled.tsx
@@ -19,18 +19,22 @@
  */
 
 import styled from 'styled-components'
-import { dim } from 'browser-styles/constants'
+
+interface ResizeableProps {
+  expanded: boolean
+  card: boolean
+}
 
 const editorPadding = 10
 
-export const BaseBar = styled.div`
-  background-color: ${props => props.theme.editorBackground};
+export const BaseBar = styled.div<ResizeableProps>`
+  background-color: ${(props): string => props.theme.editorBackground};
   border-radius: 4px;
   margin: ${editorPadding}px 0px ${editorPadding}px 0;
   display: grid;
   // minmax(0, 1fr) prevents the editor from growing the text field
   grid-template-columns: minmax(0, 1fr) auto;
-  grid-template-areas: ${props => {
+  grid-template-areas: ${(props): string => {
     if (props.expanded || props.card) {
       return "'header' 'editor'"
     }
@@ -38,10 +42,10 @@ export const BaseBar = styled.div`
   }};
 `
 
-export const Header = styled.div`
+export const Header = styled.div<ResizeableProps>`
   grid-area: header;
   border-radius: 4px 4px 0 0;
-  ${props => {
+  ${(props): string => {
     if (props.expanded) {
       return `background-color: #4d4a57;
               border-radius: 0;
@@ -58,8 +62,8 @@ export const Header = styled.div`
   justify-content: flex-end;
 `
 
-export const Bar = styled(BaseBar)`
-  ${props => {
+export const Bar = styled(BaseBar)<ResizeableProps>`
+  ${(props): string => {
     if (props.expanded) {
       return `
 position: fixed;
@@ -71,20 +75,26 @@ height: 100vh;
 border-radius: 0;
 z-index: 1030;`
     }
+    return ''
   }};
 `
-export const ActionButtonSection = styled.div`
+
+interface ActionButtonContainerProps {
+  containerWidth: number
+}
+
+export const ActionButtonSection = styled.div<ActionButtonContainerProps>`
   display: flex;
   justify-content: space-between;
-  width: ${props => props.width}px;
+  width: ${(props): number => props.containerWidth}px;
   margin: 7px;
 `
 
-const BaseEditorWrapper = styled.div`
+const BaseEditorWrapper = styled.div<ResizeableProps>`
   font-family: 'Fira Code', Monaco, 'Courier New', Terminal, monospace;
   grid-area: editor;
 
-  min-height: ${props => {
+  min-height: ${(props): string => {
     if (props.expanded) {
       return '100vh'
     }
@@ -95,10 +105,10 @@ const BaseEditorWrapper = styled.div`
     return '0'
   }};
 
-  ${props => (props.expanded ? '' : 'transition-duration: 0.1s;')}
+  ${(props): string => (props.expanded ? '' : 'transition-duration: 0.1s;')}
 
   .CodeMirror {
-    color: ${props => props.theme.editorCommandColor};
+    color: ${(props): string => props.theme.editorCommandColor};
     font-size: 17px;
   }
 
@@ -107,8 +117,8 @@ const BaseEditorWrapper = styled.div`
   }
 `
 
-export const EditorWrapper = styled(BaseEditorWrapper)`
-  ${props => {
+export const EditorWrapper = styled(BaseEditorWrapper)<ResizeableProps>`
+  ${(props): string => {
     if (props.expanded) {
       return `height: 100%;
         z-index: 2;
@@ -123,6 +133,8 @@ export const EditorWrapper = styled(BaseEditorWrapper)`
            max-height: initial !important;
         }
       `
+    } else {
+      return ''
     }
   }};
 `

--- a/src/browser/modules/Sidebar/About.tsx
+++ b/src/browser/modules/Sidebar/About.tsx
@@ -43,7 +43,7 @@ function asChangeLogUrl(serverVersion: string): string | undefined {
   return `https://github.com/neo4j/neo4j/wiki/Neo4j-${urlServerVersion}-changelog#${releaseTag}`
 }
 
-export interface AboutProps {
+interface AboutProps {
   serverVersion: string
   serverEdition: string
 }

--- a/src/browser/modules/Sidebar/Sidebar.tsx
+++ b/src/browser/modules/Sidebar/Sidebar.tsx
@@ -46,7 +46,7 @@ import {
   AboutIcon
 } from 'browser-components/icons/Icons'
 
-export type SidebarProps = {
+interface SidebarProps {
   openDrawer: string
   onNavClick: () => void
   showStaticScripts: boolean

--- a/src/browser/styles/global-styles.js
+++ b/src/browser/styles/global-styles.js
@@ -88,7 +88,7 @@ export const GlobalStyle = createGlobalStyle`
 
   .CodeMirror-scroll {
     overflow: hidden !important;
-    max-height: 140px !important;
+    max-height: 230px !important;
   }
 
   .CodeMirror div.CodeMirror-cursor {

--- a/src/browser/styles/global-styles.js
+++ b/src/browser/styles/global-styles.js
@@ -49,7 +49,7 @@ export const GlobalStyle = createGlobalStyle`
 
   .CodeMirror {
     background-color: #fff !important;
-    padding: 12px !important;
+    margin: 12px !important;
     border-radius: 4px !important;
     transition: all !important;
   }

--- a/src/browser/styles/global-styles.js
+++ b/src/browser/styles/global-styles.js
@@ -48,7 +48,7 @@ export const GlobalStyle = createGlobalStyle`
   }
 
   .CodeMirror {
-    background-color: #fff !important;
+    background: initial !important; // overrides lib css 
     margin: 12px !important;
     border-radius: 4px !important;
     transition: all !important;


### PR DESCRIPTION
PR moves buttons inside editor like so: 
<img width="645" alt="bild" src="https://user-images.githubusercontent.com/10564538/89270975-5f17d280-d63c-11ea-83f7-5d3f4dae2dd2.png">

Multiline now looks:
<img width="645" alt="bild" src="https://user-images.githubusercontent.com/10564538/89271005-6b039480-d63c-11ea-8248-8f035255b958.png">

Full screen is really fullscreen:
<img width="715" alt="bild" src="https://user-images.githubusercontent.com/10564538/89271047-7a82dd80-d63c-11ea-8fa5-e37f23c0e6b7.png">

Current multiline for reference:
<img width="808" alt="bild" src="https://user-images.githubusercontent.com/10564538/89271113-8ff80780-d63c-11ea-8ca8-e95b85b59579.png">

Colors, transitions, positioning, icons and other cosmetics still need more work though.


The gifs' framerate is to low to give it justice but there are some transitions: http://g.recordit.co/akBSL40Dhs.gif