### PR TITLE
Fix cypher docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Example: `CYPRESS_E2E_TEST_ENV="local" CYPRESS_BASE_URL=http://localhost:8081 cy
 
 ## Devtools
 
-Redux and React have useful devtools, the chrome versions are linked bellow: 
+Redux and React have useful devtools, the chrome versions are linked below: 
 
 - [Redux devtools](https://chrome.google.com/webstore/detail/redux-devtools/lmhkpmbekcpmknklioeibfkpmmfibljd?hl=en)
 - [React devtools](https://chrome.google.com/webstore/detail/react-developer-tools/fmkadmapgofadopljbjfkapdkoienihi?hl=en)

--- a/src/browser/documentation/guides/cypher.tsx
+++ b/src/browser/documentation/guides/cypher.tsx
@@ -66,7 +66,7 @@ const slides = [
           node
         </li>
         <li>
-          <code>{}</code> brackets to add properties to the node
+          <code>{'{}'}</code> brackets to add properties to the node
         </li>
       </ul>
     </div>


### PR DESCRIPTION
What:
1. Fixed `:play cypher` documentation at slide 2 - curly brackets were missing due to nature of jsx. In order to display them, it is necessary to put a string with curly brackets inside jsx brackets.
2. Fixed minor typo in README.md file.

Before:
![Screenshot 2020-12-12 at 14 26 36](https://user-images.githubusercontent.com/18195654/101985338-aca9e900-3c87-11eb-8aed-59df44335390.png)

After:
![Screenshot 2020-12-12 at 14 27 19](https://user-images.githubusercontent.com/18195654/101985345-b4698d80-3c87-11eb-8fbb-558083006aef.png)


