### PR TITLE
Track canny usage

### DIFF
--- a/src/browser/components/TabNavigation/Navigation.tsx
+++ b/src/browser/components/TabNavigation/Navigation.tsx
@@ -135,14 +135,13 @@ class Navigation extends Component<NavigationProps, NavigationState> {
       list.map(item => {
         const isOpen = item.name.toLowerCase() === selected
         return (
-          <>
+          <div key={item.name}>
             {item.enableCannyBadge ? (
               <StyledCannyBadgeAnchor data-canny-changelog />
             ) : null}
             <NavigationButtonContainer
               title={item.title}
               data-testid={'drawer' + item.name}
-              key={item.name}
               onClick={() => onNavClick(item.name.toLowerCase())}
               isOpen={isOpen}
             >
@@ -150,7 +149,7 @@ class Navigation extends Component<NavigationProps, NavigationState> {
                 {item.icon(isOpen)}
               </StyledNavigationButton>
             </NavigationButtonContainer>
-          </>
+          </div>
         )
       })
 

--- a/src/browser/modules/Sidebar/Documents.tsx
+++ b/src/browser/modules/Sidebar/Documents.tsx
@@ -17,13 +17,18 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import React, { useEffect } from 'react'
+import React, { Dispatch, useEffect } from 'react'
 import { connect } from 'react-redux'
+import { Action } from 'redux'
 import semver from 'semver'
 
 import { cannyOptions, CANNY_FEATURE_REQUEST_URL } from 'browser-services/canny'
 import { GlobalState } from 'shared/globalState'
 import { getVersion } from 'shared/modules/dbMeta/dbMetaDuck'
+import {
+  TRACK_CANNY_CHANGELOG,
+  TRACK_CANNY_FEATURE_REQUEST
+} from 'shared/modules/sidebar/sidebarDuck'
 import DocumentItems from './DocumentItems'
 import { Drawer, DrawerHeader } from 'browser-components/drawer'
 import {
@@ -131,9 +136,14 @@ const guides = [
   }
 ]
 
-type DocumentsProps = { version: string; urlVersion: string }
+type DocumentsProps = {
+  version: string
+  urlVersion: string
+  trackCannyChangelog: () => void
+  trackCannyFeatureRequest: () => void
+}
 
-const Documents = ({ version, urlVersion }: DocumentsProps) => {
+const Documents = (props: DocumentsProps) => {
   useEffect(() => {
     window.Canny && window.Canny('initChangelog', cannyOptions)
 
@@ -142,12 +152,12 @@ const Documents = ({ version, urlVersion }: DocumentsProps) => {
     }
   }, [])
 
-  const { docs, other } = getReferences(version, urlVersion)
+  const { docs, other } = getReferences(props.version, props.urlVersion)
   return (
     <Drawer id="db-documents">
       <StyledHeaderContainer>
         <DrawerHeader>Help &amp; Learn</DrawerHeader>
-        <a data-canny-changelog>
+        <a data-canny-changelog onClick={props.trackCannyChangelog}>
           <CannyNotificationsIcon />
         </a>
       </StyledHeaderContainer>
@@ -159,7 +169,10 @@ const Documents = ({ version, urlVersion }: DocumentsProps) => {
             &nbsp; Send Feedback
           </>
         }
-        onClick={() => window.open(CANNY_FEATURE_REQUEST_URL, '_blank')}
+        onClick={() => {
+          props.trackCannyFeatureRequest()
+          window.open(CANNY_FEATURE_REQUEST_URL, '_blank')
+        }}
       ></StyledFeedbackButton>
       <StyledFullSizeDrawerBody>
         <DocumentItems header="Useful commands" items={useful} />
@@ -179,4 +192,13 @@ const mapStateToProps = (state: GlobalState) => {
   }
 }
 
-export default connect(mapStateToProps)(Documents)
+const mapDispatchToProps = (dispatch: Dispatch<Action>) => ({
+  trackCannyChangelog: () => {
+    dispatch({ type: TRACK_CANNY_CHANGELOG })
+  },
+  trackCannyFeatureRequest: () => {
+    dispatch({ type: TRACK_CANNY_FEATURE_REQUEST })
+  }
+})
+
+export default connect(mapStateToProps, mapDispatchToProps)(Documents)

--- a/src/shared/globalState.ts
+++ b/src/shared/globalState.ts
@@ -55,10 +55,7 @@ import {
 } from './modules/sync/syncDuck'
 import { NAME as folders, Folder } from './modules/favorites/foldersDuck'
 import { NAME as commands } from './modules/commands/commandsDuck'
-import {
-  NAME as udc,
-  initialState as udcInitialState
-} from './modules/udc/udcDuck'
+import { NAME as udc, udcState } from './modules/udc/udcDuck'
 import { NAME as app } from './modules/app/appDuck'
 import {
   NAME as experimentalFeatures,
@@ -83,7 +80,7 @@ export interface GlobalState {
   [syncConsent]: typeof initialConsentState
   [folders]: Folder[]
   [commands]: unknown
-  [udc]: typeof udcInitialState
+  [udc]: udcState
   [app]: Record<string, unknown>
   [experimentalFeatures]: typeof experimentalFeaturesInitialState
 }

--- a/src/shared/modules/sidebar/sidebarDuck.ts
+++ b/src/shared/modules/sidebar/sidebarDuck.ts
@@ -25,6 +25,9 @@ export const NAME = 'sidebar'
 export const TOGGLE = 'sidebar/TOGGLE'
 export const OPEN = 'sidebar/OPEN'
 export const SET_DRAFT_SCRIPT = 'sidebar/SET_DRAFT_SCRIPT'
+export const TRACK_CANNY_CHANGELOG = 'sidebar/CANNY_CHANGELOG_OPENED'
+export const TRACK_CANNY_FEATURE_REQUEST =
+  'sidebar/CANNY_FEATURE_REQUEST_OPENED'
 
 export function getOpenDrawer(state: GlobalState): string | null {
   return state[NAME].drawer


### PR DESCRIPTION
This PR adds two tracking events, one for the canny change log button and one for the canny feature requests button.

I also fixed a react warning about missing key attribute in `Navigation.tsx` and some typescript warnings and a spelling mistake in `udcDuck.ts`.