### PR TITLE
Hide Peek Problem status bar, disable escape key toggling fullscreen when autocompleting

### DIFF
--- a/src/browser/modules/Editor/Monaco.tsx
+++ b/src/browser/modules/Editor/Monaco.tsx
@@ -200,7 +200,11 @@ const Monaco = forwardRef<MonacoHandles, MonacoProps>(
         KeyMod.CtrlCmd | KeyCode.US_DOT,
         onDisplayHelpKeys
       )
-      editorRef.current.addCommand(KeyCode.Escape, toggleFullscreen)
+      editorRef.current.addCommand(
+        KeyCode.Escape,
+        toggleFullscreen,
+        '!suggestWidgetVisible'
+      )
 
       onContentUpdate()
 

--- a/src/browser/modules/Editor/Monaco.tsx
+++ b/src/browser/modules/Editor/Monaco.tsx
@@ -67,6 +67,11 @@ const MonacoStyleWrapper = styled.div`
   .margin .margin-view-overlays {
     margin-left: 10px;
   }
+
+  // hides the "Peek Problem" status bar on the warnings hover widgets
+  .hover-row.status-bar {
+    display: none !important;
+  }
 `
 
 interface MonacoProps {


### PR DESCRIPTION
Two small fixes, demo: http://peek-problem.surge.sh/