### PR TITLE
Shortcuts

### DIFF
--- a/e2e_tests/integration/commands.spec.js
+++ b/e2e_tests/integration/commands.spec.js
@@ -64,7 +64,7 @@ describe('Commands', () => {
       .should('have.length', 2)
 
     // focus editor
-    cy.get('body').type('{shift}7')
+    cy.get('body').type('/')
     cy.get('.ReactCodeMirror textarea')
       .should('be', 'focused')
       .type(':clear{shift}{enter}')

--- a/e2e_tests/integration/commands.spec.js
+++ b/e2e_tests/integration/commands.spec.js
@@ -64,7 +64,7 @@ describe('Commands', () => {
       .should('have.length', 2)
 
     // focus editor
-    cy.get('body').type('/')
+    cy.get('body').type('{shift}7')
     cy.get('.ReactCodeMirror textarea')
       .should('be', 'focused')
       .type(':clear{shift}{enter}')

--- a/e2e_tests/integration/editor.spec.js
+++ b/e2e_tests/integration/editor.spec.js
@@ -72,7 +72,7 @@ describe('editor', () => {
     // discard resets size and clears editor
     cy.get(cardSizeButton).click()
     cy.get('.CodeMirror-linenumber').should('contain', '1')
-    cy.get('body').type('{shift}7test')
+    cy.get('body').type('/test')
     cy.get('.CodeMirror-line').contains('test')
     cy.get(discardButton).click()
     cy.get('.CodeMirror-linenumber').should('contain', '$')

--- a/e2e_tests/integration/editor.spec.js
+++ b/e2e_tests/integration/editor.spec.js
@@ -32,7 +32,7 @@ describe('editor', () => {
   it('full screen is always in multiline', () => {
     cy.get('.CodeMirror-linenumber').should('contain', '$')
     // Go to full screen
-    cy.get('body').type('{esc}')
+    cy.get('body').type('{cmd}{ctrl}{alt}f')
     cy.get('.CodeMirror-linenumber').should('contain', '1')
 
     // Enter enters more lines
@@ -72,7 +72,7 @@ describe('editor', () => {
     // discard resets size and clears editor
     cy.get(cardSizeButton).click()
     cy.get('.CodeMirror-linenumber').should('contain', '1')
-    cy.get('body').type('/test')
+    cy.get('body').type('{shift}7test')
     cy.get('.CodeMirror-line').contains('test')
     cy.get(discardButton).click()
     cy.get('.CodeMirror-linenumber').should('contain', '$')

--- a/src/browser/components/icons/IconContainer.jsx
+++ b/src/browser/components/icons/IconContainer.jsx
@@ -62,7 +62,12 @@ export class IconContainer extends Component {
 
     const currentIcon = icon ? (
       <StyledIconWrapper {...rest}>
-        <SVGInline svg={icon} accessibilityLabel={title} width={width + 'px'} />
+        <SVGInline
+          cleanup={['title']}
+          svg={icon}
+          accessibilityLabel={title}
+          width={width + 'px'}
+        />
       </StyledIconWrapper>
     ) : (
       <StyledIconWrapper {...rest} style={regulateSizeStyle} />

--- a/src/browser/documentation/help/keys.jsx
+++ b/src/browser/documentation/help/keys.jsx
@@ -19,6 +19,13 @@
  */
 
 import React from 'react'
+import {
+  FULLSCREEN_SHORTCUT,
+  FOCUS_SHORTCUT,
+  CARDSIZE_SHORTCUT,
+  printShortcut,
+  isMac
+} from 'browser/modules/App/keyboardShortcuts'
 const title = 'Keys'
 const subtitle = 'Keyboard shortcuts'
 const category = 'browserUiCommands'
@@ -36,7 +43,9 @@ const content = (
         <tr>
           <td>Execute current command</td>
           <td>
-            <div className="key code">{'<Ctrl-Return>'}</div>
+            <div className="key code">
+              {isMac ? '<Cmd-Return>' : '<Ctrl-Return>'}
+            </div>
           </td>
           <td>
             <div className="key code">{'<Return>'}</div>
@@ -45,7 +54,9 @@ const content = (
         <tr>
           <td>Previous command in history</td>
           <td>
-            <div className="key code">{'<Ctrl-Up-Arrow>'}</div>
+            <div className="key code">
+              {isMac ? '<Cmd-Up-Arrow>' : '<Ctrl-Up-Arrow>'}
+            </div>
           </td>
           <td>
             <div className="key code">{'<Up-Arrow>'}</div>
@@ -54,7 +65,9 @@ const content = (
         <tr>
           <td>Next command in history</td>
           <td>
-            <div className="key code">{'<Ctrl-Down-Arrow>'}</div>
+            <div className="key code">
+              {isMac ? '<Cmd-Down-Arrow>' : '<Ctrl-Down-Arrow>'}
+            </div>
           </td>
           <td>
             <div className="key code">{'<Down-Arrow>'}</div>
@@ -78,29 +91,23 @@ const content = (
         <tr>
           <td>Change focus to editor</td>
           <td>
-            <div className="key code">/</div>
+            <div className="key code">{printShortcut(FOCUS_SHORTCUT)}</div>
           </td>
         </tr>
         <tr>
           <td>Toggle fullscreen editor</td>
           <td>
-            <div className="key code">Esc</div>
+            <div className="key code">{printShortcut(FULLSCREEN_SHORTCUT)}</div>
+          </td>
+        </tr>
+        <tr>
+          <td>Toggle cardsize editor</td>
+          <td>
+            <div className="key code">{printShortcut(CARDSIZE_SHORTCUT)}</div>
           </td>
         </tr>
         <tr>
           <td />
-        </tr>
-        <tr>
-          <th>Platform specific</th>
-          <th />
-          <th />
-        </tr>
-        <tr>
-          <td>Mac users</td>
-          <td>
-            Use <span className="key code">Cmd</span> instead of{' '}
-            <span className="key code">Ctrl</span>
-          </td>
         </tr>
       </tbody>
     </table>

--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -81,6 +81,7 @@ import {
   getDesktopTheme
 } from 'browser-components/desktop-api/desktop-api.handlers'
 import { METRICS_EVENT } from 'shared/modules/udc/udcDuck'
+import { useKeyboardShortcuts } from './keyboardShortcuts'
 
 export function App(props) {
   const [derivedTheme, setEnvironmentTheme] = useDerivedTheme(
@@ -89,15 +90,7 @@ export function App(props) {
   )
   const themeData = themes[derivedTheme] || themes[LIGHT_THEME]
 
-  useEffect(() => {
-    document.addEventListener('keyup', focusEditorOnSlash)
-    document.addEventListener('keyup', expandEditorOnEsc)
-
-    return () => {
-      document.removeEventListener('keyup', focusEditorOnSlash)
-      document.removeEventListener('keyup', expandEditorOnEsc)
-    }
-  }, [])
+  useKeyboardShortcuts()
 
   const eventMetricsCallback = useRef(() => {})
 
@@ -111,16 +104,6 @@ export function App(props) {
       })
     return () => unsub && unsub()
   }, [])
-
-  const focusEditorOnSlash = e => {
-    if (['INPUT', 'TEXTAREA'].indexOf(e.target.tagName) > -1) return
-    if (e.key !== '/') return
-    props.bus && props.bus.send(FOCUS)
-  }
-  const expandEditorOnEsc = e => {
-    if (e.keyCode !== 27) return
-    props.bus && props.bus.send(EXPAND)
-  }
 
   const {
     drawer,

--- a/src/browser/modules/App/App.jsx
+++ b/src/browser/modules/App/App.jsx
@@ -90,7 +90,7 @@ export function App(props) {
   )
   const themeData = themes[derivedTheme] || themes[LIGHT_THEME]
 
-  useKeyboardShortcuts()
+  useKeyboardShortcuts(props.bus)
 
   const eventMetricsCallback = useRef(() => {})
 

--- a/src/browser/modules/App/keyboardShortcuts.ts
+++ b/src/browser/modules/App/keyboardShortcuts.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { FOCUS, EXPAND, CARDSIZE } from 'shared/modules/editor/editorDuck'
 import { Bus } from 'suber'
 
-const isMac = /Mac|iPod|iPhone|iPad/.test(navigator.platform)
+export const isMac = /Mac|iPad/.test(navigator.platform)
 const modKey = isMac ? 'metaKey' : 'ctrlKey'
 
 type ModifyerKey = 'metaKey' | 'altKey' | 'ctrlKey'
@@ -41,8 +41,8 @@ export const FOCUS_SHORTCUT: Shortcut = {
 export function printShortcut(s: Shortcut): string {
   return s.modifyers
     .map(mod => printModifyers[mod])
-    .concat(decodeKeycode[s.keyCode])
-    .join(' ')
+    .concat(decodeKeycode[s.keyCode].toUpperCase())
+    .join(isMac ? '' : ' + ')
 }
 
 function matchesShortcut(e: KeyboardEvent, shortcut: Shortcut): boolean {
@@ -65,15 +65,15 @@ export function useKeyboardShortcuts(bus: Bus): void {
   }
 
   const expandEditor = (e: KeyboardEvent): void => {
-    e.preventDefault()
     if (matchesShortcut(e, FULLSCREEN_SHORTCUT)) {
+      e.preventDefault()
       trigger(EXPAND)
     }
   }
 
   const cardSizeShortcut = (e: KeyboardEvent): void => {
-    e.preventDefault()
     if (matchesShortcut(e, CARDSIZE_SHORTCUT)) {
+      e.preventDefault()
       trigger(CARDSIZE)
     }
   }

--- a/src/browser/modules/App/keyboardShortcuts.ts
+++ b/src/browser/modules/App/keyboardShortcuts.ts
@@ -1,0 +1,40 @@
+import { useEffect } from 'react'
+import { FOCUS, EXPAND } from 'shared/modules/editor/editorDuck'
+import { Bus } from 'suber'
+
+export function useKeyboardShortcuts(bus: Bus): void {
+  // @ts-expect-error
+  const trigger = (msg: string): void => bus && bus.send(msg)
+
+  const focusEditorOnSlash = (e: KeyboardEvent): void => {
+    // @ts-expect-error
+    if (['INPUT', 'TEXTAREA'].indexOf(e.target.tagName) > -1) return
+    if (e.key !== '/') return
+    trigger(FOCUS)
+  }
+  const expandEditorOnEsc = (e: KeyboardEvent): void => {
+    if (e.keyCode !== 27) return
+    trigger(EXPAND)
+  }
+  const cardSizeShortcut = (e: KeyboardEvent): void => {
+    if (e.keyCode !== 27) return
+    trigger(EXPAND)
+  }
+
+  const keyboardShortcuts = [
+    focusEditorOnSlash,
+    expandEditorOnEsc,
+    cardSizeShortcut
+  ]
+
+  useEffect(() => {
+    keyboardShortcuts.forEach(shortcut =>
+      document.addEventListener('keyup', shortcut)
+    )
+
+    return (): void =>
+      keyboardShortcuts.forEach(shortcut =>
+        document.removeEventListener('keyup', shortcut)
+      )
+  }, [])
+}

--- a/src/browser/modules/App/keyboardShortcuts.ts
+++ b/src/browser/modules/App/keyboardShortcuts.ts
@@ -52,7 +52,7 @@ function matchesShortcut(e: KeyboardEvent, shortcut: Shortcut): boolean {
 
 function isOutsideTextArea(e: KeyboardEvent): boolean {
   const tagName = (e.target as HTMLElement).tagName
-  return ['INPUT', 'TEXTAREA'].indexOf(tagName) > -1
+  return ['INPUT', 'TEXTAREA'].indexOf(tagName) === -1
 }
 
 export function useKeyboardShortcuts(bus: Bus): void {
@@ -60,6 +60,7 @@ export function useKeyboardShortcuts(bus: Bus): void {
 
   const focusEditorOnSlash = (e: KeyboardEvent): void => {
     if (isOutsideTextArea(e) && matchesShortcut(e, FOCUS_SHORTCUT)) {
+      e.preventDefault()
       trigger(FOCUS)
     }
   }

--- a/src/browser/modules/App/keyboardShortcuts.ts
+++ b/src/browser/modules/App/keyboardShortcuts.ts
@@ -1,24 +1,35 @@
 import { useEffect } from 'react'
-import { FOCUS, EXPAND } from 'shared/modules/editor/editorDuck'
+import { FOCUS, EXPAND, CARDSIZE } from 'shared/modules/editor/editorDuck'
 import { Bus } from 'suber'
 
+const keycodes = {
+  27: 'esc',
+  esc: 27
+}
+
 export function useKeyboardShortcuts(bus: Bus): void {
-  // @ts-expect-error
-  const trigger = (msg: string): void => bus && bus.send(msg)
+  const trigger = (msg: string): void => bus && bus.send(msg, null)
 
   const focusEditorOnSlash = (e: KeyboardEvent): void => {
-    // @ts-expect-error
-    if (['INPUT', 'TEXTAREA'].indexOf(e.target.tagName) > -1) return
-    if (e.key !== '/') return
-    trigger(FOCUS)
+    const tagName = (e.target as HTMLElement).tagName
+    const writingText = ['INPUT', 'TEXTAREA'].indexOf(tagName) > -1
+    const typedSlash = e.key === '/'
+
+    if (!writingText && typedSlash) {
+      trigger(FOCUS)
+    }
   }
+
   const expandEditorOnEsc = (e: KeyboardEvent): void => {
-    if (e.keyCode !== 27) return
-    trigger(EXPAND)
+    if (e.keyCode === keycodes.esc) {
+      trigger(EXPAND)
+    }
   }
+
   const cardSizeShortcut = (e: KeyboardEvent): void => {
-    if (e.keyCode !== 27) return
-    trigger(EXPAND)
+    if (e.ctrlKey && e.key === 'b') {
+      trigger(CARDSIZE)
+    }
   }
 
   const keyboardShortcuts = [

--- a/src/browser/modules/App/keyboardShortcuts.ts
+++ b/src/browser/modules/App/keyboardShortcuts.ts
@@ -5,49 +5,49 @@ import { Bus } from 'suber'
 export const isMac = /Mac|iPad/.test(navigator.platform)
 const modKey = isMac ? 'metaKey' : 'ctrlKey'
 
-type ModifyerKey = 'metaKey' | 'altKey' | 'ctrlKey'
-const printModifyers: Record<ModifyerKey, string> = {
+type ModifierKey = 'metaKey' | 'altKey' | 'ctrlKey'
+const printModifiers: Record<ModifierKey, string> = {
   altKey: isMac ? '⌥' : 'alt',
   metaKey: isMac ? '⌘' : 'win',
   ctrlKey: isMac ? '⌃' : 'ctrl'
 }
 
 const encodeKey: Record<string, number> = { c: 67, f: 70, '/': 55 }
-const decodeKeycode: Record<number, string> = Object.entries(encodeKey).reduce(
-  (acc: Record<number, string>, [char, keyCode]: [string, number]) => ({
-    ...acc,
-    [keyCode]: char
-  }),
-  {}
-)
-
 interface Shortcut {
-  modifyers: ModifyerKey[]
-  keyCode: number
+  modifyers: ModifierKey[]
+  key: string
 }
 export const FULLSCREEN_SHORTCUT: Shortcut = {
   modifyers: [modKey, 'altKey'],
-  keyCode: encodeKey.f
+  key: 'f'
 }
 export const CARDSIZE_SHORTCUT: Shortcut = {
   modifyers: [modKey, 'altKey'],
-  keyCode: encodeKey.c
+  key: 'c'
 }
 export const FOCUS_SHORTCUT: Shortcut = {
   modifyers: [],
-  keyCode: encodeKey['/']
+  key: '/'
 }
 
 export function printShortcut(s: Shortcut): string {
   return s.modifyers
-    .map(mod => printModifyers[mod])
-    .concat(decodeKeycode[s.keyCode].toUpperCase())
+    .map(mod => printModifiers[mod])
+    .concat(s.key.toUpperCase())
     .join(isMac ? '' : ' + ')
 }
 
 function matchesShortcut(e: KeyboardEvent, shortcut: Shortcut): boolean {
-  const hasCorrectModifyers = shortcut.modifyers.every(mod => e[mod])
-  return hasCorrectModifyers && e.keyCode === shortcut.keyCode
+  const hasCorrectModifiers = shortcut.modifyers.every(mod => e[mod])
+  // comparing keys instead of keycode is preferable because it
+  // respects keyboard layouts, since using alt changes what key is sent,
+  // we need to fall back to keycode (keyboard location) on some shortcuts
+  const shortcutUsesAlt = shortcut.modifyers.includes('altKey')
+  const correctKey = shortcutUsesAlt
+    ? e.keyCode === encodeKey[shortcut.key]
+    : e.key === shortcut.key
+
+  return hasCorrectModifiers && correctKey
 }
 
 function isOutsideTextArea(e: KeyboardEvent): boolean {

--- a/src/browser/modules/App/keyboardShortcuts.ts
+++ b/src/browser/modules/App/keyboardShortcuts.ts
@@ -2,50 +2,46 @@ import { useEffect } from 'react'
 import { FOCUS, EXPAND, CARDSIZE } from 'shared/modules/editor/editorDuck'
 import { Bus } from 'suber'
 
-const keycodes = {
-  27: 'esc',
-  esc: 27
+const keycodes = { c: 67, f: 70 }
+
+const isOutsideTextArea = (e: KeyboardEvent): boolean => {
+  const tagName = (e.target as HTMLElement).tagName
+  return ['INPUT', 'TEXTAREA'].indexOf(tagName) > -1
 }
 
 export function useKeyboardShortcuts(bus: Bus): void {
   const trigger = (msg: string): void => bus && bus.send(msg, null)
 
   const focusEditorOnSlash = (e: KeyboardEvent): void => {
-    const tagName = (e.target as HTMLElement).tagName
-    const writingText = ['INPUT', 'TEXTAREA'].indexOf(tagName) > -1
-    const typedSlash = e.key === '/'
-
-    if (!writingText && typedSlash) {
+    if (isOutsideTextArea(e) && e.key === '/') {
       trigger(FOCUS)
     }
   }
 
-  const expandEditorOnEsc = (e: KeyboardEvent): void => {
-    if (e.keyCode === keycodes.esc) {
+  const expandEditor = (e: KeyboardEvent): void => {
+    e.preventDefault()
+    if ((e.ctrlKey || e.metaKey) && e.altKey && e.keyCode === keycodes.f) {
       trigger(EXPAND)
     }
   }
 
   const cardSizeShortcut = (e: KeyboardEvent): void => {
-    if (e.ctrlKey && e.key === 'b') {
+    e.preventDefault()
+    if ((e.ctrlKey || e.metaKey) && e.altKey && e.keyCode === keycodes.c) {
       trigger(CARDSIZE)
     }
   }
 
-  const keyboardShortcuts = [
-    focusEditorOnSlash,
-    expandEditorOnEsc,
-    cardSizeShortcut
-  ]
+  const keyboardShortcuts = [focusEditorOnSlash, expandEditor, cardSizeShortcut]
 
   useEffect(() => {
     keyboardShortcuts.forEach(shortcut =>
-      document.addEventListener('keyup', shortcut)
+      document.addEventListener('keydown', shortcut)
     )
 
     return (): void =>
       keyboardShortcuts.forEach(shortcut =>
-        document.removeEventListener('keyup', shortcut)
+        document.removeEventListener('keydown', shortcut)
       )
   }, [])
 }

--- a/src/browser/modules/App/keyboardShortcuts.ts
+++ b/src/browser/modules/App/keyboardShortcuts.ts
@@ -2,9 +2,55 @@ import { useEffect } from 'react'
 import { FOCUS, EXPAND, CARDSIZE } from 'shared/modules/editor/editorDuck'
 import { Bus } from 'suber'
 
-const keycodes = { c: 67, f: 70 }
+const isMac = /Mac|iPod|iPhone|iPad/.test(navigator.platform)
+const modKey = isMac ? 'metaKey' : 'ctrlKey'
 
-const isOutsideTextArea = (e: KeyboardEvent): boolean => {
+type ModifyerKey = 'metaKey' | 'altKey' | 'ctrlKey'
+const printModifyers: Record<ModifyerKey, string> = {
+  altKey: isMac ? '⌥' : 'alt',
+  metaKey: isMac ? '⌘' : 'win',
+  ctrlKey: isMac ? '⌃' : 'ctrl'
+}
+
+const encodeKey: Record<string, number> = { c: 67, f: 70, '/': 55 }
+const decodeKeycode: Record<number, string> = Object.entries(encodeKey).reduce(
+  (acc: Record<number, string>, [char, keyCode]: [string, number]) => ({
+    ...acc,
+    [keyCode]: char
+  }),
+  {}
+)
+
+interface Shortcut {
+  modifyers: ModifyerKey[]
+  keyCode: number
+}
+export const FULLSCREEN_SHORTCUT: Shortcut = {
+  modifyers: [modKey, 'altKey'],
+  keyCode: encodeKey.f
+}
+export const CARDSIZE_SHORTCUT: Shortcut = {
+  modifyers: [modKey, 'altKey'],
+  keyCode: encodeKey.c
+}
+export const FOCUS_SHORTCUT: Shortcut = {
+  modifyers: [],
+  keyCode: encodeKey['/']
+}
+
+export function printShortcut(s: Shortcut): string {
+  return s.modifyers
+    .map(mod => printModifyers[mod])
+    .concat(decodeKeycode[s.keyCode])
+    .join(' ')
+}
+
+function matchesShortcut(e: KeyboardEvent, shortcut: Shortcut): boolean {
+  const hasCorrectModifyers = shortcut.modifyers.every(mod => e[mod])
+  return hasCorrectModifyers && e.keyCode === shortcut.keyCode
+}
+
+function isOutsideTextArea(e: KeyboardEvent): boolean {
   const tagName = (e.target as HTMLElement).tagName
   return ['INPUT', 'TEXTAREA'].indexOf(tagName) > -1
 }
@@ -13,21 +59,21 @@ export function useKeyboardShortcuts(bus: Bus): void {
   const trigger = (msg: string): void => bus && bus.send(msg, null)
 
   const focusEditorOnSlash = (e: KeyboardEvent): void => {
-    if (isOutsideTextArea(e) && e.key === '/') {
+    if (isOutsideTextArea(e) && matchesShortcut(e, FOCUS_SHORTCUT)) {
       trigger(FOCUS)
     }
   }
 
   const expandEditor = (e: KeyboardEvent): void => {
     e.preventDefault()
-    if ((e.ctrlKey || e.metaKey) && e.altKey && e.keyCode === keycodes.f) {
+    if (matchesShortcut(e, FULLSCREEN_SHORTCUT)) {
       trigger(EXPAND)
     }
   }
 
   const cardSizeShortcut = (e: KeyboardEvent): void => {
     e.preventDefault()
-    if ((e.ctrlKey || e.metaKey) && e.altKey && e.keyCode === keycodes.c) {
+    if (matchesShortcut(e, CARDSIZE_SHORTCUT)) {
       trigger(CARDSIZE)
     }
   }

--- a/src/browser/modules/Editor/EditorFrame.tsx
+++ b/src/browser/modules/Editor/EditorFrame.tsx
@@ -23,7 +23,7 @@ import { withBus } from 'react-suber'
 import { Bus } from 'suber'
 import Editor from './Editor'
 import { Frame, FrameHeader, FrameHeaderText, UIControls } from './styled'
-import { EXPAND } from 'shared/modules/editor/editorDuck'
+import { EXPAND, CARDSIZE } from 'shared/modules/editor/editorDuck'
 import { FrameButton } from 'browser-components/buttons'
 import {
   ExpandIcon,
@@ -60,8 +60,6 @@ export function EditorFrame({ bus }: EditorFrameProps): JSX.Element {
     }
   }
 
-  useEffect(() => bus && bus.take(EXPAND, toggleFullscreen))
-
   function toggleCardView() {
     const editorVal = (editorRef.current && editorRef.current.getValue()) || ''
     const lineCount = editorVal.split('\n').length
@@ -81,6 +79,9 @@ export function EditorFrame({ bus }: EditorFrameProps): JSX.Element {
       setSize('CARD')
     }
   }
+
+  useEffect(() => bus && bus.take(EXPAND, toggleFullscreen))
+  useEffect(() => bus && bus.take(CARDSIZE, toggleCardView))
 
   function discardEditor() {
     editorRef.current && editorRef.current.setValue('')

--- a/src/browser/modules/Editor/EditorFrame.tsx
+++ b/src/browser/modules/Editor/EditorFrame.tsx
@@ -22,6 +22,11 @@ import React, { useState, useEffect, useRef } from 'react'
 import { withBus } from 'react-suber'
 import { Bus } from 'suber'
 import Editor from './Editor'
+import {
+  printShortcut,
+  FULLSCREEN_SHORTCUT,
+  CARDSIZE_SHORTCUT
+} from 'browser/modules/App/keyboardShortcuts'
 import { Frame, FrameHeader, FrameHeaderText, UIControls } from './styled'
 import { EXPAND, CARDSIZE } from 'shared/modules/editor/editorDuck'
 import { FrameButton } from 'browser-components/buttons'
@@ -91,13 +96,17 @@ export function EditorFrame({ bus }: EditorFrameProps): JSX.Element {
   const buttons = [
     {
       onClick: toggleFullscreen,
-      title: isFullscreen ? 'Close fullscreen' : 'Fullscreen',
+      title: `${
+        isFullscreen ? 'Close fullscreen ' : 'Fullscreen'
+      } (${printShortcut(FULLSCREEN_SHORTCUT)})`,
       icon: isFullscreen ? <ContractIcon /> : <ExpandIcon />,
       testId: 'fullscreen'
     },
     {
       onClick: toggleCardView,
-      title: isCardSize ? 'Collapse' : 'Expand',
+      title: `${isCardSize ? 'Collapse' : 'Expand'} (${printShortcut(
+        CARDSIZE_SHORTCUT
+      )})`,
       icon: isCardSize ? <UpIcon /> : <DownIcon />,
       testId: 'cardSize'
     },

--- a/src/shared/modules/editor/editorDuck.js
+++ b/src/shared/modules/editor/editorDuck.js
@@ -32,6 +32,7 @@ export const SET_CONTENT = `${NAME}/SET_CONTENT`
 export const EDIT_CONTENT = `${NAME}/EDIT_CONTENT`
 export const FOCUS = `${NAME}/FOCUS`
 export const EXPAND = `${NAME}/EXPAND`
+export const CARDSIZE = `${NAME}/CARDSIZE`
 export const NOT_SUPPORTED_URL_PARAM_COMMAND = `${NAME}/NOT_SUPPORTED_URL_PARAM_COMMAND`
 
 // Supported commands


### PR DESCRIPTION
Adds keyboard shortcuts to resize the editor. Currently uses cmd+alt+c and cmd+alt+f as shortcuts. Updates the docs and hovers as well.
![gif](https://user-images.githubusercontent.com/10564538/90400386-ae2e2080-e09c-11ea-9600-8fe7f16b6007.gif)

@HerrEmil make sure to try the shortcuts and see that the docs/hover shows the correct symbols/words on windows.