### PR TITLE
Hide empty duplicate folders

### DIFF
--- a/src/browser/components/SavedScripts/SavedScripts.tsx
+++ b/src/browser/components/SavedScripts/SavedScripts.tsx
@@ -88,12 +88,24 @@ export default function SavedScripts({
     .filter(script => !script.folder)
     .sort(sortScriptsAlfabethically)
 
-  const foldersWithScripts = folders.map(folder => ({
-    folder,
-    scripts: scripts
-      .filter(script => script.folder === folder.id)
-      .sort(sortScriptsAlfabethically)
-  }))
+  const countFoldersWithName = (name: string) =>
+    folders.filter(folder => folder.name === name).length
+
+  const foldersWithScripts = folders
+    .map(folder => ({
+      folder,
+      scripts: scripts
+        .filter(script => script.folder === folder.id)
+        .sort(sortScriptsAlfabethically)
+    }))
+    .filter(({ folder, scripts }) => {
+      const folderIsEmpty = scripts.length === 0
+      const folderIsDuplicated = countFoldersWithName(folder.name) > 1
+      const isNewFolder = folder.name === 'New Folder'
+      const shouldBeRemoved =
+        folderIsDuplicated && folderIsEmpty && !isNewFolder
+      return !shouldBeRemoved
+    })
 
   const [unNamedFolder, setUnNamedFolder] = useState<string | null>(null)
   const [selectedIds, setSelectedIds] = useState<string[]>([])


### PR DESCRIPTION
Old localstorage state contains duplicated folders, we will want to remove the duplicated folders from there, but for now let's just hide them.

demo: http://fix_duplicate_folders.surge.sh

