### PR TITLE
reset editor history position on set content

### DIFF
--- a/src/browser/modules/Editor/Monaco.tsx
+++ b/src/browser/modules/Editor/Monaco.tsx
@@ -118,6 +118,7 @@ const Monaco = forwardRef<MonacoHandles, MonacoProps>(
       },
       setValue(value: string) {
         setValue(value)
+        historyIndexRef.current = -1
       },
       resize(fillContainer = false) {
         resize(fillContainer)


### PR DESCRIPTION
This fixes an issue where if you have navigated back in query history, then run a query with the run button instead of `Ctrl+Return`, your position in history remained and the next `Ctrl+arrow key` would put you in an unexpected position in the history. A similar issue happened when navigating history and then updating the editor content by editing a favorite/project file or copying a code example from a guide.

Demo: http://query-history-fix.surge.sh/