### PR TITLE
truncate node captions to 100 chars in viz to fix crash

### DIFF
--- a/src/browser/modules/D3Visualization/lib/visualization/components/graphGeometry.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/graphGeometry.ts
@@ -96,7 +96,9 @@ const noEmptyLines = function(lines: any[]) {
 
 const fitCaptionIntoCircle = function(node: any, style: any) {
   const template = style.forNode(node).get('caption')
-  const captionText = style.interpolate(template, node)
+  const nodeText = style.interpolate(template, node)
+  const captionText =
+    nodeText.length > 100 ? nodeText.substring(0, 100) : nodeText
   const fontFamily = 'sans-serif'
   const fontSize = parseFloat(style.forNode(node).get('font-size'))
   const lineHeight = fontSize


### PR DESCRIPTION
<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

