### PR TITLE
Refresh plan statistics after re-run the query

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "jsonic": "^0.3.0",
     "jszip": "^3.2.2",
     "lodash-es": "^4.17.15",
+    "memoize-one": "^5.2.1",
     "monaco-editor": "0.23.0",
     "neo4j-driver": "^4.3.1",
     "react": "^16.9.0",

--- a/src/browser/modules/Stream/CypherFrame/PlanView.tsx
+++ b/src/browser/modules/Stream/CypherFrame/PlanView.tsx
@@ -161,69 +161,56 @@ export class PlanView extends Component<PlanViewProps, PlanViewState> {
   }
 }
 
-type PlanStatusbarState = { extractedPlan: any }
 type PlanStatusbarProps = {
   result: any
   setPlanExpand: (p: PlanExpand) => void
 }
 
-export class PlanStatusbar extends PureComponent<
-  PlanStatusbarProps,
-  PlanStatusbarState
-> {
-  state: PlanStatusbarState = {
-    extractedPlan: null
-  }
+export function PlanStatusbar(props: PlanStatusbarProps) {
+  const extractMemoizedPlan = memoize(
+    result => bolt.extractPlan(result, true),
+    (a: any, b: any) => deepEquals(a[0]?.result?.summary, b[0]?.result?.summary)
+  )
 
-  getPlan = memoize((propsResult, extractedPlan) => {
-    if (deepEquals(propsResult, extractedPlan)) {
-      return extractedPlan
-    }
-    this.setState({ extractedPlan: propsResult })
-    return propsResult
-  })
+  const { result } = props
+  if (!result || !result.summary) return null
 
-  render(): ReactNode {
-    const plan = this.getPlan(
-      bolt.extractPlan(this.props.result, true),
-      this.state.extractedPlan
-    )
-    if (!plan) return null
-    const { result = {} } = this.props
-    return (
-      <StyledOneRowStatsBar>
-        <StyledLeftPartial>
-          <Ellipsis>
-            Cypher version: {plan.root.version}, planner: {plan.root.planner},
-            runtime: {plan.root.runtime}.
-            {plan.root.totalDbHits
-              ? ` ${
-                  plan.root.totalDbHits
-                } total db hits in ${result.summary.resultAvailableAfter
-                  .add(result.summary.resultConsumedAfter)
-                  .toNumber() || 0} ms.`
-              : ''}
-          </Ellipsis>
-        </StyledLeftPartial>
-        <StyledRightPartial>
-          <StyledFrameTitlebarButtonSection>
-            <FrameButton
-              title="Collapse Plan"
-              data-testid="planCollapseButton"
-              onClick={() => this.props.setPlanExpand('COLLAPSE')}
-            >
-              <DoubleUpIcon />
-            </FrameButton>
-            <FrameButton
-              data-testid="planExpandButton"
-              title="Expand Plan"
-              onClick={() => this.props.setPlanExpand('EXPAND')}
-            >
-              <DoubleDownIcon />
-            </FrameButton>
-          </StyledFrameTitlebarButtonSection>
-        </StyledRightPartial>
-      </StyledOneRowStatsBar>
-    )
-  }
+  const plan = extractMemoizedPlan(result)
+  if (!plan) return null
+
+  return (
+    <StyledOneRowStatsBar>
+      <StyledLeftPartial>
+        <Ellipsis>
+          Cypher version: {plan.root.version}, planner: {plan.root.planner},
+          runtime: {plan.root.runtime}.
+          {plan.root.totalDbHits
+            ? ` ${
+                plan.root.totalDbHits
+              } total db hits in ${result.summary.resultAvailableAfter
+                .add(result.summary.resultConsumedAfter)
+                .toNumber() || 0} ms.`
+            : ''}
+        </Ellipsis>
+      </StyledLeftPartial>
+      <StyledRightPartial>
+        <StyledFrameTitlebarButtonSection>
+          <FrameButton
+            title="Collapse Plan"
+            data-testid="planCollapseButton"
+            onClick={() => props.setPlanExpand('COLLAPSE')}
+          >
+            <DoubleUpIcon />
+          </FrameButton>
+          <FrameButton
+            data-testid="planExpandButton"
+            title="Expand Plan"
+            onClick={() => props.setPlanExpand('EXPAND')}
+          >
+            <DoubleDownIcon />
+          </FrameButton>
+        </StyledFrameTitlebarButtonSection>
+      </StyledRightPartial>
+    </StyledOneRowStatsBar>
+  )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8916,6 +8916,11 @@ memoize-one@^5.0.0:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/memoize-one/-/memoize-one-5.1.1.tgz#047b6e3199b508eaec03504de71229b8eb1d75c0"
   integrity sha1-BHtuMZm1COrsA1BN5xIpuOsddcA=
 
+memoize-one@^5.2.1:
+  version "5.2.1"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
+  integrity sha1-gzeqPEM1WBg57AHD1ZQJDOvo8A4=
+
 memory-fs@^0.4.1:
   version "0.4.1"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/memory-fs/-/memory-fs-0.4.1.tgz#3a9a20b8462523e447cfbc7e8bb80ed667bfc552"


### PR DESCRIPTION


<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

Problem has been explained here -> https://github.com/neo4j/neo4j-browser/issues/1454

The issue is to refresh the state of the react component that display the plan stats at the bottom of the window

Here is a little video of the fix, sorry for the bad quality, you can see the stats are updating at the bottom of the query window
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/22744840/123608899-c54bac00-d831-11eb-80bf-b9d315929a05.gif)



