### PR TITLE
Don't add identical cmds to history

### DIFF
--- a/src/shared/modules/stream/streamDuck.test.ts
+++ b/src/shared/modules/stream/streamDuck.test.ts
@@ -114,9 +114,7 @@ describe('streamDuck', () => {
         "test-id": Object {
           "stack": Array [
             Object {
-              "history": Array [
-                undefined,
-              ],
+              "history": Array [],
               "id": "test-id",
               "type": "after",
             },

--- a/src/shared/modules/stream/streamDuck.ts
+++ b/src/shared/modules/stream/streamDuck.ts
@@ -64,9 +64,14 @@ function addFrame(state: FramesState, newState: Frame) {
   }
 
   const frameObject = state.byId[newState.id] || { stack: [], isPinned: false }
+  const pastHistory = frameObject.stack[0]?.history || []
+  const createNewHistoryEntry = newState.cmd !== pastHistory[0]
+
   const newFrame = {
     ...newState,
-    history: [newState.cmd, ...(frameObject.stack[0]?.history || [])]
+    history: createNewHistoryEntry
+      ? [newState.cmd, ...pastHistory]
+      : pastHistory
   }
   if (newState.isRerun) {
     frameObject.stack = [newFrame]


### PR DESCRIPTION
This PR makes sure we don't pollute history with identical entries. 
Before:
https://user-images.githubusercontent.com/10564538/122230499-00f18800-ceba-11eb-86d2-296f3002faee.mp4

After:
https://user-images.githubusercontent.com/10564538/122230636-1d8dc000-ceba-11eb-8112-4dc35fddb119.mp4

Preview @ https://history_frame.surge.sh
