### PR TITLE
Focus reusable editor on mounting it

### DIFF
--- a/src/browser/modules/Frame/FrameEditor.tsx
+++ b/src/browser/modules/Frame/FrameEditor.tsx
@@ -174,6 +174,20 @@ function FrameTitlebar({
     }
   })
 
+  useEffect(() => {
+    if (renderEditor) {
+      editorRef.current?.focus()
+
+      // Jump cursor to end
+      const lines = (editorRef.current?.getValue() || '').split('\n')
+      const linesLength = lines.length
+      editorRef.current?.setPosition({
+        lineNumber: linesLength,
+        column: lines[linesLength - 1].length + 1
+      })
+    }
+  }, [renderEditor])
+
   // the last run command (history index 1) is already in the editor
   // don't show it as history as well
   const history = (frame.history || []).slice(1)


### PR DESCRIPTION
Preview: http://focus_editor_on_click.surge.sh

Focuses editor and sets focus to the end of the statement.
https://user-images.githubusercontent.com/10564538/122192901-5a46c080-ce94-11eb-8dd7-556e2c1614bd.mp4


