### PR TITLE
Stay in viz when loading new results

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/index.tsx
+++ b/src/browser/modules/Stream/CypherFrame/index.tsx
@@ -27,6 +27,7 @@ import Centered from 'browser-components/Centered'
 import {
   getRequest,
   REQUEST_STATUS_PENDING,
+  REQUEST_STATUS_SUCCESS,
   isCancelStatus,
   BrowserRequest,
   BrowserRequestResult
@@ -171,7 +172,9 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
     }
 
     // When frame re-use leads to result without visualization
-    if (!this.canShowViz() && this.state.openView === viewTypes.VISUALIZATION) {
+    const doneLoading = this.props.request.status === REQUEST_STATUS_SUCCESS
+    const currentlyShowingViz = this.state.openView === viewTypes.VISUALIZATION
+    if (doneLoading && currentlyShowingViz && !this.canShowViz()) {
       const view = initialView(this.props, {
         ...this.state,
         openView: undefined // initial view was not meant to override another view


### PR DESCRIPTION
Sometimes reusable frame switches away from the graph visualisation. Steps to reproduce, with the movie db:
Run:
MATCH (n) RETURN n;
Edit and run:
MATCH (n :Movie) RETURN n; 

should stay as on the viz with these changes.
