### PR TITLE
Change test failing on 4.3

### DIFF
--- a/e2e_tests/integration/bolt.spec.ts
+++ b/e2e_tests/integration/bolt.spec.ts
@@ -61,7 +61,7 @@ describe('Bolt connections', () => {
       cy.connect('neo4j', password)
 
       cy.executeCommand(':queries')
-      cy.resultContains('"type": "user-action"')
+      cy.resultContains('dbms.listQueries')
     })
   }
 


### PR DESCRIPTION
With 4.3 enterprise users will be able to call dbms.cluster.overview, this in turn causes a bug in our codebase where some transaction metadata is not present in the :queries table. We'll want to fix this, but not before the 4.2.6 release.