### PR TITLE
execute commands from sidebar and editor logic

### DIFF
--- a/src/browser/modules/Editor/Editor.jsx
+++ b/src/browser/modules/Editor/Editor.jsx
@@ -59,6 +59,10 @@ import { NEO4J_BROWSER_USER_ACTION_QUERY } from 'services/bolt/txMetadata'
 import { getUseDb } from 'shared/modules/connections/connectionsDuck'
 import ActionButtons from './ActionButtons'
 import { isMac } from 'browser/modules/App/keyboardShortcuts'
+import {
+  EXECUTE_COMMAND_ORIGIN,
+  EXECUTE_COMMAND_ORIGINS
+} from 'browser/modules/Sidebar/project-files.constants'
 
 const shouldCheckForHints = code =>
   code.trim().length > 0 &&
@@ -89,9 +93,7 @@ export class Editor extends Component {
         this.setEditorValue(msg.message)
       })
       this.props.bus.take(EDIT_CONTENT, msg => {
-        if (!msg.isProjectFile) {
-          this.setContentId(msg.id)
-        }
+        this.setContentId(msg.isProjectFile ? null : msg.id)
         this.setEditorValue(msg.message)
       })
       this.props.bus.take(FOCUS, this.focusEditor.bind(this))
@@ -141,6 +143,10 @@ export class Editor extends Component {
     const onlyWhitespace = cmd.trim() === ''
 
     if (!onlyWhitespace) {
+      this.props.bus.send(
+        EXECUTE_COMMAND_ORIGIN,
+        EXECUTE_COMMAND_ORIGINS.EDITOR
+      )
       this.execCommand(cmd)
       this.clearEditor()
       this.setState({

--- a/src/browser/modules/Sidebar/ProjectsFilesScripts.tsx
+++ b/src/browser/modules/Sidebar/ProjectsFilesScripts.tsx
@@ -38,7 +38,9 @@ import {
   SELECT_PROJECT_FILE,
   GET_PROJECT_FILES,
   DELETE_PROJECT_FILE,
-  REMOVE_PROJECT_FILE
+  REMOVE_PROJECT_FILE,
+  EXECUTE_COMMAND_ORIGIN,
+  EXECUTE_COMMAND_ORIGINS
 } from './project-files.constants'
 import Render from 'browser-components/Render'
 import { Bus } from 'suber'
@@ -226,9 +228,14 @@ const mapFavoritesStateToProps = (state: any) => {
   }
 }
 
-const mapFavoritesDispatchToProps = (dispatch: any) => ({
-  onExecScript: (favorite: Favorite) =>
+const mapFavoritesDispatchToProps = (
+  dispatch: any,
+  ownProps: { bus: Bus }
+) => ({
+  onExecScript: (favorite: Favorite) => {
+    ownProps.bus.send(EXECUTE_COMMAND_ORIGIN, EXECUTE_COMMAND_ORIGINS.SIDEBAR)
     dispatch(executeCommand(favorite.contents))
+  }
 })
 
 export default withBus(

--- a/src/browser/modules/Sidebar/project-files.constants.ts
+++ b/src/browser/modules/Sidebar/project-files.constants.ts
@@ -25,6 +25,13 @@ export const REMOVE_PROJECT_FILE = 'REMOVE_PROJECT_FILE'
 export const PROJECT_FILE_ERROR = 'PROJECT_FILE_ERROR'
 export const PROJECT_FILES_MOUNTED = 'PROJECT_FILES_MOUNTED'
 export const PROJECT_FILES_UNMOUNTED = 'PROJECT_FILES_UNMOUNTED'
+export const EXECUTE_COMMAND_ORIGIN = 'EXECUTE_COMMAND_ORIGIN'
+
+export enum EXECUTE_COMMAND_ORIGINS {
+  EDITOR = 'editor',
+  SIDEBAR = 'sidebar',
+  NONE = ''
+}
 
 export interface AddProjectFile {
   addProjectFile: ProjectFile


### PR DESCRIPTION
<!--
BEFORE YOU SUBMIT make sure you've done the following:
[x] Done your work in a personal fork of the original repository
[x] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[x] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[x] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

- While a project file is selected and is in the EditorFrame, executing a command via the sidebar will not clear the editor context - project file remains as it is. However then executing the command via the editor will clear the context. This brings it more in line with how Browser operates now and what makes more sense as an interim step.
- Small fix to logic previously whereby clicking a local script would enable edit pencil icon which would not clear when clicking onto a project file.

[Video showing changes](https://drive.google.com/file/d/1zuj84H9qFXFttPqb7VJZ2T-d2mr_dvAY/view)
