### PR TITLE
Show favorites with malformed folderId

### DIFF
--- a/src/browser/components/SavedScripts/SavedScripts.tsx
+++ b/src/browser/components/SavedScripts/SavedScripts.tsx
@@ -84,8 +84,11 @@ export default function SavedScripts({
   exportScripts,
   createNewFolder
 }: SavedScriptsProps): JSX.Element {
+  const folderExists = (folderId: string) =>
+    folders.find(folder => folder.id === folderId)
+
   const scriptsOutsideFolder = scripts
-    .filter(script => !script.folder)
+    .filter(script => !script.folder || !folderExists(script.folder))
     .sort(sortScriptsAlfabethically)
 
   const countFoldersWithName = (name: string) =>


### PR DESCRIPTION
Bug is caused by drag and drop putting incorrect folderIds to favorites in a previous version of browser

demo @ http://fix_drag_outside_bug.surge.sh