### PR TITLE
Cypher editor font weight

### DIFF
--- a/src/browser/modules/Editor/Monaco.tsx
+++ b/src/browser/modules/Editor/Monaco.tsx
@@ -146,7 +146,7 @@ const Monaco = forwardRef<MonacoHandles, MonacoProps>(
           fontFamily: 'Fira Code',
           fontLigatures,
           fontSize: 17,
-          fontWeight: '500',
+          fontWeight: '400',
           hideCursorInOverviewRuler: true,
           language: 'cypher',
           lightbulb: { enabled: false },

--- a/src/browser/modules/Editor/Monaco.tsx
+++ b/src/browser/modules/Editor/Monaco.tsx
@@ -143,7 +143,7 @@ const Monaco = forwardRef<MonacoHandles, MonacoProps>(
           autoClosingOvertype: 'always',
           contextmenu: false,
           cursorStyle: 'block',
-          fontFamily: 'Fira Code',
+          fontFamily: '"Fira Code", Monaco, "Courier New", Terminal, monospace',
           fontLigatures,
           fontSize: 17,
           fontWeight: '400',


### PR DESCRIPTION
Adjust the font weight in the cypher editor and add fallbacks fonts in case Fira Code doesn't load.

Before:
![Screenshot 2021-03-08 at 09 12 10](https://user-images.githubusercontent.com/939458/110293168-84aff480-7fee-11eb-85f9-faa8d90d7dcd.png)
![Screenshot 2021-03-08 at 09 12 18](https://user-images.githubusercontent.com/939458/110293173-8679b800-7fee-11eb-8ed0-0df6e45bc16a.png)

After:
![Screenshot 2021-03-08 at 09 12 21](https://user-images.githubusercontent.com/939458/110293189-8d082f80-7fee-11eb-8dfa-5fcc4529ff8f.png)
![Screenshot 2021-03-08 at 09 12 27](https://user-images.githubusercontent.com/939458/110293194-8e395c80-7fee-11eb-8ac0-067ad33391d6.png)


Demo: http://cypher-editor-font-weight.surge.sh/