### PR TITLE
Re-add esc as shortcut

### DIFF
--- a/src/browser/modules/App/keyboardShortcuts.ts
+++ b/src/browser/modules/App/keyboardShortcuts.ts
@@ -17,6 +17,10 @@ interface Shortcut {
   modifyers: ModifierKey[]
   key: string
 }
+export const OLD_FULLSCREEN_SHORTCUT: Shortcut = {
+  modifyers: [],
+  key: 'Escape'
+}
 export const FULLSCREEN_SHORTCUT: Shortcut = {
   modifyers: [modKey, 'altKey'],
   key: 'f'
@@ -65,8 +69,11 @@ export function useKeyboardShortcuts(bus: Bus): void {
     }
   }
 
-  const expandEditor = (e: KeyboardEvent): void => {
-    if (matchesShortcut(e, FULLSCREEN_SHORTCUT)) {
+  const fullscreenEditor = (e: KeyboardEvent): void => {
+    if (
+      matchesShortcut(e, FULLSCREEN_SHORTCUT) ||
+      matchesShortcut(e, OLD_FULLSCREEN_SHORTCUT)
+    ) {
       e.preventDefault()
       trigger(EXPAND)
     }
@@ -79,7 +86,11 @@ export function useKeyboardShortcuts(bus: Bus): void {
     }
   }
 
-  const keyboardShortcuts = [focusEditorOnSlash, expandEditor, cardSizeShortcut]
+  const keyboardShortcuts = [
+    focusEditorOnSlash,
+    fullscreenEditor,
+    cardSizeShortcut
+  ]
 
   useEffect(() => {
     keyboardShortcuts.forEach(shortcut =>


### PR DESCRIPTION
We want to avoid users who used 'esc' for years having to relearn keyboard shortcuts.

@akollegger  @shkirando I let the hover text and documentation be only the "new" shortcut. This way experienced users can still use them, but new ones see the tooltip for the shortcut we think makes more sense. Do you guys think this is a good approach? Leaving the stats for which one is more used for next week