### PR TITLE
Update query when clicking links in frame

### DIFF
--- a/src/browser/components/Directives.tsx
+++ b/src/browser/components/Directives.tsx
@@ -126,11 +126,12 @@ export const Directives = (props: any) => {
 
 const mapDispatchToProps = (_dispatch: any, ownProps: any) => {
   return {
-    onItemClick: (cmd: any, autoExec: any, id: any) => {
+    onItemClick: (cmd: string, autoExec: boolean, id: string) => {
       if (!cmd.endsWith(' null') && !cmd.endsWith(':null')) {
         if (autoExec) {
           const action = executeCommand(cmd, {
             id,
+            isRerun: true,
             source: commandSources.button
           })
           ownProps.bus.send(action.type, action)

--- a/src/browser/modules/Frame/FrameTitlebar.tsx
+++ b/src/browser/modules/Frame/FrameTitlebar.tsx
@@ -90,10 +90,8 @@ import arrayHasItems from 'shared/utils/array-has-items'
 import { stringifyMod } from 'services/utils'
 import Monaco, { MonacoHandles } from '../Editor/Monaco'
 import { Bus } from 'suber'
-import FeatureToggle from '../FeatureToggle/FeatureToggle'
-import { reusableFrame } from 'shared/modules/experimentalFeatures/experimentalFeaturesDuck'
 import { addFavorite } from 'shared/modules/favorites/favoritesDuck'
-import uuid from 'uuid'
+import { useCustomBlur } from 'browser-components/SavedScripts/hooks'
 
 type FrameTitleBarBaseProps = {
   frame: any
@@ -131,6 +129,7 @@ type FrameTitleBarProps = FrameTitleBarBaseProps & {
 
 function FrameTitlebar(props: FrameTitleBarProps) {
   const [editorValue, setEditorValue] = useState(props.frame.cmd)
+  const [renderEditor, setRenderEditor] = useState(false)
   const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false)
   const editorRef = useRef<MonacoHandles>(null)
 
@@ -264,34 +263,30 @@ function FrameTitlebar(props: FrameTitleBarProps) {
   const history = (frame.history || []).slice(1)
   return (
     <StyledFrameTitleBar>
-      <FeatureToggle
-        name={reusableFrame}
-        on={
-          <FrameTitleEditorContainer data-testid="frameCommand">
-            <Monaco
-              history={history}
-              useDb={frame.useDb}
-              enableMultiStatementMode={true}
-              id={`editor-${frame.id}`}
-              bus={props.bus}
-              onChange={setEditorValue}
-              onExecute={run}
-              value={editorValue}
-              ref={editorRef}
-              toggleFullscreen={props.fullscreenToggle}
-            />
-          </FrameTitleEditorContainer>
-        }
-        off={
-          <StyledFrameCommand
-            selectedDb={frame.useDb}
-            onClick={() => props.onTitlebarClick(editorValue)}
-            data-testid="frameCommand"
-          >
-            <DottedLineHover>{editorValue}</DottedLineHover>
-          </StyledFrameCommand>
-        }
-      />
+      {renderEditor ? (
+        <FrameTitleEditorContainer data-testid="frameCommand">
+          <Monaco
+            history={history}
+            useDb={frame.useDb}
+            enableMultiStatementMode={true}
+            id={`editor-${frame.id}`}
+            bus={props.bus}
+            onChange={setEditorValue}
+            onExecute={run}
+            value={editorValue}
+            ref={editorRef}
+            toggleFullscreen={props.fullscreenToggle}
+          />
+        </FrameTitleEditorContainer>
+      ) : (
+        <StyledFrameCommand
+          selectedDb={frame.useDb}
+          onClick={() => setRenderEditor(true)}
+          data-testid="frameCommand"
+        >
+          <DottedLineHover>{editorValue.split('\n').join(' ')}</DottedLineHover>
+        </StyledFrameCommand>
+      )}
       <StyledFrameTitlebarButtonSection>
         <FrameButton
           data-testid="rerunFrameButton"

--- a/src/browser/modules/Frame/FrameTitlebar.tsx
+++ b/src/browser/modules/Frame/FrameTitlebar.tsx
@@ -129,7 +129,11 @@ type FrameTitleBarProps = FrameTitleBarBaseProps & {
 
 function FrameTitlebar(props: FrameTitleBarProps) {
   const [editorValue, setEditorValue] = useState(props.frame.cmd)
-  const [renderEditor, setRenderEditor] = useState(false)
+  useEffect(() => {
+    // makes sure the frame is updated as links in frame is followed
+    editorRef.current?.setValue(props.frame.cmd)
+  }, [props.frame.cmd])
+  const [renderEditor, setRenderEditor] = useState(props.frame.isRerun)
   const [confirmationDialogOpen, setConfirmationDialogOpen] = useState(false)
   const editorRef = useRef<MonacoHandles>(null)
 

--- a/src/browser/modules/Frame/styled.tsx
+++ b/src/browser/modules/Frame/styled.tsx
@@ -191,19 +191,6 @@ export const FrameTitleEditorContainer = styled.div`
   .disable-font-ligatures & {
     font-variant-ligatures: none !important;
   }
-
-  overflow: hidden;
-  max-height: 30px;
-
-  &:not(:focus-within):hover .view-line span {
-    color: ${props => props.theme.linkHover};
-    text-decoration: underline;
-  }
-
-  &:focus-within {
-    overflow: unset;
-    max-height: unset;
-  }
 `
 
 export const StyledFrameCommand = styled.label<{ selectedDb: string }>`

--- a/src/browser/modules/Stream/CypherFrame/index.test.tsx
+++ b/src/browser/modules/Stream/CypherFrame/index.test.tsx
@@ -36,7 +36,7 @@ const createProps = (status: string, result: BrowserRequestResult) => ({
   maxRows: 10,
   maxNeighbours: 10,
   recentView: null,
-  frame: {} as Frame,
+  frame: { cmd: 'return 1' } as Frame,
   request: {
     status,
     updated: Math.random(),

--- a/src/browser/modules/Stream/EditFrame.test.tsx
+++ b/src/browser/modules/Stream/EditFrame.test.tsx
@@ -29,7 +29,8 @@ import { Frame } from 'shared/modules/stream/streamDuck'
 describe('EditFrame', () => {
   it('creates a monaco instance with a unique id based on frame id', () => {
     const id = 'some-frame-id'
-    const frame = { id } as Frame
+    const cmd = ':edit'
+    const frame = { id, cmd } as Frame
     const { container } = render(
       <Provider
         store={configureStore()({ settings: {}, app: {}, sidebar: {} })}

--- a/src/browser/modules/Stream/styled.tsx
+++ b/src/browser/modules/Stream/styled.tsx
@@ -49,6 +49,7 @@ export const DottedLineHover = styled.span`
     border-bottom: 1px dotted #b6adad;
     padding-bottom: 2px;
   }
+  text-overflow: ellipsis;
 `
 
 export const StyledHelpFrame = styled.div`

--- a/src/shared/modules/experimentalFeatures/experimentalFeaturesDuck.ts
+++ b/src/shared/modules/experimentalFeatures/experimentalFeaturesDuck.ts
@@ -9,7 +9,6 @@ export const showFeature = (state: any, name: any) =>
   !!(state[NAME][name] || {}).on
 
 export const experimentalFeatureSelfName = 'showSelf'
-export const reusableFrame = 'reusableFrame'
 
 export const initialState = {
   [experimentalFeatureSelfName]: {
@@ -17,12 +16,6 @@ export const initialState = {
     on: true,
     displayName: 'Show experimental features',
     tooltip: 'Show feature section in settings drawer'
-  },
-  [reusableFrame]: {
-    name: reusableFrame,
-    on: true,
-    displayName: 'Enable reuseable frame',
-    tooltip: 'Edit and rerun right in a frame'
   }
 }
 


### PR DESCRIPTION
This PR makes sure the query is updated when pressing links in frames, such as :help cypher from the :help frame.

http://correct_query_header.surge.sh