### PR TITLE
Fix fullscreen issue in safari

### DIFF
--- a/src/browser/modules/App/styled.jsx
+++ b/src/browser/modules/App/styled.jsx
@@ -51,7 +51,6 @@ export const StyledMainWrapper = styled.div`
   flex: auto;
   overflow: auto;
   padding: 0;
-  z-index: 1;
   height: auto;
   width: 0;
   background-color: ${props => props.theme.primaryBackground};


### PR DESCRIPTION
On safari fullscreen looked like this:
![bild](https://user-images.githubusercontent.com/10564538/90892095-0a56b480-e3bd-11ea-8758-edb3d76469ea.png)

Now it looks like it should:
![bild](https://user-images.githubusercontent.com/10564538/90892150-25292900-e3bd-11ea-80df-792019fd7b2f.png)

In my testing, it seems the z-index: 1 causing this was unneeded, but please do take a look and see if anything looks off.

