### PR TITLE
Prevent crash on database connection lost

### DIFF
--- a/src/shared/modules/currentUser/currentUserDuck.ts
+++ b/src/shared/modules/currentUser/currentUserDuck.ts
@@ -96,9 +96,9 @@ export const getCurrentUserEpic = (some$: any, store: any) =>
         if (!authEnabled) {
           return resolve(null)
         }
-        const supportsMultiDb = await bolt.hasMultiDbSupport()
-        bolt
-          .directTransaction(
+        try {
+          const supportsMultiDb = await bolt.hasMultiDbSupport()
+          const res = await bolt.directTransaction(
             getShowCurrentUserProcedure(
               supportsMultiDb
                 ? FIRST_MULTI_DB_SUPPORT
@@ -113,8 +113,11 @@ export const getCurrentUserEpic = (some$: any, store: any) =>
               useDb: supportsMultiDb ? SYSTEM_DB : ''
             }
           )
-          .then((res: any) => resolve(res))
-          .catch(() => resolve(null))
+
+          return resolve(res)
+        } catch (e) {
+          return resolve(null)
+        }
       })
     })
     .map((result: any) => {

--- a/src/shared/modules/dbMeta/dbMetaDuck.ts
+++ b/src/shared/modules/dbMeta/dbMetaDuck.ts
@@ -376,7 +376,7 @@ const databaseList = (store: any) =>
           return resolve(null)
         }
 
-        const res = bolt.directTransaction(
+        const res = await bolt.directTransaction(
           'SHOW DATABASES',
           {},
           {

--- a/src/shared/modules/dbMeta/dbMetaDuck.ts
+++ b/src/shared/modules/dbMeta/dbMetaDuck.ts
@@ -370,12 +370,13 @@ export const serverInfoQuery =
 const databaseList = (store: any) =>
   Rx.Observable.fromPromise(
     new Promise(async (resolve, reject) => {
-      const supportsMultiDb = await bolt.hasMultiDbSupport()
-      if (!supportsMultiDb) {
-        return resolve(null)
-      }
-      bolt
-        .directTransaction(
+      try {
+        const supportsMultiDb = await bolt.hasMultiDbSupport()
+        if (!supportsMultiDb) {
+          return resolve(null)
+        }
+
+        const res = bolt.directTransaction(
           'SHOW DATABASES',
           {},
           {
@@ -386,8 +387,10 @@ const databaseList = (store: any) =>
             useDb: SYSTEM_DB
           }
         )
-        .then(resolve)
-        .catch(reject)
+        resolve(res)
+      } catch (e) {
+        reject(e)
+      }
     })
   )
     .catch(() => {
@@ -567,7 +570,13 @@ export const serverConfigEpic = (some$: any, store: any) =>
       // Server configuration
       return Rx.Observable.fromPromise(
         new Promise(async (resolve, reject) => {
-          const supportsMultiDb = await bolt.hasMultiDbSupport()
+          let supportsMultiDb: boolean
+          try {
+            supportsMultiDb = await bolt.hasMultiDbSupport()
+          } catch (e) {
+            return reject(e)
+          }
+
           bolt
             .directTransaction(
               `CALL ${

--- a/src/shared/modules/dbMeta/dbMetaDuck.ts
+++ b/src/shared/modules/dbMeta/dbMetaDuck.ts
@@ -574,6 +574,8 @@ export const serverConfigEpic = (some$: any, store: any) =>
           try {
             supportsMultiDb = await bolt.hasMultiDbSupport()
           } catch (e) {
+            // if hasMultiDbSupport throws there's no instance of neo4j running anymore
+            onLostConnection(store.dispatch)(e)
             return reject(e)
           }
 

--- a/src/shared/modules/features/featuresDuck.ts
+++ b/src/shared/modules/features/featuresDuck.ts
@@ -127,9 +127,9 @@ export const featuresDiscoveryEpic = (action$: any, store: any) => {
     .ofType(CONNECTION_SUCCESS)
     .mergeMap(() => {
       return new Promise(async (resolve, reject) => {
-        const supportsMultiDb = await bolt.hasMultiDbSupport()
-        bolt
-          .routedReadTransaction(
+        try {
+          const supportsMultiDb = await bolt.hasMultiDbSupport()
+          const res = await bolt.routedReadTransaction(
             'CALL dbms.procedures YIELD name',
             {},
             {
@@ -140,8 +140,10 @@ export const featuresDiscoveryEpic = (action$: any, store: any) => {
               })
             }
           )
-          .then(resolve)
-          .catch(reject)
+          resolve(res)
+        } catch (e) {
+          reject(e)
+        }
       })
         .then((res: any) => {
           store.dispatch(

--- a/src/shared/services/bolt/bolt.ts
+++ b/src/shared/services/bolt/bolt.ts
@@ -219,10 +219,7 @@ const closeConnectionInWorkers = (): void => {
 }
 
 export default {
-  hasMultiDbSupport: async (): Promise<boolean> => {
-    const supportsMultiDb = await boltConnection.hasMultiDbSupport()
-    return supportsMultiDb
-  },
+  hasMultiDbSupport: boltConnection.hasMultiDbSupport,
   useDb: (db: any) => (_useDb = db),
   directConnect: boltConnection.directConnect,
   openConnection,

--- a/src/shared/services/commandInterpreterHelper.ts
+++ b/src/shared/services/commandInterpreterHelper.ts
@@ -259,54 +259,62 @@ const availableCommands = [
   {
     name: 'reset-db',
     match: (cmd: any) => new RegExp(`^${useDbCommand}$`).test(cmd),
-    async exec(action: any, put: any, store: any) {
-      const supportsMultiDb = await bolt.hasMultiDbSupport()
-      if (supportsMultiDb) {
-        put(useDb(null))
-        put(fetchMetaData())
-        put(
-          frames.add({
-            useDb: getUseDb(store.getState()),
-            ...action,
-            type: 'reset-db'
-          })
-        )
-      } else {
-        put(
-          frames.add({
-            useDb: getUseDb(store.getState()),
-            ...action,
-            type: 'error',
-            error: UnsupportedError('No multi db support detected.')
-          })
-        )
-      }
+    exec(action: any, put: any, store: any) {
+      bolt
+        .hasMultiDbSupport()
+        .then(supportsMultiDb => {
+          if (supportsMultiDb) {
+            put(useDb(null))
+            put(fetchMetaData())
+            put(
+              frames.add({
+                useDb: getUseDb(store.getState()),
+                ...action,
+                type: 'reset-db'
+              })
+            )
+          } else {
+            put(
+              frames.add({
+                useDb: getUseDb(store.getState()),
+                ...action,
+                type: 'error',
+                error: UnsupportedError('No multi db support detected.')
+              })
+            )
+          }
+        })
+        .catch(() => undefined)
     }
   },
   {
     name: 'dbs',
     match: (cmd: any) => new RegExp(`^${listDbsCommand}$`).test(cmd),
-    async exec(action: any, put: any, store: any) {
-      const supportsMultiDb = await bolt.hasMultiDbSupport()
-      if (supportsMultiDb) {
-        put(
-          frames.add({
-            useDb: getUseDb(store.getState()),
-            ...action,
-            type: 'dbs',
-            dbs: getDatabases(store.getState())
-          })
-        )
-      } else {
-        put(
-          frames.add({
-            useDb: getUseDb(store.getState()),
-            ...action,
-            type: 'error',
-            error: UnsupportedError('No multi db support detected.')
-          })
-        )
-      }
+    exec(action: any, put: any, store: any) {
+      bolt
+        .hasMultiDbSupport()
+        .then(supportsMultiDb => {
+          if (supportsMultiDb) {
+            put(
+              frames.add({
+                useDb: getUseDb(store.getState()),
+                ...action,
+                type: 'dbs',
+                dbs: getDatabases(store.getState())
+              })
+            )
+          } else {
+            put(
+              frames.add({
+                useDb: getUseDb(store.getState()),
+                ...action,
+                type: 'error',
+                error: UnsupportedError('No multi db support detected.')
+              })
+            )
+          }
+        })
+        .catch(() => undefined)
     }
   },
   {

--- a/src/shared/services/commandInterpreterHelper.ts
+++ b/src/shared/services/commandInterpreterHelper.ts
@@ -80,8 +80,7 @@ import {
   InvalidGrassError,
   UnsupportedError,
   DatabaseUnavailableError,
-  DatabaseNotFoundError,
-  BoltConnectionError
+  DatabaseNotFoundError
 } from 'services/exceptions'
 import {
   parseHttpVerbCommand,
@@ -285,16 +284,7 @@ const availableCommands = [
             )
           }
         })
-        .catch(() =>
-          put(
-            frames.add({
-              useDb: getUseDb(store.getState()),
-              ...action,
-              type: 'error',
-              error: BoltConnectionError()
-            })
-          )
-        )
+        .catch(() => undefined)
     }
   },
   {


### PR DESCRIPTION
If the database was shut off, `bolt.hasMultiDbSupport` will throw which we don't handle properly. This PR catches whenever it could throw. 

Our the metadata check running every 20 seconds is _supposed_ to detect when a database connection is lost but it doesn't work properly (in part because of hasMultiDbSupport throwing). I spent a few hours trying to understand why/how it doesn't work, but didn't get anywhere and I think the whole file requires heavy refactoring. I ended up including a another call to `onConnectionLost` as part of the metadata check instead, so that we don't retry the websocket in eternity. It's somewhat of a scope creep and not a perfect solution, so I'm happy to drop it.

Preview @ http://crash_on_db_switch.surge.sh
