### PR TITLE
Disable sentry and segment in CI

### DIFF
--- a/src/browser/AppInit.tsx
+++ b/src/browser/AppInit.tsx
@@ -166,10 +166,16 @@ export function setupSentry(): void {
           return 0.2
         }
       },
-      beforeSend: event =>
-        shouldAllowOutgoingConnections(store.getState())
-          ? scrubQueryParamsAndUrl(event)
-          : null,
+      beforeSend: event => {
+        const inCI = window.Cypress
+        const allowsOutGoing = shouldAllowOutgoingConnections(store.getState())
+
+        if (allowsOutGoing && !inCI) {
+          return scrubQueryParamsAndUrl(event)
+        } else {
+          return null
+        }
+      },
       environment: 'unset'
     })
     Sentry.setUser({ id: getUuid(store.getState()) })

--- a/src/browser/custom.d.ts
+++ b/src/browser/custom.d.ts
@@ -11,6 +11,10 @@ declare module 'ascii-data-table'
 declare module 'react-timeago'
 declare module '@neo4j/browser-lambda-parser'
 
+interface Window {
+  Cypress?: unknown
+}
+
 declare module 'react-suber' {
   interface BusProps {
     bus: Bus

--- a/src/browser/modules/App/App.tsx
+++ b/src/browser/modules/App/App.tsx
@@ -114,12 +114,14 @@ export function App(props: any) {
       props.bus.take(
         METRICS_EVENT,
         ({ category, label, data }: MetricsData) => {
-          eventMetricsCallback &&
-            eventMetricsCallback.current &&
-            eventMetricsCallback.current({ category, label, data })
-          segmentTrackCallback &&
-            segmentTrackCallback.current &&
-            segmentTrackCallback.current({ category, label, data })
+          if (!window.Cypress) {
+            eventMetricsCallback &&
+              eventMetricsCallback.current &&
+              eventMetricsCallback.current({ category, label, data })
+            segmentTrackCallback &&
+              segmentTrackCallback.current &&
+              segmentTrackCallback.current({ category, label, data })
+          }
         }
       )
     const initAction = udcInit()


### PR DESCRIPTION
window.Cypress is used to detect if we're running e2e tests as per the [docs](https://docs.cypress.io/faq/questions/using-cypress-faq#Is-there-any-way-to-detect-if-my-app-is-running-under-Cypress)

Preview @ http://disable_sentry_segment_in_ci.surge.sh

I think it'd make sense to gather the constants such as isMac or isInCI in some centralized place, but unsure where. Suggestions? 