### PR TITLE
add project file name input error check util

### DIFF
--- a/src/browser/modules/Sidebar/ProjectFiles.tsx
+++ b/src/browser/modules/Sidebar/ProjectFiles.tsx
@@ -28,7 +28,8 @@ import ProjectFilesScripts, { ProjectFilesError } from './ProjectsFilesScripts'
 import NewSavedScript from './NewSavedScript'
 import {
   setProjectFileDefaultFileName,
-  updateCacheAddProjectFile
+  updateCacheAddProjectFile,
+  checkFileNameInput
 } from './project-files.utils'
 import { CYPHER_FILE_EXTENSION } from 'shared/services/export-favorites'
 import { ADD_PROJECT_FILE } from './project-files.constants'
@@ -45,23 +46,12 @@ const ProjectFiles = ({ projectId, scriptDraft, resetDraft }: ProjectFiles) => {
   const [error, setError] = useState('')
 
   function save(inputedFileName: string) {
-    const fileName = inputedFileName.replace(/\.cypher$/, '')
+    const cypherFileExt = new RegExp(`${CYPHER_FILE_EXTENSION}$`)
+    const fileName = inputedFileName.replace(cypherFileExt, '')
     setError('')
 
-    if (!fileName.length) {
-      setError('File name cannot be empty')
-      return
-    }
-
-    // @todo: this needs more thought and extracting to a util
-    if (
-      fileName.includes('/') ||
-      fileName.includes('\\') ||
-      fileName.includes('..') ||
-      fileName.startsWith('.') ||
-      fileName.includes(':') // Windows
-    ) {
-      setError("File name cannot include /, \\, .., : or start with '.'")
+    if (checkFileNameInput(fileName)) {
+      setError(checkFileNameInput(fileName))
       return
     }
 

--- a/src/browser/modules/Sidebar/project-files.constants.ts
+++ b/src/browser/modules/Sidebar/project-files.constants.ts
@@ -33,6 +33,36 @@ export enum EXECUTE_COMMAND_ORIGINS {
   NONE = ''
 }
 
+export interface ProhibitedFilenameErrors {
+  chars: string[]
+  tests: RegExp[]
+}
+
+interface ProhibitedFilenamePlatform {
+  platform?: string
+}
+
+interface ProhibitedFilenameChar extends ProhibitedFilenamePlatform {
+  char: string
+  test?: never
+}
+
+interface ProhibitedFilenameTest extends ProhibitedFilenamePlatform {
+  test: RegExp
+  char?: never
+}
+
+export const PROHIBITED_FILENAME_CHAR_TESTS: (
+  | ProhibitedFilenameChar
+  | ProhibitedFilenameTest
+)[] = [
+  { char: '/' },
+  { char: '\\' },
+  { char: '..' },
+  { test: /^[.|?]/ },
+  { char: ':', platform: 'Win32' }
+]
+
 export interface AddProjectFile {
   addProjectFile: ProjectFile
 }


### PR DESCRIPTION
<!--
BEFORE YOU SUBMIT make sure you've done the following:
[x] Done your work in a personal fork of the original repository
[x] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[x] Made sure the unit and e2e tests all pass
[x] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[x] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->
- added a project file name input error util
- [Video](https://drive.google.com/file/d/1ezdkSOZyDTIVmweewlCRLyLLEq5x06y6/view)
- cleans it up for now and can add to the chars list as they show up. Or we could be better off with existing filename module 🤷 