### PR TITLE
Improve performance when receiving large query results

### DIFF
--- a/src/browser/AppInit.tsx
+++ b/src/browser/AppInit.tsx
@@ -20,7 +20,13 @@
 
 import React from 'react'
 import { createEpicMiddleware } from 'redux-observable'
-import { createStore, combineReducers, applyMiddleware, compose } from 'redux'
+import {
+  createStore,
+  combineReducers,
+  applyMiddleware,
+  compose,
+  AnyAction
+} from 'redux'
 import { Provider } from 'react-redux'
 import {
   createBus,
@@ -70,7 +76,37 @@ const enhancer = compose(
   applyMiddleware(suberMiddleware, epicMiddleware, localStorageMiddleware),
   process.env.NODE_ENV !== 'production' &&
     (window as any).__REDUX_DEVTOOLS_EXTENSION__
-    ? (window as any).__REDUX_DEVTOOLS_EXTENSION__()
+    ? (window as any).__REDUX_DEVTOOLS_EXTENSION__({
+        actionSanitizer: (action: AnyAction) =>
+          action.type === 'requests/UPDATED'
+            ? {
+                ...action,
+                result: {
+                  summary: action.result ? action.result.summary : undefined,
+                  records:
+                    'REQUEST RECORDS OMITTED FROM REDUX DEVTOOLS TO PREVENT OUT OF MEMORY ERROR'
+                }
+              }
+            : action,
+        stateSanitizer: (state: any) => ({
+          ...state,
+          requests: Object.assign(
+            {},
+            ...Object.entries(state.requests).map(
+              ([id, request]: [string, any]) => ({
+                [id]: {
+                  ...request,
+                  result: {
+                    ...request.result,
+                    records:
+                      'REQUEST RECORDS OMITTED FROM REDUX DEVTOOLS TO PREVENT OUT OF MEMORY ERROR'
+                  }
+                }
+              })
+            )
+          )
+        })
+      })
     : (f: any) => f
 )
 

--- a/src/browser/custom.d.ts
+++ b/src/browser/custom.d.ts
@@ -117,13 +117,8 @@ declare module 'cypher-editor-support' {
   export function extractStatements(
     input: string
   ): {
-    referencesListener: { statements: [{ raw: () => {}[] }] }
+    referencesListener: {
+      statements: [{ raw: () => Record<string, unknown>[] }]
+    }
   }
-}
-
-declare module 'neo4j-driver' {
-  const { auth, driver, int, isInt, session } = await import('neo4j-driver')
-  // overwrite types export to silence type warnings
-  const types: any
-  export { auth, driver, int, isInt, session, types }
 }

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView.test.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView.test.tsx
@@ -26,7 +26,7 @@ import { Visualization } from './VisualizationView'
 const mockEmptyResult = {
   records: []
 }
-const node = new neo4j.types.Node('1', ['Person'], {
+const node = new (neo4j.types.Node as any)('1', ['Person'], {
   prop1: '<b>String</b> with HTML <strong>in</strong> it'
 })
 const mockResult = {

--- a/src/browser/modules/Stream/CypherFrame/helpers.test.ts
+++ b/src/browser/modules/Stream/CypherFrame/helpers.test.ts
@@ -180,7 +180,9 @@ describe('helpers', () => {
     })
     test('should return true if nodes are found, even nested', () => {
       // Given
-      const node = new neo4j.types.Node('2', ['Movie'], { prop2: 'prop2' })
+      const node = new (neo4j.types.Node as any)('2', ['Movie'], {
+        prop2: 'prop2'
+      })
       const mappedGet = (map: any) => (key: any) => map[key]
       const request = {
         result: {
@@ -299,7 +301,9 @@ describe('helpers', () => {
     })
     test('should return the viz view if nodes are existent', () => {
       // Given
-      const node = new neo4j.types.Node('2', ['Movie'], { prop2: 'prop2' })
+      const node = new (neo4j.types.Node as any)('2', ['Movie'], {
+        prop2: 'prop2'
+      })
       const mappedGet = (map: any) => (key: any) => map[key]
       const request = {
         result: {
@@ -385,7 +389,9 @@ describe('helpers', () => {
     })
     test('should return the ascii if thats the last view', () => {
       // Given
-      const node = new neo4j.types.Node('2', ['Movie'], { prop2: 'prop2' })
+      const node = new (neo4j.types.Node as any)('2', ['Movie'], {
+        prop2: 'prop2'
+      })
       const mappedGet = (map: any) => (key: any) => map[key]
       const request = {
         result: {
@@ -481,7 +487,9 @@ describe('helpers', () => {
     })
     test('should return viz if the last view was plan but no plan exists and viz elements exists', () => {
       // Given
-      const node = new neo4j.types.Node('2', ['Movie'], { prop2: 'prop2' })
+      const node = new (neo4j.types.Node as any)('2', ['Movie'], {
+        prop2: 'prop2'
+      })
       const mappedGet = (map: any) => (key: any) => map[key]
       const request = {
         result: {
@@ -549,11 +557,15 @@ describe('helpers', () => {
     })
     test('extractRecordsToResultArray handles regular records', () => {
       // Given
-      const start = new neo4j.types.Node(1, ['X'], { x: 1 })
-      const end = new neo4j.types.Node(2, ['Y'], { y: new neo4j.int(1) })
-      const rel = new neo4j.types.Relationship(3, 1, 2, 'REL', { rel: 1 })
-      const segments = [new neo4j.types.PathSegment(start, rel, end)]
-      const path = new neo4j.types.Path(start, end, segments)
+      const start = new (neo4j.types.Node as any)(1, ['X'], { x: 1 })
+      const end = new (neo4j.types.Node as any)(2, ['Y'], {
+        y: new (neo4j.int as any)(1)
+      })
+      const rel = new (neo4j.types.Relationship as any)(3, 1, 2, 'REL', {
+        rel: 1
+      })
+      const segments = [new (neo4j.types.PathSegment as any)(start, rel, end)]
+      const path = new (neo4j.types.Path as any)(start, end, segments)
 
       const records = [
         {
@@ -561,7 +573,7 @@ describe('helpers', () => {
           _fields: [
             'x',
             'y',
-            new neo4j.types.Node('1', ['Person'], { prop1: 'prop1' })
+            new (neo4j.types.Node as any)('1', ['Person'], { prop1: 'prop1' })
           ]
         },
         {
@@ -576,17 +588,23 @@ describe('helpers', () => {
       // Then
       expect(res).toEqual([
         ['"x"', '"y"', '"n"'],
-        ['x', 'y', new neo4j.types.Node('1', ['Person'], { prop1: 'prop1' })],
+        [
+          'x',
+          'y',
+          new (neo4j.types.Node as any)('1', ['Person'], { prop1: 'prop1' })
+        ],
         ['xx', 'yy', path]
       ])
     })
     test('flattenGraphItemsInResultArray extracts props from graph items', () => {
       // Given
-      const start = new neo4j.types.Node(1, ['X'], { x: 1 })
-      const end = new neo4j.types.Node(2, ['Y'], { y: 1 })
-      const rel = new neo4j.types.Relationship(3, 1, 2, 'REL', { rel: 1 })
-      const segments = [new neo4j.types.PathSegment(start, rel, end)]
-      const path = new neo4j.types.Path(start, end, segments)
+      const start = new (neo4j.types.Node as any)(1, ['X'], { x: 1 })
+      const end = new (neo4j.types.Node as any)(2, ['Y'], { y: 1 })
+      const rel = new (neo4j.types.Relationship as any)(3, 1, 2, 'REL', {
+        rel: 1
+      })
+      const segments = [new (neo4j.types.PathSegment as any)(start, rel, end)]
+      const path = new (neo4j.types.Path as any)(start, end, segments)
 
       const records = [
         {
@@ -594,7 +612,7 @@ describe('helpers', () => {
           _fields: [
             'x',
             'y',
-            new neo4j.types.Node('1', ['Person'], { prop1: 'prop1' })
+            new (neo4j.types.Node as any)('1', ['Person'], { prop1: 'prop1' })
           ]
         },
         {
@@ -623,11 +641,16 @@ describe('helpers', () => {
       const records = [
         {
           keys: ['"neoInt"', '"int"', '"any"', '"backslash"'],
-          _fields: [new neo4j.int('882573709873217509'), 100, 0.5, '"\\"']
+          _fields: [
+            new (neo4j.int as any)('882573709873217509'),
+            100,
+            0.5,
+            '"\\"'
+          ]
         },
         {
           keys: ['"neoInt"', '"int"', '"any"'],
-          _fields: [new neo4j.int(300), 100, 'string']
+          _fields: [new (neo4j.int as any)(300), 100, 'string']
         }
       ]
 
@@ -652,7 +675,7 @@ describe('helpers', () => {
         {
           keys: ['"neoInt"', '"int"', '"any"', '"backslash"', '"bool"'],
           _fields: [
-            new neo4j.int('882573709873217509'),
+            new (neo4j.int as any)('882573709873217509'),
             100,
             0.5,
             '"\\"',
@@ -661,7 +684,7 @@ describe('helpers', () => {
         },
         {
           keys: ['"neoInt"', '"int"', '"any"', '"string with comma"'],
-          _fields: [new neo4j.int(300), 100, 'string', 'my, string']
+          _fields: [new (neo4j.int as any)(300), 100, 'string', 'my, string']
         }
       ]
 
@@ -682,13 +705,17 @@ describe('helpers', () => {
     })
     test('stringifyResultArray handles neo4j integers nested within graph items', () => {
       // Given
-      const start = new neo4j.types.Node(1, ['X'], { x: new neo4j.int(1) })
-      const end = new neo4j.types.Node(2, ['Y'], { y: new neo4j.int(2) })
-      const rel = new neo4j.types.Relationship(3, 1, 2, 'REL', {
-        rel: new neo4j.int(1)
+      const start = new (neo4j.types.Node as any)(1, ['X'], {
+        x: new (neo4j.int as any)(1)
       })
-      const segments = [new neo4j.types.PathSegment(start, rel, end)]
-      const path = new neo4j.types.Path(start, end, segments)
+      const end = new (neo4j.types.Node as any)(2, ['Y'], {
+        y: new (neo4j.int as any)(2)
+      })
+      const rel = new (neo4j.types.Relationship as any)(3, 1, 2, 'REL', {
+        rel: new (neo4j.int as any)(1)
+      })
+      const segments = [new (neo4j.types.PathSegment as any)(start, rel, end)]
+      const path = new (neo4j.types.Path as any)(start, end, segments)
 
       const records = [
         {
@@ -696,7 +723,7 @@ describe('helpers', () => {
           _fields: [
             'x',
             'y',
-            new neo4j.types.Node('1', ['Person'], { prop1: 'prop1' })
+            new (neo4j.types.Node as any)('1', ['Person'], { prop1: 'prop1' })
           ]
         },
         {
@@ -729,21 +756,21 @@ describe('helpers', () => {
   describe('recordToJSONMapper', () => {
     describe('Nodes', () => {
       test('handles integer values', () => {
-        const node = new neo4j.types.Node(1, ['foo'], {
-          bar: new neo4j.int(3),
-          baz: new neo4j.int(1416268800000),
-          bax: new neo4j.int(9907199254740991) // Larger than Number.MAX_SAFE_INTEGER, but still in 64 bit int range
+        const node = new (neo4j.types.Node as any)(1, ['foo'], {
+          bar: new (neo4j.int as any)(3),
+          baz: new (neo4j.int as any)(1416268800000),
+          bax: new (neo4j.int as any)(9907199254740991) // Larger than Number.MAX_SAFE_INTEGER, but still in 64 bit int range
         })
-        const record = new neo4j.types.Record(['n'], [node])
+        const record = new (neo4j.types.Record as any)(['n'], [node])
         const expected = {
           n: {
             identity: 1,
             elementType: 'node',
             labels: ['foo'],
             properties: {
-              bar: new neo4j.int(3),
-              baz: new neo4j.int(1416268800000),
-              bax: new neo4j.int(9907199254740991)
+              bar: new (neo4j.int as any)(3),
+              baz: new (neo4j.int as any)(1416268800000),
+              bax: new (neo4j.int as any)(9907199254740991)
             }
           }
         }
@@ -752,8 +779,8 @@ describe('helpers', () => {
       })
 
       test('handles string values', () => {
-        const node = new neo4j.types.Node(1, ['foo'], { bar: 'baz' })
-        const record = new neo4j.types.Record(['n'], [node])
+        const node = new (neo4j.types.Node as any)(1, ['foo'], { bar: 'baz' })
+        const record = new (neo4j.types.Record as any)(['n'], [node])
         const expected = {
           n: {
             identity: 1,
@@ -769,10 +796,10 @@ describe('helpers', () => {
       })
 
       test('handles date values', () => {
-        const node = new neo4j.types.Node(1, ['foo'], {
+        const node = new (neo4j.types.Node as any)(1, ['foo'], {
           bar: new neo4j.types.Date(1970, 1, 1)
         })
-        const record = new neo4j.types.Record(['n'], [node])
+        const record = new (neo4j.types.Record as any)(['n'], [node])
         const expected = {
           n: {
             identity: 1,
@@ -788,10 +815,10 @@ describe('helpers', () => {
       })
 
       test('handles time values', () => {
-        const node = new neo4j.types.Node(1, ['foo'], {
+        const node = new (neo4j.types.Node as any)(1, ['foo'], {
           bar: new neo4j.types.Time(11, 1, 12, 0, 0)
         })
-        const record = new neo4j.types.Record(['n'], [node])
+        const record = new (neo4j.types.Record as any)(['n'], [node])
         const expected = {
           n: {
             identity: 1,
@@ -807,10 +834,10 @@ describe('helpers', () => {
       })
 
       test('handles local time values', () => {
-        const node = new neo4j.types.Node(1, ['foo'], {
+        const node = new (neo4j.types.Node as any)(1, ['foo'], {
           bar: new neo4j.types.LocalTime(11, 1, 12, 0)
         })
-        const record = new neo4j.types.Record(['n'], [node])
+        const record = new (neo4j.types.Record as any)(['n'], [node])
         const expected = {
           n: {
             identity: 1,
@@ -826,10 +853,10 @@ describe('helpers', () => {
       })
 
       test('handles datetime values', () => {
-        const node = new neo4j.types.Node(1, ['foo'], {
+        const node = new (neo4j.types.Node as any)(1, ['foo'], {
           bar: new neo4j.types.DateTime(1970, 1, 1, 11, 1, 12, 0, 0)
         })
-        const record = new neo4j.types.Record(['n'], [node])
+        const record = new (neo4j.types.Record as any)(['n'], [node])
         const expected = {
           n: {
             identity: 1,
@@ -845,10 +872,10 @@ describe('helpers', () => {
       })
 
       test('handles local datetime values', () => {
-        const node = new neo4j.types.Node(1, ['foo'], {
+        const node = new (neo4j.types.Node as any)(1, ['foo'], {
           bar: new neo4j.types.LocalDateTime(1970, 1, 1, 11, 1, 12, 0)
         })
-        const record = new neo4j.types.Record(['n'], [node])
+        const record = new (neo4j.types.Record as any)(['n'], [node])
         const expected = {
           n: {
             identity: 1,
@@ -864,10 +891,10 @@ describe('helpers', () => {
       })
 
       test('handles point values', () => {
-        const node = new neo4j.types.Node(1, ['foo'], {
+        const node = new (neo4j.types.Node as any)(1, ['foo'], {
           bar: new neo4j.types.Point(1, 10, 5, 15)
         })
-        const record = new neo4j.types.Record(['n'], [node])
+        const record = new (neo4j.types.Record as any)(['n'], [node])
         const expected = {
           n: {
             identity: 1,
@@ -883,10 +910,10 @@ describe('helpers', () => {
       })
 
       test('handles duration values', () => {
-        const node = new neo4j.types.Node(1, ['foo'], {
+        const node = new (neo4j.types.Node as any)(1, ['foo'], {
           bar: new neo4j.types.Duration(10, 5, 1, 0)
         })
-        const record = new neo4j.types.Record(['n'], [node])
+        const record = new (neo4j.types.Record as any)(['n'], [node])
         const expected = {
           n: {
             identity: 1,
@@ -904,10 +931,16 @@ describe('helpers', () => {
 
     describe('Relationships', () => {
       test('handles integer values', () => {
-        const relationship = new neo4j.types.Relationship(1, 2, 3, 'foo', {
-          bar: new neo4j.int(3)
-        })
-        const record = new neo4j.types.Record(['r'], [relationship])
+        const relationship = new (neo4j.types.Relationship as any)(
+          1,
+          2,
+          3,
+          'foo',
+          {
+            bar: new (neo4j.int as any)(3)
+          }
+        )
+        const record = new (neo4j.types.Record as any)(['r'], [relationship])
         const expected = {
           r: {
             identity: 1,
@@ -916,7 +949,7 @@ describe('helpers', () => {
             elementType: 'relationship',
             type: 'foo',
             properties: {
-              bar: new neo4j.int(3)
+              bar: new (neo4j.int as any)(3)
             }
           }
         }
@@ -925,10 +958,16 @@ describe('helpers', () => {
       })
 
       test('handles string values', () => {
-        const relationship = new neo4j.types.Relationship(1, 2, 3, 'foo', {
-          bar: 'baz'
-        })
-        const record = new neo4j.types.Record(['r'], [relationship])
+        const relationship = new (neo4j.types.Relationship as any)(
+          1,
+          2,
+          3,
+          'foo',
+          {
+            bar: 'baz'
+          }
+        )
+        const record = new (neo4j.types.Record as any)(['r'], [relationship])
         const expected = {
           r: {
             identity: 1,
@@ -946,10 +985,16 @@ describe('helpers', () => {
       })
 
       test('handles date values', () => {
-        const relationship = new neo4j.types.Relationship(1, 2, 3, 'foo', {
-          bar: new neo4j.types.Date(1970, 1, 1)
-        })
-        const record = new neo4j.types.Record(['r'], [relationship])
+        const relationship = new (neo4j.types.Relationship as any)(
+          1,
+          2,
+          3,
+          'foo',
+          {
+            bar: new neo4j.types.Date(1970, 1, 1)
+          }
+        )
+        const record = new (neo4j.types.Record as any)(['r'], [relationship])
         const expected = {
           r: {
             identity: 1,
@@ -967,10 +1012,16 @@ describe('helpers', () => {
       })
 
       test('handles time values', () => {
-        const relationship = new neo4j.types.Relationship(1, 2, 3, 'foo', {
-          bar: new neo4j.types.Time(11, 1, 12, 0, 0)
-        })
-        const record = new neo4j.types.Record(['r'], [relationship])
+        const relationship = new (neo4j.types.Relationship as any)(
+          1,
+          2,
+          3,
+          'foo',
+          {
+            bar: new neo4j.types.Time(11, 1, 12, 0, 0)
+          }
+        )
+        const record = new (neo4j.types.Record as any)(['r'], [relationship])
         const expected = {
           r: {
             identity: 1,
@@ -988,10 +1039,16 @@ describe('helpers', () => {
       })
 
       test('handles local time values', () => {
-        const relationship = new neo4j.types.Relationship(1, 2, 3, 'foo', {
-          bar: new neo4j.types.LocalTime(11, 1, 12, 0)
-        })
-        const record = new neo4j.types.Record(['r'], [relationship])
+        const relationship = new (neo4j.types.Relationship as any)(
+          1,
+          2,
+          3,
+          'foo',
+          {
+            bar: new neo4j.types.LocalTime(11, 1, 12, 0)
+          }
+        )
+        const record = new (neo4j.types.Record as any)(['r'], [relationship])
         const expected = {
           r: {
             identity: 1,
@@ -1009,10 +1066,16 @@ describe('helpers', () => {
       })
 
       test('handles datetime values', () => {
-        const relationship = new neo4j.types.Relationship(1, 2, 3, 'foo', {
-          bar: new neo4j.types.DateTime(1970, 1, 1, 11, 1, 12, 0, 0)
-        })
-        const record = new neo4j.types.Record(['r'], [relationship])
+        const relationship = new (neo4j.types.Relationship as any)(
+          1,
+          2,
+          3,
+          'foo',
+          {
+            bar: new neo4j.types.DateTime(1970, 1, 1, 11, 1, 12, 0, 0)
+          }
+        )
+        const record = new (neo4j.types.Record as any)(['r'], [relationship])
         const expected = {
           r: {
             identity: 1,
@@ -1030,10 +1093,16 @@ describe('helpers', () => {
       })
 
       test('handles local datetime values', () => {
-        const relationship = new neo4j.types.Relationship(1, 2, 3, 'foo', {
-          bar: new neo4j.types.LocalDateTime(1970, 1, 1, 11, 1, 12, 0)
-        })
-        const record = new neo4j.types.Record(['r'], [relationship])
+        const relationship = new (neo4j.types.Relationship as any)(
+          1,
+          2,
+          3,
+          'foo',
+          {
+            bar: new neo4j.types.LocalDateTime(1970, 1, 1, 11, 1, 12, 0)
+          }
+        )
+        const record = new (neo4j.types.Record as any)(['r'], [relationship])
         const expected = {
           r: {
             identity: 1,
@@ -1051,10 +1120,16 @@ describe('helpers', () => {
       })
 
       test('handles point values', () => {
-        const relationship = new neo4j.types.Relationship(1, 2, 3, 'foo', {
-          bar: new neo4j.types.Point(1, 10, 5, 15)
-        })
-        const record = new neo4j.types.Record(['r'], [relationship])
+        const relationship = new (neo4j.types.Relationship as any)(
+          1,
+          2,
+          3,
+          'foo',
+          {
+            bar: new neo4j.types.Point(1, 10, 5, 15)
+          }
+        )
+        const record = new (neo4j.types.Record as any)(['r'], [relationship])
         const expected = {
           r: {
             identity: 1,
@@ -1072,10 +1147,16 @@ describe('helpers', () => {
       })
 
       test('handles duration values', () => {
-        const relationship = new neo4j.types.Relationship(1, 2, 3, 'foo', {
-          bar: new neo4j.types.Duration(10, 5, 1, 0)
-        })
-        const record = new neo4j.types.Record(['r'], [relationship])
+        const relationship = new (neo4j.types.Relationship as any)(
+          1,
+          2,
+          3,
+          'foo',
+          {
+            bar: new neo4j.types.Duration(10, 5, 1, 0)
+          }
+        )
+        const record = new (neo4j.types.Record as any)(['r'], [relationship])
         const expected = {
           r: {
             identity: 1,
@@ -1095,16 +1176,22 @@ describe('helpers', () => {
 
     describe('Nodes and Relationships', () => {
       test('Node -> Relationship -> Node', () => {
-        const node1 = new neo4j.types.Node(1, ['foo'], {
-          bar: new neo4j.int(3)
+        const node1 = new (neo4j.types.Node as any)(1, ['foo'], {
+          bar: new (neo4j.int as any)(3)
         })
-        const relationship = new neo4j.types.Relationship(3, 1, 2, 'bom', {
-          bar: 'apa'
-        })
-        const node2 = new neo4j.types.Node(2, ['bam'], {
+        const relationship = new (neo4j.types.Relationship as any)(
+          3,
+          1,
+          2,
+          'bom',
+          {
+            bar: 'apa'
+          }
+        )
+        const node2 = new (neo4j.types.Node as any)(2, ['bam'], {
           bar: new neo4j.types.Date(1970, 1, 1)
         })
-        const record = new neo4j.types.Record(
+        const record = new (neo4j.types.Record as any)(
           ['n1', 'r1', 'n2'],
           [node1, relationship, node2]
         )
@@ -1114,7 +1201,7 @@ describe('helpers', () => {
             elementType: 'node',
             labels: ['foo'],
             properties: {
-              bar: new neo4j.int(3)
+              bar: new (neo4j.int as any)(3)
             }
           },
           r1: {
@@ -1143,19 +1230,25 @@ describe('helpers', () => {
 
     describe('Paths', () => {
       test('MATCH p = (:Person)-[r]-(:Movie) RETURN p', () => {
-        const node1 = new neo4j.types.Node(1, ['foo'], {
-          bar: new neo4j.int(3)
+        const node1 = new (neo4j.types.Node as any)(1, ['foo'], {
+          bar: new (neo4j.int as any)(3)
         })
-        const relationship = new neo4j.types.Relationship(3, 1, 2, 'bom', {
-          bar: 'apa'
-        })
-        const node2 = new neo4j.types.Node(2, ['bam'], {
+        const relationship = new (neo4j.types.Relationship as any)(
+          3,
+          1,
+          2,
+          'bom',
+          {
+            bar: 'apa'
+          }
+        )
+        const node2 = new (neo4j.types.Node as any)(2, ['bam'], {
           bar: new neo4j.types.Date(1970, 1, 1)
         })
-        const path = new neo4j.types.Path(node1, node2, [
-          new neo4j.types.PathSegment(node1, relationship, node2)
+        const path = new (neo4j.types.Path as any)(node1, node2, [
+          new (neo4j.types.PathSegment as any)(node1, relationship, node2)
         ])
-        const record = new neo4j.types.Record(['p'], [path])
+        const record = new (neo4j.types.Record as any)(['p'], [path])
         const expected = {
           p: {
             length: 1,
@@ -1164,7 +1257,7 @@ describe('helpers', () => {
               elementType: 'node',
               labels: ['foo'],
               properties: {
-                bar: new neo4j.int(3)
+                bar: new (neo4j.int as any)(3)
               }
             },
             end: {
@@ -1182,7 +1275,7 @@ describe('helpers', () => {
                   elementType: 'node',
                   labels: ['foo'],
                   properties: {
-                    bar: new neo4j.int(3)
+                    bar: new (neo4j.int as any)(3)
                   }
                 },
                 relationship: {
@@ -1214,12 +1307,12 @@ describe('helpers', () => {
 
     describe('Returns of raw data', () => {
       test('RETURN {...data} as foo', () => {
-        const record = new neo4j.types.Record(
+        const record = new (neo4j.types.Record as any)(
           ['foo'],
           [
             {
               data: [
-                new neo4j.int(1),
+                new (neo4j.int as any)(1),
                 'car',
                 new neo4j.types.Point(1, 10, 5, 15),
                 new neo4j.types.Date(1970, 1, 1)
@@ -1230,7 +1323,7 @@ describe('helpers', () => {
         const expected = {
           foo: {
             data: [
-              new neo4j.int(1),
+              new (neo4j.int as any)(1),
               'car',
               { srid: 1, x: 10, y: 5, z: 15 },
               '1970-01-01'

--- a/src/browser/modules/Stream/CypherFrame/helpers.ts
+++ b/src/browser/modules/Stream/CypherFrame/helpers.ts
@@ -148,7 +148,9 @@ export const resultHasNodes = (request: any, types = neo4j.types) => {
     const items = recursivelyExtractGraphItems(types, graphItems)
     const flat: any[] = flattenArrayDeep(items)
     const nodes = flat.filter(
-      item => item instanceof types.Node || item instanceof types.Path
+      item =>
+        item instanceof (types.Node as any) ||
+        item instanceof (types.Path as any)
     )
     if (nodes.length) return true
   }
@@ -325,10 +327,10 @@ export const flattenGraphItems = (
 
 export const isGraphItem = (types = neo4j.types, item: any) => {
   return (
-    item instanceof types.Node ||
-    item instanceof types.Relationship ||
-    item instanceof types.Path ||
-    item instanceof types.PathSegment ||
+    item instanceof (types.Node as any) ||
+    item instanceof (types.Relationship as any) ||
+    item instanceof (types.Path as any) ||
+    item instanceof (types.PathSegment as any) ||
     item instanceof neo4j.types.Date ||
     item instanceof neo4j.types.DateTime ||
     item instanceof neo4j.types.Duration ||
@@ -340,9 +342,12 @@ export const isGraphItem = (types = neo4j.types, item: any) => {
 }
 
 export function extractPropertiesFromGraphItems(types = neo4j.types, obj: any) {
-  if (obj instanceof types.Node || obj instanceof types.Relationship) {
+  if (
+    obj instanceof (types.Node as any) ||
+    obj instanceof (types.Relationship as any)
+  ) {
     return obj.properties
-  } else if (obj instanceof types.Path) {
+  } else if (obj instanceof (types.Path as any)) {
     return [].concat.apply([], arrayifyPath(types, obj))
   }
   return obj

--- a/src/shared/modules/connections/connectionsDuck.ts
+++ b/src/shared/modules/connections/connectionsDuck.ts
@@ -452,7 +452,7 @@ export const startupConnectEpic = (action$: any, store: any) => {
       ) {
         try {
           await bolt.openConnection(
-            savedConnection,
+            savedConnection!,
             { connectionTimeout },
             onLostConnection(store.dispatch)
           )
@@ -475,7 +475,7 @@ export const startupConnectEpic = (action$: any, store: any) => {
             // Try to connect with stored creds
             bolt
               .openConnection(
-                connUpdatedWithDiscovery,
+                connUpdatedWithDiscovery!,
                 { connectionTimeout },
                 onLostConnection(store.dispatch)
               )

--- a/src/shared/modules/cypher/cypherDuck.ts
+++ b/src/shared/modules/cypher/cypherDuck.ts
@@ -60,27 +60,28 @@ const queryAndResolve = async (
       ...useDb
     })
     const txFn = buildTxFunctionByMode(session)
-    txFn((tx: any) => tx.run(action.query, action.parameters))
-      .then((r: any) => {
-        session.close()
-        resolve({
-          type: action.$$responseChannel,
-          success: true,
-          result: {
-            ...r,
-            meta: action.host
-          }
+    txFn &&
+      txFn((tx: any) => tx.run(action.query, action.parameters))
+        .then((r: any) => {
+          session.close()
+          resolve({
+            type: action.$$responseChannel,
+            success: true,
+            result: {
+              ...r,
+              meta: action.host
+            }
+          })
         })
-      })
-      .catch((e: any) => {
-        session.close()
-        resolve({
-          type: action.$$responseChannel,
-          success: false,
-          error: e,
-          host
+        .catch((e: any) => {
+          session.close()
+          resolve({
+            type: action.$$responseChannel,
+            success: false,
+            error: e,
+            host
+          })
         })
-      })
   })
 }
 const callClusterMember = async (connection: any, action: any, _store: any) => {
@@ -244,59 +245,78 @@ export const clusterCypherRequestEpic = (some$: any, store: any) =>
 // We need this because this is the only case where we still
 // want to execute cypher even though we get an connection error back
 export const handleForcePasswordChangeEpic = (some$: any, store: any) =>
-  some$.ofType(FORCE_CHANGE_PASSWORD).mergeMap((action: any) => {
-    if (!action.$$responseChannel) return Rx.Observable.of(null)
+  some$
+    .ofType(FORCE_CHANGE_PASSWORD)
+    .mergeMap(
+      (
+        action: Record<
+          | '$$responseChannel'
+          | 'username'
+          | 'host'
+          | 'password'
+          | 'newPassword',
+          string
+        >
+      ) => {
+        if (!action.$$responseChannel) return Rx.Observable.of(null)
 
-    return new Promise((resolve, _reject) => {
-      bolt
-        .directConnect(
-          action,
-          {},
-          undefined,
-          false // Ignore validation errors
-        )
-        .then(async driver => {
-          // Let's establish what server version we're connected to if not in state
-          if (!getVersion(store.getState())) {
-            const versionRes: any = await queryAndResolve(
-              driver,
-              { ...action, query: serverInfoQuery, parameters: {} },
-              undefined
+        return new Promise((resolve, _reject) => {
+          bolt
+            .directConnect(
+              action,
+              {},
+              undefined,
+              false // Ignore validation errors
             )
-            // What does the driver say, does the server support multidb?
-            const supportsMultiDb = await driver.supportsMultiDb()
-            if (!versionRes.success) {
-              // This is just a placeholder version to figure out how to
-              // change password. This will be updated to the correct server version
-              // when we're connected and dbMetaEpic runs
-              const fakeVersion = supportsMultiDb
-                ? FIRST_MULTI_DB_SUPPORT
-                : FIRST_NO_MULTI_DB_SUPPORT
-              versionRes.result = {
-                records: [],
-                summary: { server: { version: `placeholder/${fakeVersion}` } }
+            .then(async driver => {
+              // Let's establish what server version we're connected to if not in state
+              if (!getVersion(store.getState())) {
+                const versionRes: any = await queryAndResolve(
+                  driver,
+                  { ...action, query: serverInfoQuery, parameters: {} },
+                  undefined
+                )
+                // What does the driver say, does the server support multidb?
+                const supportsMultiDb = await driver.supportsMultiDb()
+                if (!versionRes.success) {
+                  // This is just a placeholder version to figure out how to
+                  // change password. This will be updated to the correct server version
+                  // when we're connected and dbMetaEpic runs
+                  const fakeVersion = supportsMultiDb
+                    ? FIRST_MULTI_DB_SUPPORT
+                    : FIRST_NO_MULTI_DB_SUPPORT
+                  versionRes.result = {
+                    records: [],
+                    summary: {
+                      server: { version: `placeholder/${fakeVersion}` }
+                    }
+                  }
+                }
+                store.dispatch(updateServerInfo(versionRes.result))
               }
-            }
-            store.dispatch(updateServerInfo(versionRes.result))
-          }
-          // Figure out how to change the pw on that server version
-          const queryObj = changeUserPasswordQuery(
-            store.getState(),
-            action.password,
-            action.newPassword
-          )
-          // and then change the password
-          const res = await queryAndResolve(
-            driver,
-            { ...action, ...queryObj },
-            undefined,
-            driverDatabaseSelection(store.getState(), 'system') // target system db if it has multi-db support
-          )
-          driver.close()
-          resolve(res)
+              // Figure out how to change the pw on that server version
+              const queryObj = changeUserPasswordQuery(
+                store.getState(),
+                action.password,
+                action.newPassword
+              )
+              // and then change the password
+              const res = await queryAndResolve(
+                driver,
+                { ...action, ...queryObj },
+                undefined,
+                driverDatabaseSelection(store.getState(), 'system') // target system db if it has multi-db support
+              )
+              driver.close()
+              resolve(res)
+            })
+            .catch(e =>
+              resolve({
+                type: action.$$responseChannel,
+                success: false,
+                error: e
+              })
+            )
         })
-        .catch(e =>
-          resolve({ type: action.$$responseChannel, success: false, error: e })
-        )
-    })
-  })
+      }
+    )

--- a/src/shared/modules/cypher/cypherDuck.ts
+++ b/src/shared/modules/cypher/cypherDuck.ts
@@ -21,7 +21,10 @@
 import Rx from 'rxjs'
 import neo4j from 'neo4j-driver'
 import bolt from 'services/bolt/bolt'
-import { getActiveConnectionData } from 'shared/modules/connections/connectionsDuck'
+import {
+  Connection,
+  getActiveConnectionData
+} from 'shared/modules/connections/connectionsDuck'
 import { getCausalClusterAddresses } from './queriesProcedureHelper'
 import { buildTxFunctionByMode } from 'services/bolt/boltHelpers'
 import { flatten } from 'services/utils'
@@ -249,14 +252,7 @@ export const handleForcePasswordChangeEpic = (some$: any, store: any) =>
     .ofType(FORCE_CHANGE_PASSWORD)
     .mergeMap(
       (
-        action: Record<
-          | '$$responseChannel'
-          | 'username'
-          | 'host'
-          | 'password'
-          | 'newPassword',
-          string
-        >
+        action: Connection & { $$responseChannel: string; newPassword: string }
       ) => {
         if (!action.$$responseChannel) return Rx.Observable.of(null)
 

--- a/src/shared/services/bolt/applyGraphTypes.test.ts
+++ b/src/shared/services/bolt/applyGraphTypes.test.ts
@@ -128,7 +128,7 @@ describe('applyGraphTypes', () => {
   })
 
   test('should apply node type', () => {
-    const node = new neo4j.types.Node(neo4j.int(5), ['Test'], {})
+    const node = new (neo4j.types.Node as any)(neo4j.int(5), ['Test'], {})
     const rawNode = nativeTypesToCustom(node)
 
     const typedNode = applyGraphTypes(rawNode)
@@ -175,7 +175,11 @@ describe('applyGraphTypes', () => {
       prop11: { [reservedTypePropertyName]: 'Yolo' }
     }
 
-    const origNode = new neo4j.types.Node(neo4j.int(5), ['Test'], properties)
+    const origNode = new (neo4j.types.Node as any)(
+      neo4j.int(5),
+      ['Test'],
+      properties
+    )
     const rawNode = nativeTypesToCustom(origNode)
 
     const typedNode = applyGraphTypes(rawNode)
@@ -214,8 +218,8 @@ describe('applyGraphTypes', () => {
 
   test('should apply node type to array of data', () => {
     const nodes = [
-      new neo4j.types.Node(neo4j.int(5), ['Test'], {}),
-      new neo4j.types.Node(neo4j.int(15), ['Test2'], {})
+      new (neo4j.types.Node as any)(neo4j.int(5), ['Test'], {}),
+      new (neo4j.types.Node as any)(neo4j.int(15), ['Test2'], {})
     ]
 
     const rawNodes = nativeTypesToCustom(nodes)
@@ -229,7 +233,7 @@ describe('applyGraphTypes', () => {
   })
 
   test('should apply relationship type', () => {
-    const rel = new neo4j.types.Relationship(
+    const rel = new (neo4j.types.Relationship as any)(
       neo4j.int(5),
       neo4j.int(1),
       neo4j.int(2),
@@ -247,14 +251,14 @@ describe('applyGraphTypes', () => {
 
   test('should apply relationship type to array of data', () => {
     const rels = [
-      new neo4j.types.Relationship(
+      new (neo4j.types.Relationship as any)(
         neo4j.int(1),
         neo4j.int(5),
         neo4j.int(10),
         'TestType',
         {}
       ),
-      new neo4j.types.Relationship(
+      new (neo4j.types.Relationship as any)(
         neo4j.int(2),
         neo4j.int(15),
         neo4j.int(20),
@@ -279,7 +283,7 @@ describe('applyGraphTypes', () => {
 
   test('should apply to custom object properties', () => {
     const num = neo4j.int(5)
-    const node = new neo4j.types.Node(neo4j.int(5), ['Test'], {})
+    const node = new (neo4j.types.Node as any)(neo4j.int(5), ['Test'], {})
     const obj = { num, node }
 
     const rawData = nativeTypesToCustom(obj)
@@ -291,10 +295,14 @@ describe('applyGraphTypes', () => {
 
   test('should apply to array of custom object properties', () => {
     const rawNumber1 = neo4j.int(5)
-    const rawNode1 = new neo4j.types.Node(neo4j.int(5), ['Test-1'], {})
+    const rawNode1 = new (neo4j.types.Node as any)(neo4j.int(5), ['Test-1'], {})
 
     const rawNumber2 = neo4j.int(10)
-    const rawNode2 = new neo4j.types.Node(neo4j.int(10), ['Test-2'], {})
+    const rawNode2 = new (neo4j.types.Node as any)(
+      neo4j.int(10),
+      ['Test-2'],
+      {}
+    )
 
     const rawObj = nativeTypesToCustom([
       { num: rawNumber1, node: rawNode1 },
@@ -367,13 +375,13 @@ describe('applyGraphTypes', () => {
   })
 
   test('should apply to a complex object of graph types', () => {
-    const rawNode = new neo4j.types.Node(neo4j.int(5), ['Test'], {})
+    const rawNode = new (neo4j.types.Node as any)(neo4j.int(5), ['Test'], {})
     const rawNum = neo4j.int(100)
     const rawPath = getAPath([
       { start: 5, end: 10, relationship: 1 },
       { start: 10, end: 15, relationship: 2 }
     ])
-    const rawRelationship = new neo4j.types.Relationship(
+    const rawRelationship = new (neo4j.types.Relationship as any)(
       neo4j.int(1),
       neo4j.int(5),
       neo4j.int(10),
@@ -423,7 +431,7 @@ describe('applyGraphTypes', () => {
       12,
       44,
       0,
-      null,
+      null as any,
       'Europe/Stockholm'
     )
     const rawDateTime = nativeTypesToCustom(dateTime)
@@ -471,8 +479,8 @@ describe('applyGraphTypes', () => {
       )
     const boltResponse = {
       records: [
-        new neo4j.types.Record(['mydate'], [createDate(12)]),
-        new neo4j.types.Record(['mydate'], [createDate(2)])
+        new (neo4j.types.Record as any)(['mydate'], [createDate(12)]),
+        new (neo4j.types.Record as any)(['mydate'], [createDate(2)])
       ],
       summary: {}
     }
@@ -496,18 +504,20 @@ describe('applyGraphTypes', () => {
   })
   test('should identify time in nodes in paths with refs for start and end', () => {
     const date = new neo4j.types.Time(11, 1, 12, 3600, 0)
-    const start = new neo4j.types.Node(neo4j.int(1), ['From'], { date })
-    const end = new neo4j.types.Node(neo4j.int(3), ['To'], {})
-    const rel = new neo4j.types.Relationship(
+    const start = new (neo4j.types.Node as any)(neo4j.int(1), ['From'], {
+      date
+    })
+    const end = new (neo4j.types.Node as any)(neo4j.int(3), ['To'], {})
+    const rel = new (neo4j.types.Relationship as any)(
       neo4j.int(2),
       neo4j.int(1),
       neo4j.int(3),
       'TestType',
       {}
     )
-    const seg = new neo4j.types.PathSegment(start, rel, end)
+    const seg = new (neo4j.types.PathSegment as any)(start, rel, end)
     const segments = [seg]
-    const path = new neo4j.types.Path(
+    const path = new (neo4j.types.Path as any)(
       segments[0].start,
       segments[segments.length - 1].end,
       segments
@@ -525,20 +535,28 @@ describe('applyGraphTypes', () => {
   })
   test('should identify time in nodes in paths', () => {
     const date = new neo4j.types.Time(11, 1, 12, 3600, 0)
-    const start = new neo4j.types.Node(neo4j.int(1), ['From'], { date })
-    const segmentStart = new neo4j.types.Node(neo4j.int(1), ['From'], { date })
-    const end = new neo4j.types.Node(neo4j.int(3), ['To'], {})
-    const segmentEnd = new neo4j.types.Node(neo4j.int(3), ['To'], {})
-    const rel = new neo4j.types.Relationship(
+    const start = new (neo4j.types.Node as any)(neo4j.int(1), ['From'], {
+      date
+    })
+    const segmentStart = new (neo4j.types.Node as any)(neo4j.int(1), ['From'], {
+      date
+    })
+    const end = new (neo4j.types.Node as any)(neo4j.int(3), ['To'], {})
+    const segmentEnd = new (neo4j.types.Node as any)(neo4j.int(3), ['To'], {})
+    const rel = new (neo4j.types.Relationship as any)(
       neo4j.int(2),
       neo4j.int(1),
       neo4j.int(3),
       'TestType',
       {}
     )
-    const seg = new neo4j.types.PathSegment(segmentStart, rel, segmentEnd)
+    const seg = new (neo4j.types.PathSegment as any)(
+      segmentStart,
+      rel,
+      segmentEnd
+    )
     const segments = [seg]
-    const path = new neo4j.types.Path(start, end, segments)
+    const path = new (neo4j.types.Path as any)(start, end, segments)
 
     // When
     const res = nativeTypesToCustom(path)
@@ -567,23 +585,23 @@ const typeHintArray = (x: any) =>
     .map(JSON.parse)
 
 const getAPathSegment = (startId: any, relId: any, endId: any) => {
-  const start = new neo4j.types.Node(neo4j.int(startId), ['From'], {})
-  const end = new neo4j.types.Node(neo4j.int(endId), ['To'], {})
-  const rel = new neo4j.types.Relationship(
+  const start = new (neo4j.types.Node as any)(neo4j.int(startId), ['From'], {})
+  const end = new (neo4j.types.Node as any)(neo4j.int(endId), ['To'], {})
+  const rel = new (neo4j.types.Relationship as any)(
     neo4j.int(relId),
     neo4j.int(startId),
     neo4j.int(endId),
     'TestType',
     {}
   )
-  return new neo4j.types.PathSegment(start, rel, end)
+  return new (neo4j.types.PathSegment as any)(start, rel, end)
 }
 
 const getAPath = (segmentList: any) => {
   const segments = segmentList.map((segment: any) =>
     getAPathSegment(segment.start, segment.relationship, segment.end)
   )
-  return new neo4j.types.Path(
+  return new (neo4j.types.Path as any)(
     segments[0].start,
     segments[segments.length - 1].end,
     segments

--- a/src/shared/services/bolt/bolt.ts
+++ b/src/shared/services/bolt/bolt.ts
@@ -39,18 +39,14 @@ import { setupBoltWorker, addTypesAsField } from './setup-bolt-worker'
 
 // @ts-expect-error ts-migrate(2307) FIXME: Cannot find module 'worker-loader?inline!./boltWor... Remove this comment to see the full error message
 import BoltWorkerModule from 'worker-loader?inline!./boltWorker'
+import { Connection } from 'shared/modules/connections/connectionsDuck'
 
 let connectionProperties: {} | null = null
 let _useDb: string | null = null
 const boltWorkPool = new WorkPool(() => new BoltWorkerModule(), 10)
 
 function openConnection(
-  props: {
-    host: string
-    username: string
-    password: string
-    authenticationMethod?: string
-  },
+  props: Connection,
   opts = {},
   onLostConnection?: (error: Error) => void
 ): Promise<void> {

--- a/src/shared/services/bolt/boltConnection.ts
+++ b/src/shared/services/bolt/boltConnection.ts
@@ -20,6 +20,7 @@
 
 import neo4j, { Driver } from 'neo4j-driver'
 import { buildTxFunctionByMode } from 'services/bolt/boltHelpers'
+import { Connection } from 'shared/modules/connections/connectionsDuck'
 import { createDriverOrFailFn } from './driverFactory'
 import {
   setGlobalDrivers,
@@ -95,14 +96,14 @@ export const validateConnection = (
 }
 
 export function directConnect(
-  props: { host: string; username: string; password: string },
+  props: Connection,
   opts = {},
   onLostConnection: (error: Error) => void = (): void => undefined,
   shouldValidateConnection = true
 ): Promise<Driver> {
   const p = new Promise<Driver>((resolve, reject) => {
     const auth = buildAuthObj(props)
-    const driver = createDriverOrFailFn(props.host, auth, opts, e => {
+    const driver = createDriverOrFailFn(props.host || '', auth, opts, e => {
       onLostConnection(e)
       reject(e)
     })
@@ -116,7 +117,7 @@ export function directConnect(
 }
 
 export function openConnection(
-  props: { host: string; password: string; username: string },
+  props: Connection,
   opts = {},
   onLostConnection: (error: Error) => void = (): void => undefined
 ): Promise<unknown> {
@@ -156,7 +157,7 @@ export const closeConnection = (): void => {
 }
 
 export const ensureConnection = (
-  props: { host: string; username: string; password: string },
+  props: Connection,
   opts: Record<string, unknown>,
   onLostConnection: () => void
 ): Promise<unknown> => {

--- a/src/shared/services/bolt/boltHelpers.test.ts
+++ b/src/shared/services/bolt/boltHelpers.test.ts
@@ -26,7 +26,7 @@ const READ = 'READ'
 describe('buildTxFunctionByMode', () => {
   test('it returns WRITE tx when in WRITE mode', () => {
     // Given
-    const fakeSession = {
+    const fakeSession: any = {
       _mode: WRITE,
       readTransaction: jest.fn(),
       writeTransaction: jest.fn()
@@ -42,7 +42,7 @@ describe('buildTxFunctionByMode', () => {
   })
   test('it returns READ tx when in READ mode', () => {
     // Given
-    const fakeSession = {
+    const fakeSession: any = {
       _mode: READ,
       readTransaction: jest.fn(),
       writeTransaction: jest.fn()
@@ -58,7 +58,7 @@ describe('buildTxFunctionByMode', () => {
   })
   test('it by DEFAULT returns tx in WRITE mode', () => {
     // Given
-    const fakeSession = {
+    const fakeSession: any = {
       readTransaction: jest.fn(),
       writeTransaction: jest.fn()
     }

--- a/src/shared/services/bolt/boltHelpers.ts
+++ b/src/shared/services/bolt/boltHelpers.ts
@@ -18,27 +18,28 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { Session } from 'neo4j-driver'
 import { getUrlInfo } from 'services/utils'
 
 export const KERBEROS = 'KERBEROS'
 export const NATIVE = 'NATIVE'
 export const NO_AUTH = 'NO_AUTH'
 
-export const getDiscoveryEndpoint = (url?: any) => {
+export const getDiscoveryEndpoint = (url?: string): string => {
   const info = getUrlInfo(url || 'http://localhost:7474/')
   return `${info.protocol}//${info.host}/`
 }
 
-export const isConfigValTruthy = (val: any) =>
+export const isConfigValTruthy = (val: boolean | string | number): boolean =>
   [true, 'true', 'yes', 1, '1'].indexOf(val) > -1
-export const isConfigValFalsy = (val: any) =>
+export const isConfigValFalsy = (val: boolean | string | number): boolean =>
   [false, 'false', 'no', 0, '0'].indexOf(val) > -1
 
-export const buildTxFunctionByMode = (session: any) => {
+export const buildTxFunctionByMode = (session?: Session): any => {
   if (!session) {
     return null
   }
-  return session._mode !== 'READ'
+  return (session as any)._mode !== 'READ'
     ? session.writeTransaction.bind(session)
     : session.readTransaction.bind(session)
 }

--- a/src/shared/services/bolt/boltMappings.test.ts
+++ b/src/shared/services/bolt/boltMappings.test.ts
@@ -159,26 +159,28 @@ describe('boltMappings', () => {
 
   describe('extractNodesAndRelationshipsFromRecords', () => {
     test('should map bolt records with a path to nodes and relationships', () => {
-      const startNode = new neo4j.types.Node('1', ['Person'], {
+      const startNode = new (neo4j.types.Node as any)('1', ['Person'], {
         prop1: 'prop1'
       })
-      const endNode = new neo4j.types.Node('2', ['Movie'], {
+      const endNode = new (neo4j.types.Node as any)('2', ['Movie'], {
         prop2: 'prop2'
       })
-      const relationship = new neo4j.types.Relationship(
+      const relationship = new (neo4j.types.Relationship as any)(
         '3',
         startNode.identity,
         endNode.identity,
         'ACTED_IN',
         {}
       )
-      const pathSegment = new neo4j.types.PathSegment(
+      const pathSegment = new (neo4j.types.PathSegment as any)(
         startNode,
         relationship,
         endNode
       )
-      const path = new neo4j.types.Path(startNode, endNode, [pathSegment])
-      const boltRecord = {
+      const path = new (neo4j.types.Path as any)(startNode, endNode, [
+        pathSegment
+      ])
+      const boltRecord: any = {
         keys: ['p'],
         get: () => path
       }
@@ -205,13 +207,13 @@ describe('boltMappings', () => {
     })
 
     test('should truncate field items when told to do so', () => {
-      const startNode = new neo4j.types.Node('1', ['Person'], {
+      const startNode = new (neo4j.types.Node as any)('1', ['Person'], {
         prop1: 'prop1'
       })
-      const endNode = new neo4j.types.Node('2', ['Movie'], {
+      const endNode = new (neo4j.types.Node as any)('2', ['Movie'], {
         prop2: 'prop2'
       })
-      const boltRecord = {
+      const boltRecord: any = {
         keys: ['p'],
         get: () => [startNode, endNode]
       }
@@ -230,20 +232,20 @@ describe('boltMappings', () => {
     })
 
     test('should map bolt nodes and relationships to graph nodes and relationships', () => {
-      const startNode = new neo4j.types.Node('1', ['Person'], {
+      const startNode = new (neo4j.types.Node as any)('1', ['Person'], {
         prop1: 'prop1'
       })
-      const endNode = new neo4j.types.Node('2', ['Movie'], {
+      const endNode = new (neo4j.types.Node as any)('2', ['Movie'], {
         prop2: 'prop2'
       })
-      const relationship = new neo4j.types.Relationship(
+      const relationship = new (neo4j.types.Relationship as any)(
         '3',
         startNode.identity,
         endNode.identity,
         'ACTED_IN',
         {}
       )
-      const boltRecord = {
+      const boltRecord: any = {
         keys: ['r', 'n1', 'n2'],
         get: (key: any) => {
           if (key === 'r') {
@@ -379,13 +381,13 @@ describe('boltMappings', () => {
   describe('extractNodesAndRelationshipsFromRecordsForOldVis', () => {
     test('should recursively look for graph items', () => {
       // Given
-      const firstNode = new neo4j.types.Node('1', ['Person'], {
+      const firstNode = new (neo4j.types.Node as any)('1', ['Person'], {
         prop1: 'prop1'
       })
       const nodeCollection = [
-        new neo4j.types.Node('2', ['Person'], { prop1: 'prop1' }),
-        new neo4j.types.Node('3', ['Person'], { prop1: 'prop1' }),
-        new neo4j.types.Node('4', ['Person'], { prop1: 'prop1' })
+        new (neo4j.types.Node as any)('2', ['Person'], { prop1: 'prop1' }),
+        new (neo4j.types.Node as any)('3', ['Person'], { prop1: 'prop1' }),
+        new (neo4j.types.Node as any)('4', ['Person'], { prop1: 'prop1' })
       ]
       const boltRecord = {
         keys: ['n', 'c'],
@@ -398,7 +400,7 @@ describe('boltMappings', () => {
           }
         }
       }
-      const records = [boltRecord]
+      const records: any = [boltRecord]
 
       // When
       const out = extractNodesAndRelationshipsFromRecordsForOldVis(
@@ -421,23 +423,27 @@ describe('boltMappings', () => {
         intConverter: (a: any) => a,
         objectConverter: extractFromNeoObjects
       }
-      const start = new neo4j.types.Node(1, ['X'], { x: 1 })
-      const rel1 = new neo4j.types.Relationship(3, 1, 2, 'REL', { rel: 1 })
-      const end1 = new neo4j.types.Node(2, ['Y'], { y: 1 })
-      const rel2 = new neo4j.types.Relationship(6, 4, 5, 'REL2', { rel: 2 })
-      const end = new neo4j.types.Node(5, ['Y'], { y: 2 })
+      const start = new (neo4j.types.Node as any)(1, ['X'], { x: 1 })
+      const rel1 = new (neo4j.types.Relationship as any)(3, 1, 2, 'REL', {
+        rel: 1
+      })
+      const end1 = new (neo4j.types.Node as any)(2, ['Y'], { y: 1 })
+      const rel2 = new (neo4j.types.Relationship as any)(6, 4, 5, 'REL2', {
+        rel: 2
+      })
+      const end = new (neo4j.types.Node as any)(5, ['Y'], { y: 2 })
       const segments = [
-        new neo4j.types.PathSegment(start, rel1, end1),
-        new neo4j.types.PathSegment(end1, rel2, end)
+        new (neo4j.types.PathSegment as any)(start, rel1, end1),
+        new (neo4j.types.PathSegment as any)(end1, rel2, end)
       ]
-      const path = new neo4j.types.Path(start, end, segments)
+      const path = new (neo4j.types.Path as any)(start, end, segments)
       const boltRecord = {
         keys: ['p'],
         get: (key: any) => {
           if (key === 'p') return path
         }
       }
-      const records = [boltRecord]
+      const records: any = [boltRecord]
 
       // When
       const out = extractNodesAndRelationshipsFromRecordsForOldVis(
@@ -457,17 +463,17 @@ describe('boltMappings', () => {
         intConverter: (a: any) => a,
         objectConverter: extractFromNeoObjects
       }
-      const start = new neo4j.types.Node(1, ['X'], { x: 2 })
+      const start = new (neo4j.types.Node as any)(1, ['X'], { x: 2 })
       const end = start
       const segments: any = []
-      const path = new neo4j.types.Path(start, end, segments)
+      const path = new (neo4j.types.Path as any)(start, end, segments)
       const boltRecord = {
         keys: ['p'],
         get: (key: any) => {
           if (key === 'p') return path
         }
       }
-      const records = [boltRecord]
+      const records: any = [boltRecord]
 
       // When
       const out = extractNodesAndRelationshipsFromRecordsForOldVis(
@@ -490,10 +496,10 @@ describe('boltMappings', () => {
         intConverter: (a: any) => a,
         objectConverter: extractFromNeoObjects
       }
-      const start = new neo4j.types.Node(1, ['X'], { x: 1 })
+      const start = new (neo4j.types.Node as any)(1, ['X'], { x: 1 })
       const end = start
       const segments: any = []
-      const path = new neo4j.types.Path(start, end, segments)
+      const path = new (neo4j.types.Path as any)(start, end, segments)
 
       // When
       const result = extractFromNeoObjects(path, converters)
@@ -508,11 +514,13 @@ describe('boltMappings', () => {
         intConverter: (a: any) => a,
         objectConverter: extractFromNeoObjects
       }
-      const start = new neo4j.types.Node(1, ['X'], { x: 1 })
-      const end = new neo4j.types.Node(2, ['Y'], { y: 1 })
-      const rel = new neo4j.types.Relationship(3, 1, 2, 'REL', { rel: 1 })
-      const segments = [new neo4j.types.PathSegment(start, rel, end)]
-      const path = new neo4j.types.Path(start, end, segments)
+      const start = new (neo4j.types.Node as any)(1, ['X'], { x: 1 })
+      const end = new (neo4j.types.Node as any)(2, ['Y'], { y: 1 })
+      const rel = new (neo4j.types.Relationship as any)(3, 1, 2, 'REL', {
+        rel: 1
+      })
+      const segments = [new (neo4j.types.PathSegment as any)(start, rel, end)]
+      const path = new (neo4j.types.Path as any)(start, end, segments)
 
       // When
       const result = extractFromNeoObjects(path, converters)
@@ -530,16 +538,20 @@ describe('boltMappings', () => {
         intConverter: (a: any) => a,
         objectConverter: extractFromNeoObjects
       }
-      const start = new neo4j.types.Node(1, ['X'], { x: 1 })
-      const rel1 = new neo4j.types.Relationship(3, 1, 2, 'REL', { rel: 1 })
-      const end1 = new neo4j.types.Node(2, ['Y'], { y: 1 })
-      const rel2 = new neo4j.types.Relationship(6, 4, 5, 'REL2', { rel: 2 })
-      const end = new neo4j.types.Node(5, ['Y'], { y: 2 })
+      const start = new (neo4j.types.Node as any)(1, ['X'], { x: 1 })
+      const rel1 = new (neo4j.types.Relationship as any)(3, 1, 2, 'REL', {
+        rel: 1
+      })
+      const end1 = new (neo4j.types.Node as any)(2, ['Y'], { y: 1 })
+      const rel2 = new (neo4j.types.Relationship as any)(6, 4, 5, 'REL2', {
+        rel: 2
+      })
+      const end = new (neo4j.types.Node as any)(5, ['Y'], { y: 2 })
       const segments = [
-        new neo4j.types.PathSegment(start, rel1, end1),
-        new neo4j.types.PathSegment(end1, rel2, end)
+        new (neo4j.types.PathSegment as any)(start, rel1, end1),
+        new (neo4j.types.PathSegment as any)(end1, rel2, end)
       ]
-      const path = new neo4j.types.Path(start, end, segments)
+      const path = new (neo4j.types.Path as any)(start, end, segments)
 
       // When
       const result = extractFromNeoObjects(path, converters)

--- a/src/shared/services/bolt/boltMappings.ts
+++ b/src/shared/services/bolt/boltMappings.ts
@@ -194,11 +194,14 @@ export function extractNodesAndRelationshipsFromRecordsForOldVis(
   })
   let relationships = rawRels
   if (filterRels) {
-    relationships = rawRels.filter(
-      item =>
-        nodes.filter(node => node.id === item.start.toString()).length > 0 &&
-        nodes.filter(node => node.id === item.end.toString()).length > 0
-    )
+    relationships = rawRels.filter(item => {
+      const start = item.start.toString()
+      const end = item.end.toString()
+      return (
+        nodes.filter(node => node.id === start).length > 0 &&
+        nodes.filter(node => node.id === end).length > 0
+      )
+    })
   }
   relationships = relationships.map(item => {
     return {

--- a/src/shared/services/bolt/boltMappings.ts
+++ b/src/shared/services/bolt/boltMappings.ts
@@ -23,8 +23,8 @@ import { flatten, map, take } from 'lodash-es'
 import neo4j from 'neo4j-driver'
 import { stringModifier } from 'services/bolt/cypherTypesFormatting'
 import {
-  safetlyRemoveObjectProp,
-  safetlyAddObjectProp,
+  safelyRemoveObjectProp,
+  safelyAddObjectProp,
   escapeReservedProps,
   unEscapeReservedProps
 } from '../utils'
@@ -346,7 +346,7 @@ export const applyGraphTypes = (rawItem: any, types = neo4j.types): any => {
   ) {
     const item = { ...rawItem }
     const className = item[reservedTypePropertyName]
-    const tmpItem = safetlyRemoveObjectProp(item, reservedTypePropertyName)
+    const tmpItem = safelyRemoveObjectProp(item, reservedTypePropertyName)
     switch (className) {
       case 'Node':
         return new types[className](
@@ -463,62 +463,62 @@ export const recursivelyTypeGraphItems = (
   }
   if (item instanceof types.Node) {
     const tmp = copyAndType(item, types)
-    safetlyAddObjectProp(tmp, reservedTypePropertyName, 'Node')
+    safelyAddObjectProp(tmp, reservedTypePropertyName, 'Node')
     return tmp
   }
   if (item instanceof types.PathSegment) {
     const tmp = copyAndType(item, types)
-    safetlyAddObjectProp(tmp, reservedTypePropertyName, 'PathSegment')
+    safelyAddObjectProp(tmp, reservedTypePropertyName, 'PathSegment')
     return tmp
   }
   if (item instanceof types.Path) {
     const tmp = copyAndType(item, types)
-    safetlyAddObjectProp(tmp, reservedTypePropertyName, 'Path')
+    safelyAddObjectProp(tmp, reservedTypePropertyName, 'Path')
     return tmp
   }
   if (item instanceof types.Relationship) {
     const tmp = copyAndType(item, types)
-    safetlyAddObjectProp(tmp, reservedTypePropertyName, 'Relationship')
+    safelyAddObjectProp(tmp, reservedTypePropertyName, 'Relationship')
     return tmp
   }
   if (item instanceof types.Point) {
     const tmp = copyAndType(item, types)
-    safetlyAddObjectProp(tmp, reservedTypePropertyName, 'Point')
+    safelyAddObjectProp(tmp, reservedTypePropertyName, 'Point')
     return tmp
   }
   if (item instanceof types.Date) {
     const tmp = copyAndType(item, types)
-    safetlyAddObjectProp(tmp, reservedTypePropertyName, 'Date')
+    safelyAddObjectProp(tmp, reservedTypePropertyName, 'Date')
     return tmp
   }
   if (item instanceof types.DateTime) {
     const tmp = copyAndType(item, types)
-    safetlyAddObjectProp(tmp, reservedTypePropertyName, 'DateTime')
+    safelyAddObjectProp(tmp, reservedTypePropertyName, 'DateTime')
     return tmp
   }
   if (item instanceof types.Duration) {
     const tmp = copyAndType(item, types)
-    safetlyAddObjectProp(tmp, reservedTypePropertyName, 'Duration')
+    safelyAddObjectProp(tmp, reservedTypePropertyName, 'Duration')
     return tmp
   }
   if (item instanceof types.LocalDateTime) {
     const tmp = copyAndType(item, types)
-    safetlyAddObjectProp(tmp, reservedTypePropertyName, 'LocalDateTime')
+    safelyAddObjectProp(tmp, reservedTypePropertyName, 'LocalDateTime')
     return tmp
   }
   if (item instanceof types.LocalTime) {
     const tmp = copyAndType(item, types)
-    safetlyAddObjectProp(tmp, reservedTypePropertyName, 'LocalTime')
+    safelyAddObjectProp(tmp, reservedTypePropertyName, 'LocalTime')
     return tmp
   }
   if (item instanceof types.Time) {
     const tmp = copyAndType(item, types)
-    safetlyAddObjectProp(tmp, reservedTypePropertyName, 'Time')
+    safelyAddObjectProp(tmp, reservedTypePropertyName, 'Time')
     return tmp
   }
   if (neo4j.isInt(item)) {
     const tmp = { ...item }
-    safetlyAddObjectProp(tmp, reservedTypePropertyName, 'Integer')
+    safelyAddObjectProp(tmp, reservedTypePropertyName, 'Integer')
     return tmp
   }
   if (typeof item === 'object') {

--- a/src/shared/services/bolt/boltMappings.ts
+++ b/src/shared/services/bolt/boltMappings.ts
@@ -198,8 +198,8 @@ export function extractNodesAndRelationshipsFromRecordsForOldVis(
       const start = item.start.toString()
       const end = item.end.toString()
       return (
-        nodes.filter(node => node.id === start).length > 0 &&
-        nodes.filter(node => node.id === end).length > 0
+        nodes.some(node => node.id === start) &&
+        nodes.some(node => node.id === end)
       )
     })
   }

--- a/src/shared/services/bolt/boltMappings.ts
+++ b/src/shared/services/bolt/boltMappings.ts
@@ -31,22 +31,34 @@ import {
 
 export const reservedTypePropertyName = 'transport-class'
 
-export function toObjects(records: any, converters: any) {
-  const recordValues = records.map((record: any) => {
-    const out: any = []
-    record.forEach((val: any) => out.push(itemIntToString(val, converters)))
+interface Converters {
+  intChecker: (item: {}) => boolean
+  intConverter: (item: {}) => any
+  objectConverter?: (item: {}, converters: Converters) => any
+}
+
+export function toObjects(
+  records: typeof neo4j.Record[],
+  converters: Converters
+) {
+  const recordValues = records.map(record => {
+    const out: string[] = []
+    record.forEach((val: {}) => out.push(itemIntToString(val, converters)))
     return out
   })
   return recordValues
 }
 
-export function recordsToTableArray(records: any, converters: any) {
+export function recordsToTableArray(
+  records: typeof neo4j.Record[],
+  converters: Converters
+) {
   const recordValues = toObjects(records, converters)
   const keys = records[0].keys
   return [[...keys], ...recordValues]
 }
 
-export function itemIntToString(item: any, converters: any) {
+export function itemIntToString(item: any, converters: Converters): any {
   const res = stringModifier(item)
   if (res) return res
   if (converters.intChecker(item)) return converters.intConverter(item)
@@ -56,8 +68,8 @@ export function itemIntToString(item: any, converters: any) {
   if (typeof item === 'object') return objIntToString(item, converters)
 }
 
-export function arrayIntToString(arr: any, converters: any) {
-  return arr.map((item: any) => itemIntToString(item, converters))
+export function arrayIntToString(arr: {}[], converters: Converters) {
+  return arr.map(item => itemIntToString(item, converters))
 }
 
 export function objIntToString(obj: any, converters: any) {
@@ -74,23 +86,29 @@ export function objIntToString(obj: any, converters: any) {
   return newObj
 }
 
-export function extractFromNeoObjects(obj: any, converters: any) {
+export function extractFromNeoObjects(obj: any, converters: Converters) {
   if (
     obj instanceof (neo4j.types.Node as any) ||
     obj instanceof (neo4j.types.Relationship as any)
   ) {
     return obj.properties
   } else if (obj instanceof (neo4j.types.Path as any)) {
-    return [].concat.apply([], extractPathForRows(obj, converters))
+    return [].concat.apply<any[], any[], any[]>(
+      [],
+      extractPathForRows(obj, converters)
+    )
   }
   return obj
 }
 
-const extractPathForRows = (path: any, converters: any) => {
+const extractPathForRows = (
+  path: typeof neo4j.Path,
+  converters: Converters
+) => {
   let segments = path.segments
   // Zero length path. No relationship, end === start
   if (!Array.isArray(path.segments) || path.segments.length < 1) {
-    segments = [{ ...path, end: null }]
+    segments = [{ ...path, end: null } as any]
   }
   return segments.map((segment: any) =>
     [
@@ -152,7 +170,7 @@ const collectHits = function(operator: any) {
 }
 
 export function extractNodesAndRelationshipsFromRecords(
-  records: any,
+  records: typeof neo4j.types.Record[],
   types = neo4j.types,
   maxFieldItems?: any
 ) {
@@ -170,10 +188,10 @@ export function extractNodesAndRelationshipsFromRecords(
 }
 
 export function extractNodesAndRelationshipsFromRecordsForOldVis(
-  records: any,
+  records: typeof neo4j.types.Record[],
   types: any,
   filterRels: any,
-  converters: any,
+  converters: Converters,
   maxFieldItems?: any
 ) {
   if (records.length === 0) {
@@ -233,7 +251,7 @@ export const recursivelyExtractGraphItems = (types: any, item: any): any => {
 }
 
 export function extractRawNodesAndRelationShipsFromRecords(
-  records: any,
+  records: typeof neo4j.types.Record[],
   types = neo4j.types,
   maxFieldItems: any
 ) {
@@ -336,7 +354,10 @@ export const flattenProperties = (rows: any) => {
   )
 }
 
-export const applyGraphTypes = (rawItem: any, types = neo4j.types): any => {
+export const applyGraphTypes = (
+  rawItem: any,
+  types: any = neo4j.types
+): any => {
   if (rawItem === null || rawItem === undefined) {
     return rawItem
   } else if (Array.isArray(rawItem)) {
@@ -450,7 +471,7 @@ export const applyGraphTypes = (rawItem: any, types = neo4j.types): any => {
 
 export const recursivelyTypeGraphItems = (
   item: any,
-  types = neo4j.types
+  types: any = neo4j.types
 ): any => {
   if (item === null || item === undefined) {
     return item

--- a/src/shared/services/bolt/boltWorker.ts
+++ b/src/shared/services/bolt/boltWorker.ts
@@ -98,11 +98,15 @@ const onmessage = function(message: {
     } = message.data
     beforeWork()
     const { txMetadata, useDb, autoCommit } = connectionProperties
-    ensureConnection(connectionProperties, connectionProperties.opts, () => {
-      ;((self as unknown) as ServiceWorker).postMessage(
-        boltConnectionErrorMessage(createErrorObject(BoltConnectionError))
-      )
-    })
+    ensureConnection(
+      connectionProperties as any,
+      connectionProperties.opts,
+      () => {
+        ;((self as unknown) as ServiceWorker).postMessage(
+          boltConnectionErrorMessage(createErrorObject(BoltConnectionError))
+        )
+      }
+    )
       .then(() => {
         const res: any = connectionTypeMap[connectionType].create(
           input,

--- a/src/shared/services/bolt/boltWorkerMessages.ts
+++ b/src/shared/services/bolt/boltWorkerMessages.ts
@@ -17,6 +17,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+
+import { Action, AnyAction } from 'redux'
+
 import { recursivelyTypeGraphItems } from './boltMappings'
 import { ROUTED_WRITE_CONNECTION } from './boltConnection'
 
@@ -29,13 +32,13 @@ export const BOLT_CONNECTION_ERROR_MESSAGE = 'BOLT_CONNECTION_ERROR_MESSAGE'
 export const CLOSE_CONNECTION_MESSAGE = 'CLOSE_CONNECTION_MESSAGE'
 
 export const runCypherMessage = (
-  input: any,
-  parameters: any,
+  input: string,
+  parameters: unknown,
   connectionType = ROUTED_WRITE_CONNECTION,
   requestId = null,
   cancelable = false,
-  connectionProperties: any
-) => {
+  connectionProperties: unknown
+): AnyAction => {
   return {
     type: RUN_CYPHER_MESSAGE,
     input,
@@ -47,40 +50,43 @@ export const runCypherMessage = (
   }
 }
 
-export const cancelTransactionMessage = (id: any) => {
+export const cancelTransactionMessage = (id: string): AnyAction => {
   return {
     type: CANCEL_TRANSACTION_MESSAGE,
     id
   }
 }
 
-export const cypherResponseMessage = (result: any) => {
+export const cypherResponseMessage = (result: unknown): AnyAction => {
   return {
     type: CYPHER_RESPONSE_MESSAGE,
     result: recursivelyTypeGraphItems(result)
   }
 }
 
-export const cypherErrorMessage = (error: any) => {
+export const cypherErrorMessage = (error: {
+  code: number
+  message: string
+}): AnyAction => {
   return {
     type: CYPHER_ERROR_MESSAGE,
     error
   }
 }
 
-export const postCancelTransactionMessage = () => {
+export const postCancelTransactionMessage = (): Action => {
   return {
     type: POST_CANCEL_TRANSACTION_MESSAGE
   }
 }
 
-export const boltConnectionErrorMessage = (error: any) => {
+export const boltConnectionErrorMessage = (error: Error): AnyAction => {
   return {
     type: BOLT_CONNECTION_ERROR_MESSAGE,
     error
   }
 }
 
-export const closeConnectionMessage = () => ({
+export const closeConnectionMessage = (): Action => ({
   type: CLOSE_CONNECTION_MESSAGE
 })

--- a/src/shared/services/bolt/driverFactory.ts
+++ b/src/shared/services/bolt/driverFactory.ts
@@ -18,15 +18,15 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import neo4j from 'neo4j-driver'
+import neo4j, { AuthToken, Config, Driver } from 'neo4j-driver'
 import { version } from 'project-root/package.json'
 
 export const createDriverOrFailFn = (
-  url: any,
-  auth: any,
-  opts: any,
-  failFn: any = () => {}
-) => {
+  url: string,
+  auth: AuthToken,
+  opts: Config,
+  failFn: (error: Error) => void = () => {}
+): Driver | null => {
   // This is needed, I haven't figured out why. I don't find any mutations to
   // the object, so not sure what's going on.
   const spreadOpts = { ...opts, userAgent: `neo4j-browser/v${version}` }

--- a/src/shared/services/boltscheme.utils.ts
+++ b/src/shared/services/boltscheme.utils.ts
@@ -21,18 +21,21 @@
 const BOLT_DIRECT_SCHEME = 'bolt'
 const BOLT_ROUTING_SCHEME = 'neo4j'
 
-export const isNonSupportedRoutingSchemeError = (e: any) =>
+export const isNonSupportedRoutingSchemeError = (e: {
+  code: string
+  message: string
+}) =>
   e.code === 'ServiceUnavailable' &&
   e.message.includes('Could not perform discovery')
 
 export const isNonRoutingScheme = (url = '') =>
   typeof url === 'string' && url.startsWith(`${BOLT_DIRECT_SCHEME}://`)
 
-export const toNonRoutingScheme = (url: any) =>
+export const toNonRoutingScheme = (url: string) =>
   typeof url === 'string' &&
   `${BOLT_DIRECT_SCHEME}${getSchemeFlag(url)}://${stripScheme(url)}`
 
-export const getScheme = (url: any) => {
+export const getScheme = (url: string) => {
   if (!url) {
     return ''
   }
@@ -43,7 +46,7 @@ export const getScheme = (url: any) => {
   return scheme
 }
 
-export const stripScheme = (url: any) => {
+export const stripScheme = (url: string) => {
   const [_scheme, ...rest] = (url || '').split('://')
   if (!rest || !rest.length) {
     return _scheme
@@ -51,7 +54,7 @@ export const stripScheme = (url: any) => {
   return rest.join('://')
 }
 
-export const isSecureBoltScheme = (url: any) => {
+export const isSecureBoltScheme = (url: string) => {
   if (url && !url.includes('://')) {
     return false
   }
@@ -72,7 +75,7 @@ export const getSchemeFlag = (url = '') => {
   }
   return `+${scheme.split('+').pop()}`
 }
-const stripSchemeFlag = (url: any) => {
+const stripSchemeFlag = (url: string) => {
   if (url && !url.includes('://')) {
     return ''
   }
@@ -83,7 +86,7 @@ const stripSchemeFlag = (url: any) => {
   return scheme.split('+')[0]
 }
 
-const toggleSchemeSecurity = (url: any) => {
+const toggleSchemeSecurity = (url: string) => {
   if (url && !url.includes('://')) {
     return url
   }
@@ -111,11 +114,11 @@ export const toggleSchemeRouting = (url = '') => {
 }
 
 export const generateBoltUrl = (
-  allowedSchemes: any,
-  url: any,
-  fallbackScheme?: any
+  allowedSchemes: string[],
+  url: string,
+  fallbackScheme?: string
 ) => {
-  const rewrites: any = {
+  const rewrites: Record<string, string> = {
     'bolt+routing://': `${BOLT_ROUTING_SCHEME}://`
   }
 

--- a/src/shared/services/utils.test.ts
+++ b/src/shared/services/utils.test.ts
@@ -559,34 +559,34 @@ describe('Object props manipulation', () => {
   const res1 = { x: 1, y: 2, z: { zz: 1 } }
   const res2 = { '\\x': 1, x: 2 }
   const res3 = { x: 4, '\\x': 1, '\\\\x': 2, '\\\\\\x': 3 }
-  test('safetlyAddObjectProp adds prop if no collision', () => {
+  test('safelyAddObjectProp adds prop if no collision', () => {
     const orig = { ...start1 }
-    const res = utils.safetlyAddObjectProp(orig, 'y', 2)
+    const res = utils.safelyAddObjectProp(orig, 'y', 2)
     expect(res).toEqual({ ...res1 })
   })
-  test('safetlyAddObjectProp escapes existing props if collision', () => {
+  test('safelyAddObjectProp escapes existing props if collision', () => {
     const orig = { ...start2 }
-    const res = utils.safetlyAddObjectProp(orig, 'x', 2)
+    const res = utils.safelyAddObjectProp(orig, 'x', 2)
     expect(res).toEqual({ ...res2 })
   })
-  test('safetlyAddObjectProp escapes existing props if collision chain', () => {
+  test('safelyAddObjectProp escapes existing props if collision chain', () => {
     const orig = { ...start3 }
-    const res = utils.safetlyAddObjectProp(orig, 'x', 4)
+    const res = utils.safelyAddObjectProp(orig, 'x', 4)
     expect(res).toEqual({ ...res3 })
   })
-  test('safetlyRemoveObjectProp removes when no escapes', () => {
+  test('safelyRemoveObjectProp removes when no escapes', () => {
     const orig = { ...res1 }
-    const res = utils.safetlyRemoveObjectProp(orig, 'y')
+    const res = utils.safelyRemoveObjectProp(orig, 'y')
     expect(res).toEqual({ ...start1 })
   })
-  test('safetlyRemoveObjectProp removes when one escape', () => {
+  test('safelyRemoveObjectProp removes when one escape', () => {
     const orig = { ...res2 }
-    const res = utils.safetlyRemoveObjectProp(orig, 'x')
+    const res = utils.safelyRemoveObjectProp(orig, 'x')
     expect(res).toEqual({ ...start2 })
   })
-  test('safetlyRemoveObjectProp removes when chained escapes', () => {
+  test('safelyRemoveObjectProp removes when chained escapes', () => {
     const orig = { ...res3 }
-    const res = utils.safetlyRemoveObjectProp(orig, 'x')
+    const res = utils.safelyRemoveObjectProp(orig, 'x')
     expect(res).toEqual({ ...start3 })
   })
   describe('escaping reserved props', () => {

--- a/src/shared/services/utils.test.ts
+++ b/src/shared/services/utils.test.ts
@@ -424,13 +424,6 @@ describe('utils', () => {
         expect(res).toEqual(tCase.expect)
       })
     })
-    test('can remove commented lines from a string', () => {
-      // Given
-      const stringWithComments = '//Hello is is a comment\nSome string'
-
-      // When & Then
-      expect(utils.removeComments(stringWithComments)).toEqual('Some string')
-    })
   })
   test('stringifyMod works just as JSON.stringify with no modFn', () => {
     // Given

--- a/src/shared/services/utils.ts
+++ b/src/shared/services/utils.ts
@@ -263,13 +263,6 @@ export const getBrowserName = function() {
   return 'Unknown'
 }
 
-export const removeComments = (string = '') => {
-  return string
-    .split(/\r?\n/)
-    .filter(line => !line.startsWith('//'))
-    .join('\r\n')
-}
-
 export const canUseDOM = () =>
   !!(
     typeof window !== 'undefined' &&
@@ -452,9 +445,6 @@ const getUnescapedObjectProp = (prop: any) =>
 
 export const hasReservedProp = (obj: any, propName: any) =>
   Object.prototype.hasOwnProperty.call(obj, propName)
-
-// Epic helpers
-export const put = (dispatch: any) => (action: any) => dispatch(action)
 
 export const optionalToString = (v: any) =>
   ![null, undefined].includes(v) && typeof v.toString === 'function'

--- a/src/shared/services/utils.ts
+++ b/src/shared/services/utils.ts
@@ -396,13 +396,13 @@ export const stringifyMod = (
 export const unescapeDoubleQuotesForDisplay = (str: any) =>
   str.replace(/\\"/g, '"')
 
-export const safetlyAddObjectProp = (obj: any, prop: any, val: any): any => {
+export const safelyAddObjectProp = (obj: any, prop: any, val: any): any => {
   const localObj = escapeReservedProps(obj, prop)
   localObj[prop] = val
   return localObj
 }
 
-export const safetlyRemoveObjectProp = (obj: any, prop: any) => {
+export const safelyRemoveObjectProp = (obj: any, prop: any) => {
   if (!hasReservedProp(obj, prop)) {
     return obj
   }
@@ -414,7 +414,7 @@ export const escapeReservedProps = (obj: any, prop: any) => {
   if (!hasReservedProp(obj, prop)) {
     return obj
   }
-  const localObj = safetlyAddObjectProp(
+  const localObj = safelyAddObjectProp(
     obj,
     getEscapedObjectProp(prop),
     obj[prop]


### PR DESCRIPTION
After reading [Dan Flavin's post on waiting for large query results in browser](https://medium.com/neo4j/wheres-my-neo4j-cypher-query-results-%EF%B8%8F-%EF%B8%8F-9c3b150e6e19), I did some performance testing of browser. I found the loop that builds the graph visualisation to be unoptimised and reworked it which lead to a noticeable performance improvement. The first two commits in the branch are the performance improvements.

While testing large query results in a dev build, redux devtools crashed a few times due to out of memory errors. The third commit is a change that omits query results from redux devtools.

The 4th, 5th and 6th commits are code cleanups. They touch many lines so I recommend reviewing commit by commit to not miss other changes. Note that the typing commit does contain some changes to prevent runtime type errors that typescript found with the added type information.