### PR TITLE
Autocollapse reusable editor when not in use

### DIFF
--- a/src/browser/modules/Frame/styled.tsx
+++ b/src/browser/modules/Frame/styled.tsx
@@ -191,6 +191,19 @@ export const FrameTitleEditorContainer = styled.div`
   .disable-font-ligatures & {
     font-variant-ligatures: none !important;
   }
+
+  overflow: hidden;
+  max-height: 30px;
+
+  &:not(:focus-within):hover .view-line span {
+    color: ${props => props.theme.linkHover};
+    text-decoration: underline;
+  }
+
+  &:focus-within {
+    overflow: unset;
+    max-height: unset;
+  }
 `
 
 export const StyledFrameCommand = styled.label<{ selectedDb: string }>`


### PR DESCRIPTION
This is a pure css change that collapses the editor when it doesn't have focus to preserve space in the stream.

Preview @ http://autocollapse.surge.sh
![CleanShot 2021-02-22 at 14 50 54](https://user-images.githubusercontent.com/10564538/108719176-89b97200-751f-11eb-8153-8e748129a721.gif)

