### PR TITLE
Reusable frame history bug fix

### DIFF
--- a/src/browser/components/ClickableUrls.tsx
+++ b/src/browser/components/ClickableUrls.tsx
@@ -21,18 +21,19 @@ import React from 'react'
 const URL_REGEX = /(?:https?|s?ftp|bolt):\/\/(?:(?:[^\s()<>]+|\((?:[^\s()<>]+|(?:\([^\s()<>]+\)))?\))+(?:\((?:[^\s()<>]+|(?:\(?:[^\s()<>]+\)))?\)|[^\s`!()\[\]{};:'".,<>?«»“”‘’]))?/gi
 
 interface ClickableUrlsProps {
-  text: string
+  text?: string | null
   WrappingTag?: keyof JSX.IntrinsicElements
 }
 
 export default function ClickableUrls({
-  text = '',
+  text,
   WrappingTag = 'span'
 }: ClickableUrlsProps): JSX.Element {
-  const urls = text.match(URL_REGEX) || []
+  const definedText = text || ''
+  const urls = definedText.match(URL_REGEX) || []
   return (
     <WrappingTag>
-      {text.split(URL_REGEX).map((text, index) => {
+      {definedText.split(URL_REGEX).map((text, index) => {
         /* since we never move these components this key should be fine */
         return (
           <React.Fragment key={index}>

--- a/src/browser/modules/Editor/Monaco.tsx
+++ b/src/browser/modules/Editor/Monaco.tsx
@@ -39,6 +39,7 @@ import { Bus } from 'suber'
 
 import { NEO4J_BROWSER_USER_ACTION_QUERY } from 'services/bolt/txMetadata'
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
+import { debug } from 'webpack'
 
 const shouldCheckForHints = (code: any) =>
   code.trim().length > 0 &&

--- a/src/browser/modules/Frame/FrameTitlebar.tsx
+++ b/src/browser/modules/Frame/FrameTitlebar.tsx
@@ -259,7 +259,9 @@ function FrameTitlebar(props: FrameTitleBarProps) {
   const { frame = {} } = props
   const fullscreenIcon = props.fullscreen ? <ContractIcon /> : <ExpandIcon />
   const expandCollapseIcon = props.collapse ? <DownIcon /> : <UpIcon />
-
+  // the last run command (history index 1) is already in the editor
+  // don't show it as history as well
+  const history = (frame.history || []).slice(1)
   return (
     <StyledFrameTitleBar>
       <FeatureToggle
@@ -267,7 +269,7 @@ function FrameTitlebar(props: FrameTitleBarProps) {
         on={
           <FrameTitleEditorContainer data-testid="frameCommand">
             <Monaco
-              history={frame.history || []}
+              history={history}
               useDb={frame.useDb}
               enableMultiStatementMode={true}
               id={`editor-${frame.id}`}


### PR DESCRIPTION
You have to press the up arrow twice to go to the previous query without these changes.