### PR TITLE
bump param lambda command timeout to 3000ms

### DIFF
--- a/e2e_tests/integration/commands.spec.ts
+++ b/e2e_tests/integration/commands.spec.ts
@@ -46,7 +46,7 @@ const commands = [
 ]
 
 const commandDelays: Record<string, number> = {
-  ':param x => 1': 600
+  ':param x => 1': 3000
 }
 
 const getCommandDelay = (command: string) => commandDelays[command] || 300


### PR DESCRIPTION
As discussed, this will hopefully help the e2e tests to pass against Aura Pro where the `:param x => 1` command test seems to take especially long.

