### PR TITLE
Show comment in frame header

### DIFF
--- a/src/browser/modules/Editor/Editor.jsx
+++ b/src/browser/modules/Editor/Editor.jsx
@@ -258,6 +258,12 @@ export class Editor extends Component {
   }
 
   setEditorValue(cmd) {
+    if (cmd.includes('\n') && this.props.editorSize === 'LINE') {
+      this.props.setSize('CARD')
+    }
+    if (!cmd.includes('\n') && this.props.editorSize === 'CARD') {
+      this.props.setSize('LINE')
+    }
     this.codeMirror.setValue(cmd)
     this.updateCode(undefined, undefined, () => {
       this.focusEditor()

--- a/src/shared/modules/commands/commandsDuck.js
+++ b/src/shared/modules/commands/commandsDuck.js
@@ -176,7 +176,7 @@ export const handleCommandEpic = (action$, store) =>
       }
       if (statements.length === 1) {
         // Single command
-        return store.dispatch(executeSingleCommand(statements[0], action))
+        return store.dispatch(executeSingleCommand(action.cmd, action))
       }
       const parentId = action.parentId || v4()
       store.dispatch(


### PR DESCRIPTION
Leaves the comments in place when there's only one comment.

Properly resizes editor when moving through history and setting from clicking a frame header.