### PR TITLE
Inline @relate-by-ui/saved-scripts

### DIFF
--- a/LICENSES.txt
+++ b/LICENSES.txt
@@ -836,7 +836,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 -----
 
-The following software may be included in this product: @relate-by-ui/css, @relate-by-ui/relatable, @relate-by-ui/saved-scripts. A copy of the source code may be downloaded from https://github.com/neo4j-apps/relate-by-ui (@relate-by-ui/css), https://github.com/neo4j-apps/relatable (@relate-by-ui/relatable), https://github.com/neo4j-apps/relate-by-ui (@relate-by-ui/saved-scripts). This software contains the following license and notice below:
+The following software may be included in this product: @relate-by-ui/css, @relate-by-ui/relatable. A copy of the source code may be downloaded from https://github.com/neo4j-apps/relate-by-ui (@relate-by-ui/css), https://github.com/neo4j-apps/relatable (@relate-by-ui/relatable). This software contains the following license and notice below:
 
 Apache License
                            Version 2.0, January 2004
@@ -1094,6 +1094,66 @@ SOFTWARE.
 
 -----
 
+The following software may be included in this product: @sentry/browser, @sentry/core, @sentry/hub, @sentry/integrations, @sentry/minimal, @sentry/react, @sentry/types, @sentry/utils. A copy of the source code may be downloaded from git://github.com/getsentry/sentry-javascript.git (@sentry/browser), git://github.com/getsentry/sentry-javascript.git (@sentry/core), git://github.com/getsentry/sentry-javascript.git (@sentry/hub), git://github.com/getsentry/sentry-javascript.git (@sentry/integrations), git://github.com/getsentry/sentry-javascript.git (@sentry/minimal), git://github.com/getsentry/sentry-javascript.git (@sentry/react), git://github.com/getsentry/sentry-javascript.git (@sentry/types), git://github.com/getsentry/sentry-javascript.git (@sentry/utils). This software contains the following license and notice below:
+
+BSD 3-Clause License
+
+Copyright (c) 2019, Sentry
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-----
+
+The following software may be included in this product: @sentry/tracing. A copy of the source code may be downloaded from git://github.com/getsentry/sentry-javascript.git. This software contains the following license and notice below:
+
+MIT License
+
+Copyright (c) 2020 Sentry (https://sentry.io/) and individual contributors.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-----
+
 The following software may be included in this product: @stardust-ui/react-component-event-listener, @stardust-ui/react-component-ref, semantic-ui-react. A copy of the source code may be downloaded from https://github.com/stardust-ui/react.git (@stardust-ui/react-component-event-listener), https://github.com/stardust-ui/react.git (@stardust-ui/react-component-ref), git+ssh://github.com/Semantic-Org/Semantic-UI-React.git (semantic-ui-react). This software contains the following license and notice below:
 
 MIT License
@@ -1120,7 +1180,7 @@ SOFTWARE.
 
 -----
 
-The following software may be included in this product: @types/asap, @types/color-name, @types/hoist-non-react-statics, @types/long, @types/mdast, @types/parse-json, @types/prop-types, @types/shallowequal, @types/unist. A copy of the source code may be downloaded from https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/asap), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/color-name), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/hoist-non-react-statics), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/long), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/mdast), https://www.github.com/DefinitelyTyped/DefinitelyTyped.git (@types/parse-json), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/prop-types), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/shallowequal), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/unist). This software contains the following license and notice below:
+The following software may be included in this product: @types/asap, @types/color-name, @types/dateformat, @types/file-saver, @types/hoist-non-react-statics, @types/jsonic, @types/long, @types/mdast, @types/parse-json, @types/prop-types, @types/shallowequal, @types/unist, @types/url-parse. A copy of the source code may be downloaded from https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/asap), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/color-name), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/dateformat), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/file-saver), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/hoist-non-react-statics), https://github.com/DefinitelyTyped/DefinitelyTyped.git.git (@types/jsonic), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/long), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/mdast), https://www.github.com/DefinitelyTyped/DefinitelyTyped.git (@types/parse-json), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/prop-types), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/shallowequal), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/unist), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/url-parse). This software contains the following license and notice below:
 
 MIT License
 
@@ -1146,7 +1206,7 @@ MIT License
 
 -----
 
-The following software may be included in this product: @types/hast, @types/invariant, @types/node, @types/parse5, @types/react, @types/zen-observable. A copy of the source code may be downloaded from https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/hast), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/invariant), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/node), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/parse5), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/react), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/zen-observable). This software contains the following license and notice below:
+The following software may be included in this product: @types/d3, @types/hast, @types/invariant, @types/node, @types/parse5, @types/react, @types/semver, @types/zen-observable. A copy of the source code may be downloaded from https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/d3), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/hast), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/invariant), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/node), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/parse5), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/react), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/semver), https://github.com/DefinitelyTyped/DefinitelyTyped.git (@types/zen-observable). This software contains the following license and notice below:
 
 MIT License
 
@@ -5825,6 +5885,18 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 The following software may be included in this product: lie. A copy of the source code may be downloaded from https://github.com/calvinmetcalf/lie.git. This software contains the following license and notice below:
 
+#Copyright (c) 2014 Calvin Metcalf 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+**THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.**
+
+-----
+
+The following software may be included in this product: lie. A copy of the source code may be downloaded from https://github.com/calvinmetcalf/lie.git. This software contains the following license and notice below:
+
 #Copyright (c) 2014-2018 Calvin Metcalf, Jordan Harband
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
@@ -5858,6 +5930,212 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+-----
+
+The following software may be included in this product: localforage. A copy of the source code may be downloaded from git://github.com/localForage/localForage.git. This software contains the following license and notice below:
+
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2014 Mozilla
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 
 -----
 

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -181,8 +181,6 @@ Third-party licenses
 │  │  └─ URL: https://github.com/neo4j-apps/relate-by-ui
 │  ├─ @relate-by-ui/relatable@1.0.1
 │  │  └─ URL: https://github.com/neo4j-apps/relatable
-│  ├─ @relate-by-ui/saved-scripts@1.0.5
-│  │  └─ URL: https://github.com/neo4j-apps/relate-by-ui
 │  ├─ aws-sign2@0.7.0
 │  │  ├─ URL: https://github.com/mikeal/aws-sign
 │  │  ├─ VendorName: Mikeal Rogers
@@ -218,6 +216,10 @@ Third-party licenses
 │  ├─ google-auth-library@6.0.6
 │  │  ├─ URL: https://github.com/googleapis/google-auth-library-nodejs.git
 │  │  └─ VendorName: Google Inc.
+│  ├─ localforage@1.8.1
+│  │  ├─ URL: git://github.com/localForage/localForage.git
+│  │  ├─ VendorName: Mozilla
+│  │  └─ VendorUrl: https://github.com/localForage/localForage
 │  ├─ long@4.0.0
 │  │  ├─ URL: https://github.com/dcodeIO/long.js.git
 │  │  └─ VendorName: Daniel Wirtz
@@ -316,6 +318,54 @@ Third-party licenses
 │  ├─ @protobufjs/utf8@1.1.0
 │  │  ├─ URL: https://github.com/dcodeIO/protobuf.js.git
 │  │  └─ VendorName: Daniel Wirtz
+│  ├─ @sentry/browser@5.29.0
+│  │  ├─ URL: git://github.com/getsentry/sentry-javascript.git
+│  │  ├─ VendorName: Sentry
+│  │  └─ VendorUrl: https://github.com/getsentry/sentry-javascript/tree/master/packages/browser
+│  ├─ @sentry/core@5.29.0
+│  │  ├─ URL: git://github.com/getsentry/sentry-javascript.git
+│  │  ├─ VendorName: Sentry
+│  │  └─ VendorUrl: https://github.com/getsentry/sentry-javascript/tree/master/packages/core
+│  ├─ @sentry/hub@5.27.0
+│  │  ├─ URL: git://github.com/getsentry/sentry-javascript.git
+│  │  ├─ VendorName: Sentry
+│  │  └─ VendorUrl: https://github.com/getsentry/sentry-javascript/tree/master/packages/hub
+│  ├─ @sentry/hub@5.29.0
+│  │  ├─ URL: git://github.com/getsentry/sentry-javascript.git
+│  │  ├─ VendorName: Sentry
+│  │  └─ VendorUrl: https://github.com/getsentry/sentry-javascript/tree/master/packages/hub
+│  ├─ @sentry/integrations@5.29.0
+│  │  ├─ URL: git://github.com/getsentry/sentry-javascript.git
+│  │  ├─ VendorName: Sentry
+│  │  └─ VendorUrl: https://github.com/getsentry/sentry-javascript/tree/master/packages/integrations
+│  ├─ @sentry/minimal@5.27.0
+│  │  ├─ URL: git://github.com/getsentry/sentry-javascript.git
+│  │  ├─ VendorName: Sentry
+│  │  └─ VendorUrl: https://github.com/getsentry/sentry-javascript/tree/master/packages/minimal
+│  ├─ @sentry/minimal@5.29.0
+│  │  ├─ URL: git://github.com/getsentry/sentry-javascript.git
+│  │  ├─ VendorName: Sentry
+│  │  └─ VendorUrl: https://github.com/getsentry/sentry-javascript/tree/master/packages/minimal
+│  ├─ @sentry/react@5.29.0
+│  │  ├─ URL: git://github.com/getsentry/sentry-javascript.git
+│  │  ├─ VendorName: Sentry
+│  │  └─ VendorUrl: https://github.com/getsentry/sentry-javascript/tree/master/packages/react
+│  ├─ @sentry/types@5.27.0
+│  │  ├─ URL: git://github.com/getsentry/sentry-javascript.git
+│  │  ├─ VendorName: Sentry
+│  │  └─ VendorUrl: https://github.com/getsentry/sentry-javascript/tree/master/packages/types
+│  ├─ @sentry/types@5.29.0
+│  │  ├─ URL: git://github.com/getsentry/sentry-javascript.git
+│  │  ├─ VendorName: Sentry
+│  │  └─ VendorUrl: https://github.com/getsentry/sentry-javascript/tree/master/packages/types
+│  ├─ @sentry/utils@5.27.0
+│  │  ├─ URL: git://github.com/getsentry/sentry-javascript.git
+│  │  ├─ VendorName: Sentry
+│  │  └─ VendorUrl: https://github.com/getsentry/sentry-javascript/tree/master/packages/utils
+│  ├─ @sentry/utils@5.29.0
+│  │  ├─ URL: git://github.com/getsentry/sentry-javascript.git
+│  │  ├─ VendorName: Sentry
+│  │  └─ VendorUrl: https://github.com/getsentry/sentry-javascript/tree/master/packages/utils
 │  ├─ antlr4@4.8.0
 │  │  ├─ URL: https://github.com/antlr/antlr4.git
 │  │  └─ VendorUrl: https://github.com/antlr/antlr4
@@ -373,10 +423,10 @@ Third-party licenses
 │     ├─ VendorName: Tab Atkins Jr.
 │     └─ VendorUrl: https://github.com/tabatkins/railroad-diagrams
 ├─ GPL-3.0
-│  ├─ cypher-codemirror@1.1.6
+│  ├─ cypher-codemirror@1.1.7
 │  │  ├─ URL: git://github.com/neo4j-contrib/cypher-editor.git
 │  │  └─ VendorName: Neo Technology Inc.
-│  └─ cypher-editor-support@1.1.6
+│  └─ cypher-editor-support@1.1.7
 │     ├─ URL: git://github.com/neo4j-contrib/cypher-editor.git
 │     └─ VendorName: Neo Technology Inc.
 ├─ ISC
@@ -598,6 +648,10 @@ Third-party licenses
 │  ├─ @semantic-ui-react/event-stack@3.1.1
 │  │  ├─ URL: https://github.com/layershifter/event-stack
 │  │  └─ VendorName: layershifter
+│  ├─ @sentry/tracing@5.27.0
+│  │  ├─ URL: git://github.com/getsentry/sentry-javascript.git
+│  │  ├─ VendorName: Sentry
+│  │  └─ VendorUrl: https://github.com/getsentry/sentry-javascript/tree/master/packages/tracing
 │  ├─ @stardust-ui/react-component-event-listener@0.38.0
 │  │  ├─ URL: https://github.com/stardust-ui/react.git
 │  │  ├─ VendorName: Oleksandr Fediashov
@@ -610,12 +664,20 @@ Third-party licenses
 │  │  └─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
 │  ├─ @types/color-name@1.1.1
 │  │  └─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
+│  ├─ @types/d3@3.5.44
+│  │  └─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
+│  ├─ @types/dateformat@3.0.1
+│  │  └─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
+│  ├─ @types/file-saver@2.0.1
+│  │  └─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
 │  ├─ @types/hast@2.3.1
 │  │  └─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
 │  ├─ @types/hoist-non-react-statics@3.3.1
 │  │  └─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
 │  ├─ @types/invariant@2.2.34
 │  │  └─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
+│  ├─ @types/jsonic@0.3.0
+│  │  └─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git.git
 │  ├─ @types/long@4.0.1
 │  │  └─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
 │  ├─ @types/mdast@3.0.3
@@ -632,9 +694,13 @@ Third-party licenses
 │  │  └─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
 │  ├─ @types/react@16.9.49
 │  │  └─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
+│  ├─ @types/semver@7.3.4
+│  │  └─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
 │  ├─ @types/shallowequal@1.1.1
 │  │  └─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
 │  ├─ @types/unist@2.0.3
+│  │  └─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
+│  ├─ @types/url-parse@1.4.3
 │  │  └─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
 │  ├─ @types/zen-observable@0.8.1
 │  │  └─ URL: https://github.com/DefinitelyTyped/DefinitelyTyped.git
@@ -1230,6 +1296,8 @@ Third-party licenses
 │  │  ├─ URL: git://github.com/gkz/levn.git
 │  │  ├─ VendorName: George Zahariev
 │  │  └─ VendorUrl: https://github.com/gkz/levn
+│  ├─ lie@3.1.1
+│  │  └─ URL: https://github.com/calvinmetcalf/lie.git
 │  ├─ lie@3.3.0
 │  │  └─ URL: https://github.com/calvinmetcalf/lie.git
 │  ├─ lines-and-columns@1.1.6

--- a/package.json
+++ b/package.json
@@ -153,7 +153,6 @@
     "@neo4j/browser-lambda-parser": "1.0.5",
     "@relate-by-ui/css": "1.0.5",
     "@relate-by-ui/relatable": "1.0.1",
-    "@relate-by-ui/saved-scripts": "^1.0.5",
     "@sentry/integrations": "^5.29.0",
     "@sentry/react": "^5.29.0",
     "@sentry/tracing": "^5.27.0",

--- a/src/browser/components/SavedScripts/SavedScripts.tsx
+++ b/src/browser/components/SavedScripts/SavedScripts.tsx
@@ -43,21 +43,20 @@ export interface ISavedScriptsProps {
   onRemoveFolder: AnyFunc
 }
 
-export default function SavedScripts(props: ISavedScriptsProps) {
-  const {
-    title,
-    isStatic,
-    scriptsNamespace,
-    scripts,
-    isProjectFiles,
-    newFolderPathGenerator,
-    onSelectScript,
-    onExportScripts,
-    onExecScript,
-    onRemoveScript,
-    onUpdateFolder,
-    onRemoveFolder
-  } = props
+export default function SavedScripts({
+  title = 'Saved Scripts',
+  isStatic,
+  scriptsNamespace,
+  scripts,
+  isProjectFiles,
+  newFolderPathGenerator,
+  onSelectScript,
+  onExportScripts,
+  onExecScript,
+  onRemoveScript,
+  onUpdateFolder,
+  onRemoveFolder
+}: ISavedScriptsProps) {
   const [rootFolder, subFolders] = useScriptsFolders(scriptsNamespace, scripts)
   // lodash-es typings cant handle tuples
   const allSavedFolderNames = compact([
@@ -157,8 +156,4 @@ export default function SavedScripts(props: ISavedScriptsProps) {
       </DndProvider>
     </SavedScriptsMain>
   )
-}
-
-SavedScripts.defaultProps = {
-  title: 'Saved Scripts'
 }

--- a/src/browser/components/SavedScripts/icons.tsx
+++ b/src/browser/components/SavedScripts/icons.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import { Icon } from 'semantic-ui-react'
+
+export const ExpandMenuRightIcon = () => <Icon name="caret right" />
+
+export const CollapseMenuIcon = () => <Icon name="caret down" />

--- a/src/browser/components/SavedScripts/index.ts
+++ b/src/browser/components/SavedScripts/index.ts
@@ -1,4 +1,4 @@
-import SavedScripts from './saved-scripts'
+import SavedScripts from './SavedScripts'
 
 export default SavedScripts
 export {

--- a/src/browser/components/SavedScripts/index.ts
+++ b/src/browser/components/SavedScripts/index.ts
@@ -1,0 +1,9 @@
+import SavedScripts from './saved-scripts'
+
+export default SavedScripts
+export {
+  addScriptPathPrefix,
+  getScriptDisplayName,
+  sortAndGroupScriptsByPath,
+  omitScriptPathPrefix
+} from './saved-scripts.utils'

--- a/src/browser/components/SavedScripts/saved-scripts-edit-button.tsx
+++ b/src/browser/components/SavedScripts/saved-scripts-edit-button.tsx
@@ -1,0 +1,22 @@
+import React, { ReactEventHandler } from 'react'
+import { Icon } from 'semantic-ui-react'
+
+import { SavedScriptsEditButtonButton } from './saved-scripts.styled'
+
+export interface ISavedScriptsEditButtonProps {
+  onEdit: ReactEventHandler
+}
+
+export default function SavedScriptsEditButton({
+  onEdit
+}: ISavedScriptsEditButtonProps) {
+  return (
+    <SavedScriptsEditButtonButton
+      className="saved-scripts__button saved-scripts__edit-button"
+      title="Edit"
+      onClick={onEdit}
+    >
+      <Icon name="pencil" />
+    </SavedScriptsEditButtonButton>
+  )
+}

--- a/src/browser/components/SavedScripts/saved-scripts-exec-button.tsx
+++ b/src/browser/components/SavedScripts/saved-scripts-exec-button.tsx
@@ -1,0 +1,21 @@
+import React, { ReactEventHandler } from 'react'
+import { Icon } from 'semantic-ui-react'
+
+import { SavedScriptsButton } from './saved-scripts.styled'
+
+export interface ISavedScriptsExecButtonProps {
+  onExec: ReactEventHandler
+}
+
+export default function SavedScriptsExecButton({
+  onExec
+}: ISavedScriptsExecButtonProps) {
+  return (
+    <SavedScriptsButton
+      className="saved-scripts__button saved-scripts__exec-button"
+      onClick={onExec}
+    >
+      <Icon name="play" />
+    </SavedScriptsButton>
+  )
+}

--- a/src/browser/components/SavedScripts/saved-scripts-export-button.tsx
+++ b/src/browser/components/SavedScripts/saved-scripts-export-button.tsx
@@ -1,0 +1,21 @@
+import React, { ReactEventHandler } from 'react'
+import { Icon } from 'semantic-ui-react'
+
+import { SavedScriptsButton } from './saved-scripts.styled'
+
+export interface ISavedScriptsExportButtonProps {
+  onExport: ReactEventHandler
+}
+
+export default function SavedScriptsExportButton({
+  onExport
+}: ISavedScriptsExportButtonProps) {
+  return (
+    <SavedScriptsButton
+      className="saved-scripts__button saved-scripts__export-button"
+      onClick={onExport}
+    >
+      <Icon name="download" />
+    </SavedScriptsButton>
+  )
+}

--- a/src/browser/components/SavedScripts/saved-scripts-folder.tsx
+++ b/src/browser/components/SavedScripts/saved-scripts-folder.tsx
@@ -1,0 +1,174 @@
+import React, { useState } from 'react'
+import { lowerCase, map, sortBy, without } from 'lodash-es'
+import { DropTarget } from 'react-dnd'
+
+import { AnyFunc, IScript } from './types'
+
+import { ENTER_KEY_CODE } from './saved-scripts.constants'
+import {
+  addScriptPathPrefix,
+  getScriptDisplayName,
+  omitScriptPathPrefix
+} from './saved-scripts.utils'
+import { useCustomBlur, useNameUpdate } from './saved-scripts.hooks'
+
+import SavedScriptsListItem from './saved-scripts-list-item'
+import SavedScriptsEditButton from './saved-scripts-edit-button'
+import SavedScriptsRemoveButton from './saved-scripts-remove-button'
+import { CollapseMenuIcon, ExpandMenuRightIcon } from './icons'
+
+import {
+  SavedScriptsButtonWrapper,
+  SavedScriptsFolderBody,
+  SavedScriptsFolderCollapseIcon,
+  SavedScriptsFolderHeader,
+  SavedScriptsFolderLabel,
+  SavedScriptsFolderMain,
+  SavedScriptsInput
+} from './saved-scripts.styled'
+
+export interface ISavedScriptsFolderProps {
+  isRoot?: boolean
+  scriptsNamespace: string
+  allFolderNames: string[]
+  folderName: string
+  scripts: IScript[]
+  isProjectFiles?: boolean
+  onSelectScript: AnyFunc
+  onExecScript: AnyFunc
+  onRemoveScript: AnyFunc
+  onUpdateFolder: AnyFunc
+  onRemoveFolder: AnyFunc
+  isStatic?: boolean
+  connectDropTarget?: AnyFunc
+}
+
+export default DropTarget<ISavedScriptsFolderProps>(
+  ({ allFolderNames, folderName }) =>
+    map(without(allFolderNames, folderName), name => name),
+  {
+    drop({ onUpdateFolder, folderName }, monitor) {
+      const item = monitor.getItem()
+
+      onUpdateFolder([item], { path: folderName })
+    }
+  },
+  connect => ({
+    connectDropTarget: connect.dropTarget()
+  })
+)(SavedScriptsFolder)
+
+function SavedScriptsFolder({
+  isRoot = false,
+  scriptsNamespace,
+  folderName,
+  scripts,
+  isProjectFiles,
+  isStatic,
+  onSelectScript,
+  onExecScript,
+  onRemoveScript,
+  onUpdateFolder,
+  onRemoveFolder,
+  connectDropTarget
+}: ISavedScriptsFolderProps) {
+  const sortedScripts = sortBy(scripts, script =>
+    lowerCase(getScriptDisplayName(script))
+  )
+  const [isEditing, labelInput, setIsEditing, setLabelInput] = useNameUpdate(
+    folderName,
+    name =>
+      onUpdateFolder(scripts, {
+        isFolderName: true,
+        path: addScriptPathPrefix(scriptsNamespace, name)
+      })
+  )
+  const [expanded, setExpanded] = useState(false)
+  const [blurRef] = useCustomBlur(() => setIsEditing(false))
+
+  if (isRoot) {
+    return connectDropTarget!(
+      <div style={{ paddingTop: 16 }}>
+        <SavedScriptsFolderMain className="saved-scripts-folder saved-scripts-folder--root">
+          {map(sortedScripts, (script, index) => (
+            <SavedScriptsListItem
+              key={`my-script-${script.id || index}`}
+              isStatic={isStatic}
+              script={script}
+              isProjectFiles={isProjectFiles}
+              onSelectScript={onSelectScript}
+              onExecScript={onExecScript}
+              onUpdateScript={(script: IScript, payload: any) =>
+                onUpdateFolder([script], payload)
+              }
+              onRemoveScript={onRemoveScript}
+            />
+          ))}
+        </SavedScriptsFolderMain>
+      </div>
+    )
+  }
+
+  return connectDropTarget!(
+    <div>
+      <SavedScriptsFolderMain className="saved-scripts-folder">
+        <SavedScriptsFolderHeader
+          title={folderName}
+          ref={blurRef}
+          className="saved-scripts-folder__header"
+        >
+          {isEditing ? (
+            <SavedScriptsInput
+              className="saved-scripts-folder__label-input"
+              type="text"
+              autoFocus
+              onKeyPress={({ charCode }) => {
+                charCode === ENTER_KEY_CODE && setIsEditing(false)
+              }}
+              value={omitScriptPathPrefix(scriptsNamespace, labelInput)}
+              onChange={({ target }) => setLabelInput(target.value)}
+            />
+          ) : (
+            <SavedScriptsFolderLabel
+              className="saved-scripts-folder__label"
+              onClick={() => setExpanded(!expanded)}
+            >
+              <SavedScriptsFolderCollapseIcon className="saved-scripts-folder__collapse-icon">
+                {expanded ? <CollapseMenuIcon /> : <ExpandMenuRightIcon />}
+              </SavedScriptsFolderCollapseIcon>
+              {omitScriptPathPrefix(scriptsNamespace, folderName)}
+            </SavedScriptsFolderLabel>
+          )}
+          <SavedScriptsButtonWrapper className="saved-scripts__button-wrapper">
+            {isStatic || isProjectFiles || isEditing ? null : (
+              <SavedScriptsEditButton onEdit={() => setIsEditing(!isEditing)} />
+            )}
+            {isStatic || isProjectFiles || !isEditing ? null : (
+              <SavedScriptsRemoveButton
+                onRemove={() => onRemoveFolder(scripts)}
+              />
+            )}
+          </SavedScriptsButtonWrapper>
+        </SavedScriptsFolderHeader>
+        {expanded ? (
+          <SavedScriptsFolderBody className="saved-scripts-folder__body">
+            {map(sortedScripts, (script, index) => (
+              <SavedScriptsListItem
+                key={`my-script-${script.id || index}`}
+                isStatic={isStatic}
+                script={script}
+                isProjectFiles={isProjectFiles}
+                onSelectScript={onSelectScript}
+                onExecScript={onExecScript}
+                onUpdateScript={(script: IScript, payload: any) =>
+                  onUpdateFolder([script], payload)
+                }
+                onRemoveScript={onRemoveScript}
+              />
+            ))}
+          </SavedScriptsFolderBody>
+        ) : null}
+      </SavedScriptsFolderMain>
+    </div>
+  )
+}

--- a/src/browser/components/SavedScripts/saved-scripts-list-item.tsx
+++ b/src/browser/components/SavedScripts/saved-scripts-list-item.tsx
@@ -1,0 +1,97 @@
+import React from 'react'
+import { DragSource } from 'react-dnd'
+
+import { AnyFunc, IScript } from './types'
+
+import { ENTER_KEY_CODE } from './saved-scripts.constants'
+import { getScriptDisplayName } from './saved-scripts.utils'
+import { useCustomBlur, useNameUpdate } from './saved-scripts.hooks'
+
+import SavedScriptsExecButton from './saved-scripts-exec-button'
+import SavedScriptsEditButton from './saved-scripts-edit-button'
+import SavedScriptsRemoveButton from './saved-scripts-remove-button'
+
+import {
+  SavedScriptsButtonWrapper,
+  SavedScriptsInput,
+  SavedScriptsListItemDisplayName,
+  SavedScriptsListItemMain
+} from './saved-scripts.styled'
+
+export interface ISavedScriptsListItemProps {
+  isStatic?: boolean
+  script: IScript
+  isProjectFiles?: boolean
+  onSelectScript: AnyFunc
+  onExecScript: AnyFunc
+  onUpdateScript: AnyFunc
+  onRemoveScript: AnyFunc
+  connectDragSource?: AnyFunc
+}
+
+export default DragSource<ISavedScriptsListItemProps>(
+  ({ script }) => script.path,
+  {
+    beginDrag: ({ script }) => script
+  },
+  connect => ({
+    connectDragSource: connect.dragSource()
+  })
+)(SavedScriptsListItem)
+
+function SavedScriptsListItem({
+  isStatic,
+  script,
+  isProjectFiles,
+  onSelectScript,
+  onExecScript,
+  onUpdateScript,
+  onRemoveScript,
+  connectDragSource
+}: ISavedScriptsListItemProps) {
+  const displayName = getScriptDisplayName(script)
+  const [
+    isEditing,
+    nameValue,
+    setIsEditing,
+    setLabelInput
+  ] = useNameUpdate(displayName, name => onUpdateScript(script, { name }))
+  const [blurRef] = useCustomBlur(() => setIsEditing(false))
+
+  return (
+    <SavedScriptsListItemMain ref={blurRef} className="saved-scripts-list-item">
+      {isEditing && !isProjectFiles ? (
+        <SavedScriptsInput
+          className="saved-scripts-list-item__name-input"
+          type="text"
+          autoFocus
+          onKeyPress={({ charCode }) => {
+            charCode === ENTER_KEY_CODE && setIsEditing(false)
+          }}
+          value={nameValue}
+          onChange={({ target }) => setLabelInput(target.value)}
+        />
+      ) : (
+        <SavedScriptsListItemDisplayName
+          className="saved-scripts-list-item__display-name"
+          onClick={() =>
+            (isProjectFiles || !isEditing) && onSelectScript(script)
+          }
+        >
+          {connectDragSource!(<span>{displayName}</span>)}
+        </SavedScriptsListItemDisplayName>
+      )}
+      <SavedScriptsButtonWrapper className="saved-scripts__button-wrapper">
+        {isStatic || isEditing ? null : (
+          <SavedScriptsEditButton onEdit={() => setIsEditing(!isEditing)} />
+        )}
+        {isStatic || !isEditing ? null : (
+          <SavedScriptsRemoveButton onRemove={() => onRemoveScript(script)} />
+        )}
+        {script.isSuggestion || isEditing ? null : (
+          <SavedScriptsExecButton onExec={() => onExecScript(script)} />
+        )}
+      </SavedScriptsButtonWrapper>
+    </SavedScriptsListItemMain>
+  )
+}

--- a/src/browser/components/SavedScripts/saved-scripts-new-folder-button.tsx
+++ b/src/browser/components/SavedScripts/saved-scripts-new-folder-button.tsx
@@ -1,0 +1,25 @@
+import React, { ReactEventHandler } from 'react'
+import { Icon } from 'semantic-ui-react'
+
+import { SavedScriptsNewFolderButtonButton } from './saved-scripts.styled'
+
+export interface ISavedScriptsNewFolderButtonProps {
+  disabled?: boolean
+  onAdd: ReactEventHandler
+}
+
+export default function SavedScriptsNewFolderButton({
+  disabled,
+  onAdd
+}: ISavedScriptsNewFolderButtonProps) {
+  return (
+    <SavedScriptsNewFolderButtonButton
+      className="saved-scripts__button saved-scripts__new-folder-button"
+      disabled={Boolean(disabled)}
+      title="Add folder"
+      onClick={onAdd}
+    >
+      <Icon name="folder open outline" />
+    </SavedScriptsNewFolderButtonButton>
+  )
+}

--- a/src/browser/components/SavedScripts/saved-scripts-remove-button.tsx
+++ b/src/browser/components/SavedScripts/saved-scripts-remove-button.tsx
@@ -1,0 +1,45 @@
+import React, { ReactEventHandler, useState } from 'react'
+import { Icon } from 'semantic-ui-react'
+
+import { SavedScriptsButton } from './saved-scripts.styled'
+
+export interface ISavedScriptsRemoveButtonProps {
+  onRemove: ReactEventHandler
+}
+
+export default function SavedScriptsRemoveButton({
+  onRemove
+}: ISavedScriptsRemoveButtonProps) {
+  const [isConfirming, setIsConfirming] = useState(false)
+
+  if (isConfirming) {
+    return (
+      <>
+        <SavedScriptsButton
+          className="saved-scripts__button saved-scripts__remove-button saved-scripts__remove-button--danger"
+          title="Remove"
+          onClick={onRemove}
+        >
+          <Icon name="trash alternate outline" />
+        </SavedScriptsButton>
+        <SavedScriptsButton
+          className="saved-scripts__button saved-scripts__cancel-remove-button"
+          title="Cancel"
+          onClick={() => setIsConfirming(false)}
+        >
+          <Icon name="delete" />
+        </SavedScriptsButton>
+      </>
+    )
+  }
+
+  return (
+    <SavedScriptsButton
+      className="saved-scripts__button saved-scripts__remove-button"
+      title="Remove"
+      onClick={() => setIsConfirming(true)}
+    >
+      <Icon name="trash alternate outline" />
+    </SavedScriptsButton>
+  )
+}

--- a/src/browser/components/SavedScripts/saved-scripts.constants.ts
+++ b/src/browser/components/SavedScripts/saved-scripts.constants.ts
@@ -1,0 +1,3 @@
+export const NEW_LINE = '\n'
+export const COMMENT_PREFIX = '//'
+export const ENTER_KEY_CODE = 13

--- a/src/browser/components/SavedScripts/saved-scripts.hooks.ts
+++ b/src/browser/components/SavedScripts/saved-scripts.hooks.ts
@@ -1,0 +1,126 @@
+import { useState, useEffect, useRef } from 'react'
+import { isEmpty, indexOf, join, slice, without } from 'lodash-es'
+
+import { AnyFunc, IScript, ScriptFolder, NewFolderPathGenerator } from './types'
+
+import {
+  getRootLevelFolder,
+  getSubLevelFolders,
+  sortAndGroupScriptsByPath
+} from './saved-scripts.utils'
+
+/**
+ * Maintains a state of script folders, separated into root and sub folders
+ * @param     {string}                            namespace
+ * @param     {IScript[]}                         scripts
+ * @return    {[ScriptFolder, ScriptFolder[]]}                root and sub folders
+ */
+export function useScriptsFolders(
+  namespace: string,
+  scripts: IScript[]
+): [ScriptFolder | null, ScriptFolder[]] {
+  const [sortedScriptGroups, setSortedScriptGroups] = useState(
+    sortAndGroupScriptsByPath(namespace, scripts)
+  )
+
+  useEffect(() => {
+    setSortedScriptGroups(sortAndGroupScriptsByPath(namespace, scripts))
+  }, [scripts])
+
+  return [
+    getRootLevelFolder(namespace, sortedScriptGroups),
+    getSubLevelFolders(namespace, sortedScriptGroups)
+  ]
+}
+
+/**
+ * Maintains a state of a name and calls update action whenever user exits editing
+ * @param     {string}                                  name
+ * @param     {AnyFunc}                                 onUpdate
+ * @return    {[boolean, string, AnyFunc, AnyFunc]}
+ */
+export function useNameUpdate(
+  name: string,
+  onUpdate: AnyFunc
+): [boolean, string, AnyFunc, AnyFunc] {
+  const [inputValue, setNameInput] = useState(name)
+  const [isEditing, setIsEditing] = useState(false)
+
+  useEffect(() => {
+    if (!isEditing && inputValue !== name) {
+      onUpdate(inputValue)
+    }
+  }, [isEditing])
+
+  return [isEditing, inputValue, setIsEditing, setNameInput]
+}
+
+/**
+ * Maintains a state of empty folders
+ * @param   {string}                                      namespace
+ * @param   {NewFolderPathGenerator}                      pathGenerator
+ * @param   {string[]}                                    allSavedFolderNames
+ * @return  {[string[], AnyFunc, AnyFunc, AnyFunc]}
+ */
+export function useEmptyFolders(
+  namespace: string,
+  pathGenerator: NewFolderPathGenerator,
+  allSavedFolderNames: string[]
+): [string[], boolean, AnyFunc, AnyFunc, AnyFunc] {
+  const [emptyFolders, setEmptyFolders] = useState([] as string[])
+  const canAddFolder = isEmpty(emptyFolders)
+  const addEmptyFolder = () =>
+    setEmptyFolders([
+      ...emptyFolders,
+      pathGenerator(namespace, allSavedFolderNames)
+    ])
+  const removeEmptyFolder = (path: string) =>
+    setEmptyFolders(without(emptyFolders, path))
+  const updateEmptyFolder = (oldPath: string, newPath: string) => {
+    const index = indexOf(emptyFolders, oldPath)
+
+    setEmptyFolders([
+      ...slice(emptyFolders, 0, index),
+      newPath,
+      ...slice(emptyFolders, index + 1)
+    ])
+  }
+
+  useEffect(() => {
+    setEmptyFolders(without(emptyFolders, ...allSavedFolderNames))
+  }, [join(allSavedFolderNames)])
+
+  return [
+    emptyFolders,
+    canAddFolder,
+    addEmptyFolder,
+    updateEmptyFolder,
+    removeEmptyFolder
+  ]
+}
+
+/**
+ * Fires an onBlur only when clicked outside ref
+ * @param     {AnyFunc}               onBlur
+ * @return    {[MutableRefObject]}
+ */
+export function useCustomBlur(onBlur: AnyFunc) {
+  const ref = useRef(null)
+  const clickHandler = (event: Event) => {
+    // i honestly dont know whats wrong with ts here
+    // @ts-ignore
+    if (ref.current && !ref.current.contains(event.target)) {
+      onBlur()
+    }
+  }
+
+  useEffect(() => {
+    document.addEventListener('mousedown', clickHandler)
+
+    return () => {
+      document.removeEventListener('mousedown', clickHandler)
+    }
+  }, [])
+
+  return [ref]
+}

--- a/src/browser/components/SavedScripts/saved-scripts.styled.ts
+++ b/src/browser/components/SavedScripts/saved-scripts.styled.ts
@@ -1,0 +1,143 @@
+import styled from '@emotion/styled'
+
+export const SavedScriptsMain = styled.div``
+
+/**
+ * Static content
+ */
+export const SavedScriptsBody = styled.div`
+  padding: 0 24px;
+`
+
+export const SavedScriptsBodySection = styled.div`
+  margin-bottom: 12px;
+`
+
+export const SavedScriptsHeader = styled.h5`
+  display: flex;
+  justify-content: space-between;
+  border-bottom: 1px solid #424650;
+  font-size: 16px;
+  margin-bottom: 12px;
+  line-height: 39px;
+  position: relative;
+  font-weight: bold;
+  -webkit-font-smoothing: antialiased;
+  text-shadow: rgba(0, 0, 0, 0.4) 0px 1px 0px;
+`
+
+export const SavedScriptsListItemMain = styled.div`
+  padding: 5px 3px;
+  display: flex;
+  justify-content: space-between;
+
+  &:hover {
+    color: inherit;
+  }
+
+  &:hover .saved-scripts__edit-button {
+    visibility: visible;
+  }
+`
+
+export const SavedScriptsListItemDisplayName = styled.div`
+  flex: 1;
+  user-select: none;
+  cursor: pointer;
+  color: #bcc0c9;
+  font-size: 13px;
+  padding: 1px 0;
+  margin-right: 10px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  transition: color ease-in-out 0.3s;
+
+  &:hover {
+    color: inherit;
+  }
+`
+
+export const SavedScriptsFolderMain = styled.div`
+  padding-bottom: 16px;
+`
+
+export const SavedScriptsFolderHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding-bottom: 5px;
+
+  &:hover .saved-scripts__edit-button {
+    visibility: visible;
+  }
+`
+
+export const SavedScriptsFolderBody = styled.div`
+  margin-left: 15px;
+`
+
+export const SavedScriptsFolderLabel = styled.div`
+  flex: 1;
+  margin-right: 10px;
+  user-select: none;
+  cursor: pointer;
+  font-weight: bold;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`
+
+export const SavedScriptsFolderCollapseIcon = styled.span`
+  margin-right: 10px;
+  width: 8px;
+  display: inline-block;
+`
+
+/**
+ * Buttons
+ */
+export const SavedScriptsButtonWrapper = styled.div`
+  min-width: 21px;
+
+  > button:not(:last-of-type) {
+    margin-right: 5px;
+  }
+`
+
+export const SavedScriptsButton = styled.button`
+  color: #bcc0c9;
+  background: transparent;
+  border: none;
+  outline: none;
+  padding: 3px;
+  transition: color ease-in-out 0.3s;
+  cursor: pointer;
+
+  &:hover {
+    color: inherit;
+  }
+`
+
+export const SavedScriptsNewFolderButtonButton = styled(SavedScriptsButton)`
+  &[disabled] {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+`
+
+export const SavedScriptsEditButtonButton = styled(SavedScriptsButton)`
+  min-width: 26px;
+  visibility: hidden;
+`
+
+/**
+ * Input fields
+ */
+export const SavedScriptsInput = styled.input`
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-weight: normal;
+  margin-right: 5px;
+`

--- a/src/browser/components/SavedScripts/saved-scripts.styled.ts
+++ b/src/browser/components/SavedScripts/saved-scripts.styled.ts
@@ -1,10 +1,7 @@
-import styled from '@emotion/styled'
+import styled from 'styled-components'
 
 export const SavedScriptsMain = styled.div``
 
-/**
- * Static content
- */
 export const SavedScriptsBody = styled.div`
   padding: 0 24px;
 `
@@ -93,9 +90,6 @@ export const SavedScriptsFolderCollapseIcon = styled.span`
   display: inline-block;
 `
 
-/**
- * Buttons
- */
 export const SavedScriptsButtonWrapper = styled.div`
   min-width: 21px;
 
@@ -130,9 +124,6 @@ export const SavedScriptsEditButtonButton = styled(SavedScriptsButton)`
   visibility: hidden;
 `
 
-/**
- * Input fields
- */
 export const SavedScriptsInput = styled.input`
   flex: 1;
   border: none;

--- a/src/browser/components/SavedScripts/saved-scripts.tsx
+++ b/src/browser/components/SavedScripts/saved-scripts.tsx
@@ -1,0 +1,164 @@
+import React from 'react'
+import { DndProvider } from 'react-dnd'
+import HTML5Backend from 'react-dnd-html5-backend'
+import {
+  map,
+  first,
+  last,
+  sortBy,
+  lowerCase,
+  compact,
+  isEmpty
+} from 'lodash-es'
+
+import { AnyFunc, IScript, NewFolderPathGenerator } from './types'
+
+import { useEmptyFolders, useScriptsFolders } from './saved-scripts.hooks'
+
+import SavedScriptsFolder from './saved-scripts-folder'
+import SavedScriptsNewFolderButton from './saved-scripts-new-folder-button'
+import SavedScriptsExportButton from './saved-scripts-export-button'
+
+import {
+  SavedScriptsMain,
+  SavedScriptsBody,
+  SavedScriptsBodySection,
+  SavedScriptsHeader,
+  SavedScriptsButtonWrapper
+} from './saved-scripts.styled'
+import { getEmptyFolderDefaultPath } from './saved-scripts.utils'
+
+export interface ISavedScriptsProps {
+  title?: string
+  isStatic?: boolean
+  scriptsNamespace: string
+  scripts: IScript[]
+  isProjectFiles?: boolean
+  newFolderPathGenerator?: NewFolderPathGenerator
+  onSelectScript: AnyFunc
+  onExportScripts: AnyFunc
+  onExecScript: AnyFunc
+  onRemoveScript: AnyFunc
+  onUpdateFolder: AnyFunc
+  onRemoveFolder: AnyFunc
+}
+
+export default function SavedScripts(props: ISavedScriptsProps) {
+  const {
+    title,
+    isStatic,
+    scriptsNamespace,
+    scripts,
+    isProjectFiles,
+    newFolderPathGenerator,
+    onSelectScript,
+    onExportScripts,
+    onExecScript,
+    onRemoveScript,
+    onUpdateFolder,
+    onRemoveFolder
+  } = props
+  const [rootFolder, subFolders] = useScriptsFolders(scriptsNamespace, scripts)
+  // lodash-es typings cant handle tuples
+  const allSavedFolderNames = compact([
+    first(rootFolder),
+    ...map(subFolders, first)
+  ]) as string[]
+  const [
+    emptyFolders,
+    canAddFolder,
+    addEmptyFolder,
+    updateEmptyFolder,
+    removeEmptyFolder
+  ] = useEmptyFolders(
+    scriptsNamespace,
+    newFolderPathGenerator || getEmptyFolderDefaultPath,
+    allSavedFolderNames
+  )
+  const allFolderNames = [...allSavedFolderNames, ...emptyFolders]
+  const sortedSubFolders = sortBy(subFolders, folder =>
+    // lodash-es typings cant handle tuples
+    lowerCase(first(folder) as string | undefined)
+  )
+
+  return (
+    <SavedScriptsMain className="saved-scripts">
+      <DndProvider backend={HTML5Backend}>
+        <SavedScriptsBody className="saved-scripts__body">
+          <SavedScriptsBodySection className="saved-scripts__body-section">
+            <SavedScriptsHeader className="saved-scripts__header">
+              {title}
+              <SavedScriptsButtonWrapper className="saved-scripts__button-wrapper">
+                {isStatic || isProjectFiles ? null : (
+                  <>
+                    <SavedScriptsExportButton
+                      onExport={() => onExportScripts()}
+                    />
+                    <SavedScriptsNewFolderButton
+                      disabled={!canAddFolder}
+                      onAdd={() => addEmptyFolder()}
+                    />
+                  </>
+                )}
+              </SavedScriptsButtonWrapper>
+            </SavedScriptsHeader>
+            <SavedScriptsFolder
+              isRoot
+              isStatic={isStatic}
+              scriptsNamespace={scriptsNamespace}
+              allFolderNames={allFolderNames}
+              folderName={first(rootFolder) as string}
+              scripts={last(rootFolder) as IScript[]}
+              isProjectFiles={isProjectFiles}
+              onSelectScript={onSelectScript}
+              onExecScript={onExecScript}
+              onRemoveScript={onRemoveScript}
+              onUpdateFolder={onUpdateFolder}
+              onRemoveFolder={Function.prototype}
+            />
+            {map(sortedSubFolders, ([folderName, subScripts]) => (
+              <SavedScriptsFolder
+                key={`my-folder-${folderName}`}
+                isStatic={isStatic}
+                scriptsNamespace={scriptsNamespace}
+                allFolderNames={allFolderNames}
+                folderName={folderName}
+                scripts={subScripts}
+                isProjectFiles={isProjectFiles}
+                onSelectScript={onSelectScript}
+                onExecScript={onExecScript}
+                onRemoveScript={onRemoveScript}
+                onUpdateFolder={onUpdateFolder}
+                onRemoveFolder={onRemoveFolder}
+              />
+            ))}
+            {map(emptyFolders, folderName => (
+              <SavedScriptsFolder
+                key={`my-empty-folder-${folderName}`}
+                isStatic={isStatic}
+                scriptsNamespace={scriptsNamespace}
+                allFolderNames={allFolderNames}
+                folderName={folderName}
+                scripts={[]}
+                isProjectFiles={isProjectFiles}
+                onSelectScript={Function.prototype}
+                onExecScript={Function.prototype}
+                onRemoveScript={Function.prototype}
+                onUpdateFolder={(folderScripts: IScript[], { path }: any) =>
+                  !isEmpty(folderScripts)
+                    ? onUpdateFolder(folderScripts, { isNewFolder: true, path })
+                    : updateEmptyFolder(folderName, path)
+                }
+                onRemoveFolder={() => removeEmptyFolder(folderName)}
+              />
+            ))}
+          </SavedScriptsBodySection>
+        </SavedScriptsBody>
+      </DndProvider>
+    </SavedScriptsMain>
+  )
+}
+
+SavedScripts.defaultProps = {
+  title: 'Saved Scripts'
+}

--- a/src/browser/components/SavedScripts/saved-scripts.utils.test.ts
+++ b/src/browser/components/SavedScripts/saved-scripts.utils.test.ts
@@ -1,0 +1,183 @@
+import {
+  addScriptPathPrefix,
+  getEmptyFolderDefaultPath,
+  getRootLevelFolder,
+  getScriptDisplayName,
+  getSubLevelFolders,
+  omitScriptPathPrefix,
+  sortAndGroupScriptsByPath
+} from './saved-scripts.utils'
+
+describe('saved-scripts.utils', () => {
+  describe('getScriptDisplayName', () => {
+    const scriptNoNameNoCommentSingleLine = {
+      contents: 'Foo bar',
+      path: 'apa'
+    }
+    const scriptNoNameNoCommentMultiLine = {
+      contents: 'Foo bar\nBar baz',
+      path: 'apa'
+    }
+    const scriptNoNameWithComment = {
+      contents: '//Comment\nBar baz',
+      path: 'apa'
+    }
+    const scriptNoNameWithCommentWhiteSpace = {
+      contents: '//   Comment\nBar baz',
+      path: 'apa'
+    }
+    const scriptWithNameNoComment = {
+      name: 'Apa',
+      contents: 'Bar baz',
+      path: 'apa'
+    }
+    const scriptWithNameAndComment = {
+      name: 'Apa',
+      contents: '//donkey\nBar baz',
+      path: 'apa'
+    }
+
+    test('Uses content as name when nothing else available', () => {
+      expect(getScriptDisplayName(scriptNoNameNoCommentSingleLine)).toBe(
+        'Foo bar'
+      )
+    })
+
+    test('Uses only first line of content', () => {
+      expect(getScriptDisplayName(scriptNoNameNoCommentMultiLine)).toBe(
+        'Foo bar'
+      )
+    })
+
+    test('Uses comment as name when available', () => {
+      expect(getScriptDisplayName(scriptNoNameWithComment)).toBe('Comment')
+    })
+
+    test('Uses comment as name when available, stripping leading whitespace', () => {
+      expect(getScriptDisplayName(scriptNoNameWithCommentWhiteSpace)).toBe(
+        'Comment'
+      )
+    })
+
+    test('Uses name as name when available', () => {
+      expect(getScriptDisplayName(scriptWithNameNoComment)).toBe('Apa')
+    })
+
+    test('Uses name as name even when comment is available', () => {
+      expect(getScriptDisplayName(scriptWithNameAndComment)).toBe('Apa')
+    })
+  })
+
+  describe('sortAndGroupScriptsByPath', () => {
+    const scripts = [
+      { path: '/' },
+      { path: '/foo' },
+      { path: '/bar' },
+      { path: '/foo/baz' }
+    ]
+
+    test('sorts scripts in ascending order by path', () => {
+      // @ts-ignore
+      expect(sortAndGroupScriptsByPath('/', scripts)).toEqual([
+        ['/', [{ path: '/' }]],
+        ['/bar', [{ path: '/bar' }]],
+        ['/foo', [{ path: '/foo' }]],
+        ['/foo/baz', [{ path: '/foo/baz' }]]
+      ])
+    })
+
+    test('Omits scripts not in provided namespace', () => {
+      // @ts-ignore
+      expect(sortAndGroupScriptsByPath('/foo', scripts)).toEqual([
+        ['/foo', [{ path: '/foo' }]],
+        ['/foo/baz', [{ path: '/foo/baz' }]]
+      ])
+    })
+  })
+
+  describe('omitScriptPathPrefix', () => {
+    test('omits prefix from path if present', () => {
+      expect(omitScriptPathPrefix('/foo', '/foo/bar/baz')).toBe('/bar/baz')
+    })
+
+    test('returns path untouched when prefix not present', () => {
+      expect(omitScriptPathPrefix('/apa', '/foo/bar/baz')).toBe('/foo/bar/baz')
+    })
+  })
+
+  describe('addScriptPathPrefix', () => {
+    test('adds prefix to path if present', () => {
+      expect(addScriptPathPrefix('/foo', '/bar/baz')).toBe('/foo/bar/baz')
+    })
+
+    test('returns path untouched when prefix already present', () => {
+      expect(addScriptPathPrefix('/foo', '/foo/bar/baz')).toBe('/foo/bar/baz')
+    })
+  })
+
+  describe('getRootLevelFolder', () => {
+    const namespace = '/foo'
+    const scripts = [{ path: '/foo' }, { path: '/foo/baz' }]
+    // @ts-ignore
+    const folders = sortAndGroupScriptsByPath(namespace, scripts)
+
+    test('Returns only root level folder', () => {
+      expect(getRootLevelFolder(namespace, folders)).toEqual([
+        namespace,
+        [{ path: '/foo' }]
+      ])
+    })
+
+    test('Returns empty folder when none found', () => {
+      expect(getRootLevelFolder('/bar', folders)).toEqual(['/bar', []])
+    })
+  })
+
+  describe('getSubLevelFolders', () => {
+    const namespace = '/foo'
+    const scripts = [
+      { path: '/foo' },
+      { path: '/foo/baz' },
+      { path: '/foo/bam' }
+    ]
+    // @ts-ignore
+    const folders = sortAndGroupScriptsByPath(namespace, scripts)
+
+    test('Returns only sub level folders', () => {
+      expect(getSubLevelFolders(namespace, folders)).toEqual([
+        ['/foo/bam', [{ path: '/foo/bam' }]],
+        ['/foo/baz', [{ path: '/foo/baz' }]]
+      ])
+    })
+  })
+
+  describe('getEmptyFolderDefaultPath', () => {
+    const namespace = '/foo/'
+
+    test('Generates default path when no folders exists', () => {
+      expect(getEmptyFolderDefaultPath(namespace, [])).toBe('/foo/New Folder')
+    })
+
+    test('Generates default path when no folders with same path exists', () => {
+      expect(getEmptyFolderDefaultPath(namespace, ['/foo/bar'])).toBe(
+        '/foo/New Folder'
+      )
+    })
+
+    test('Generates default path with numerical suffix when folder with same path exists', () => {
+      expect(
+        getEmptyFolderDefaultPath(namespace, ['/foo/New Folder', '/foo/bar'])
+      ).toBe('/foo/New Folder 1')
+    })
+
+    test('Generates default path with sufficiently incremented numerical suffix when folder with same path and suffix exists', () => {
+      expect(
+        getEmptyFolderDefaultPath(namespace, [
+          '/foo/New Folder',
+          '/foo/bar',
+          '/foo/New Folder 4'
+        ])
+      ).toBe('/foo/New Folder 5')
+    })
+  })
+})

--- a/src/browser/components/SavedScripts/saved-scripts.utils.ts
+++ b/src/browser/components/SavedScripts/saved-scripts.utils.ts
@@ -1,0 +1,141 @@
+import {
+  filter,
+  find,
+  split,
+  head,
+  trim,
+  startsWith,
+  sortBy,
+  entries,
+  groupBy,
+  without,
+  includes,
+  compact,
+  map,
+  isEmpty
+} from 'lodash-es'
+
+import { IScript, ScriptFolder } from './types'
+
+import { COMMENT_PREFIX, NEW_LINE } from './saved-scripts.constants'
+
+/**
+ * Gets the display name of a script
+ * @param     {IScript}   script
+ * @param     {string}    script.name         script name
+ * @param     {string}    script.contents     script contents
+ * @return    {string}                        script display name
+ */
+export function getScriptDisplayName({ name, contents }: IScript) {
+  if (name) {
+    return name
+  }
+
+  const lines = split(contents, NEW_LINE)
+  const firstLine = trim(head(lines) || '')
+
+  if (isEmpty(firstLine)) {
+    return ''
+  }
+
+  return startsWith(firstLine, COMMENT_PREFIX)
+    ? trim(firstLine.slice(COMMENT_PREFIX.length))
+    : firstLine
+}
+
+/**
+ * groups and sorts scripts by path
+ * @param     {string}                  namespace
+ * @param     {IScript[]}               scripts
+ * @return    {ScriptFolder[]}                     sorted, grouped, scripts
+ */
+export function sortAndGroupScriptsByPath(
+  namespace: string,
+  scripts: IScript[]
+): ScriptFolder[] {
+  const namespaceScripts = filter(scripts, ({ path }) =>
+    startsWith(path, namespace)
+  )
+
+  return sortBy(
+    entries(groupBy(namespaceScripts, ({ path }) => path)),
+    ([path]) => path
+  )
+}
+
+/**
+ * Omits script path prefix from path
+ * @param     {string}    namespace
+ * @param     {string}    path
+ * @return    {string}
+ */
+export function omitScriptPathPrefix(namespace: string, path: string) {
+  if (!isEmpty(path)) {
+    return startsWith(path, namespace) ? path.slice(namespace.length) : path
+  }
+
+  return ''
+}
+
+/**
+ * Adds script path prefix to path
+ * @param     {string}    namespace
+ * @param     {string}    path
+ * @return    {string}
+ */
+export function addScriptPathPrefix(namespace: string, path: string) {
+  if (!isEmpty(path)) {
+    return startsWith(path, namespace) ? path : `${namespace}${path}`
+  }
+
+  return namespace
+}
+
+/**
+ *  Finds the root level folder returned from {@link sortAndGroupScriptsByPath}
+ * @param     {string}                    namespace
+ * @param     {ScriptFolder[]}           folders     return of {@link sortAndGroupScriptsByPath}
+ * @return    {ScriptFolder}                         root level script group
+ */
+export function getRootLevelFolder(namespace: string, folders: ScriptFolder[]) {
+  return find(folders, ([path]) => path === namespace) || [namespace, []]
+}
+
+/**
+ *  Finds the sub level folders returned from {@link sortAndGroupScriptsByPath}
+ * @param     {string}                    namespace
+ * @param     {ScriptFolder[]}           folders     return of {@link sortAndGroupScriptsByPath}
+ * @return    {ScriptFolder[]}                       sub level script groups
+ */
+export function getSubLevelFolders(namespace: string, folders: ScriptFolder[]) {
+  return without(folders, getRootLevelFolder(namespace, folders))
+}
+
+/**
+ * Returns the default path for an empty folder
+ * @param     {string}      namespace
+ * @param     {string[]}    allFolderPaths
+ * @return    {string}
+ */
+export function getEmptyFolderDefaultPath(
+  namespace: string,
+  allFolderPaths: string[]
+) {
+  const defaultPath = `${namespace}New Folder`
+
+  if (!includes(allFolderPaths, defaultPath)) return defaultPath
+
+  const numericalSuffixes = compact(
+    map(allFolderPaths, path => {
+      const numberEOL = path.match(/\d+$/)
+
+      if (!numberEOL) return ''
+
+      return parseInt(head(numberEOL)!)
+    })
+  )
+
+  const highestSuffix = head(sortBy(numericalSuffixes, v => -v)) || 0
+
+  return `${defaultPath} ${highestSuffix + 1}`
+}

--- a/src/browser/components/SavedScripts/types.ts
+++ b/src/browser/components/SavedScripts/types.ts
@@ -1,0 +1,16 @@
+export interface IScript {
+  id?: string // static scripts have no id
+  name?: string
+  contents: string
+  path: string
+  isSuggestion?: boolean // dummy prop for static scripts
+}
+
+export type AnyFunc = Function | ((...args: any[]) => any)
+
+export type ScriptFolder = [string, IScript[]]
+
+export type NewFolderPathGenerator = (
+  namespace: string,
+  allFolderPaths: string[]
+) => string

--- a/src/browser/modules/Sidebar/ProjectsFilesScripts.tsx
+++ b/src/browser/modules/Sidebar/ProjectsFilesScripts.tsx
@@ -19,7 +19,7 @@ import { useEffect, useState, Dispatch } from 'react'
 import { Action } from 'redux'
 import { withBus } from 'react-suber'
 import { connect } from 'react-redux'
-import MyScripts from '@relate-by-ui/saved-scripts'
+import MyScripts from 'browser/components/SavedScripts'
 import { useQuery, useMutation, ApolloError } from '@apollo/client'
 import { filter, size } from 'lodash-es'
 

--- a/src/browser/modules/Sidebar/favorites.ts
+++ b/src/browser/modules/Sidebar/favorites.ts
@@ -17,7 +17,7 @@
 
 import { withBus } from 'react-suber'
 import { connect } from 'react-redux'
-import MyScripts from '@relate-by-ui/saved-scripts'
+import MyScripts from 'browser/components/SavedScripts'
 
 import * as editor from 'shared/modules/editor/editorDuck'
 import {

--- a/src/browser/modules/Sidebar/favorites.utils.ts
+++ b/src/browser/modules/Sidebar/favorites.utils.ts
@@ -33,7 +33,7 @@ import {
 import {
   getScriptDisplayName,
   omitScriptPathPrefix
-} from '@relate-by-ui/saved-scripts'
+} from 'browser/components/SavedScripts'
 
 import { SLASH } from 'shared/services/export-favorites'
 import arrayHasItems from 'shared/utils/array-has-items'

--- a/src/browser/modules/Sidebar/static-scripts.ts
+++ b/src/browser/modules/Sidebar/static-scripts.ts
@@ -17,7 +17,7 @@
 
 import { withBus } from 'react-suber'
 import { connect } from 'react-redux'
-import MyScripts from '@relate-by-ui/saved-scripts'
+import MyScripts from 'browser/components/SavedScripts'
 import semver from 'semver'
 
 import * as editor from 'shared/modules/editor/editorDuck'

--- a/src/shared/services/export-favorites/export-favorites.utils.ts
+++ b/src/shared/services/export-favorites/export-favorites.utils.ts
@@ -34,7 +34,7 @@ import {
   addScriptPathPrefix,
   getScriptDisplayName,
   sortAndGroupScriptsByPath
-} from '@relate-by-ui/saved-scripts'
+} from 'browser/components/SavedScripts'
 
 import { SLASH, CYPHER_FILE_EXTENSION } from './export-favorites.constants'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1831,15 +1831,6 @@
     react-table "7.0.4"
     semantic-ui-react "0.88.2"
 
-"@relate-by-ui/saved-scripts@^1.0.5":
-  version "1.0.5"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/@relate-by-ui/saved-scripts/-/saved-scripts-1.0.5.tgz#40b8833bc07771398f605fd7f07bf50923e1a629"
-  integrity sha1-QLiDO8B3cTmPYF/X8Hv1CSPhpik=
-  dependencies:
-    "@emotion/core" "10.0.10"
-    "@emotion/styled" "10.0.10"
-    lodash-es "4.17.15"
-
 "@samverschueren/stream-to-observable@^0.3.0":
   version "0.3.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.1.tgz#a21117b19ee9be70c379ec1877537ef2e1c63301"


### PR DESCRIPTION
From our work on project files it's clear we need to make changes to the saved-scripts component. As the relate-by-ui repo is pretty much dead and we're the only users of this component, I'm moving it into the main repo. 

Changes:
- Move files here from relate-by-ui repo
- Remove dependency from package.json/licenses

Will follow up with a PR with tests to show that the original behaviour is preserved and then a PR with refactorings to make the code match our code standards, and finally a PR to implement the needed changes.

Preview: http://remove_saved_scripts_dep.surge.sh
