### PR TITLE
add new playbook to demo edit this page link

### DIFF
--- a/docs/publish.yml
+++ b/docs/publish.yml
@@ -1,0 +1,48 @@
+site:
+  title: Neo4j Docs
+  url: https://neo4j.com/docs
+  start_page: browser-manual:ROOT:index.adoc
+
+content:
+  sources:
+  - url: https://github.com/neo4j/neo4j-browser.git
+    start_path: docs
+    branches: 
+    - master
+    include: docs/
+    exclude:
+    - '!**/_includes/*'
+    - '!**/readme.adoc'
+    - '!**/README.adoc'
+ui:
+  bundle:
+    url: https://s3-eu-west-1.amazonaws.com/static-content.neo4j.com/build/ui-bundle-latest.zip
+    snapshot: true
+  output_dir: /assets
+
+urls:
+  html_extension_style: indexify
+
+asciidoc:
+  extensions:
+  - "@neo4j-documentation/remote-include"
+  - "@neo4j-documentation/macros"
+  attributes:
+    page-theme: docs
+    page-type: Docs
+    page-search-type: Docs
+    page-search-site: Reference Docs
+    page-canonical-root: /docs
+    page-pagination: true
+    page-no-canonical: true
+    page-origin-private: false
+    page-hide-toc: false
+    page-mixpanel: 4bfb2414ab973c741b6f067bf06d5575
+    # page-cdn: /static/assets
+    includePDF: false
+    nonhtmloutput: ""
+    sectnums: true,
+    sectnumlevel: 3,
+    experimental: ''
+    copyright: 2021
+    common-license-page-uri: https://neo4j.com/docs/license/


### PR DESCRIPTION
Creates a new Antora playbook that builds from the github url rather than local content.

Advantages of this are

- VCS checkout no longer required as part of build
- this repo is public, so we can add an 'Edit this page' link by setting `page-origin-private: false` or removing the attribute.

To test, use `$(npm bin)/antora publish.yml --stacktrace --fetch`
