### PR TITLE
clear editor heading and active project file context on execute command

### DIFF
--- a/src/browser/modules/Editor/EditorFrame.tsx
+++ b/src/browser/modules/Editor/EditorFrame.tsx
@@ -57,6 +57,7 @@ import {
   EDIT_PROJECT_FILE_END,
   REMOVE_PROJECT_FILE
 } from 'browser/modules/Sidebar/project-files.constants'
+import { COMMAND_QUEUED } from 'shared/modules/commands/commandsDuck'
 
 type EditorSize = 'CARD' | 'LINE' | 'FULLSCREEN'
 type EditorFrameProps = { bus: Bus }
@@ -162,6 +163,14 @@ export function EditorFrame({ bus }: EditorFrameProps): JSX.Element {
       bus.take(PROJECT_FILE_ERROR, () => {
         if (isStillMounted) {
           setActiveProjectFileStatus('error saving...')
+        }
+      })
+    // On Execute command, clear the heading
+    bus &&
+      bus.take(COMMAND_QUEUED, () => {
+        if (isStillMounted) {
+          setActiveProjectFile(null)
+          setActiveProjectFileStatus(null)
         }
       })
 

--- a/src/browser/modules/Editor/ProjectFilesButton.tsx
+++ b/src/browser/modules/Editor/ProjectFilesButton.tsx
@@ -27,6 +27,7 @@ import { EditorButton } from 'browser-components/buttons'
 import floppyDisk from 'icons/floppy-disk.svg'
 import * as drawer from 'shared/modules/sidebar/sidebarDuck'
 import { EDIT_CONTENT, SET_CONTENT } from 'shared/modules/editor/editorDuck'
+import { COMMAND_QUEUED } from 'shared/modules/commands/commandsDuck'
 import {
   ADD_PROJECT_FILE,
   SELECT_PROJECT_FILE,
@@ -111,11 +112,19 @@ const ProjectFileButton = ({
           setProjectFilesMounted(true)
         }
       })
-    // Prject Files is unmounted
+    // Project Files is unmounted
     bus &&
       bus.take(PROJECT_FILES_UNMOUNTED, () => {
         if (isStillMounted) {
           setProjectFilesMounted(false)
+        }
+      })
+    // When execute button is clicked
+    bus &&
+      bus.take(COMMAND_QUEUED, () => {
+        if (isStillMounted) {
+          setEditMode(false)
+          setActiveRelateFile(null)
         }
       })
 


### PR DESCRIPTION
<!--
BEFORE YOU SUBMIT make sure you've done the following:
[x] Done your work in a personal fork of the original repository
[x] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[x] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[x] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

Adds in the ability to clear Editor heading and Project File context from the ProjectFilesButton, when the execute command button is clicked. This is currently incorrect in master and doesn't lose project file context or remove the heading (leading to the save button still being in edit mode and looks confusing).

[Video](https://drive.google.com/file/d/1EK75nX-SqOy1IUpLgYOlue2DfdicO-49/view)
