### PR TITLE
Re-add populating main editor

### DIFF
--- a/e2e_tests/integration/commands.spec.ts
+++ b/e2e_tests/integration/commands.spec.ts
@@ -118,4 +118,23 @@ describe('Commands', () => {
       cy.wait(getCommandDelay(cmd))
     })
   })
+
+  it('can ctrl+click to re-populate the main editor', () => {
+    cy.executeCommand(':clear')
+    cy.executeCommand('return 1')
+    cy.get('[data-testid="frameCommand"]')
+      .contains('return 1')
+      .click()
+
+    cy.typeInFrame('Vermilion')
+
+    // click outside frame
+    cy.get('#monaco-main-editor').click()
+
+    cy.get('body').type('{ctrl}', { force: true, release: false })
+    cy.get('[data-testid="frameCommand"]').click()
+    cy.get('body').type('{ctrl}') // release mod
+
+    cy.get('#monaco-main-editor').contains('Vermilion')
+  })
 })

--- a/src/browser/components/TabNavigation/Navigation.tsx
+++ b/src/browser/components/TabNavigation/Navigation.tsx
@@ -188,7 +188,7 @@ class Navigation extends Component<NavigationProps, NavigationState> {
         </StyledTabsWrapper>
         <StyledDrawer
           width={width}
-          ref={(ref: any) => {
+          ref={ref => {
             if (ref) {
               // Remove old listeners so we don't get multiple callbacks.
               // This function is called more than once with same html element

--- a/src/browser/modules/App/App.tsx
+++ b/src/browser/modules/App/App.tsx
@@ -86,6 +86,7 @@ import {
 import { METRICS_EVENT, udcInit } from 'shared/modules/udc/udcDuck'
 import { useKeyboardShortcuts } from './keyboardShortcuts'
 import PerformanceOverlay from './PerformanceOverlay'
+export const MAIN_WRAPPER_DOM_ID = 'MAIN_WRAPPER_DOM_ID'
 
 declare let SEGMENT_KEY: string
 
@@ -211,7 +212,7 @@ export function App(props: any) {
                   <ErrorBoundary>
                     <Sidebar openDrawer={drawer} onNavClick={handleNavClick} />
                   </ErrorBoundary>
-                  <StyledMainWrapper>
+                  <StyledMainWrapper id={MAIN_WRAPPER_DOM_ID}>
                     <Main
                       activeConnection={activeConnection}
                       connectionState={connectionState}

--- a/src/browser/modules/Frame/FrameTitlebar.tsx
+++ b/src/browser/modules/Frame/FrameTitlebar.tsx
@@ -294,9 +294,9 @@ function FrameTitlebar(props: FrameTitleBarProps) {
       }
     }
 
-    document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('mouseup', handleClickOutside)
     return () => {
-      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('mouseup', handleClickOutside)
     }
   })
 

--- a/src/browser/modules/Frame/FrameTitlebar.tsx
+++ b/src/browser/modules/Frame/FrameTitlebar.tsx
@@ -285,7 +285,9 @@ function FrameTitlebar(props: FrameTitleBarProps) {
         ?.contains(event.target)
 
       if (!insideFrame && insideMainWrapper) {
-        // a really quick click will lose some of the last edits
+        // Monaco has a 300ms debounce on calling it's onChange
+        // using this ref prevents us from losing the edits made in the
+        // last 300ms before clicking
         const editorRefVal = editorRef.current?.getValue()
         if (editorRefVal && editorRefVal !== editorValue) {
           setEditorValue(editorRefVal)

--- a/src/browser/modules/Frame/FrameTitlebar.tsx
+++ b/src/browser/modules/Frame/FrameTitlebar.tsx
@@ -265,35 +265,6 @@ function FrameTitlebar(props: FrameTitleBarProps) {
     }
   }
 
-  const titleBarRef = useRef<HTMLDivElement>(null)
-  useEffect(() => {
-    // We want clicks outside the frame itself, not just the titlebar.
-    // Because of how the component tree is built (we don't have a
-    // reference to the full frame body) we'd need to pass
-    // a ref from each parent to avoid this dom traversal
-    function handleClickOutside(event: MouseEvent) {
-      const frameElement =
-        titleBarRef.current && titleBarRef.current.closest('article')
-
-      if (
-        event.target instanceof Element &&
-        !frameElement?.contains(event.target)
-      ) {
-        // a really quick click will lose some of the last edits
-        const editorRefVal = editorRef.current?.getValue()
-        if (editorRefVal && editorRefVal !== editorValue) {
-          setEditorValue(editorRefVal)
-        }
-        setRenderEditor(false)
-      }
-    }
-
-    document.addEventListener('mousedown', handleClickOutside)
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside)
-    }
-  })
-
   const { frame = {} } = props
   const fullscreenIcon = props.fullscreen ? <ContractIcon /> : <ExpandIcon />
   const expandCollapseIcon = props.collapse ? <DownIcon /> : <UpIcon />
@@ -301,9 +272,12 @@ function FrameTitlebar(props: FrameTitleBarProps) {
   // don't show it as history as well
   const history = (frame.history || []).slice(1)
   return (
-    <StyledFrameTitleBar ref={titleBarRef}>
+    <StyledFrameTitleBar>
       {renderEditor ? (
-        <FrameTitleEditorContainer data-testid="frameCommand">
+        <FrameTitleEditorContainer
+          onClick={onPreviewClick}
+          data-testid="frameCommand"
+        >
           <Monaco
             history={history}
             useDb={frame.useDb}

--- a/src/browser/modules/Frame/FrameTitlebar.tsx
+++ b/src/browser/modules/Frame/FrameTitlebar.tsx
@@ -279,6 +279,11 @@ function FrameTitlebar(props: FrameTitleBarProps) {
         event.target instanceof Element &&
         !frameElement?.contains(event.target)
       ) {
+        // a really quick click will lose some of the last edits
+        const editorRefVal = editorRef.current?.getValue()
+        if (editorRefVal && editorRefVal !== editorValue) {
+          setEditorValue(editorRefVal)
+        }
         setRenderEditor(false)
       }
     }

--- a/src/browser/modules/Stream/__snapshots__/SchemaFrame.test.tsx.snap
+++ b/src/browser/modules/Stream/__snapshots__/SchemaFrame.test.tsx.snap
@@ -10,13 +10,13 @@ exports[`SchemaFrame renders empty 1`] = `
         class="sc-ibxdXY lnvWNA"
       >
         <table
-          class="sc-bmyXtO igmend"
+          class="sc-ecaExY pzTAf"
           data-testid="schemaFrameIndexesTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-jtggT iXZCOT table-header"
+                class="sc-jqIZGH dcsmCY table-header"
               >
                 Indexes
               </th>
@@ -24,10 +24,10 @@ exports[`SchemaFrame renders empty 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-dEoRIm dgcKdd table-row"
+              class="sc-gbzWSY gkTicA table-row"
             >
               <td
-                class="sc-ebFjAB enMvAC table-properties"
+                class="sc-jMMfwr igisOH table-properties"
               >
                 None
               </td>
@@ -35,13 +35,13 @@ exports[`SchemaFrame renders empty 1`] = `
           </tbody>
         </table>
         <table
-          class="sc-bmyXtO igmend"
+          class="sc-ecaExY pzTAf"
           data-testid="schemaFrameConstraintsTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-jtggT iXZCOT table-header"
+                class="sc-jqIZGH dcsmCY table-header"
               >
                 Constraints
               </th>
@@ -49,10 +49,10 @@ exports[`SchemaFrame renders empty 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-dEoRIm dgcKdd table-row"
+              class="sc-gbzWSY gkTicA table-row"
             >
               <td
-                class="sc-ebFjAB enMvAC table-properties"
+                class="sc-jMMfwr igisOH table-properties"
               >
                 None
               </td>
@@ -92,43 +92,43 @@ exports[`SchemaFrame renders empty for Neo4j >= 4.0 1`] = `
         class="sc-ibxdXY lnvWNA"
       >
         <table
-          class="sc-bmyXtO igmend"
+          class="sc-ecaExY pzTAf"
           data-testid="schemaFrameIndexesTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-jtggT iXZCOT table-header"
+                class="sc-jqIZGH dcsmCY table-header"
               >
                 Index Name
               </th>
               <th
-                class="sc-jtggT iXZCOT table-header"
+                class="sc-jqIZGH dcsmCY table-header"
               >
                 Type
               </th>
               <th
-                class="sc-jtggT iXZCOT table-header"
+                class="sc-jqIZGH dcsmCY table-header"
               >
                 Uniqueness
               </th>
               <th
-                class="sc-jtggT iXZCOT table-header"
+                class="sc-jqIZGH dcsmCY table-header"
               >
                 EntityType
               </th>
               <th
-                class="sc-jtggT iXZCOT table-header"
+                class="sc-jqIZGH dcsmCY table-header"
               >
                 LabelsOrTypes
               </th>
               <th
-                class="sc-jtggT iXZCOT table-header"
+                class="sc-jqIZGH dcsmCY table-header"
               >
                 Properties
               </th>
               <th
-                class="sc-jtggT iXZCOT table-header"
+                class="sc-jqIZGH dcsmCY table-header"
               >
                 State
               </th>
@@ -136,42 +136,42 @@ exports[`SchemaFrame renders empty for Neo4j >= 4.0 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-dEoRIm dgcKdd table-row"
+              class="sc-gbzWSY gkTicA table-row"
             >
               <td
-                class="sc-ebFjAB enMvAC table-properties"
+                class="sc-jMMfwr igisOH table-properties"
               >
                 None
               </td>
               <td
-                class="sc-ebFjAB enMvAC table-properties"
+                class="sc-jMMfwr igisOH table-properties"
               />
               <td
-                class="sc-ebFjAB enMvAC table-properties"
+                class="sc-jMMfwr igisOH table-properties"
               />
               <td
-                class="sc-ebFjAB enMvAC table-properties"
+                class="sc-jMMfwr igisOH table-properties"
               />
               <td
-                class="sc-ebFjAB enMvAC table-properties"
+                class="sc-jMMfwr igisOH table-properties"
               />
               <td
-                class="sc-ebFjAB enMvAC table-properties"
+                class="sc-jMMfwr igisOH table-properties"
               />
               <td
-                class="sc-ebFjAB enMvAC table-properties"
+                class="sc-jMMfwr igisOH table-properties"
               />
             </tr>
           </tbody>
         </table>
         <table
-          class="sc-bmyXtO igmend"
+          class="sc-ecaExY pzTAf"
           data-testid="schemaFrameConstraintsTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-jtggT iXZCOT table-header"
+                class="sc-jqIZGH dcsmCY table-header"
               >
                 Constraints
               </th>
@@ -179,10 +179,10 @@ exports[`SchemaFrame renders empty for Neo4j >= 4.0 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-dEoRIm dgcKdd table-row"
+              class="sc-gbzWSY gkTicA table-row"
             >
               <td
-                class="sc-ebFjAB enMvAC table-properties"
+                class="sc-jMMfwr igisOH table-properties"
               >
                 None
               </td>
@@ -222,13 +222,13 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
         class="sc-ibxdXY lnvWNA"
       >
         <table
-          class="sc-bmyXtO igmend"
+          class="sc-ecaExY pzTAf"
           data-testid="schemaFrameIndexesTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-jtggT iXZCOT table-header"
+                class="sc-jqIZGH dcsmCY table-header"
               >
                 Indexes
               </th>
@@ -236,10 +236,10 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-dEoRIm dgcKdd table-row"
+              class="sc-gbzWSY gkTicA table-row"
             >
               <td
-                class="sc-ebFjAB enMvAC table-properties"
+                class="sc-jMMfwr igisOH table-properties"
               >
                  ON :Movie(released) ONLINE 
               </td>
@@ -247,13 +247,13 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
           </tbody>
         </table>
         <table
-          class="sc-bmyXtO igmend"
+          class="sc-ecaExY pzTAf"
           data-testid="schemaFrameConstraintsTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-jtggT iXZCOT table-header"
+                class="sc-jqIZGH dcsmCY table-header"
               >
                 Constraints
               </th>
@@ -261,10 +261,10 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-dEoRIm dgcKdd table-row"
+              class="sc-gbzWSY gkTicA table-row"
             >
               <td
-                class="sc-ebFjAB enMvAC table-properties"
+                class="sc-jMMfwr igisOH table-properties"
               >
                  ON ( book:Book ) ASSERT book.isbn IS UNIQUE
               </td>


### PR DESCRIPTION
When introducing the re-usable frame we removed to ability to populate the main editor easily. This PR adds it back as a CMD/CTRL click. I've opted to have both ctrl and cmd work. Tested to work in a windows VM.

Preview at: http://bring_to_editor.surge.sh
![CleanShot 2021-05-04 at 11 39 58](https://user-images.githubusercontent.com/10564538/116985977-8126aa00-accd-11eb-9679-eb3d216cb7bf.gif)

