### PR TITLE
Update "create index" examples to use new syntax

### DIFF
--- a/src/browser/documentation/help/create-index-on.jsx
+++ b/src/browser/documentation/help/create-index-on.jsx
@@ -52,6 +52,11 @@ const content = (
     </div>
     <section className="example">
       <figure>
+        <p>On neo4j version 4.X</p>
+        <pre className="code runnable standalone-example">
+          CREATE INDEX [optionalName] FOR (p:Person) ON (p.name)
+        </pre>
+        <p>On neo4j version 3.X</p>
         <pre className="code runnable standalone-example">
           CREATE INDEX ON :Person(name)
         </pre>

--- a/src/shared/modules/favorites/staticScripts.js
+++ b/src/shared/modules/favorites/staticScripts.js
@@ -40,7 +40,21 @@ export const scripts = [
     not_executable: true,
     content:
       "// Create an index\n// Replace:\n//   'LabelName' with label to index\n//   'propertyKey' with property to be indexed\nCREATE INDEX ON :<LabelName>(<propertyKey>)",
-    versionRange: '>=3'
+    versionRange: '>=3 <4'
+  },
+  {
+    folder: 'basics',
+    not_executable: true,
+    content: `// Create an index
+// Replace:
+//   'IndexName' with name of index (optional)
+//   'LabelName' with label to index
+//   'propertyName' with property to be indexed
+CREATE INDEX [IndexName] 
+FOR (n:LabelName)
+ON (n.propertyName)
+`,
+    versionRange: '>=4'
   },
   {
     folder: 'basics',


### PR DESCRIPTION
Example in :help create index-on and static script now includes modern syntax.

