### PR TITLE
Fullscreen fix

### DIFF
--- a/src/browser/modules/D3Visualization/components/Explorer.tsx
+++ b/src/browser/modules/D3Visualization/components/Explorer.tsx
@@ -205,6 +205,10 @@ export class ExplorerComponent extends Component<any, ExplorerComponentState> {
         />
       )
     }
+    const inspectingItemType =
+      !this.state.inspectorContracted &&
+      ((this.state.hoveredItem && this.state.hoveredItem.type !== 'canvas') ||
+        (this.state.selectedItem && this.state.selectedItem.type !== 'canvas'))
 
     return (
       <StyledFullSizeContainer

--- a/src/browser/modules/D3Visualization/components/Explorer.tsx
+++ b/src/browser/modules/D3Visualization/components/Explorer.tsx
@@ -205,10 +205,6 @@ export class ExplorerComponent extends Component<any, ExplorerComponentState> {
         />
       )
     }
-    const inspectingItemType =
-      !this.state.inspectorContracted &&
-      ((this.state.hoveredItem && this.state.hoveredItem.type !== 'canvas') ||
-        (this.state.selectedItem && this.state.selectedItem.type !== 'canvas'))
 
     return (
       <StyledFullSizeContainer

--- a/src/browser/modules/D3Visualization/components/Graph.tsx
+++ b/src/browser/modules/D3Visualization/components/Graph.tsx
@@ -134,7 +134,7 @@ export class GraphComponent extends Component<any, State> {
 
   zoomButtons() {
     return (
-      <StyledZoomHolder>
+      <StyledZoomHolder fullscreen={this.props.fullscreen}>
         <StyledZoomButton
           className={
             this.state.zoomInLimitReached ? 'faded zoom-in' : 'zoom-in'

--- a/src/browser/modules/D3Visualization/components/Inspector.tsx
+++ b/src/browser/modules/D3Visualization/components/Inspector.tsx
@@ -216,7 +216,10 @@ export class InspectorComponent extends Component<
     }
 
     return (
-      <StyledStatusBar className="status-bar">
+      <StyledStatusBar
+        fullscreen={this.props.fullscreen}
+        className="status-bar"
+      >
         <StyledStatus className="status">
           <StyledInspectorFooter
             className={

--- a/src/browser/modules/D3Visualization/components/styled.tsx
+++ b/src/browser/modules/D3Visualization/components/styled.tsx
@@ -181,12 +181,13 @@ export const StyledStatusBarWrapper = styled.div`
   display: none;
 `
 
-export const StyledStatusBar = styled.div`
+export const StyledStatusBar = styled.div<{ fullscreen?: boolean }>`
   min-height: 39px;
   line-height: 39px;
   color: ${props => props.theme.secondaryText};
   font-size: 13px;
-  position: absolute;
+  position: ${props => (props.fullscreen ? 'fixed' : 'absolute')};
+  z-index: ${props => (props.fullscreen ? 1 : 0)};
   background-color: ${props => props.theme.frameBackground};
   white-space: nowrap;
   overflow: hidden;
@@ -337,8 +338,8 @@ export const StyledInspectorFooterStatusMessage = styled.div`
   font-weight: bold;
 `
 
-export const StyledZoomHolder = styled.div`
-  position: absolute;
+export const StyledZoomHolder = styled.div<{ fullscreen: boolean }>`
+  position: ${props => (props.fullscreen ? 'fixed' : 'absolute')};
   bottom: 39px;
   right: 0;
   padding: 6px 6px 0 6px;

--- a/src/browser/modules/D3Visualization/components/styled.tsx
+++ b/src/browser/modules/D3Visualization/components/styled.tsx
@@ -187,7 +187,7 @@ export const StyledStatusBar = styled.div<{ fullscreen?: boolean }>`
   color: ${props => props.theme.secondaryText};
   font-size: 13px;
   position: ${props => (props.fullscreen ? 'fixed' : 'absolute')};
-  z-index: ${props => (props.fullscreen ? 1 : 0)};
+  z-index: ${props => (props.fullscreen ? 1 : 'auto')};
   background-color: ${props => props.theme.frameBackground};
   white-space: nowrap;
   overflow: hidden;

--- a/src/browser/modules/Frame/FrameTemplate.tsx
+++ b/src/browser/modules/Frame/FrameTemplate.tsx
@@ -134,16 +134,16 @@ function FrameTemplate({
             </StyledFrameContents>
           </StyledFrameMainSection>
         </StyledFrameBody>
-      </ContentContainer>
 
-      {statusbar && (
-        <StyledFrameStatusbar
-          fullscreen={isFullscreen}
-          data-testid="frameStatusbar"
-        >
-          {statusbar}
-        </StyledFrameStatusbar>
-      )}
+        {statusbar && (
+          <StyledFrameStatusbar
+            fullscreen={isFullscreen}
+            data-testid="frameStatusbar"
+          >
+            {statusbar}
+          </StyledFrameStatusbar>
+        )}
+      </ContentContainer>
     </StyledFrame>
   )
 }

--- a/src/browser/modules/Frame/styled.tsx
+++ b/src/browser/modules/Frame/styled.tsx
@@ -65,6 +65,7 @@ export const StyledFrameBody = styled.div<
   flex-direction: row;
   width: 100%;
   padding: 30px 30px 10px 30px;
+  ${props => props.fullscreen && `margin-bottom: ${dim.frameStatusbarHeight}px`}
 
   .has-carousel &,
   .has-stack & {

--- a/src/browser/modules/Frame/styled.tsx
+++ b/src/browser/modules/Frame/styled.tsx
@@ -65,7 +65,6 @@ export const StyledFrameBody = styled.div<
   flex-direction: row;
   width: 100%;
   padding: 30px 30px 10px 30px;
-  ${props => props.fullscreen && `margin-bottom: 30px;`}
 
   .has-carousel &,
   .has-stack & {
@@ -125,15 +124,6 @@ export const StyledFrameContents = styled.div<FullscreenProps>`
 export const StyledFrameStatusbar = styled.div<FullscreenProps>`
   border-top: ${props => props.theme.inFrameBorder};
   height: ${dim.frameStatusbarHeight - 1}px;
-  ${props =>
-    props.fullscreen &&
-    `position: fixed; 
-     bottom: 0;
-     left: 0;
-     right: 0;
-     z-index: 2;
-     background-color: ${props.theme.frameBackground}
-  `}
   display: flex;
   flex-direction: row;
   flex: none;
@@ -207,7 +197,7 @@ export const ContentContainer = styled.div`
   padding: 2px 2px 0 2px;
   display: flex;
   flex-direction: column;
-  max-height: 100vh;
+  max-height: calc(100vh - 23px);
 `
 
 export const TitleBarHeader = styled.div`

--- a/src/browser/modules/Frame/styled.tsx
+++ b/src/browser/modules/Frame/styled.tsx
@@ -47,9 +47,10 @@ z-index: 130;`
 `
 
 export const StyledFrameBody = styled.div<
-  FullscreenProps & { collapsed: boolean }
+  FullscreenProps & { collapsed: boolean; preventOverflow?: boolean }
 >`
-  overflow: auto;
+  flex: 1;
+  overflow: ${props => (props.preventOverflow ? 'hidden' : 'auto')};
   min-height: ${dim.frameBodyHeight / 2}px;
   max-height: ${props => {
     if (props.collapsed) {

--- a/src/browser/modules/Frame/styled.tsx
+++ b/src/browser/modules/Frame/styled.tsx
@@ -124,7 +124,7 @@ export const StyledFrameContents = styled.div<FullscreenProps>`
 
 export const StyledFrameStatusbar = styled.div<FullscreenProps>`
   border-top: ${props => props.theme.inFrameBorder};
-  height: ${dim.frameStatusbarHeight}px;
+  height: ${dim.frameStatusbarHeight - 1}px;
   ${props =>
     props.fullscreen &&
     `position: fixed; 

--- a/src/browser/modules/Frame/styled.tsx
+++ b/src/browser/modules/Frame/styled.tsx
@@ -49,6 +49,7 @@ z-index: 130;`
 export const StyledFrameBody = styled.div<
   FullscreenProps & { collapsed: boolean }
 >`
+  flex-grow: 1;
   overflow: auto;
   min-height: ${dim.frameBodyHeight / 2}px;
   max-height: ${props => {
@@ -64,6 +65,7 @@ export const StyledFrameBody = styled.div<
   flex-direction: row;
   width: 100%;
   padding: 30px 30px 10px 30px;
+  ${props => props.fullscreen && 'margin-bottom: 31px;'}
 
   .has-carousel &,
   .has-stack & {
@@ -122,8 +124,16 @@ export const StyledFrameContents = styled.div<FullscreenProps>`
 
 export const StyledFrameStatusbar = styled.div<FullscreenProps>`
   border-top: ${props => props.theme.inFrameBorder};
-  height: ${dim.frameStatusbarHeight - 1}px;
-  ${props => (props.fullscreen ? 'margin-top: -78px;' : '')};
+  height: ${dim.frameStatusbarHeight}px;
+  ${props =>
+    props.fullscreen &&
+    `position: fixed; 
+     bottom: 0;
+     left: 0;
+     right: 0;
+     z-index: 2;
+     background-color: ${props.theme.frameBackground}
+  `}
   display: flex;
   flex-direction: row;
   flex: none;
@@ -195,6 +205,9 @@ export const StyledFrameCommand = styled.label<{ selectedDb: string | null }>`
 export const ContentContainer = styled.div`
   margin: 0px 3px;
   padding: 2px 2px 0 2px;
+  display: flex;
+  flex-direction: column;
+  max-height: 100vh;
 `
 
 export const TitleBarHeader = styled.div`

--- a/src/browser/modules/Frame/styled.tsx
+++ b/src/browser/modules/Frame/styled.tsx
@@ -49,7 +49,6 @@ z-index: 130;`
 export const StyledFrameBody = styled.div<
   FullscreenProps & { collapsed: boolean }
 >`
-  flex-grow: 1;
   overflow: auto;
   min-height: ${dim.frameBodyHeight / 2}px;
   max-height: ${props => {
@@ -65,7 +64,7 @@ export const StyledFrameBody = styled.div<
   flex-direction: row;
   width: 100%;
   padding: 30px 30px 10px 30px;
-  ${props => props.fullscreen && `margin-bottom: ${dim.frameStatusbarHeight}px`}
+  ${props => props.fullscreen && `margin-bottom: 30px;`}
 
   .has-carousel &,
   .has-stack & {

--- a/src/browser/modules/Frame/styled.tsx
+++ b/src/browser/modules/Frame/styled.tsx
@@ -65,7 +65,6 @@ export const StyledFrameBody = styled.div<
   flex-direction: row;
   width: 100%;
   padding: 30px 30px 10px 30px;
-  ${props => props.fullscreen && 'margin-bottom: 31px;'}
 
   .has-carousel &,
   .has-stack & {

--- a/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
+++ b/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
@@ -347,27 +347,19 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
           />
         </Display>
         <Display if={this.state.openView === viewTypes.VISUALIZATION} lazy>
-          <div
-            style={{
-              maxHeight: '100%',
-              overflow: 'hidden',
-              position: 'relative'
+          <VisualizationConnectedBus
+            fullscreen={this.state.fullscreen}
+            result={result}
+            updated={this.props.request.updated}
+            frameHeight={this.state.frameHeight}
+            assignVisElement={(svgElement: any, graphElement: any) => {
+              this.visElement = { svgElement, graphElement, type: 'graph' }
+              this.setState({ hasVis: true })
             }}
-          >
-            <VisualizationConnectedBus
-              fullscreen={this.state.fullscreen}
-              result={result}
-              updated={this.props.request.updated}
-              frameHeight={this.state.frameHeight}
-              assignVisElement={(svgElement: any, graphElement: any) => {
-                this.visElement = { svgElement, graphElement, type: 'graph' }
-                this.setState({ hasVis: true })
-              }}
-              initialNodeDisplay={this.props.initialNodeDisplay}
-              autoComplete={this.props.autoComplete}
-              maxNeighbours={this.props.maxNeighbours}
-            />
-          </div>
+            initialNodeDisplay={this.props.initialNodeDisplay}
+            autoComplete={this.props.autoComplete}
+            maxNeighbours={this.props.maxNeighbours}
+          />
         </Display>
       </StyledFrameBody>
     )

--- a/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
+++ b/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
@@ -307,6 +307,7 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
         data-testid="frame-loaded-contents"
         fullscreen={this.state.fullscreen}
         collapsed={this.state.collapse}
+        preventOverflow={this.state.openView === viewTypes.VISUALIZATION}
       >
         <Display if={this.state.openView === viewTypes.TEXT} lazy>
           <AsciiView

--- a/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
+++ b/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
@@ -347,18 +347,27 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
           />
         </Display>
         <Display if={this.state.openView === viewTypes.VISUALIZATION} lazy>
-          <VisualizationConnectedBus
-            result={result}
-            updated={this.props.request.updated}
-            frameHeight={this.state.frameHeight}
-            assignVisElement={(svgElement: any, graphElement: any) => {
-              this.visElement = { svgElement, graphElement, type: 'graph' }
-              this.setState({ hasVis: true })
+          <div
+            style={{
+              maxHeight: '100%',
+              overflow: 'hidden',
+              position: 'relative'
             }}
-            initialNodeDisplay={this.props.initialNodeDisplay}
-            autoComplete={this.props.autoComplete}
-            maxNeighbours={this.props.maxNeighbours}
-          />
+          >
+            <VisualizationConnectedBus
+              fullscreen={this.state.fullscreen}
+              result={result}
+              updated={this.props.request.updated}
+              frameHeight={this.state.frameHeight}
+              assignVisElement={(svgElement: any, graphElement: any) => {
+                this.visElement = { svgElement, graphElement, type: 'graph' }
+                this.setState({ hasVis: true })
+              }}
+              initialNodeDisplay={this.props.initialNodeDisplay}
+              autoComplete={this.props.autoComplete}
+              maxNeighbours={this.props.maxNeighbours}
+            />
+          </div>
         </Display>
       </StyledFrameBody>
     )

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView.styled.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView.styled.tsx
@@ -23,8 +23,6 @@ import { dim } from 'browser-styles/constants'
 
 export const StyledVisContainer = styled.div<{ fullscreen: boolean }>`
   width: 100%;
-  overflow: hidden;
-  ${props => (props.fullscreen ? 'padding-bottom: 39px' : null)};
   height: ${props =>
     props.fullscreen
       ? '100vh'

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Visualization renders 1`] = `<div />`;
 exports[`Visualization renders with result and escapes any HTML 1`] = `
 <div>
   <div
-    class="sc-bwCtUz bxryAr"
+    class="sc-bwCtUz hJgGYC"
   >
     <div
       class="sc-iAyFgw ikvPvE one-legend-row"
@@ -152,7 +152,7 @@ exports[`Visualization renders with result and escapes any HTML 1`] = `
         </div>
       </div>
       <div
-        class="sc-gqjmRU dwJWly status-bar"
+        class="sc-gqjmRU jKEGNe status-bar"
       >
         <div
           class="sc-VigVT joQvFy status"

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
@@ -152,7 +152,7 @@ exports[`Visualization renders with result and escapes any HTML 1`] = `
         </div>
       </div>
       <div
-        class="sc-gqjmRU jKEGNe status-bar"
+        class="sc-gqjmRU iNDOUA status-bar"
       >
         <div
           class="sc-VigVT joQvFy status"


### PR DESCRIPTION
To solve the problem of the bottom bar moving of the screen when adding lines to a query in fullscreen a new flexbox was added to give the middle content 100% height and scroll on overflow, taking the available space not used for the editor or the bottom bar. For the main viz though, resizing the container seems to change the size of the nodes, so I've opted to use position fixed for the bottom bar and zoom controls there. Worth noting that the viz bottom bar is probably going away soon as part of our work on node properties. I'm sure there's a cleaner way to structure the css and element tree, so far this is the cleanest I've worked out after too many hours of fiddling. 

preview @ http://fullscreen_fix.surge.sh

Fixes #1460 
![image](https://user-images.githubusercontent.com/10564538/124783884-b194f980-df45-11eb-957e-71ee5e05c66e.png)
