### PR TITLE
Bump cypher-editor-support and update licenses

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -427,7 +427,7 @@ Third-party licenses
 │     ├─ VendorName: Tab Atkins Jr.
 │     └─ VendorUrl: https://github.com/tabatkins/railroad-diagrams
 ├─ GPL-3.0
-│  └─ cypher-editor-support@1.1.7
+│  └─ cypher-editor-support@1.1.8
 │     ├─ URL: git://github.com/neo4j-contrib/cypher-editor.git
 │     └─ VendorName: Neo Technology Inc.
 ├─ ISC

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "ascii-data-table": "^2.1.1",
     "canvg": "^1.5.3",
     "core-js": "3",
-    "cypher-editor-support": "^1.1.7",
+    "cypher-editor-support": "^1.1.8",
     "d3": "3",
     "deepmerge": "^2.1.1",
     "file-saver": "^1.3.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4693,10 +4693,10 @@ cyclist@^1.0.1:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/cyclist/-/cyclist-1.0.1.tgz#596e9698fd0c80e12038c2b82d6eb1b35b6224d9"
   integrity sha1-WW6WmP0MgOEgOMK4LW6xs1tiJNk=
 
-cypher-editor-support@^1.1.7:
-  version "1.1.7"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/cypher-editor-support/-/cypher-editor-support-1.1.7.tgz#14daa7dde9ad8128c06bfc51e31d513ba9cd0fa0"
-  integrity sha1-FNqn3emtgSjAa/xR4x1RO6nND6A=
+cypher-editor-support@^1.1.8:
+  version "1.1.8"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/cypher-editor-support/-/cypher-editor-support-1.1.8.tgz#6b173de2a67fe91e8493fbbc6ee41cf4c90ee84e"
+  integrity sha1-axc94qZ/6R6Ek/u8buQc9MkO6E4=
   dependencies:
     antlr4 "4.7.0"
     fuzzaldrin "2.1.0"


### PR DESCRIPTION
This will add new keywords from 4.3, not fully support it. Se the cypher editor repo for more details.

Preview at http://bump_cypher_support.surge.sh

