### PR TITLE
Filter out warnings when building

### DIFF
--- a/build_scripts/webpack-plugins.js
+++ b/build_scripts/webpack-plugins.js
@@ -91,9 +91,9 @@ module.exports = () => {
     }),
     new ForkTsCheckerWebpackPlugin({
       eslint: {
-        files: './src/**/*.{ts,tsx,js,jsx}',
-        enabled: helpers.isProduction // reloading becomes really slow when we have 5k+ warnings
-      }
+        files: './src/**/*.{ts,tsx,js,jsx}'
+      },
+      issue: { exclude: { severity: 'warning' } }
     }),
     new ForkTsCheckerNotifierWebpackPlugin({
       title: 'TypeScript'


### PR DESCRIPTION
This will make logs easier to read and faster, the warnings still show up in vscode, so we can act on them when able.