### PR TITLE
Fix unreadable text

### DIFF
--- a/src/browser/modules/Carousel/style.less
+++ b/src/browser/modules/Carousel/style.less
@@ -59,8 +59,9 @@
   & pre,
   & samp,
   & figure pre {
-    font-family:"Fira Code", "Monaco", "Lucida Console", Courier, monospace;
+    font-family: 'Fira Code', 'Monaco', 'Lucida Console', Courier, monospace;
     background: #f3f3f3;
+    color: #333;
     padding-left: 0.25em;
     padding-right: 0.25em;
     white-space: pre-wrap;
@@ -87,7 +88,6 @@
       border: transparent;
       border-radius: 2px;
       background-color: rgba(0, 0, 0, 0.1);
-    
     }
     &.clicked {
       border: 2px solid #8dd465;
@@ -293,7 +293,9 @@
     border-radius: 3px;
     border: 0px;
     display: inline-block;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif /*"Fira Code",Monaco,"Courier New",Terminal,monospace*/;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen,
+      Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue',
+      sans-serif /*"Fira Code",Monaco,"Courier New",Terminal,monospace*/;
     font-size: 12px;
     line-height: 18px;
     margin-bottom: 5px;
@@ -336,8 +338,6 @@
     border-radius: 4px;
     border: 0;
     display: inline-block;
-
-
   }
   .teasers {
     display: flex;
@@ -353,7 +353,8 @@
     height: 270px;
     float: left;
     position: relative;
-    box-shadow: 0px 0px 2px rgba(52, 58, 67, 0.1), 0px 1px 2px rgba(52, 58, 67, 0.08), 0px 1px 4px rgba(52, 58, 67, 0.08);
+    box-shadow: 0px 0px 2px rgba(52, 58, 67, 0.1),
+      0px 1px 2px rgba(52, 58, 67, 0.08), 0px 1px 4px rgba(52, 58, 67, 0.08);
     &.teaser-2 {
       width: 45%;
       min-width: 285px;

--- a/src/browser/modules/D3Visualization/lib/visualization/components/queryPlan.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/queryPlan.ts
@@ -489,7 +489,7 @@ function queryPlan(this: any, element: any) {
         ].join(' ')
       )
 
-    var join = (parent: any, children: any) =>
+    const join = (parent: any, children: any) =>
       ((): any[] => {
         const result = []
         for (const child of Array.from(d3.entries<any>(children))) {
@@ -607,6 +607,7 @@ function queryPlan(this: any, element: any) {
                     .append('text')
                     .attr('font-size', detailFontSize)
                     .attr('font-family', standardFont)
+                    .attr('fill', 'rgb(107, 174, 214)')
 
                   return update
                     .transition()


### PR DESCRIPTION
Mitigates #1241 by using blue instead of black text. Not perfect, but at least it's visible now. Also sets color for the code blocks so they are readable in dark mode, the other changes in style.less are autoformatting.

:help match before
![bild](https://user-images.githubusercontent.com/10564538/108837123-17ee3080-75d2-11eb-8851-d18e6fa44006.png)

:help match after
<img width="675" alt="bild" src="https://user-images.githubusercontent.com/10564538/108837225-3b18e000-75d2-11eb-8f61-6a1df9cef8ed.png">

Preview at: http://unreadable_text.surge.sh