### PR TITLE
Sentry updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "@relate-by-ui/css": "1.0.5",
     "@relate-by-ui/relatable": "1.0.1",
     "@relate-by-ui/saved-scripts": "^1.0.5",
+    "@sentry/integrations": "^5.29.0",
     "@sentry/react": "^5.29.0",
     "@sentry/tracing": "^5.27.0",
     "@types/d3": "^3",

--- a/package.json
+++ b/package.json
@@ -154,7 +154,7 @@
     "@relate-by-ui/css": "1.0.5",
     "@relate-by-ui/relatable": "1.0.1",
     "@relate-by-ui/saved-scripts": "^1.0.5",
-    "@sentry/browser": "^5.27.0",
+    "@sentry/react": "^5.29.0",
     "@sentry/tracing": "^5.27.0",
     "@types/d3": "^3",
     "@types/dateformat": "^3.0.1",

--- a/src/browser/AppInit.tsx
+++ b/src/browser/AppInit.tsx
@@ -92,39 +92,38 @@ bus.applyMiddleware(
 )
 
 export function setupSentry() {
-  //if (process.env.NODE_ENV === 'production') {
-  Sentry.init({
-    dsn:
-      'https://1ea9f7ebd51441cc95906afb2d31d841@o110884.ingest.sentry.io/1232865',
-    release: `neo4j-browser@${version}`,
-    integrations: [
-      new Integrations.BrowserTracing(),
-      new CaptureConsole({ levels: ['error'] })
-    ],
-    //     tracesSampleRate: 0.2,
-    tracesSampleRate: 1,
-    beforeSend: event =>
-      allowOutgoingConnections(store.getState()) ? event : null,
-    environment: 'unset'
-  })
-  Sentry.setUser({ id: getUuid(store.getState()) })
-
-  fetch('./manifest.json')
-    .then(res => res.json())
-    .then(json => {
-      const isCanary = Boolean(
-        json && json.name.toLowerCase().includes('canary')
-      )
-
-      Sentry.configureScope(scope =>
-        scope.addEventProcessor(event => ({
-          ...event,
-          environment: isCanary ? 'canary' : 'production'
-        }))
-      )
+  if (process.env.NODE_ENV === 'production') {
+    Sentry.init({
+      dsn:
+        'https://1ea9f7ebd51441cc95906afb2d31d841@o110884.ingest.sentry.io/1232865',
+      release: `neo4j-browser@${version}`,
+      integrations: [
+        new Integrations.BrowserTracing(),
+        new CaptureConsole({ levels: ['error'] })
+      ],
+      tracesSampleRate: 0.2,
+      beforeSend: event =>
+        allowOutgoingConnections(store.getState()) ? event : null,
+      environment: 'unset'
     })
-    .catch(() => {})
-  //  }
+    Sentry.setUser({ id: getUuid(store.getState()) })
+
+    fetch('./manifest.json')
+      .then(res => res.json())
+      .then(json => {
+        const isCanary = Boolean(
+          json && json.name.toLowerCase().includes('canary')
+        )
+
+        Sentry.configureScope(scope =>
+          scope.addEventProcessor(event => ({
+            ...event,
+            environment: isCanary ? 'canary' : 'production'
+          }))
+        )
+      })
+      .catch(() => {})
+  }
 }
 
 // Introduce environment to be able to fork functionality

--- a/src/browser/AppInit.tsx
+++ b/src/browser/AppInit.tsx
@@ -32,16 +32,17 @@ import reducers from 'shared/rootReducer'
 import epics from 'shared/rootEpic'
 import { ApolloClient, InMemoryCache, ApolloProvider } from '@apollo/client'
 import { createUploadLink } from 'apollo-upload-client'
+import * as Sentry from '@sentry/react'
+import { Integrations } from '@sentry/tracing'
 
 import { createReduxMiddleware, getAll, applyKeys } from 'services/localstorage'
 import { APP_START } from 'shared/modules/app/appDuck'
 import { GlobalStyle } from './styles/global-styles'
 import { detectRuntimeEnv } from 'services/utils'
 import { NEO4J_CLOUD_DOMAINS } from 'shared/modules/settings/settingsDuck'
-import * as Sentry from '@sentry/browser'
-import { Integrations } from '@sentry/tracing'
 import { version } from 'project-root/package.json'
 import { allowOutgoingConnections } from 'shared/modules/dbMeta/dbMetaDuck'
+import { getUuid } from 'shared/modules/udc/udcDuck'
 
 // Configure localstorage sync
 applyKeys(
@@ -89,26 +90,29 @@ bus.applyMiddleware(
   }
 )
 
-async function setupSentry() {
+export function setupSentry() {
   if (process.env.NODE_ENV === 'production') {
-    let isCanary = false
-    try {
-      const json = await (await fetch('./manifest.json')).json()
-      isCanary = Boolean(json && json.name.toLowerCase().includes('canary'))
-    } catch {}
-
     Sentry.init({
       dsn:
         'https://1ea9f7ebd51441cc95906afb2d31d841@o110884.ingest.sentry.io/1232865',
-      release: `neo4j-browser@${version}${isCanary ? '-canary' : ''}`,
+      release: `neo4j-browser@${version}`,
       integrations: [new Integrations.BrowserTracing()],
       tracesSampleRate: 0.2,
       beforeSend: event =>
         allowOutgoingConnections(store.getState()) ? event : null
     })
+    Sentry.setUser({ id: getUuid(store.getState()) })
+
+    fetch('./manifest.json')
+      .then(res => res.json())
+      .then(json => {
+        const isCanary = Boolean(
+          json && json.name.toLowerCase().includes('canary')
+        )
+        Sentry.setTag('deployment', isCanary ? 'canary' : 'prod')
+      })
   }
 }
-setupSentry()
 
 // Introduce environment to be able to fork functionality
 const env = detectRuntimeEnv(window, NEO4J_CLOUD_DOMAINS)

--- a/src/browser/AppInit.tsx
+++ b/src/browser/AppInit.tsx
@@ -91,27 +91,36 @@ bus.applyMiddleware(
 )
 
 export function setupSentry() {
-  if (process.env.NODE_ENV === 'production') {
-    Sentry.init({
-      dsn:
-        'https://1ea9f7ebd51441cc95906afb2d31d841@o110884.ingest.sentry.io/1232865',
-      release: `neo4j-browser@${version}`,
-      integrations: [new Integrations.BrowserTracing()],
-      tracesSampleRate: 0.2,
-      beforeSend: event =>
-        allowOutgoingConnections(store.getState()) ? event : null
-    })
-    Sentry.setUser({ id: getUuid(store.getState()) })
+  //if (process.env.NODE_ENV === 'production') {
+  Sentry.init({
+    dsn:
+      'https://1ea9f7ebd51441cc95906afb2d31d841@o110884.ingest.sentry.io/1232865',
+    release: `neo4j-browser@${version}`,
+    integrations: [new Integrations.BrowserTracing()],
+    //     tracesSampleRate: 0.2,
+    tracesSampleRate: 1,
+    beforeSend: event =>
+      allowOutgoingConnections(store.getState()) ? event : null,
+    environment: 'unset'
+  })
+  Sentry.setUser({ id: getUuid(store.getState()) })
 
-    fetch('./manifest.json')
-      .then(res => res.json())
-      .then(json => {
-        const isCanary = Boolean(
-          json && json.name.toLowerCase().includes('canary')
-        )
-        Sentry.setTag('deployment', isCanary ? 'canary' : 'prod')
-      })
-  }
+  fetch('./manifest.json')
+    .then(res => res.json())
+    .then(json => {
+      const isCanary = Boolean(
+        json && json.name.toLowerCase().includes('canary')
+      )
+
+      Sentry.configureScope(scope =>
+        scope.addEventProcessor(event => ({
+          ...event,
+          environment: isCanary ? 'canary' : 'production'
+        }))
+      )
+    })
+    .catch(() => {})
+  //  }
 }
 
 // Introduce environment to be able to fork functionality

--- a/src/browser/AppInit.tsx
+++ b/src/browser/AppInit.tsx
@@ -34,6 +34,7 @@ import { ApolloClient, InMemoryCache, ApolloProvider } from '@apollo/client'
 import { createUploadLink } from 'apollo-upload-client'
 import * as Sentry from '@sentry/react'
 import { Integrations } from '@sentry/tracing'
+import { CaptureConsole } from '@sentry/integrations'
 
 import { createReduxMiddleware, getAll, applyKeys } from 'services/localstorage'
 import { APP_START } from 'shared/modules/app/appDuck'
@@ -96,7 +97,10 @@ export function setupSentry() {
     dsn:
       'https://1ea9f7ebd51441cc95906afb2d31d841@o110884.ingest.sentry.io/1232865',
     release: `neo4j-browser@${version}`,
-    integrations: [new Integrations.BrowserTracing()],
+    integrations: [
+      new Integrations.BrowserTracing(),
+      new CaptureConsole({ levels: ['error'] })
+    ],
     //     tracesSampleRate: 0.2,
     tracesSampleRate: 1,
     beforeSend: event =>

--- a/src/browser/components/ErrorBoundary.tsx
+++ b/src/browser/components/ErrorBoundary.tsx
@@ -19,6 +19,7 @@
  */
 import React, { Component } from 'react'
 import styled from 'styled-components'
+import * as Sentry from '@sentry/react'
 import { StyledErrorBoundaryButton } from 'browser-components/buttons/index'
 
 const ErrorWrapper = styled.div`
@@ -27,39 +28,29 @@ const ErrorWrapper = styled.div`
   text-align: center;
   color: #da4433;
 `
+type ErrorBoundaryProps = {
+  caption?: string
+  children: React.ReactNode
+}
 
-type State = any
-
-export default class ErrorBoundary extends Component<
-  { caption?: string },
-  State
-> {
-  state = {
-    errorInfo: null,
-    error: null
-  }
-
-  componentDidCatch(error: any, errorInfo: any) {
-    this.setState({ errorInfo, error })
-  }
-
-  render() {
-    if (this.state.error) {
-      return (
+export default function ErrorBoundary(props: ErrorBoundaryProps): JSX.Element {
+  return (
+    <Sentry.ErrorBoundary
+      fallback={({ error }) => (
         <ErrorWrapper>
           <p>
-            Something went wrong:{' '}
-            <em>"{(this.state.error || '').toString()}"</em> and the application
-            can't recover.
+            Something went wrong: <em>"{(error || '').toString()}"</em> and the
+            application can't recover.
           </p>
           <div style={{ marginTop: '5px' }}>
             <StyledErrorBoundaryButton onClick={() => window.location.reload()}>
-              {this.props.caption || 'Reload application'}
+              {props.caption || 'Reload application'}
             </StyledErrorBoundaryButton>
           </div>
         </ErrorWrapper>
-      )
-    }
-    return this.props.children
-  }
+      )}
+    >
+      {props.children}
+    </Sentry.ErrorBoundary>
+  )
 }

--- a/src/browser/index.tsx
+++ b/src/browser/index.tsx
@@ -20,6 +20,7 @@
 import './init'
 import React from 'react'
 import ReactDOM from 'react-dom'
-import AppInit from './AppInit'
+import AppInit, { setupSentry } from './AppInit'
 
+setupSentry()
 ReactDOM.render(<AppInit />, document.getElementById('mount'))

--- a/src/shared/modules/udc/udcDuck.ts
+++ b/src/shared/modules/udc/udcDuck.ts
@@ -118,6 +118,7 @@ const getCompanies = (state: any) => {
   return null
 }
 const getEvents = (state: any) => state[NAME].events || initialState.events
+export const getUuid = (state: any) => state[NAME].uuid || initialState.uuid
 
 const initialState = {
   uuid: v4(),

--- a/src/shared/services/commandInterpreterHelper.ts
+++ b/src/shared/services/commandInterpreterHelper.ts
@@ -436,6 +436,7 @@ const availableCommands = [
         description:
           'Time from all actions dispatched until request is resolved'
       })
+      throw new Error('pang!')
       return request
         .then((res: any) => {
           put(updateQueryResult(id, res, REQUEST_STATUS_SUCCESS))
@@ -456,7 +457,6 @@ const availableCommands = [
           put(fetchMetaData())
           finishRequestSpan.finish()
           transaction.finish()
-          throw new Error('pang!')
         })
     }
   },

--- a/src/shared/services/commandInterpreterHelper.ts
+++ b/src/shared/services/commandInterpreterHelper.ts
@@ -381,8 +381,9 @@ const availableCommands = [
       /^cypher$/.test(cmd) ||
       new RegExp(`^${autoCommitTxCommand}`, 'i').test(cmd),
     exec: (action: any, put: any, store: any) => {
+      // Sentry crashes tests without the ?. when it's not been initiated
       const transaction = Sentry.startTransaction({ name: 'Cypher query' })
-      const startingRequest = transaction.startChild({
+      const startingRequest = transaction?.startChild({
         op: 'Starting request and dispatching'
       })
 
@@ -430,13 +431,12 @@ const availableCommands = [
           requestId: id
         })
       )
-      startingRequest.finish()
-      const finishRequestSpan = transaction.startChild({
+      startingRequest?.finish()
+      const finishRequestSpan = transaction?.startChild({
         op: 'Resolve request',
         description:
           'Time from all actions dispatched until request is resolved'
       })
-      throw new Error('pang!')
       return request
         .then((res: any) => {
           put(updateQueryResult(id, res, REQUEST_STATUS_SUCCESS))
@@ -455,8 +455,8 @@ const availableCommands = [
         })
         .finally(() => {
           put(fetchMetaData())
-          finishRequestSpan.finish()
-          transaction.finish()
+          finishRequestSpan?.finish()
+          transaction?.finish()
         })
     }
   },

--- a/src/shared/services/commandInterpreterHelper.ts
+++ b/src/shared/services/commandInterpreterHelper.ts
@@ -17,6 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import * as Sentry from '@sentry/react'
 import bolt from 'services/bolt/bolt'
 import * as frames from 'shared/modules/stream/streamDuck'
 import { getHostedUrl } from 'shared/modules/app/appDuck'
@@ -380,6 +381,11 @@ const availableCommands = [
       /^cypher$/.test(cmd) ||
       new RegExp(`^${autoCommitTxCommand}`, 'i').test(cmd),
     exec: (action: any, put: any, store: any) => {
+      const transaction = Sentry.startTransaction({ name: 'Cypher query' })
+      const startingRequest = transaction.startChild({
+        op: 'Starting request and dispatching'
+      })
+
       const state = store.getState()
 
       // Since we now also handle queries with the :auto prefix,
@@ -424,6 +430,12 @@ const availableCommands = [
           requestId: id
         })
       )
+      startingRequest.finish()
+      const finishRequestSpan = transaction.startChild({
+        op: 'Resolve request',
+        description:
+          'Time from all actions dispatched until request is resolved'
+      })
       return request
         .then((res: any) => {
           put(updateQueryResult(id, res, REQUEST_STATUS_SUCCESS))
@@ -442,6 +454,9 @@ const availableCommands = [
         })
         .finally(() => {
           put(fetchMetaData())
+          finishRequestSpan.finish()
+          transaction.finish()
+          throw new Error('pang!')
         })
     }
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,8 @@
     "target": "ES6",
     "strict": true,
     "sourceMap": true,
+    "inlineSources": true,
+    "sourceRoot": "/",
     "noImplicitAny": true,
     "noUnusedLocals": false,
     "noUnusedParameters": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,8 +6,6 @@
     "target": "ES6",
     "strict": true,
     "sourceMap": true,
-    "inlineSources": true,
-    "sourceRoot": "/",
     "noImplicitAny": true,
     "noUnusedLocals": false,
     "noUnusedParameters": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1860,25 +1860,25 @@
     exenv "^1.2.2"
     prop-types "^15.6.2"
 
-"@sentry/browser@^5.27.0":
-  version "5.27.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/@sentry/browser/-/browser-5.27.0.tgz#35b77f076fb5f08c91eff23f3c067ee15df0ab90"
-  integrity sha1-Nbd/B2+18IyR7/I/PAZ+4V3wq5A=
+"@sentry/browser@5.29.0":
+  version "5.29.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/@sentry/browser/-/browser-5.29.0.tgz#a8cab91729c759c456bd2254cef65bafa5cdc4ea"
+  integrity sha1-qMq5FynHWcRWvSJUzvZbr6XNxOo=
   dependencies:
-    "@sentry/core" "5.27.0"
-    "@sentry/types" "5.27.0"
-    "@sentry/utils" "5.27.0"
+    "@sentry/core" "5.29.0"
+    "@sentry/types" "5.29.0"
+    "@sentry/utils" "5.29.0"
     tslib "^1.9.3"
 
-"@sentry/core@5.27.0":
-  version "5.27.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/@sentry/core/-/core-5.27.0.tgz#661b2fd1beecaa37c013a6c364330fa29c847b3c"
-  integrity sha1-Zhsv0b7sqjfAE6bDZDMPopyEezw=
+"@sentry/core@5.29.0":
+  version "5.29.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/@sentry/core/-/core-5.29.0.tgz#4410ca0dc5785abf3df02fa23c18e83ad90d7cda"
+  integrity sha1-RBDKDcV4Wr898C+iPBjoOtkNfNo=
   dependencies:
-    "@sentry/hub" "5.27.0"
-    "@sentry/minimal" "5.27.0"
-    "@sentry/types" "5.27.0"
-    "@sentry/utils" "5.27.0"
+    "@sentry/hub" "5.29.0"
+    "@sentry/minimal" "5.29.0"
+    "@sentry/types" "5.29.0"
+    "@sentry/utils" "5.29.0"
     tslib "^1.9.3"
 
 "@sentry/hub@5.27.0":
@@ -1890,6 +1890,15 @@
     "@sentry/utils" "5.27.0"
     tslib "^1.9.3"
 
+"@sentry/hub@5.29.0":
+  version "5.29.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/@sentry/hub/-/hub-5.29.0.tgz#d018b978fdffc6c8261744b0d08e8d25a3f4dc58"
+  integrity sha1-0Bi5eP3/xsgmF0Sw0I6NJaP03Fg=
+  dependencies:
+    "@sentry/types" "5.29.0"
+    "@sentry/utils" "5.29.0"
+    tslib "^1.9.3"
+
 "@sentry/minimal@5.27.0":
   version "5.27.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/@sentry/minimal/-/minimal-5.27.0.tgz#8c2fdcf9cd1e59d8ff1848a7905bac304f8e206b"
@@ -1897,6 +1906,27 @@
   dependencies:
     "@sentry/hub" "5.27.0"
     "@sentry/types" "5.27.0"
+    tslib "^1.9.3"
+
+"@sentry/minimal@5.29.0":
+  version "5.29.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/@sentry/minimal/-/minimal-5.29.0.tgz#bd8b52f388abcec2234dbbc6d6721ff65aa30e35"
+  integrity sha1-vYtS84irzsIjTbvG1nIf9lqjDjU=
+  dependencies:
+    "@sentry/hub" "5.29.0"
+    "@sentry/types" "5.29.0"
+    tslib "^1.9.3"
+
+"@sentry/react@^5.29.0":
+  version "5.29.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/@sentry/react/-/react-5.29.0.tgz#367bf4113c4abc6477385383013aaaa381668baa"
+  integrity sha1-Nnv0ETxKvGR3OFODATqqo4Fmi6o=
+  dependencies:
+    "@sentry/browser" "5.29.0"
+    "@sentry/minimal" "5.29.0"
+    "@sentry/types" "5.29.0"
+    "@sentry/utils" "5.29.0"
+    hoist-non-react-statics "^3.3.2"
     tslib "^1.9.3"
 
 "@sentry/tracing@^5.27.0":
@@ -1915,12 +1945,25 @@
   resolved "https://neo.jfrog.io/neo/api/npm/npm/@sentry/types/-/types-5.27.0.tgz#cea288d02c727ef83541768b8738e6a829dfc831"
   integrity sha1-zqKI0Cxyfvg1QXaLhzjmqCnfyDE=
 
+"@sentry/types@5.29.0":
+  version "5.29.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/@sentry/types/-/types-5.29.0.tgz#af5cec98cde54316c14df3121f0e8106e56b578e"
+  integrity sha1-r1zsmM3lQxbBTfMSHw6BBuVrV44=
+
 "@sentry/utils@5.27.0":
   version "5.27.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/@sentry/utils/-/utils-5.27.0.tgz#21c15401b43041b1208521465c09c64eafc2e0ff"
   integrity sha1-IcFUAbQwQbEghSFGXAnGTq/C4P8=
   dependencies:
     "@sentry/types" "5.27.0"
+    tslib "^1.9.3"
+
+"@sentry/utils@5.29.0":
+  version "5.29.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/@sentry/utils/-/utils-5.29.0.tgz#b4c1223ba362a94cf4850e9ca2cb24655b006b53"
+  integrity sha1-tMEiO6NiqUz0hQ6cosskZVsAa1M=
+  dependencies:
+    "@sentry/types" "5.29.0"
     tslib "^1.9.3"
 
 "@sinonjs/commons@^1.7.0":

--- a/yarn.lock
+++ b/yarn.lock
@@ -1899,6 +1899,16 @@
     "@sentry/utils" "5.29.0"
     tslib "^1.9.3"
 
+"@sentry/integrations@^5.29.0":
+  version "5.29.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/@sentry/integrations/-/integrations-5.29.0.tgz#65523b3e01c4ae6ebacf5f0a882811661bb3db0b"
+  integrity sha1-ZVI7PgHErm66z18KiCgRZhuz2ws=
+  dependencies:
+    "@sentry/types" "5.29.0"
+    "@sentry/utils" "5.29.0"
+    localforage "1.8.1"
+    tslib "^1.9.3"
+
 "@sentry/minimal@5.27.0":
   version "5.27.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/@sentry/minimal/-/minimal-5.27.0.tgz#8c2fdcf9cd1e59d8ff1848a7905bac304f8e206b"
@@ -8363,6 +8373,13 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
+lie@3.1.1:
+  version "3.1.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
+  integrity sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=
+  dependencies:
+    immediate "~3.0.5"
+
 lie@~3.3.0:
   version "3.3.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
@@ -8528,6 +8545,13 @@ loader-utils@^2.0.0:
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^2.1.2"
+
+localforage@1.8.1:
+  version "1.8.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/localforage/-/localforage-1.8.1.tgz#f6c0a24b41ab33b10e4dc84342dd696f6f3e3433"
+  integrity sha1-9sCiS0GrM7EOTchDQt1pb28+NDM=
+  dependencies:
+    lie "3.1.1"
 
 locate-path@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Changes:
- Reuse mixpanel id to track how many users unique users run into issues
- Sends console.errors to sentry, not just uncaught errors
- Use sentry's errorboundry so see errors caught by errorboundries as well
- Seperates prod/canary env properly
- Sets up a sentry "transaction", to track how slow cypher queries generally are
