### PR TITLE
Add exports to individual folder

### DIFF
--- a/src/browser/components/SavedScripts/SavedScripts.tsx
+++ b/src/browser/components/SavedScripts/SavedScripts.tsx
@@ -39,6 +39,7 @@ import { Favorite } from 'shared/modules/favorites/favoritesDuck'
 import { useCustomBlur } from './hooks'
 import { AddIcon } from 'browser-components/icons/Icons'
 import uuid from 'uuid'
+import { ExportFormat } from 'services/exporting/favoriteUtils'
 
 interface SavedScriptsProps {
   title?: string
@@ -47,7 +48,11 @@ interface SavedScriptsProps {
   selectScript: (script: Favorite) => void
   execScript: (script: Favorite) => void
   // When optional callbacks aren't provided, respective UI elements are hidden
-  exportScripts?: (scripts: Favorite[], folders: Folder[]) => void
+  exportScripts?: (
+    scripts: Favorite[],
+    folders: Folder[],
+    format?: ExportFormat
+  ) => void
   renameScript?: (script: Favorite, name: string) => void
   moveScript?: (scriptId: string, folderId?: string) => void
   addScript?: (content: string) => void
@@ -245,6 +250,10 @@ export default function SavedScripts({
           folder={folder}
           renameFolder={renameFolder}
           removeFolder={removeFolder}
+          exportScripts={
+            exportScripts &&
+            ((format: ExportFormat) => exportScripts(scripts, [], format))
+          }
           moveScript={moveScript}
           key={folder.id}
           selectedScriptIds={selectedIds}

--- a/src/browser/components/SavedScripts/SavedScriptsFolder.tsx
+++ b/src/browser/components/SavedScripts/SavedScriptsFolder.tsx
@@ -42,11 +42,13 @@ import {
   ContextMenuItem
 } from './styled'
 import { Folder } from 'shared/modules/favorites/foldersDuck'
+import { ExportFormat } from 'services/exporting/favoriteUtils'
 
 interface SavedScriptsFolderProps {
   folder: Folder
   renameFolder?: (folderId: string, name: string) => void
   removeFolder?: (folderId: string) => void
+  exportScripts?: (format: ExportFormat) => void
   moveScript?: (scriptId: string, folderId: string) => void
   forceEdit: boolean
   onDoneEditing: () => void
@@ -59,6 +61,7 @@ function SavedScriptsFolder({
   moveScript,
   renameFolder,
   removeFolder,
+  exportScripts,
   selectedScriptIds,
   forceEdit,
   onDoneEditing,
@@ -115,6 +118,24 @@ function SavedScriptsFolder({
         key="remove"
       >
         Delete folder
+      </ContextMenuItem>
+    ),
+    exportScripts && (
+      <ContextMenuItem
+        data-testid="contextMenuExport"
+        onClick={() => exportScripts('ZIPFILE')}
+        key="exportZip"
+      >
+        Export scripts as .zip file
+      </ContextMenuItem>
+    ),
+    exportScripts && (
+      <ContextMenuItem
+        data-testid="contextMenuRemove"
+        onClick={() => exportScripts('CYPHERFILE')}
+        key="exportAsCypher"
+      >
+        Export scripts as .cypher file
       </ContextMenuItem>
     )
   ].filter(defined => defined)

--- a/src/browser/modules/Sidebar/favorites.ts
+++ b/src/browser/modules/Sidebar/favorites.ts
@@ -27,7 +27,7 @@ import {
 } from 'shared/modules/commands/commandsDuck'
 import * as favoritesDuck from 'shared/modules/favorites/favoritesDuck'
 import * as foldersDuck from 'shared/modules/favorites/foldersDuck'
-import { exportFavorites } from 'services/exporting/favoriteUtils'
+import { exporters, ExportFormat } from 'services/exporting/favoriteUtils'
 
 const mapFavoritesStateToProps = (state: any) => {
   const folders = foldersDuck
@@ -83,9 +83,10 @@ const mapFavoritesDispatchToProps = (dispatch: any, ownProps: any) => ({
   },
   exportScripts(
     favorites: favoritesDuck.Favorite[],
-    folders: foldersDuck.Folder[]
+    folders: foldersDuck.Folder[],
+    format: ExportFormat
   ) {
-    exportFavorites(favorites, folders)
+    exporters[format](favorites, folders)
   },
   addScript(content: string) {
     dispatch(favoritesDuck.addFavorite(content))

--- a/src/shared/services/exporting/favoriteUtils.ts
+++ b/src/shared/services/exporting/favoriteUtils.ts
@@ -25,6 +25,14 @@ import { getScriptDisplayName } from 'browser/components/SavedScripts'
 import { Folder } from 'shared/modules/favorites/foldersDuck'
 
 export const CYPHER_FILE_EXTENSION = '.cypher'
+export type ExportFormat = 'CYPHERFILE' | 'ZIPFILE'
+export const exporters: Record<
+  ExportFormat,
+  (favorites: Favorite[], folders: Folder[]) => void
+> = {
+  ZIPFILE: exportFavoritesAsZip,
+  CYPHERFILE: exportFavoritesAsBigCypherFile
+}
 
 export function exportFavoritesAsBigCypherFile(favorites: Favorite[]): void {
   const fileContent = favorites
@@ -42,7 +50,7 @@ type WriteableFavorite = {
   content: string
   fullFilename: string
 }
-export function exportFavorites(
+export function exportFavoritesAsZip(
   favorites: Favorite[],
   folders: Folder[]
 ): void {


### PR DESCRIPTION
Big inspired to to implement [this](https://neo4j-browser.canny.io/feature-requests/p/ability-to-select-backup-folders-of-scripts) feature request, that I've been thinking about for a while.

Preview. http://export_folder.surge.sh