### PR TITLE
Bump elliptic dependency

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4998,9 +4998,9 @@ elegant-spinner@^1.0.1:
   integrity sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
 
 elliptic@^6.0.0, elliptic@^6.5.2:
-  version "6.5.2"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/elliptic/-/elliptic-6.5.2.tgz#05c5678d7173c049d8ca433552224a495d0e3762"
-  integrity sha1-BcVnjXFzwEnYykM1UiJKSV0ON2I=
+  version "6.5.3"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
+  integrity sha1-y1nrLv2vc6C9eMzXAVpirW4Pk9Y=
   dependencies:
     bn.js "^4.4.0"
     brorand "^1.0.1"


### PR DESCRIPTION
`elliptic` 6.5.2 has a security warning that is fixed in 6.5.3.
We depend on elliptic through the chain of dependencies `webpack@4` --> `node-libs-browser` --> `crypto-browserify` --> `browserify-sign` and `create-ecdh`. Of these only browserify-sign have bumped ellipic to 6.5.3, so bumping our resolved dependency in our lock file is the practical way of solving the security warning short-term. Next patch version of webpack should have elliptic 6.5.3 and next major version of webpack will drop node-libs-browser completely.