### PR TITLE
Ensure frames.allIds is always an array

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@types/react": "^16.9.23",
     "@types/react-redux": "^7.1.9",
     "@types/styled-components": "^5.1.1",
+    "@types/uuid": "^8.3.0",
     "@typescript-eslint/eslint-plugin": "^3.9.0",
     "@typescript-eslint/parser": "^3.9.0",
     "autoprefixer": "^7.1.4",

--- a/src/shared/modules/stream/frameViewTypes.ts
+++ b/src/shared/modules/stream/frameViewTypes.ts
@@ -26,3 +26,13 @@ export const TABLE = 'TABLE'
 export const CODE = 'CODE'
 export const ERROR = 'ERROR'
 export const TEXT = 'TEXT'
+
+export type FrameView =
+  | typeof VISUALIZATION
+  | typeof PLAN
+  | typeof WARNINGS
+  | typeof ERRORS
+  | typeof TABLE
+  | typeof CODE
+  | typeof ERROR
+  | typeof TEXT

--- a/src/shared/modules/stream/streamDuck.ts
+++ b/src/shared/modules/stream/streamDuck.ts
@@ -24,6 +24,9 @@ import 'rxjs/add/operator/mapTo'
 import { moveInArray } from 'services/utils'
 import { APP_START } from 'shared/modules/app/appDuck'
 import { UPDATE as SETTINGS_UPDATE } from '../settings/settingsDuck'
+import { Epic } from 'redux-observable'
+import { Action } from 'redux'
+import { FrameView } from 'shared/modules/stream/frameViewTypes'
 
 export const NAME = 'frames'
 export const ADD = 'frames/ADD'
@@ -35,29 +38,26 @@ export const UNPIN = `${NAME}/UNPIN`
 export const SET_RECENT_VIEW = 'frames/SET_RECENT_VIEW'
 export const SET_MAX_FRAMES = `${NAME}/SET_MAX_FRAMES`
 
-/**
- * Selectors
- */
-export function getFrame(state, id) {
+interface GlobalState {
+  [NAME]: FramesState
+}
+
+export function getFrame(state: GlobalState, id: string): FrameStack {
   return state[NAME].byId[id]
 }
 
-export function getFrames(state) {
+export function getFrames(state: GlobalState): FrameStack[] {
   return state[NAME].allIds.map(id => state[NAME].byId[id])
 }
 
-export function getFramesInContext(state, context) {
-  return getFrames(state).filter(f => f.context === context)
-}
-
-export function getRecentView(state) {
+export function getRecentView(state: GlobalState): null | FrameView {
   return state[NAME].recentView
 }
 
 /**
  * Reducer helpers
  */
-function addFrame(state, newState) {
+function addFrame(state: FramesState, newState: Frame) {
   if (newState.parentId && state.allIds.indexOf(newState.parentId) < 0) {
     // No parent
     return state
@@ -73,7 +73,7 @@ function addFrame(state, newState) {
     ...state.byId,
     [newState.id]: frameObject
   }
-  let allIds = [].concat(state.allIds)
+  let allIds = [...state.allIds]
 
   if (newState.parentId) {
     const currentStatements = byId[newState.parentId].stack[0].statements || []
@@ -102,7 +102,11 @@ function addFrame(state, newState) {
   })
 }
 
-function insertIntoAllIds(state, allIds, newState) {
+function insertIntoAllIds(
+  state: FramesState,
+  allIds: string[],
+  newState: Frame
+) {
   if (allIds.indexOf(newState.id) < 0) {
     // new frame
     const pos = findFirstFreePos(state)
@@ -111,7 +115,7 @@ function insertIntoAllIds(state, allIds, newState) {
   return allIds
 }
 
-function removeFrame(state, id) {
+function removeFrame(state: FramesState, id: string) {
   const byId = {
     ...state.byId
   }
@@ -124,9 +128,9 @@ function removeFrame(state, id) {
   }
 }
 
-function pinFrame(state, id) {
+function pinFrame(state: FramesState, id: string): FramesState {
   const pos = state.allIds.indexOf(id)
-  const allIds = moveInArray(pos, 0, state.allIds) // immutable operation
+  const allIds = moveInArray(pos, 0, state.allIds)
   const byId = {
     ...state.byId
   }
@@ -138,10 +142,10 @@ function pinFrame(state, id) {
   }
 }
 
-function unpinFrame(state, id) {
+function unpinFrame(state: FramesState, id: string): FramesState {
   const currentPos = state.allIds.indexOf(id)
   const pos = findFirstFreePos(state)
-  const allIds = moveInArray(currentPos, pos - 1, state.allIds) // immutable operation
+  const allIds = moveInArray(currentPos, pos - 1, state.allIds)
   const byId = {
     ...state.byId
   }
@@ -153,7 +157,7 @@ function unpinFrame(state, id) {
   }
 }
 
-function findFirstFreePos({ byId, allIds }) {
+function findFirstFreePos({ byId, allIds }: FramesState) {
   let freePos = -1
   allIds.forEach((id, index) => {
     if (freePos > -1 || byId[id].isPinned) return
@@ -162,14 +166,14 @@ function findFirstFreePos({ byId, allIds }) {
   return freePos === -1 ? allIds.length : freePos
 }
 
-function setRecentViewHelper(state, recentView) {
+function setRecentViewHelper(state: FramesState, recentView: FrameView) {
   return {
     ...state,
     recentView
   }
 }
 
-function ensureFrameLimit(state) {
+function ensureFrameLimit(state: FramesState) {
   const limit = state.maxFrames || 1
   if (state.allIds.length <= limit) return state
   const numToRemove = state.allIds.length - limit
@@ -185,43 +189,99 @@ function ensureFrameLimit(state) {
   }
 }
 
-/** Inital state */
-export const initialState = {
+interface ConnectionData {
+  authEnabled: boolean
+  authenticatedMethod: string
+  db: null
+  host: string
+  id: string
+  name: string
+  password: string
+  type: string
+  username: string
+}
+
+interface FrameError {
+  cmd: string
+  code: string
+  message: string
+  type: string
+}
+
+// When more code is typed, frame should be a union type of different frames
+interface Frame {
+  autoCommit: boolean
+  cmd: string
+  connectionData: ConnectionData
+  error: FrameError
+  id: string
+  initialSlide: number
+  isRerun: boolean
+  parentId: string
+  query: string
+  result: string
+  requestId: string
+  statements: string[]
+  ts: number
+  type: string
+  useDb: string | null
+}
+
+interface FrameStack {
+  stack: Frame[]
+  isPinned: boolean
+}
+
+interface FramesState {
+  allIds: string[]
+  byId: { [key: string]: FrameStack }
+  recentView: null | FrameView
+  maxFrames: number
+}
+
+export const initialState: FramesState = {
   allIds: [],
   byId: {},
   recentView: null,
   maxFrames: 30
 }
 
-/**
- * Reducer
- */
-export default function reducer(state = initialState, action) {
+export default function reducer(
+  state = initialState,
+  action: StreamActions
+): FramesState {
   switch (action.type) {
     case APP_START:
       return { ...initialState, ...state }
     case ADD:
-      return addFrame(state, action.state)
+      return addFrame(state, (action as AddFrameAction).state)
     case REMOVE:
-      return removeFrame(state, action.id)
+      return removeFrame(state, (action as RemoveFrameAction).id)
     case CLEAR_ALL:
       return { ...initialState }
     case PIN:
-      return pinFrame(state, action.id)
+      return pinFrame(state, (action as PinFrameAction).id)
     case UNPIN:
-      return unpinFrame(state, action.id)
+      return unpinFrame(state, (action as UnpinFrameAction).id)
     case SET_RECENT_VIEW:
-      return setRecentViewHelper(state, action.view)
+      return setRecentViewHelper(state, (action as SetRecentViewAction).view)
     case SET_MAX_FRAMES:
-      const newState = { ...state, maxFrames: action.maxFrames }
+      const newState = {
+        ...state,
+        maxFrames: (action as SetMaxFramesAction).maxFrames
+      }
       return ensureFrameLimit(newState)
     default:
       return state
   }
 }
 
-// Action creators
-export function add(payload) {
+interface AddFrameAction {
+  type: typeof ADD
+  state: Frame
+}
+
+export function add(payload: Frame): AddFrameAction {
   return {
     type: ADD,
     state: {
@@ -231,47 +291,96 @@ export function add(payload) {
   }
 }
 
-export function remove(id) {
+interface RemoveFrameAction {
+  type: typeof REMOVE
+  id: string
+}
+
+export function remove(id: string): RemoveFrameAction {
   return {
     type: REMOVE,
     id
   }
 }
 
-export function clear() {
+interface ClearFramesAction {
+  type: typeof CLEAR_ALL
+}
+
+export function clear(): ClearFramesAction {
   return {
     type: CLEAR_ALL
   }
 }
 
-export function pin(id) {
+interface PinFrameAction {
+  type: typeof PIN
+  id: string
+}
+
+export function pin(id: string): PinFrameAction {
   return {
     type: PIN,
     id
   }
 }
 
-export function unpin(id) {
+interface UnpinFrameAction {
+  type: typeof UNPIN
+  id: string
+}
+
+export function unpin(id: string): UnpinFrameAction {
   return {
     type: UNPIN,
     id
   }
 }
 
-export function setRecentView(view) {
+interface SetRecentViewAction {
+  type: typeof SET_RECENT_VIEW
+  view: FrameView
+}
+
+export function setRecentView(view: FrameView): SetRecentViewAction {
   return {
     type: SET_RECENT_VIEW,
     view
   }
 }
 
+interface SetMaxFramesAction {
+  type: typeof SET_MAX_FRAMES
+  maxFrames: number
+}
+
+type StreamActions =
+  | AddFrameAction
+  | RemoveFrameAction
+  | ClearFramesAction
+  | PinFrameAction
+  | UnpinFrameAction
+  | SetRecentViewAction
+  | SetMaxFramesAction
+
+interface SettingsUpdateAction {
+  type: typeof SETTINGS_UPDATE
+  state: { maxFrames: number }
+}
+
 // Epics
-export const maxFramesConfigEpic = (action$, store) =>
+export const maxFramesConfigEpic: Epic<Action, GlobalState> = (
+  action$,
+  store
+) =>
   action$
     .ofType(SETTINGS_UPDATE)
     .do(action => {
-      const newMaxFrames = action.state.maxFrames
+      const newMaxFrames = (action as SettingsUpdateAction).state.maxFrames
       if (!newMaxFrames) return
-      store.dispatch({ type: SET_MAX_FRAMES, maxFrames: newMaxFrames })
+      store.dispatch({
+        type: SET_MAX_FRAMES,
+        maxFrames: newMaxFrames
+      } as SetMaxFramesAction)
     })
     .mapTo({ type: 'NOOP' })

--- a/src/shared/services/utils.js
+++ b/src/shared/services/utils.js
@@ -110,9 +110,9 @@ export const flatten = arr =>
   arr.reduce((a, b) => a.concat(Array.isArray(b) ? flatten(b) : b), [])
 
 export const moveInArray = (fromIndex, toIndex, arr) => {
-  if (!Array.isArray(arr)) return false
-  if (fromIndex < 0 || fromIndex >= arr.length) return false
-  if (toIndex < 0 || toIndex >= arr.length) return false
+  if (!Array.isArray(arr)) return []
+  if (fromIndex < 0 || fromIndex >= arr.length) return arr
+  if (toIndex < 0 || toIndex >= arr.length) return arr
   const newArr = [].concat(arr)
   const el = arr[fromIndex]
   newArr.splice(fromIndex, 1)

--- a/src/shared/services/utils.test.js
+++ b/src/shared/services/utils.test.js
@@ -155,10 +155,10 @@ describe('utils', () => {
   test('can move items in an array', () => {
     // Given
     const tests = [
-      { test: [1, 2, 3], from: -1, to: 1, expect: false },
-      { test: [1, 2, 3], from: 0, to: 3, expect: false },
-      { test: [1, 2, 3], from: 5, to: 1, expect: false },
-      { test: 'string', from: 0, to: 3, expect: false },
+      { test: [1, 2, 3], from: -1, to: 1, expect: [1, 2, 3] },
+      { test: [1, 2, 3], from: 0, to: 3, expect: [1, 2, 3] },
+      { test: [1, 2, 3], from: 5, to: 1, expect: [1, 2, 3] },
+      { test: 'string', from: 0, to: 3, expect: [] },
       { test: [1, 2, 3], from: 0, to: 1, expect: [2, 1, 3] },
       { test: [1, 2, 3], from: 2, to: 1, expect: [1, 3, 2] },
       { test: [1, 2, 3], from: 2, to: 0, expect: [3, 1, 2] }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2359,6 +2359,11 @@
   resolved "https://neo.jfrog.io/neo/api/npm/npm/@types/unist/-/unist-2.0.3.tgz#9c088679876f374eb5983f150d4787aa6fb32d7e"
   integrity sha1-nAiGeYdvN061mD8VDUeHqm+zLX4=
 
+"@types/uuid@^8.3.0":
+  version "8.3.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
+  integrity sha1-IVwjHf9zbVupJBDm1gIFDM5+Jz8=
+
 "@types/webpack-sources@*":
   version "0.1.7"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/@types/webpack-sources/-/webpack-sources-0.1.7.tgz#0a330a9456113410c74a5d64180af0cbca007141"


### PR DESCRIPTION
A user reported getting a TypeError:
<img width="1771" alt="Screen Shot 2020-08-03 at 6 14 27 PM" src="https://user-images.githubusercontent.com/939458/90645722-97233600-e236-11ea-9512-51e09945ba49.png">

We were unable to reproduce the issue, but we can at least prevent the type error by strictly typing the variable and updating the code that could assign a different type value. The variable is the list of frames in the stream and the updated code is called when pinning or unpinning a frame in stream. If the issue is reproduced after this change, the failure could potentially result in an out-of-order list or a cleared list, but never a TypeError.