### PR TITLE
Add skeleton docs folders and maps

### DIFF
--- a/docs/antora/antora.yml
+++ b/docs/antora/antora.yml
@@ -1,0 +1,12 @@
+name: browser-manual
+title: Neo4j Browser
+version: '1.0'
+start_page: ROOT:index.adoc
+nav:
+- modules/ROOT/content-nav.adoc
+asciidoc:
+  attributes:
+    neo4j-version: '4.2'
+    neo4j-version-exact: '4.2.2'
+    neo4j-buildnumber: '4.2'
+    docs-version: '1.0'

--- a/docs/antora/content-nav.adoc
+++ b/docs/antora/content-nav.adoc
@@ -1,0 +1,1 @@
+* xref:index.adoc[]

--- a/docs/asciidoc/index.adoc
+++ b/docs/asciidoc/index.adoc
@@ -1,0 +1,24 @@
+[[browser]]
+= Neo4j Browser
+:experimental:
+:sectnums:
+:chapter-label:
+:toc-title: Contents
+//:front-cover-image: image::title-page.png[]
+:header-title: NEO4J BROWSER
+:title-page-background-image: image::title-page.png[]
+
+ifndef::backend-pdf[]
+License: link:{common-license-page-uri}[Creative Commons 4.0]
+endif::[]
+
+ifdef::backend-pdf[]
+(C) {copyright}
+
+License: <<license, Creative Commons 4.0>>
+endif::[]
+
+{nbsp} +
+
+[.lead]
+*Neo4j Browser*

--- a/docs/docbook/content-map.xml
+++ b/docs/docbook/content-map.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<d:toc xmlns:d="http://docbook.org/ns/docbook" xmlns="http://www.w3.org/1999/xhtml" role="chunk-toc">
+  <d:tocentry linkend="browser"><?dbhtml filename="index.html"?>
+  </d:tocentry>
+</d:toc>


### PR DESCRIPTION
Hi @oskarhane & @linuslundahl

This PR adds the basic docs infrastructure for us to start building a draft manual. New content can go into the /asciidoc folder when we have some source material, and linked up in the content maps in the /antora folder and /docbook folder.

FYI @AlexicaWright & @recrwplay

