### PR TITLE
Update monaco settings

### DIFF
--- a/src/browser/modules/Editor/Monaco.tsx
+++ b/src/browser/modules/Editor/Monaco.tsx
@@ -160,6 +160,7 @@ const Monaco = forwardRef<MonacoHandles, MonacoProps>(
           links: false,
           minimap: { enabled: false },
           overviewRulerBorder: false,
+          overviewRulerLanes: 0,
           quickSuggestions: false,
           renderLineHighlight: 'none',
           scrollbar: {
@@ -171,9 +172,7 @@ const Monaco = forwardRef<MonacoHandles, MonacoProps>(
           selectionHighlight: false,
           value,
           wordWrap: 'on',
-          wrappingStrategy: 'advanced',
-          occurrencesHighlight: false,
-          matchBrackets: 'never'
+          wrappingStrategy: 'advanced'
         }
       )
 


### PR DESCRIPTION
A few settings were for hiding the "overviewruler" on the right of the editor. As a side effect they remove the highlighting occurrences and matching brackets in the editor as well. To explain what the settings were there to disable, see video

https://user-images.githubusercontent.com/10564538/122176166-9a9e4280-ce84-11eb-852d-315feada9da1.mp4

With these changes we still get the highlight in the editor, but not by the scrollbar.

https://user-images.githubusercontent.com/10564538/122176444-e2bd6500-ce84-11eb-883d-4bb2f81b912a.mp4


To find the relevant setting I dug through the monaco code and found it here:
https://github.com/microsoft/vscode/blob/3f363797cf5bde6965c5150dde1a8a93a88babf4/src/vs/editor/browser/viewParts/overviewRuler/decorationsOverviewRuler.ts#L317

Preview @ http://update_monaco_settings.surge.sh/
