### PR TITLE
Fix issue where fullscreen couldn't be closed

### DIFF
--- a/src/browser/components/FileDrop/styled.tsx
+++ b/src/browser/components/FileDrop/styled.tsx
@@ -43,7 +43,7 @@ export const StyledFileDropInner = styled.div`
     background-color: rgba(0, 0, 0, 0.6);
     opacity: 1;
     transition: opacity 0.2s ease-in-out;
-    z-index: 1000;
+    z-index: 100;
   }
 
   .has-user-select & {

--- a/src/browser/components/SavedScripts/styled.ts
+++ b/src/browser/components/SavedScripts/styled.ts
@@ -162,7 +162,7 @@ export const ContextMenu = styled.div`
   width: 156px;
   left: -156px;
   top: -3px;
-  z-index: 999;
+  z-index: 99;
   border: 1px solid transparent;
   background-color: ${props => props.theme.secondaryBackground};
   border: ${props => props.theme.frameBorder};

--- a/src/browser/modules/App/PerformanceOverlay.tsx
+++ b/src/browser/modules/App/PerformanceOverlay.tsx
@@ -133,7 +133,7 @@ const Overlay = styled.div`
   position: absolute;
   bottom: 10px;
   right: 10px;
-  z-index: 99999999999;
+  z-index: 9999999999;
   padding: 10px;
 `
 

--- a/src/browser/modules/Carousel/styled.tsx
+++ b/src/browser/modules/Carousel/styled.tsx
@@ -114,7 +114,7 @@ const CarouselIndicator = styled.li`
     padding: 5px;
     line-height: 1;
     text-align: center;
-    z-index: 1000;
+    z-index: 100;
     visibility: hidden;
   }
 
@@ -128,7 +128,7 @@ const CarouselIndicator = styled.li`
     pointer-events: none;
     position: absolute;
     transform: translateX(-50%);
-    z-index: 1000;
+    z-index: 100;
     visibility: hidden;
   }
 

--- a/src/browser/modules/Editor/styled.tsx
+++ b/src/browser/modules/Editor/styled.tsx
@@ -53,7 +53,7 @@ export const Frame = styled.div<FullscreenProps>`
   right: 0;
   height: 100vh;
   border-radius: 0;
-  z-index: 1030;
+  z-index: 103;
   margin: 0;
 
   [id^=monaco-] .monaco-editor {

--- a/src/browser/modules/Frame/styled.tsx
+++ b/src/browser/modules/Frame/styled.tsx
@@ -36,7 +36,7 @@ left: 0;
 top: 0;
 bottom: 0;
 right: 0;
-z-index: 1300;`
+z-index: 130;`
       : 'margin 0 0 10px 0;'}
 
   &:hover .carousel-intro-animation {

--- a/src/browser/modules/Stream/styled.tsx
+++ b/src/browser/modules/Stream/styled.tsx
@@ -218,7 +218,7 @@ export const DropdownButton = styled.li`
     fill: ${props => props.theme.secondaryButtonTextHover};
     text-decoration: none;
     position: relative;
-    z-index: 99999;
+    z-index: 9999;
   }
   &:hover {
     > ul li {


### PR DESCRIPTION
Previously fullscreen couldn't be closed after doing the following:
Steps to reproduce

1. Write a query (eg RETURN 1) and execute
2. Update the query in reusable frame (eg make it RETURN 2) and execute
3. Go fullscreen in reusable frame
4. Try to delete the reusable frame with X

This was due to the built in modal going underneath the fullscreen. I decreased all our z-indexes so the modal is now on top.
Preview at http://fullscreen_close.surge.sh