### PR TITLE
reimplement isValidURL to fix performance bug

### DIFF
--- a/src/shared/modules/commands/helpers/http.js
+++ b/src/shared/modules/commands/helpers/http.js
@@ -49,15 +49,14 @@ export const parseHttpVerbCommand = input => {
 }
 
 // Check if valid url, from http://stackoverflow.com/questions/5717093/check-if-a-javascript-string-is-a-url
-export function isValidURL(str) {
-  const pattern = new RegExp(
-    '^(https?:\\/\\/)?' + // protocol
-    '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.?)+[a-z]{2,}|' + // domain name
-    '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
-    '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
-    '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
-      '(\\#[-a-z\\d_]*)?$',
-    'i'
-  ) // fragment locator
-  return pattern.test(str)
+export function isValidURL(string) {
+  let url
+
+  try {
+    url = new URL(string)
+  } catch (_) {
+    return false
+  }
+
+  return url.protocol.startsWith('http')
 }

--- a/src/shared/modules/commands/helpers/http.test.js
+++ b/src/shared/modules/commands/helpers/http.test.js
@@ -18,7 +18,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { parseHttpVerbCommand } from './http'
+import { isValidURL, parseHttpVerbCommand } from './http'
+
+describe('isValidUrl', () => {
+  it('finishes within a second when called with "EnableMultiStatement:true"', () => {
+    const start = Date.now()
+    const result = isValidURL('EnableMultiStatement:true')
+    const end = Date.now()
+
+    expect(result).toBe(false)
+    expect(end - start).toBeLessThan(1000)
+  })
+})
 
 describe('HTTP verbs command', () => {
   test('Fails with error on wrong command', done => {


### PR DESCRIPTION
Current implementation of isValidURL is very slow for some values, which was noticed when a user set `EnableMultiStatement:true` which takes around 2 minutes(!) on my machine. I don't know what part of the regex is slow, but with all web browser we support now supporting the URL constructor we can remove the regex to fix the issue.
![Sep-04-2020 13-59-39](https://user-images.githubusercontent.com/939458/92237943-84f0fb00-eeb8-11ea-9eb2-16f32f18a9ee.gif)
