### PR TITLE
Display Cypher warnings on correct positions

### DIFF
--- a/src/browser/custom.d.ts
+++ b/src/browser/custom.d.ts
@@ -118,11 +118,20 @@ declare module 'cypher-editor-support' {
     setSchema(schema: EditorSupportSchema): void
     update(input: string): void
   }
+  interface CypherPosition {
+    column: number
+    line: number
+  }
+  export interface QueryOrCommand {
+    getText: () => string
+    start: CypherPosition
+    stop: CypherPosition
+  }
   export function parse(
     input: string
   ): {
     referencesListener: {
-      queriesAndCommands: { getText: () => string; start: { line: number } }[]
+      queriesAndCommands: QueryOrCommand[]
     }
   }
   export function extractStatements(

--- a/src/browser/modules/Editor/Monaco.tsx
+++ b/src/browser/modules/Editor/Monaco.tsx
@@ -19,7 +19,7 @@
  */
 
 import { QuickInputList } from 'monaco-editor/esm/vs/base/parts/quickinput/browser/quickInputList'
-import { parse } from 'cypher-editor-support'
+import { parse, QueryOrCommand } from 'cypher-editor-support'
 import { debounce } from 'lodash-es'
 import {
   editor,
@@ -406,9 +406,7 @@ const Monaco = forwardRef<MonacoHandles, MonacoProps>(
       debouncedUpdateCode()
     }
 
-    const addWarnings = (
-      statements: { start: { line: number }; getText: () => string }[]
-    ) => {
+    const addWarnings = (statements: QueryOrCommand[]) => {
       if (!statements.length) return
 
       const model = editorRef.current?.getModel() as editor.ITextModel
@@ -463,9 +461,11 @@ const Monaco = forwardRef<MonacoHandles, MonacoProps>(
                     return {
                       startLineNumber: statementLineNumber + line,
                       // The 8 subtracted from the column on the first line is the length of 'EXPLAIN '
-                      startColumn: line === 1 ? column - 8 : column,
-                      endLineNumber: statementLineNumber + line,
-                      endColumn: 1000,
+                      startColumn:
+                        statement.start.column +
+                        (line === 1 ? column - 8 : column),
+                      endLineNumber: statement.stop.line,
+                      endColumn: statement.stop.column + 2,
                       message: title + '\n\n' + description,
                       severity: MarkerSeverity.Warning
                     }

--- a/src/browser/modules/Editor/Monaco.tsx
+++ b/src/browser/modules/Editor/Monaco.tsx
@@ -459,7 +459,8 @@ const Monaco = forwardRef<MonacoHandles, MonacoProps>(
                 ...editor.getModelMarkers({ owner: monacoId }),
                 ...response.result.summary.notifications.map(
                   ({ description, position, title }) => {
-                    const { line, column } = position as NotificationPosition
+                    const line = 'line' in position ? position.line : 0
+                    const column = 'column' in position ? position.column : 0
                     return {
                       startLineNumber: statementLineNumber + line,
                       startColumn:

--- a/src/browser/modules/Editor/Monaco.tsx
+++ b/src/browser/modules/Editor/Monaco.tsx
@@ -90,6 +90,8 @@ interface MonacoProps {
   toggleFullscreen: () => void
 }
 
+const EXPLAIN_QUERY_PREFIX = 'EXPLAIN '
+const EXPLAIN_QUERY_PREFIX_LENGTH = EXPLAIN_QUERY_PREFIX.length
 const Monaco = forwardRef<MonacoHandles, MonacoProps>(
   (
     {
@@ -445,7 +447,7 @@ const Monaco = forwardRef<MonacoHandles, MonacoProps>(
         bus.self(
           CYPHER_REQUEST,
           {
-            query: 'EXPLAIN ' + text,
+            query: EXPLAIN_QUERY_PREFIX + text,
             queryType: NEO4J_BROWSER_USER_ACTION_QUERY
           },
           (response: { result: QueryResult; success?: boolean }) => {
@@ -460,10 +462,11 @@ const Monaco = forwardRef<MonacoHandles, MonacoProps>(
                     const { line, column } = position as NotificationPosition
                     return {
                       startLineNumber: statementLineNumber + line,
-                      // The 8 subtracted from the column on the first line is the length of 'EXPLAIN '
                       startColumn:
                         statement.start.column +
-                        (line === 1 ? column - 8 : column),
+                        (line === 1
+                          ? column - EXPLAIN_QUERY_PREFIX_LENGTH
+                          : column),
                       endLineNumber: statement.stop.line,
                       endColumn: statement.stop.column + 2,
                       message: title + '\n\n' + description,


### PR DESCRIPTION
Before:
![Screenshot 2021-03-05 at 14 50 37](https://user-images.githubusercontent.com/939458/110124381-4d5d0000-7dc2-11eb-8b97-a305c9ed0255.png)
After:
![Screenshot 2021-03-05 at 14 50 51](https://user-images.githubusercontent.com/939458/110124399-5352e100-7dc2-11eb-8f17-9c6c79edcb99.png)

Demo: http://warning-column-position.surge.sh/