### PR TITLE
Attempt to fix flaky test where favorite is not created

### DIFF
--- a/e2e_tests/integration/saved-scripts.spec.ts
+++ b/e2e_tests/integration/saved-scripts.spec.ts
@@ -63,6 +63,7 @@ describe('Saved Scripts', () => {
     cy.executeCommand(':clear')
     cy.executeCommand(':help cypher')
     cy.get('[data-testid=frame-Favorite]').click()
+    cy.get('[data-testid="scriptTitle-:help cypher"]').should('exist')
 
     cy.get('[data-testid="savedScriptsButton-New folder"]').click()
     cy.get('[data-testid=editSavedScriptFolderName]').type('fldr{enter}')


### PR DESCRIPTION
Can't reproduce the flakiness locally, but looking at the recorded video it seems the favorite is not created properly. If nothing else this change will give more information if the test is still flaky.

