### PR TITLE
Enable google analytics tracking meta

### DIFF
--- a/docs/preview.yml
+++ b/docs/preview.yml
@@ -32,7 +32,6 @@ asciidoc:
     page-search-type: Docs
     page-search-site: Reference Docs
     page-canonical-root: /docs
-    page-disabletracking: true
     page-pagination: true
     page-no-canonical: true
     page-origin-private: true


### PR DESCRIPTION
The `page-disabletracking` attribute should be removed when docs are no longer preview, so that the Google Tag Manager script is added, and  Google Analytics tracking is enabled.