### PR TITLE
Use Relate ID instead of Desktop ID for projects

### DIFF
--- a/src/browser/AppInit.tsx
+++ b/src/browser/AppInit.tsx
@@ -121,7 +121,9 @@ const searchParams = new URL(url).searchParams
 // Desktop/Relate params
 const relateUrl = searchParams.get('relateUrl')
 const relateApiToken = searchParams.get('relateApiToken')
-const neo4jDesktopProjectId = searchParams.get('neo4jDesktopProjectId')
+const relateProjectId =
+  searchParams.get('relateProjectId') ||
+  searchParams.get('neo4jDesktopProjectId')
 const neo4jDesktopGraphAppId = searchParams.get('neo4jDesktopGraphAppId')
 
 // Signal app upstart (for epics)
@@ -131,7 +133,7 @@ store.dispatch({
   env,
   relateUrl,
   relateApiToken,
-  neo4jDesktopProjectId,
+  relateProjectId,
   neo4jDesktopGraphAppId
 })
 

--- a/src/browser/modules/Editor/ProjectFilesButton.tsx
+++ b/src/browser/modules/Editor/ProjectFilesButton.tsx
@@ -229,8 +229,8 @@ const mapStateToProps = (state: any) => {
     isRelateAvailable:
       state.app.relateUrl &&
       state.app.relateApiToken &&
-      state.app.neo4jDesktopProjectId,
-    projectId: state.app.neo4jDesktopProjectId
+      state.app.relateProjectId,
+    projectId: state.app.relateProjectId
   }
 }
 

--- a/src/browser/modules/Sidebar/ProjectsFilesScripts.tsx
+++ b/src/browser/modules/Sidebar/ProjectsFilesScripts.tsx
@@ -224,7 +224,7 @@ function ProjectFilesScripts(props: ProjectFilesScripts): JSX.Element {
 
 const mapFavoritesStateToProps = (state: any) => {
   return {
-    projectId: state.app.neo4jDesktopProjectId,
+    projectId: state.app.relateProjectId,
     relateApiToken: state.app.relateApiToken,
     neo4jDesktopGraphAppId: state.app.neo4jDesktopGraphAppId,
     relateUrl: state.app.relateUrl

--- a/src/shared/modules/app/appDuck.ts
+++ b/src/shared/modules/app/appDuck.ts
@@ -66,8 +66,8 @@ export const getAllowedBoltSchemes = (state: any, encryptionFlag?: any) => {
 export const isRelateAvailable = (state: any) =>
   state[NAME].relateUrl &&
   state[NAME].relateApiToken &&
-  state[NAME].neo4jDesktopProjectId
-export const getProjectId = (state: any) => state[NAME].neo4jDesktopProjectId
+  state[NAME].relateProjectId
+export const getProjectId = (state: any) => state[NAME].relateProjectId
 
 // Reducer
 export default function reducer(state = { hostedUrl: null }, action: any) {
@@ -79,7 +79,7 @@ export default function reducer(state = { hostedUrl: null }, action: any) {
         env: action.env,
         relateUrl: action.relateUrl,
         relateApiToken: action.relateApiToken,
-        neo4jDesktopProjectId: action.neo4jDesktopProjectId,
+        relateProjectId: action.relateProjectId,
         neo4jDesktopGraphAppId: action.neo4jDesktopGraphAppId
       }
     default:


### PR DESCRIPTION
Everything mentioned here only affects the saved files feature.

Due to a change in how Desktop is retrieving projects, using the Desktop ID to get a project through Relate will no longer work. To avoid breaking this feature, and to be more semantically correct, Desktop will be passing the Relate ID instead when launching graph apps. 

This PR makes Browser aware of the new URL parameter if it exists and falls back to the old one if it doesn't, making the change backward compatible.

More information about the Desktop changes can be found here: https://github.com/neo-technology/neo4j-desktop/pull/927 