### PR TITLE
Add multi statement query warning when multi statement is disabled

### DIFF
--- a/src/browser/modules/Editor/Editor.jsx
+++ b/src/browser/modules/Editor/Editor.jsx
@@ -274,10 +274,13 @@ export class Editor extends Component {
   checkForMultiStatementWarnings(statements) {
     if (statements.length > 1 && !this.props.enableMultiStatementMode) {
       const { offset, line, column } = statements[1].start
+      const message =
+        'To use multi statement queries, please enable multi statement in the settings panel.'
       this.setState({
         notifications: [
           {
             code: 'frontendWarning',
+            description: message,
             position: {
               offset,
               line,
@@ -285,12 +288,14 @@ export class Editor extends Component {
             },
             severity: 'WARNING',
             errors: {
-              message:
-                'Multi statement query will be rejected unless multi statement is enabled in settings.'
-            }
+              message
+            },
+            title: 'Multi Statement Query'
           }
         ]
       })
+    } else {
+      this.setState({ notifications: [] })
     }
   }
 

--- a/src/browser/modules/Editor/Editor.jsx
+++ b/src/browser/modules/Editor/Editor.jsx
@@ -106,7 +106,8 @@ export class Editor extends Component {
       nextState.editorHeight === this.state.editorHeight &&
       shallowEquals(nextState.notifications, this.state.notifications) &&
       deepEquals(nextProps.schema, this.props.schema) &&
-      nextProps.useDb === this.props.useDb
+      nextProps.useDb === this.props.useDb &&
+      nextProps.enableMultiStatementMode === this.props.enableMultiStatementMode
     )
   }
 
@@ -271,6 +272,15 @@ export class Editor extends Component {
     this.setState({ contentId: id })
   }
 
+  componentDidUpdate(prevProps) {
+    if (
+      prevProps.enableMultiStatementMode !== this.props.enableMultiStatementMode
+    ) {
+      // Set value to current value to trigger warning checks
+      this.setEditorValue(this.getEditorValue())
+    }
+  }
+
   checkForMultiStatementWarnings(statements) {
     if (statements.length > 1 && !this.props.enableMultiStatementMode) {
       const { offset, line, column } = statements[1].start
@@ -342,7 +352,10 @@ export class Editor extends Component {
               const notifications = response.result.summary.notifications.map(
                 n => ({
                   ...n,
-                  position: { ...n.position, line: n.position.line + offset },
+                  position: {
+                    ...n.position,
+                    line: n.position.line + offset
+                  },
                   statement: response.result.summary.query.text
                 })
               )


### PR DESCRIPTION
When the editor checks the current query with `explain`, the potential mistake of sending multiple statements in one query is not caught. Frontend has the info to flag this issue so this PR adds an extra check on editor update, and displays the warning as a warning triangle in the editor gutter.

![multi statement warning](https://user-images.githubusercontent.com/939458/89643642-88439780-d8b6-11ea-9962-b6f8b1a2c717.gif)

When clicking other warnings in the editor, an explain query is sent and the result displayed in a warning frame. Since this warning is caught in frontend, that query is skipped and a simple error frame with a message is displayed.