### PR TITLE
Info about lack of some data in sysinfo for non-legacy community version

### DIFF
--- a/src/browser/modules/Stream/SysInfoFrame/helpers.js
+++ b/src/browser/modules/Stream/SysInfoFrame/helpers.js
@@ -21,16 +21,14 @@
 import React from 'react'
 import {
   buildTableData,
+  buildDatabaseTable,
   flattenAttributes,
   mapSysInfoRecords
 } from './sysinfo-utils'
 import { toHumanReadableBytes, toKeyString } from 'services/utils'
-import {
-  SysInfoTableContainer,
-  SysInfoTable,
-  SysInfoTableEntry
-} from 'browser-components/Tables'
+import { SysInfoTableContainer, SysInfoTable } from 'browser-components/Tables'
 import Render from 'browser-components/Render/index'
+import { StyledInfoMessage } from './../../Stream/styled'
 
 const jmxPrefix = 'neo4j.metrics:name='
 
@@ -95,6 +93,7 @@ export const Sysinfo = ({
   idAllocation,
   transactions,
   isACausalCluster,
+  isEnterpriseEdition,
   cc
 }) => {
   const mappedDatabases = [
@@ -112,7 +111,7 @@ export const Sysinfo = ({
     }
   ]
 
-  return (
+  return isEnterpriseEdition ? (
     <SysInfoTableContainer>
       <SysInfoTable key="StoreSize" header="Store Size" colspan="2">
         {buildTableData(storeSizes)}
@@ -123,17 +122,20 @@ export const Sysinfo = ({
       <SysInfoTable key="PageCache" header="Page Cache">
         {buildTableData(pageCache)}
       </SysInfoTable>
-      <SysInfoTable key="Transactionss" header="Transactions">
+      <SysInfoTable key="Transactions" header="Transactions">
         {buildTableData(transactions)}
       </SysInfoTable>
-      <SysInfoTable key="database-table" header="Databases" colspan="6">
-        <SysInfoTableEntry
-          key="database-entry"
-          headers={['Name', 'Address', 'Role', 'Status', 'Default', 'Error']}
-        />
-        {buildTableData(mappedDatabases)}
-      </SysInfoTable>
+      {buildDatabaseTable(mappedDatabases)}
     </SysInfoTableContainer>
+  ) : (
+    <div>
+      <StyledInfoMessage>
+        Complete sysinfo is available only in Neo4j Enterprise Edition.
+      </StyledInfoMessage>
+      <SysInfoTableContainer>
+        {buildDatabaseTable(mappedDatabases)}
+      </SysInfoTableContainer>
+    </div>
   )
 }
 

--- a/src/browser/modules/Stream/SysInfoFrame/index.jsx
+++ b/src/browser/modules/Stream/SysInfoFrame/index.jsx
@@ -24,6 +24,7 @@ import { withBus } from 'react-suber'
 import dateFormat from 'dateformat'
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
 import { isACausalCluster } from 'shared/modules/features/featuresDuck'
+import { isEnterprise } from 'shared/modules/dbMeta/dbMetaDuck'
 import {
   isConnected,
   getUseDb
@@ -134,6 +135,7 @@ export class SysInfoFrame extends Component {
         {...this.state}
         databases={this.props.databases}
         isACausalCluster={this.props.isACausalCluster}
+        isEnterpriseEdition={this.props.isEnterprise}
         useDb={this.props.useDb}
       />
     )
@@ -144,7 +146,7 @@ export class SysInfoFrame extends Component {
         contents={content}
         statusbar={
           <StatusbarWrapper>
-            <Render if={this.state.errors}>
+            <Render if={this.state.error}>
               <FrameError message={this.state.error} />
             </Render>
             <Render if={this.state.success}>
@@ -171,6 +173,7 @@ const mapStateToProps = state => {
   return {
     hasMultiDbSupport: hasMultiDbSupport(state),
     isACausalCluster: isACausalCluster(state),
+    isEnterprise: isEnterprise(state),
     isConnected: isConnected(state),
     databases: getDatabases(state),
     useDb: getUseDb(state)

--- a/src/browser/modules/Stream/SysInfoFrame/index.test.js
+++ b/src/browser/modules/Stream/SysInfoFrame/index.test.js
@@ -70,4 +70,65 @@ describe('sysinfo component', () => {
     // Then
     expect(getByText(/No connection available/i)).not.toBeNull()
   })
+
+  test('should display all sysinfo content for enterprise edition', () => {
+    // Given
+    const databases = [
+      { name: 'neo4j', address: '0.0.0.0:7687', status: 'online' },
+      { name: 'system', address: '0.0.0.0:7687', status: 'online' }
+    ]
+    const props = {
+      isConnected: true,
+      isEnterprise: true,
+      hasMultiDbSupport: true,
+      databases: databases
+    }
+
+    // When
+    const { queryByText } = render(<SysInfoFrame {...props} />)
+
+    // Then
+    expect(queryByText('Databases')).not.toBeNull()
+    expect(queryByText('Store Size')).not.toBeNull()
+    expect(queryByText('Id Allocation')).not.toBeNull()
+    expect(queryByText('Page Cache')).not.toBeNull()
+    expect(queryByText('Transactions')).not.toBeNull()
+
+    expect(
+      queryByText(
+        'Complete sysinfo is available only in Neo4j Enterprise Edition.'
+      )
+    ).toBeNull()
+  })
+
+  test('should display only databases table and disclaimer for not enterprise editions', () => {
+    // Given
+    const databases = [
+      { name: 'neo4j', address: '0.0.0.0:7687', status: 'online' },
+      { name: 'system', address: '0.0.0.0:7687', status: 'online' }
+    ]
+    const props = {
+      isConnected: true,
+      isEnterprise: false,
+      hasMultiDbSupport: true,
+      databases: databases
+    }
+
+    // When
+    const { queryByText } = render(<SysInfoFrame {...props} />)
+
+    // Then
+    expect(queryByText('Databases')).not.toBeNull()
+    expect(
+      queryByText(
+        'Complete sysinfo is available only in Neo4j Enterprise Edition.'
+      )
+    ).not.toBeNull()
+
+    // And
+    expect(queryByText('Store Size')).toBeNull()
+    expect(queryByText('Id Allocation')).toBeNull()
+    expect(queryByText('Page Cache')).toBeNull()
+    expect(queryByText('Transactions')).toBeNull()
+  })
 })

--- a/src/browser/modules/Stream/SysInfoFrame/sysinfo-utils.js
+++ b/src/browser/modules/Stream/SysInfoFrame/sysinfo-utils.js
@@ -23,7 +23,7 @@ import {
   itemIntToString,
   extractFromNeoObjects
 } from 'services/bolt/boltMappings'
-import { SysInfoTableEntry } from 'browser-components/Tables'
+import { SysInfoTable, SysInfoTableEntry } from 'browser-components/Tables'
 import { toKeyString } from 'services/utils'
 
 export const getTableDataFromRecords = records => {
@@ -130,4 +130,16 @@ export function buildTableData(data) {
     }
     return <SysInfoTableEntry key={props.label} {...props} />
   })
+}
+
+export function buildDatabaseTable(mappedDatabases) {
+  return (
+    <SysInfoTable key="database-table" header="Databases" colspan="6">
+      <SysInfoTableEntry
+        key="database-entry"
+        headers={['Name', 'Address', 'Role', 'Status', 'Default', 'Error']}
+      />
+      {buildTableData(mappedDatabases)}
+    </SysInfoTable>
+  )
 }


### PR DESCRIPTION
**What:**
Change introduces a message for non-legacy community version on sysinfo component which informs user that complete data is available only in enterprise version of Neo4j.

**Why:**
Fixes #1100 

Few months ago I was wandering why - after installing 4.0.3 CE Neo4j on my VPS - sysinfo component does not contain all info available on my other 3.5+ server. I thought that i had something misconfigured, but then i found #1100 issue opened on github.

**Details:**
1. I've decided not to hide all columns - I left the 'Databases' untouched. Other tables without data are hidden if there is no data.
2. Legacy sysinfo behaves as before.
3. Please find the screenshots I've made (after change):

**Change:** 
_(v4.0.3-CE)_ - Displays info that some data is missing - and why:
![4 0 3-community](https://user-images.githubusercontent.com/18195654/95024102-55810a00-0681-11eb-81f7-23eeb697cf2b.png)

_4.0.3 Enterprise_ - works as before
![4 0 3-enterprise](https://user-images.githubusercontent.com/18195654/95024104-5619a080-0681-11eb-9bbf-f9f371ac6a24.png)

Legacy versions also works as before:

![3 5 16-community](https://user-images.githubusercontent.com/18195654/95024099-52861980-0681-11eb-995f-e6c2fe42ba6a.png)

![3 5 21-enterprise](https://user-images.githubusercontent.com/18195654/95024100-54e87380-0681-11eb-919b-773a4ab58800.png)



