### PR TITLE
Persist UUID

### DIFF
--- a/src/shared/modules/udc/udcDuck.ts
+++ b/src/shared/modules/udc/udcDuck.ts
@@ -191,7 +191,7 @@ export default function reducer(
     case CLEAR_EVENTS:
       return { ...state, events: [] }
     case USER_CLEAR:
-      return initialState
+      return { ...initialState, uuid: state.uuid || initialState.uuid }
     case UPDATE_DATA:
       const { type, ...rest } = action
       return { ...state, ...rest }


### PR DESCRIPTION
Currently UUID is lost when clearing favorites/localstorage through the browser sync tab, which is not the intention of the feature