### PR TITLE
remove click handler on editor container

### DIFF
--- a/src/browser/modules/Editor/EditorFrame.tsx
+++ b/src/browser/modules/Editor/EditorFrame.tsx
@@ -69,6 +69,7 @@ import {
 } from 'browser-components/ProjectFiles/projectFilesConstants'
 import { getProjectFileDefaultFileName } from 'browser-components/ProjectFiles/projectFilesUtils'
 import Monaco, { MonacoHandles } from './Monaco'
+import { GlobalState } from 'shared/globalState'
 import {
   codeFontLigatures,
   shouldEnableMultiStatementMode
@@ -252,7 +253,7 @@ export function EditorFrame({
       )}
       <FlexContainer>
         <Header>
-          <EditorContainer onClick={() => editorRef.current?.focus()}>
+          <EditorContainer>
             <Monaco
               bus={bus}
               enableMultiStatementMode={enableMultiStatementMode}
@@ -330,7 +331,7 @@ export function EditorFrame({
   )
 }
 
-const mapStateToProps = (state: any) => {
+const mapStateToProps = (state: GlobalState) => {
   return {
     codeFontLigatures: codeFontLigatures(state),
     enableMultiStatementMode: shouldEnableMultiStatementMode(state),

--- a/src/browser/modules/Editor/styled.tsx
+++ b/src/browser/modules/Editor/styled.tsx
@@ -66,7 +66,6 @@ export const Frame = styled.div<FullscreenProps>`
 `
 
 export const EditorContainer = styled.div`
-  cursor: text;
   display: flex;
   align-items: center;
   flex-grow: 1;


### PR DESCRIPTION
The click handler was causing the search and replace input fields to immediately lose focus when clicking them. The click handler was not necessary since the monaco component fills almost the whole container in any case.

demo: http://search-input-click.surge.sh/

GIFs recorded of opening search and clicking the input fields, before:
![old](https://user-images.githubusercontent.com/939458/109482101-e10a9580-7a7d-11eb-9ca0-0bf93e7d171a.gif)

After:
![new](https://user-images.githubusercontent.com/939458/109482124-e831a380-7a7d-11eb-8f2f-bcfb2f808e43.gif)
