### PR TITLE
Do not store connection passwords in local storage before receiving neo4j config

### DIFF
--- a/src/shared/modules/dbMeta/__snapshots__/dbMetaDuck.test.js.snap
+++ b/src/shared/modules/dbMeta/__snapshots__/dbMetaDuck.test.js.snap
@@ -20,7 +20,7 @@ Object {
   "settings": Object {
     "browser.allow_outgoing_connections": false,
     "browser.remote_content_hostname_allowlist": "guides.neo4j.com, localhost",
-    "browser.retain_connection_credentials": true,
+    "browser.retain_connection_credentials": false,
   },
 }
 `;
@@ -44,7 +44,7 @@ Object {
   "settings": Object {
     "browser.allow_outgoing_connections": false,
     "browser.remote_content_hostname_allowlist": "guides.neo4j.com, localhost",
-    "browser.retain_connection_credentials": true,
+    "browser.retain_connection_credentials": false,
   },
 }
 `;

--- a/src/shared/modules/dbMeta/dbMetaDuck.js
+++ b/src/shared/modules/dbMeta/dbMetaDuck.js
@@ -113,7 +113,7 @@ export const getDefaultRemoteContentHostnameAllowlist = state =>
 export const shouldRetainConnectionCredentials = state => {
   const settings = getAvailableSettings(state)
   const conf = settings['browser.retain_connection_credentials']
-  if (conf === null || typeof conf === 'undefined') return true
+  if (conf === null || typeof conf === 'undefined') return false
   return !isConfigValFalsy(conf)
 }
 export const getDatabases = state => (state[NAME] || initialState).databases
@@ -208,7 +208,7 @@ const initialState = {
   settings: {
     'browser.allow_outgoing_connections': false,
     'browser.remote_content_hostname_allowlist': 'guides.neo4j.com, localhost',
-    'browser.retain_connection_credentials': true
+    'browser.retain_connection_credentials': false
   }
 }
 

--- a/src/shared/modules/stream/streamDuck.ts
+++ b/src/shared/modules/stream/streamDuck.ts
@@ -40,6 +40,7 @@ export const SET_MAX_FRAMES = 'frames/SET_MAX_FRAMES'
 
 export interface GlobalState {
   [NAME]: FramesState
+  [key: string]: Record<string, any>
 }
 
 export function getFrame(state: GlobalState, id: string): FrameStack {


### PR DESCRIPTION
Passwords are temporarily stored in local storage between connecting and receiving the config even if the `browser.retain_connection_credentials` neo4j config flag is false. To avoid storing passwords in localstorage unless the config flag is true, this PR changes three things:
 - The default value for the flag in redux store is now false
 - The store selector returns false if the flag is null or undefined
 - The local storage middleware checks the flag before saving to storage and replaces all passwords with an empty string unless the flag is true.