### PR TITLE
display cypher errors in cypher editor

### DIFF
--- a/src/browser/modules/Editor/Monaco.tsx
+++ b/src/browser/modules/Editor/Monaco.tsx
@@ -477,6 +477,19 @@ const Monaco = forwardRef<MonacoHandles, MonacoProps>(
                   }
                 )
               ])
+            } else if (response.success === false && response.error) {
+              editor.setModelMarkers(model, monacoId, [
+                ...editor.getModelMarkers({ owner: monacoId }),
+                {
+                  startLineNumber: statement.start.line,
+                  startColumn: statement.start.column + 1,
+                  endLineNumber: statement.stop.line,
+                  endColumn: statement.stop.column + 2,
+                  message:
+                    response.error.code + '\n\n' + response.error.message,
+                  severity: MarkerSeverity.Error
+                }
+              ])
             }
           }
         )


### PR DESCRIPTION
![Screenshot_2021-03-05_at_14 31 20](https://user-images.githubusercontent.com/939458/110777617-9c42e380-8261-11eb-9009-8a34840884c4.png)

This is a quick proof of concept implementation of displaying cypher errors in the cypher editor. A demo is available here: http://display-cypher-errors.surge.sh/

This implementation simply displays the error code and error message in a model marker (red squiggly line) that spans the entire statement. A Proper implementation should parse the error message text to extract position of the error and remove any added markup from the code snippet.