### PR TITLE
Fix: AsciiView ligatures disable

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/AsciiView.tsx
+++ b/src/browser/modules/Stream/CypherFrame/AsciiView.tsx
@@ -30,7 +30,8 @@ import {
   StyledRightPartial,
   StyledWidthSliderContainer,
   StyledWidthSlider,
-  StyledTruncatedMessage
+  StyledTruncatedMessage,
+  StyledAsciiPre
 } from '../styled'
 import {
   getBodyAndStatusBarMessages,
@@ -56,8 +57,11 @@ interface BaseAsciiViewComponentProps {
 interface AsciiViewComponentProps extends BaseAsciiViewComponentProps {
   maxFieldItems: number
 }
+
+type SerializedRows = string[][]
+
 interface AsciiViewComponentState {
-  serializedRows: string[]
+  serializedRows: SerializedRows
   bodyMessage: string | null
 }
 
@@ -122,6 +126,16 @@ export class AsciiViewComponent extends Component<
     this.props.setAsciiMaxColWidth(maxColWidth)
   }
 
+  /**
+   * Replaces newline characters, with a double \\ to escape newline in render
+   */
+  removeNewlines(serializedRows: SerializedRows): SerializedRows {
+    const newSerializedRows: SerializedRows = serializedRows.map(row => {
+      return row.map(value => value.replace('\n', '\\n'))
+    })
+    return newSerializedRows
+  }
+
   render(): JSX.Element {
     const { _asciiSetColWidth: maxColWidth = 70 } = this.props
     const { serializedRows, bodyMessage } = this.state
@@ -131,10 +145,11 @@ export class AsciiViewComponent extends Component<
       serializedRows.length &&
       serializedRows[0].length
     ) {
+      const stripedRows = this.removeNewlines(serializedRows)
       contents = (
-        <pre>
-          {asciitable.tableFromSerializedData(serializedRows, maxColWidth)}
-        </pre>
+        <StyledAsciiPre>
+          {asciitable.tableFromSerializedData(stripedRows, maxColWidth)}
+        </StyledAsciiPre>
       )
     }
     return <PaddedDiv>{contents}</PaddedDiv>

--- a/src/browser/modules/Stream/styled.tsx
+++ b/src/browser/modules/Stream/styled.tsx
@@ -178,6 +178,11 @@ export const StyledStatsBar = styled.div`
   padding-left: 24px;
   width: 100%;
 `
+
+export const StyledAsciiPre = styled.pre`
+  font-family: 'Courier New', monospace;
+`
+
 export const StyledTruncatedMessage = styled.span`
   color: orange;
 `


### PR DESCRIPTION
<!--
BEFORE YOU SUBMIT make sure you've done the following:
[x] Done your work in a personal fork of the original repository
[x] Created a branch with a useful name
[x] Include unit tests if appropriate (obviously not necessary for documentation changes)
[x] Made sure the unit and e2e tests all pass
[x] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[x] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

Fixed the ligatures of the `Fira` font family in Text View, by replacing with `Courier New`.

Also replaced `\n` with the escape version `\\n` in table so there are no new lines that will break the ascii table.

Before: ![before](https://user-images.githubusercontent.com/12672541/109321116-12eae480-7851-11eb-910e-e8ac7528769f.png)

After:
![image](https://user-images.githubusercontent.com/12672541/109321383-5e9d8e00-7851-11eb-97d1-ff7250004e16.png)




