### PR TITLE
add workaround to squashed command palette in small cypher editors

### DIFF
--- a/src/browser/custom.d.ts
+++ b/src/browser/custom.d.ts
@@ -133,3 +133,13 @@ declare module 'cypher-editor-support' {
     }
   }
 }
+
+declare module 'monaco-editor/esm/vs/base/parts/quickinput/browser/quickInputList' {
+  export class QuickInputList {
+    layout: (maxHeight: number) => void
+    list: {
+      getHTMLElement: () => HTMLElement
+      layout: () => void
+    }
+  }
+}

--- a/src/browser/modules/Editor/Monaco.tsx
+++ b/src/browser/modules/Editor/Monaco.tsx
@@ -223,6 +223,25 @@ const Monaco = forwardRef<MonacoHandles, MonacoProps>(
       })
       resizeObserver.observe(container)
 
+      /*
+       * This moves the the command palette widget out of of the overflow-guard div where overlay widgets
+       * are located, into the overflowing content widgets div.
+       * This solves the command palette being squashed when the cypher editor is only a few lines high.
+       * The workaround is based on a suggestion found in the github issue: https://github.com/microsoft/monaco-editor/issues/70
+       */
+      const quickInputDOMNode = editorRef.current.getContribution<
+        { widget: { domNode: HTMLElement } } & editor.IEditorContribution
+      >('editor.controller.quickInput').widget.domNode
+      ;(editorRef.current as any)._modelData.view._contentWidgets.overflowingContentWidgetsDomNode.domNode.appendChild(
+        quickInputDOMNode.parentNode?.removeChild(quickInputDOMNode)
+      )
+      const module = require('monaco-editor/esm/vs/base/parts/quickinput/browser/quickInputList')
+      module.QuickInputList.prototype.layout = function(maxHeight: number) {
+        this.list.getHTMLElement().style.maxHeight =
+          maxHeight < 200 ? '200px' : Math.floor(maxHeight) + 'px'
+        this.list.layout()
+      }
+
       return () => {
         editorRef.current?.dispose()
         debouncedUpdateCode.cancel()

--- a/src/browser/modules/Editor/Monaco.tsx
+++ b/src/browser/modules/Editor/Monaco.tsx
@@ -18,6 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { QuickInputList } from 'monaco-editor/esm/vs/base/parts/quickinput/browser/quickInputList'
 import { parse } from 'cypher-editor-support'
 import { debounce } from 'lodash-es'
 import {
@@ -235,8 +236,7 @@ const Monaco = forwardRef<MonacoHandles, MonacoProps>(
       ;(editorRef.current as any)._modelData.view._contentWidgets.overflowingContentWidgetsDomNode.domNode.appendChild(
         quickInputDOMNode.parentNode?.removeChild(quickInputDOMNode)
       )
-      const module = require('monaco-editor/esm/vs/base/parts/quickinput/browser/quickInputList')
-      module.QuickInputList.prototype.layout = function(maxHeight: number) {
+      QuickInputList.prototype.layout = function(maxHeight: number) {
         this.list.getHTMLElement().style.maxHeight =
           maxHeight < 200 ? '200px' : Math.floor(maxHeight) + 'px'
         this.list.layout()


### PR DESCRIPTION
Fix for squashed command palette. Demo: http://command-palette-height.surge.sh/

Before:
![old](https://user-images.githubusercontent.com/939458/110014150-c0af3500-7d22-11eb-9dfb-1a2eb370acb7.gif)

After:
![new](https://user-images.githubusercontent.com/939458/110014215-d3296e80-7d22-11eb-9924-38abf49ea2d0.gif)
