### PR TITLE
Basic performance overlay

### DIFF
--- a/src/browser/modules/App/App.test.tsx
+++ b/src/browser/modules/App/App.test.tsx
@@ -32,6 +32,7 @@ const store = mockStore({})
 jest.mock('../FeatureToggle/FeatureToggleProvider', () => {
   return ({ children }: any) => <div>{children}</div>
 })
+jest.mock('./PerformanceOverlay.tsx', () => () => <div />)
 jest.mock('./styled', () => {
   const orig = jest.requireActual('./styled')
   return {

--- a/src/browser/modules/App/App.tsx
+++ b/src/browser/modules/App/App.tsx
@@ -26,7 +26,8 @@ import {
   getTheme,
   getBrowserSyncConfig,
   codeFontLigatures,
-  LIGHT_THEME
+  LIGHT_THEME,
+  shouldShowPerfomanceOverlay
 } from 'shared/modules/settings/settingsDuck'
 import { utilizeBrowserSync } from 'shared/modules/features/featuresDuck'
 import { getOpenDrawer } from 'shared/modules/sidebar/sidebarDuck'
@@ -163,6 +164,22 @@ export function App(props: any) {
         }
         setEventMetricsCallback={setEventMetricsCallback}
       />
+      {props.showPerformanceOverlay && (
+        <div
+          style={{
+            color: 'red',
+            width: '100px',
+            height: '100px',
+            backgroundColor: 'blue',
+            position: 'absolute',
+            bottom: '10px',
+            right: '10px',
+            zIndex: 99999999999
+          }}
+        >
+          Very Overlay
+        </div>
+      )}
       <ThemeProvider theme={themeData}>
         <FeatureToggleProvider features={experimentalFeatures}>
           <FileDrop store={store}>
@@ -228,7 +245,8 @@ const mapStateToProps = (state: any) => {
     loadSync: utilizeBrowserSync(state),
     isWebEnv: inWebEnv(state),
     useDb: getUseDb(state),
-    databases: getDatabases(state)
+    databases: getDatabases(state),
+    showPerformanceOverlay: shouldShowPerfomanceOverlay(state)
   }
 }
 

--- a/src/browser/modules/App/App.tsx
+++ b/src/browser/modules/App/App.tsx
@@ -26,8 +26,7 @@ import {
   getTheme,
   getBrowserSyncConfig,
   codeFontLigatures,
-  LIGHT_THEME,
-  shouldShowPerfomanceOverlay
+  LIGHT_THEME
 } from 'shared/modules/settings/settingsDuck'
 import { utilizeBrowserSync } from 'shared/modules/features/featuresDuck'
 import { getOpenDrawer } from 'shared/modules/sidebar/sidebarDuck'
@@ -82,6 +81,7 @@ import {
 } from 'browser-components/desktop-api/desktop-api.handlers'
 import { METRICS_EVENT, udcInit } from 'shared/modules/udc/udcDuck'
 import { useKeyboardShortcuts } from './keyboardShortcuts'
+import PerformanceOverlay from './PerformanceOverlay'
 
 export function App(props: any) {
   const [derivedTheme, setEnvironmentTheme] = useDerivedTheme(
@@ -164,22 +164,7 @@ export function App(props: any) {
         }
         setEventMetricsCallback={setEventMetricsCallback}
       />
-      {props.showPerformanceOverlay && (
-        <div
-          style={{
-            color: 'red',
-            width: '100px',
-            height: '100px',
-            backgroundColor: 'blue',
-            position: 'absolute',
-            bottom: '10px',
-            right: '10px',
-            zIndex: 99999999999
-          }}
-        >
-          Very Overlay
-        </div>
-      )}
+      <PerformanceOverlay />
       <ThemeProvider theme={themeData}>
         <FeatureToggleProvider features={experimentalFeatures}>
           <FileDrop store={store}>
@@ -245,8 +230,7 @@ const mapStateToProps = (state: any) => {
     loadSync: utilizeBrowserSync(state),
     isWebEnv: inWebEnv(state),
     useDb: getUseDb(state),
-    databases: getDatabases(state),
-    showPerformanceOverlay: shouldShowPerfomanceOverlay(state)
+    databases: getDatabases(state)
   }
 }
 

--- a/src/browser/modules/App/PerformanceOverlay.tsx
+++ b/src/browser/modules/App/PerformanceOverlay.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react'
+import styled from 'styled-components'
+import { connect } from 'react-redux'
+import { shouldShowPerfomanceOverlay } from 'shared/modules/settings/settingsDuck'
+
+const Overlay = styled.div`
+  width: 100px;
+  height: 100px;
+  background-color: black;
+  color: white;
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  z-index: 99999999999;
+`
+
+function perfTracker() {
+  let lastTime = performance.now()
+  let frames = 0
+
+  return function(onFpsData: (fps: number) => void) {
+    frames = frames + 1
+    const currentTime = performance.now()
+    if (currentTime >= lastTime + 1000) {
+      const fps = (frames * 1000) / (currentTime - lastTime)
+      onFpsData(fps)
+      frames = 0
+      lastTime = currentTime
+    }
+  }
+}
+
+type PerformanceOverlayProps = { shouldShow: boolean }
+
+function PerformanceOverlay({
+  shouldShow
+}: PerformanceOverlayProps): JSX.Element | null {
+  useEffect(() => {
+    const tick = perfTracker()
+
+    let requestId = requestAnimationFrame(function loop() {
+      tick((fps: number) => {
+        // Avoid using react state to not tie number to reacts re-render cycle
+        const fpsCounter = document.getElementById('fps-counter')
+        if (fpsCounter) {
+          fpsCounter.textContent = fps.toFixed(2).toString()
+        }
+      })
+
+      requestId = requestAnimationFrame(loop)
+    })
+    return () => cancelAnimationFrame(requestId)
+  }, [])
+
+  return shouldShow ? (
+    <Overlay>
+      <div id="fps-counter" /> OVERLAY
+    </Overlay>
+  ) : null
+}
+
+const mapStateToProps = (state: any) => ({
+  shouldShow: shouldShowPerfomanceOverlay(state)
+})
+
+export default connect(mapStateToProps)(PerformanceOverlay)

--- a/src/browser/modules/App/PerformanceOverlay.tsx
+++ b/src/browser/modules/App/PerformanceOverlay.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useRef } from 'react'
 import { connect } from 'react-redux'
-import { shouldShowPerfomanceOverlay } from 'shared/modules/settings/settingsDuck'
+import { shouldshowPerformanceOverlay } from 'shared/modules/settings/settingsDuck'
 import styled from 'styled-components'
 
 function perfTracker() {
@@ -134,7 +134,7 @@ const Overlay = styled.div`
 `
 
 const mapStateToProps = (state: any) => ({
-  shouldShow: shouldShowPerfomanceOverlay(state)
+  shouldShow: shouldshowPerformanceOverlay(state)
 })
 
 export default connect(mapStateToProps)(PerformanceOverlay)

--- a/src/browser/modules/App/PerformanceOverlay.tsx
+++ b/src/browser/modules/App/PerformanceOverlay.tsx
@@ -4,14 +4,16 @@ import { connect } from 'react-redux'
 import { shouldShowPerfomanceOverlay } from 'shared/modules/settings/settingsDuck'
 
 const Overlay = styled.div`
-  width: 100px;
-  height: 100px;
+  width: 250px;
+  height: 200px;
   background-color: black;
   color: white;
   position: absolute;
   bottom: 10px;
   right: 10px;
   z-index: 99999999999;
+  padding: 10px;
+  opacity: 0.95;
 `
 
 function perfTracker() {
@@ -38,12 +40,27 @@ function PerformanceOverlay({
   useEffect(() => {
     const tick = perfTracker()
 
+    let samples: number[] = []
+
     let requestId = requestAnimationFrame(function loop() {
       tick((fps: number) => {
         // Avoid using react state to not tie number to reacts re-render cycle
         const fpsCounter = document.getElementById('fps-counter')
         if (fpsCounter) {
-          fpsCounter.textContent = fps.toFixed(2).toString()
+          samples = [fps, ...samples]
+          const limit = 10
+          if (samples.length > limit) {
+            samples = samples.slice(0, limit)
+          }
+          const low = Math.min(...samples)
+          const add = (a: number, b: number) => a + b
+          const average = samples.reduce(add, 0) / samples.length
+
+          fpsCounter.textContent = `
+Current FPS: ${fps.toFixed(2).toString()}
+Average in the last minute: ${average.toFixed(2)}
+Lowest in last minute: ${low.toFixed(2)}
+          `
         }
       })
 
@@ -54,7 +71,7 @@ function PerformanceOverlay({
 
   return shouldShow ? (
     <Overlay>
-      <div id="fps-counter" /> OVERLAY
+      <div style={{ whiteSpace: 'pre' }} id="fps-counter" />
     </Overlay>
   ) : null
 }

--- a/src/browser/modules/App/PerformanceOverlay.tsx
+++ b/src/browser/modules/App/PerformanceOverlay.tsx
@@ -42,46 +42,50 @@ function PerformanceOverlay({
   const limit = 100
 
   useEffect(() => {
-    const tick = perfTracker()
+    if (shouldShow) {
+      const tick = perfTracker()
 
-    let requestId = requestAnimationFrame(function loop() {
-      tick((fps: number) => {
-        updateStats('fps', fps)
+      let requestId = requestAnimationFrame(function loop() {
+        tick((fps: number) => {
+          updateStats('fps', fps)
 
-        samples.current = [fps, ...samples.current]
-        if (samples.current.length > limit) {
-          samples.current = samples.current.slice(0, limit)
-        }
-        updateStats('minFps', Math.min(...samples.current))
+          samples.current = [fps, ...samples.current]
+          if (samples.current.length > limit) {
+            samples.current = samples.current.slice(0, limit)
+          }
+          updateStats('minFps', Math.min(...samples.current))
 
-        const add = (a: number, b: number) => a + b
-        updateStats(
-          'meanFps',
-          samples.current.reduce(add, 0) / samples.current.length
-        )
+          const add = (a: number, b: number) => a + b
+          updateStats(
+            'meanFps',
+            samples.current.reduce(add, 0) / samples.current.length
+          )
 
-        const memory: { usedJSHeapSize: number; jsHeapSizeLimit: number } =
-          // @ts-ignore chrome only field
-          performance.memory
+          const memory: { usedJSHeapSize: number; jsHeapSizeLimit: number } =
+            // @ts-ignore chrome only field
+            performance.memory
 
-        if (memory) {
-          const { usedJSHeapSize, jsHeapSizeLimit } = memory
-          const percentageMemoryUsed = `${(
-            (100 * usedJSHeapSize) /
-            jsHeapSizeLimit
-          ).toFixed(2)}%`
-          updateStats('percentOfTotalMemUsed', percentageMemoryUsed)
+          if (memory) {
+            const { usedJSHeapSize, jsHeapSizeLimit } = memory
+            const percentageMemoryUsed = `${(
+              100 *
+              (usedJSHeapSize / jsHeapSizeLimit)
+            ).toFixed(2)}%`
+            updateStats('percentOfTotalMemUsed', percentageMemoryUsed)
 
-          const bytesInMegaByte = 1048576
-          const MBused = usedJSHeapSize / bytesInMegaByte
-          updateStats('memUsage', `${MBused.toFixed(2)}MB`)
-        }
+            const bytesInMegaByte = 1048576
+            const MBused = usedJSHeapSize / bytesInMegaByte
+            updateStats('memUsage', `${MBused.toFixed(2)}MB`)
+          }
+        })
+
+        requestId = requestAnimationFrame(loop)
       })
-
-      requestId = requestAnimationFrame(loop)
-    })
-    return () => cancelAnimationFrame(requestId)
-  }, [])
+      return () => cancelAnimationFrame(requestId)
+    } else {
+      return undefined
+    }
+  }, [shouldShow])
 
   function dumpStats() {
     console.log(['fps', ...samples.current].join('\n'))

--- a/src/shared/modules/settings/__snapshots__/settingsDuck.test.ts.snap
+++ b/src/shared/modules/settings/__snapshots__/settingsDuck.test.ts.snap
@@ -20,6 +20,7 @@ Object {
   "playImplicitInitCommands": true,
   "scrollToTop": true,
   "shouldReportUdc": true,
+  "showPerformanceOverlay": false,
   "showSampleScripts": true,
   "theme": "auto",
   "useBoltRouting": false,

--- a/src/shared/modules/settings/settingsDuck.ts
+++ b/src/shared/modules/settings/settingsDuck.ts
@@ -63,6 +63,8 @@ export const shouldAutoComplete = (state: any) =>
 export const shouldEditorLint = (state: any) => state[NAME].editorLint === true
 export const shouldEnableMultiStatementMode = (state: any) =>
   state[NAME].enableMultiStatementMode
+export const shouldShowPerfomanceOverlay = (state: any): boolean =>
+  state[NAME].showPerfomanceOverlay === true
 
 const browserSyncConfig = (host = 'https://auth.neo4j.com') => ({
   authWindowUrl: `${host}/indexNewBrowser.html`,
@@ -104,7 +106,8 @@ const initialState = {
   editorLint: false,
   useCypherThread: true,
   enableMultiStatementMode: true,
-  connectionTimeout: 30 * 1000 // 30 seconds
+  connectionTimeout: 30 * 1000, // 30 seconds
+  showPerfomanceOverlay: false
 }
 
 export default function settings(state = initialState, action: any) {

--- a/src/shared/modules/settings/settingsDuck.ts
+++ b/src/shared/modules/settings/settingsDuck.ts
@@ -63,8 +63,8 @@ export const shouldAutoComplete = (state: any) =>
 export const shouldEditorLint = (state: any) => state[NAME].editorLint === true
 export const shouldEnableMultiStatementMode = (state: any) =>
   state[NAME].enableMultiStatementMode
-export const shouldShowPerfomanceOverlay = (state: any): boolean =>
-  state[NAME].showPerfomanceOverlay === true
+export const shouldshowPerformanceOverlay = (state: any): boolean =>
+  state[NAME].showPerformanceOverlay === true
 
 const browserSyncConfig = (host = 'https://auth.neo4j.com') => ({
   authWindowUrl: `${host}/indexNewBrowser.html`,
@@ -107,7 +107,7 @@ const initialState = {
   useCypherThread: true,
   enableMultiStatementMode: true,
   connectionTimeout: 30 * 1000, // 30 seconds
-  showPerfomanceOverlay: false
+  showPerformanceOverlay: false
 }
 
 export default function settings(state = initialState, action: any) {


### PR DESCRIPTION
First step with performance instrument, more metrics and refinement to come. To turn the overlay on run `:config "showPerformanceOverlay": true`

Keep in mind memory usage is only available in chrome sadly
