### PR TITLE
Only remove :auto if it is a prefix

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/VisualizationView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView.jsx
@@ -93,6 +93,7 @@ export class Visualization extends Component {
 
       this.getInternalRelationships(existingNodeIds, newNodeIds)
         .then(graph => {
+          console.log(graph.relationships)
           this.autoCompleteCallback &&
             this.autoCompleteCallback(graph.relationships)
         })

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView.jsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView.jsx
@@ -93,7 +93,6 @@ export class Visualization extends Component {
 
       this.getInternalRelationships(existingNodeIds, newNodeIds)
         .then(graph => {
-          console.log(graph.relationships)
           this.autoCompleteCallback &&
             this.autoCompleteCallback(graph.relationships)
         })

--- a/src/shared/modules/commands/cypher.test.js
+++ b/src/shared/modules/commands/cypher.test.js
@@ -156,7 +156,7 @@ multiline comment
 // comment
 
 // comment
-:${autoCommitTxCommand} RETURN 1`
+/*cmnt*/:${autoCommitTxCommand} RETURN 1`
     )
     action.$$responseChannel = $$responseChannel
 
@@ -171,7 +171,7 @@ multiline comment
 // comment
 
 // comment
- RETURN 1`,
+/*cmnt*/ RETURN 1`,
         {},
         expect.objectContaining({
           autoCommit: true

--- a/src/shared/modules/commands/cypher.test.js
+++ b/src/shared/modules/commands/cypher.test.js
@@ -156,7 +156,7 @@ multiline comment
 // comment
 
 // comment
-/*cmnt*/:${autoCommitTxCommand} RETURN 1`
+/*:auto*/:${autoCommitTxCommand} RETURN ":auto"`
     )
     action.$$responseChannel = $$responseChannel
 
@@ -171,7 +171,7 @@ multiline comment
 // comment
 
 // comment
-/*cmnt*/ RETURN 1`,
+/*:auto*/RETURN ":auto"`,
         {},
         expect.objectContaining({
           autoCommit: true

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -385,7 +385,7 @@ const availableCommands = [
       const isAutocommit = query.startsWith(`:${autoCommitTxCommand}`)
 
       action.autoCommit = isAutocommit
-      action.query = isAutocommit ? query.slice(1) : query
+      action.query = isAutocommit ? query.slice(1).trim() : query
 
       const [id, request] = handleCypherCommand(
         action,

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -378,15 +378,14 @@ const availableCommands = [
     exec: (action, put, store) => {
       const state = store.getState()
 
-      // Since we now also handle queries with the :auto prefix, we need to strip that
-      // and attach to the actions object
-      const query = action.cmd.replace(`:${autoCommitTxCommand}`, '')
-      action.query = query.trim()
+      // Since we now also handle queries with the :auto prefix,
+      // we need to strip that and attach to the actions object
+      const query = action.cmd.trim()
 
-      // We need to find out if this is an auto-committing tx or not
-      // i.e. Did we strip something off above here?
-      const autoCommit = action.query.length < action.cmd.trim().length
-      action.autoCommit = autoCommit
+      const isAutocommit = query.startsWith(`:${autoCommitTxCommand}`)
+
+      action.autoCommit = isAutocommit
+      action.query = isAutocommit ? query.slice(1) : query
 
       const [id, request] = handleCypherCommand(
         action,
@@ -400,7 +399,7 @@ const availableCommands = [
           : getBackgroundTxMetadata({
               hasServerSupport: canSendTxMetadata(store.getState())
             }),
-        autoCommit
+        isAutocommit
       )
       put(cypher(action.cmd))
       put(

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -380,20 +380,22 @@ const availableCommands = [
 
       // Since we now also handle queries with the :auto prefix,
       // we need to strip that and attach to the actions object
-      // note that comment removal is crude and will remove
-      // false positives inside strings. but it's good enough
-      // for our use case here
       const query = action.cmd.trim()
 
-      const autoPrefix = getCmdChar(state) + autoCommitTxCommand
-      const isAutocommit = query
-        .replace(/\/\*(.|\n)*?\*\//g, '') // mutliline comment
-        .replace(/\/\/[^\n]*\n/g, '') // singleline comment
-        .trim()
-        .startsWith(autoPrefix)
+      const autoPrefix = `:${autoCommitTxCommand} `
+      const blankedComments = query
+        .replace(/\/\*(.|\n)*?\*\//g, match => ' '.repeat(match.length)) // mutliline comment
+        .replace(/\/\/[^\n]*\n/g, match => ' '.repeat(match.length)) // singleline comment
 
+      const isAutocommit = blankedComments.trim().startsWith(autoPrefix)
       action.autoCommit = isAutocommit
-      action.query = isAutocommit ? query.replace(autoPrefix, '').trim() : query
+
+      const prefixIndex = blankedComments.indexOf(autoPrefix)
+      const withoutAutoPrefix =
+        query.substring(0, prefixIndex) +
+        query.substring(prefixIndex + autoPrefix.length)
+
+      action.query = isAutocommit ? withoutAutoPrefix : query
 
       const [id, request] = handleCypherCommand(
         action,

--- a/src/shared/services/commandInterpreterHelper.js
+++ b/src/shared/services/commandInterpreterHelper.js
@@ -380,12 +380,20 @@ const availableCommands = [
 
       // Since we now also handle queries with the :auto prefix,
       // we need to strip that and attach to the actions object
+      // note that comment removal is crude and will remove
+      // false positives inside strings. but it's good enough
+      // for our use case here
       const query = action.cmd.trim()
 
-      const isAutocommit = query.startsWith(`:${autoCommitTxCommand}`)
+      const autoPrefix = getCmdChar(state) + autoCommitTxCommand
+      const isAutocommit = query
+        .replace(/\/\*(.|\n)*?\*\//g, '') // mutliline comment
+        .replace(/\/\/[^\n]*\n/g, '') // singleline comment
+        .trim()
+        .startsWith(autoPrefix)
 
       action.autoCommit = isAutocommit
-      action.query = isAutocommit ? query.slice(1).trim() : query
+      action.query = isAutocommit ? query.replace(autoPrefix, '').trim() : query
 
       const [id, request] = handleCypherCommand(
         action,


### PR DESCRIPTION
Previously ":auto" would be removed from the middle of queries such as "match (n) where n.key = "test:auto". 

Resolves #1149 