### PR TITLE
Colorize node labels in sidebar

### DIFF
--- a/src/browser/modules/DBMSInfo/DBMSInfo.jsx
+++ b/src/browser/modules/DBMSInfo/DBMSInfo.jsx
@@ -26,6 +26,7 @@ import {
   useDbCommand
 } from 'shared/modules/commands/commandsDuck'
 import { getCurrentUser } from 'shared/modules/currentUser/currentUserDuck'
+import { getGraphStyleData } from 'shared/modules/grass/grassDuck'
 import { LabelItems, RelationshipItems, PropertyItems } from './MetaItems'
 import { UserDetails } from './UserDetails'
 import DatabaseKernelInfo from './DatabaseKernelInfo'
@@ -75,6 +76,7 @@ export function DBMSInfo(props) {
           onItemClick={onItemClick}
           onMoreClick={onMoreClick('labels', labelsMax)}
           moreStep={moreStep}
+          graphStyleData={props.graphStyleData}
         />
         <RelationshipItems
           count={relationships}
@@ -107,6 +109,7 @@ const mapStateToProps = state => {
   const useDb = getUseDb(state)
   const databases = getDatabases(state)
   return {
+    graphStyleData: getGraphStyleData(state),
     meta: state.meta,
     user: getCurrentUser(state),
     useDb,

--- a/src/browser/modules/DBMSInfo/MetaItems.jsx
+++ b/src/browser/modules/DBMSInfo/MetaItems.jsx
@@ -34,6 +34,8 @@ import {
 } from './styled'
 import Render from 'browser-components/Render'
 import numberToUSLocale from 'shared/utils/number-to-US-locale'
+import neoGraphStyle from 'browser/modules/D3Visualization/graphStyle'
+import deepmerge from 'deepmerge'
 
 const wrapperStyle = (styles && styles.wrapper) || ''
 
@@ -60,7 +62,8 @@ const createItems = (
   RenderType,
   editorCommandTemplate,
   showStar = true,
-  count
+  count,
+  graphStyleData
 ) => {
   const items = [...originalList]
   if (showStar) {
@@ -70,26 +73,44 @@ const createItems = (
     }
     items.unshift(str)
   }
+  const graphStyle = neoGraphStyle()
+  if (graphStyleData) {
+    graphStyle.loadRules(deepmerge(graphStyle.toSheet(), graphStyleData || {}))
+  }
+
   return items.map((text, index) => {
+    let style = {}
+    if (graphStyleData) {
+      const styleForItem = graphStyle.forNode({
+        labels: [text]
+      })
+      style = {
+        backgroundColor: styleForItem.get('color'),
+        color: styleForItem.get('text-color-internal')
+      }
+    }
     const getNodesCypher = editorCommandTemplate(text, index)
     return (
       <RenderType.component
         data-testid="sidebarMetaItem"
         key={index}
         onClick={() => onItemClick(getNodesCypher)}
+        style={style}
       >
         {text}
       </RenderType.component>
     )
   })
 }
+
 const LabelItems = ({
   labels = [],
   totalNumItems,
   onItemClick,
   moreStep,
   onMoreClick,
-  count
+  count,
+  graphStyleData
 }) => {
   let labelItems = <p>There are no labels in database</p>
   if (labels.length) {
@@ -105,7 +126,8 @@ const LabelItems = ({
       { component: StyledLabel },
       editorCommandTemplate,
       true,
-      count
+      count,
+      graphStyleData
     )
   }
   return (

--- a/src/browser/modules/Editor/styled.tsx
+++ b/src/browser/modules/Editor/styled.tsx
@@ -97,7 +97,7 @@ export const Frame = styled.div<FullscreenProps>`
     if (props.fullscreen) {
       return `
   position: fixed;
-  top: -10px;
+  top: 0px;
   bottom: 0;
   left: 0;
   right: 0;


### PR DESCRIPTION
The full screen was a few pixels off:
<img width="146" alt="bild" src="https://user-images.githubusercontent.com/10564538/93479290-6e0cc880-f8fc-11ea-964e-cd9a9e8878a5.png">

Fix:
![bild](https://user-images.githubusercontent.com/10564538/93479244-5fbeac80-f8fc-11ea-9121-396760ffb23c.png)

Since we have the colours of node labels readily available I thought it'd be neat if we used them when showing labels in the sidebar!
![bild](https://user-images.githubusercontent.com/10564538/93479181-4fa6cd00-f8fc-11ea-8c3a-b4be2662054a.png)


