### PR TITLE
Remove unneeded mixpanel events

### DIFF
--- a/src/browser/AppInit.tsx
+++ b/src/browser/AppInit.tsx
@@ -91,6 +91,13 @@ bus.applyMiddleware(
   }
 )
 
+function scrubQueryparams(event: Sentry.Event): Sentry.Event {
+  if (event.request?.query_string) {
+    event.request.query_string = ''
+  }
+  return event
+}
+
 export function setupSentry() {
   if (process.env.NODE_ENV === 'production') {
     Sentry.init({
@@ -103,7 +110,9 @@ export function setupSentry() {
       ],
       tracesSampleRate: 0.2,
       beforeSend: event =>
-        allowOutgoingConnections(store.getState()) ? event : null,
+        allowOutgoingConnections(store.getState())
+          ? scrubQueryparams(event)
+          : null,
       environment: 'unset'
     })
     Sentry.setUser({ id: getUuid(store.getState()) })

--- a/src/shared/modules/commands/commandsDuck.test.ts
+++ b/src/shared/modules/commands/commandsDuck.test.ts
@@ -99,7 +99,6 @@ describe('commandsDuck', () => {
         expect(store.getActions()).toEqual([
           action,
           send('cypher', requestId),
-          commands.cypher(cmd),
           frames.add({ ...action, type: 'cypher' } as any),
           updateQueryResult(
             requestId,
@@ -417,7 +416,6 @@ describe('commandsDuck', () => {
         expect(store.getActions()).toEqual([
           action,
           send('cypher', requestId),
-          commands.cypher(cmd),
           frames.add({ ...action, type: 'cypher' } as any),
           updateQueryResult(
             requestId,

--- a/src/shared/modules/commands/commandsDuck.ts
+++ b/src/shared/modules/commands/commandsDuck.ts
@@ -59,7 +59,6 @@ export const SYSTEM_COMMAND_QUEUED = `${NAME}/SYSTEM_COMMAND_QUEUED`
 export const UNKNOWN_COMMAND = `${NAME}/UNKNOWN_COMMAND`
 export const SHOW_ERROR_MESSAGE = `${NAME}/SHOW_ERROR_MESSAGE`
 export const CLEAR_ERROR_MESSAGE = `${NAME}/CLEAR_ERROR_MESSAGE`
-export const CYPHER = `${NAME}/CYPHER`
 export const CYPHER_SUCCEEDED = `${NAME}/CYPHER_SUCCEEDED`
 export const CYPHER_FAILED = `${NAME}/CYPHER_FAILED`
 export const FETCH_GUIDE_FROM_ALLOWLIST = `${NAME}FETCH_GUIDE_FROM_ALLOWLIST`
@@ -157,10 +156,6 @@ export const clearErrorMessage = () => ({
   type: CLEAR_ERROR_MESSAGE
 })
 
-export const cypher = (query: any) => ({
-  type: CYPHER,
-  query
-})
 export const successfulCypher = (query: any) => ({
   type: CYPHER_SUCCEEDED,
   query

--- a/src/shared/modules/udc/udcEpics.test.ts
+++ b/src/shared/modules/udc/udcEpics.test.ts
@@ -35,11 +35,7 @@ import {
   EVENT_BROWSER_SYNC_LOGIN,
   EVENT_DRIVER_CONNECTED
 } from './udcDuck'
-import {
-  CYPHER,
-  CYPHER_SUCCEEDED,
-  CYPHER_FAILED
-} from '../commands/commandsDuck'
+import { CYPHER_SUCCEEDED, CYPHER_FAILED } from '../commands/commandsDuck'
 import { AUTHORIZED, CLEAR_SYNC } from '../sync/syncDuck'
 import { CONNECTION_SUCCESS } from '../connections/connectionsDuck'
 
@@ -82,23 +78,7 @@ describe('Udc Epics', () => {
       store.clearActions()
       bus.reset()
     })
-    test('sends metric event when a cypher query is sent by the user', done => {
-      // Given
-      const action = { type: CYPHER }
-      bus.take(METRICS_EVENT, currentAction => {
-        // Then
-        expect(currentAction).toEqual(
-          expect.objectContaining(typeToMetricsObject[CYPHER])
-        )
-        expect(store.getActions()).toEqual([action, currentAction])
-        done()
-      })
-      // When
-      store.dispatch(action)
 
-      // Then
-      // See above
-    })
     test('sends metric event when a successful cypher query is sent by the user', done => {
       // Given
       const action = { type: CYPHER_SUCCEEDED }

--- a/src/shared/services/commandInterpreterHelper.ts
+++ b/src/shared/services/commandInterpreterHelper.ts
@@ -55,7 +55,6 @@ import { handleServerCommand } from 'shared/modules/commands/helpers/server'
 import { handleCypherCommand } from 'shared/modules/commands/helpers/cypher'
 import {
   showErrorMessage,
-  cypher,
   successfulCypher,
   unsuccessfulCypher,
   SINGLE_COMMAND_QUEUED,
@@ -422,7 +421,6 @@ const availableCommands = [
             }),
         isAutocommit
       )
-      put(cypher(action.cmd))
       put(
         frames.add({
           ...action,


### PR DESCRIPTION
When switching plans from monthly active users to number of events. Since we have cypher succeeded and failed, we don't need a separate event for totals.
