### PR TITLE
Move new large deps from app bundle to vendor bundle

### DIFF
--- a/build_scripts/webpack.config.js
+++ b/build_scripts/webpack.config.js
@@ -62,7 +62,7 @@ module.exports = {
         splitChunks: {
           cacheGroups: {
             vendor: {
-              test: /[\\/]node_modules[\\/](react|react-dom|@firebase|d3|codemirror)[\\/]/,
+              test: /[\\/]node_modules[\\/](react|react-dom|@firebase|d3|codemirror|faker|remark-mdx|@mdx-js)[\\/]/,
               name: 'vendor',
               chunks: 'all'
             },


### PR DESCRIPTION
The app size has increased quite a bit since the introduction of mdx. 
The `faker` lib is **HUGE** considering what we use it for. 
Maybe we should consider dropping that and rewriting the parts we need manually.

Try to avoid one large file, even them out a bit.

Before:
<img width="1572" alt="Screen Shot 2020-08-28 at 08 59 22" src="https://user-images.githubusercontent.com/570998/91532246-5306f400-e90e-11ea-9e5e-43a343c78844.png">


After:
<img width="1568" alt="Screen Shot 2020-08-28 at 09 01 31" src="https://user-images.githubusercontent.com/570998/91532273-5b5f2f00-e90e-11ea-8be8-1f83a7e3ec24.png">
