### PR TITLE
Fix bug where button shrunk in safari

### DIFF
--- a/src/browser/components/buttons/index.tsx
+++ b/src/browser/components/buttons/index.tsx
@@ -72,6 +72,7 @@ const BaseButton: any = styled.span`
   cursor: pointer;
   vertical-align: middle;
   display: inline-block;
+  flex-shrink: 0; // Prevents button from shrinking in safari
   &:hover {
     opacity: 0.55;
   }


### PR DESCRIPTION
Min item width is not respected by default in safari.
Preview @ http://safari_button_shrink_bug.surge.sh

Before:
![CleanShot 2021-06-16 at 17 28 44](https://user-images.githubusercontent.com/10564538/122248527-69476600-cec8-11eb-8c5d-fba77e5c9e20.png)

After:
![CleanShot 2021-06-16 at 17 29 18](https://user-images.githubusercontent.com/10564538/122248587-75332800-cec8-11eb-9074-8fcad96bac37.png)



