### PR TITLE
Update serializer to escape newlines

### DIFF
--- a/src/shared/services/serializer.test.ts
+++ b/src/shared/services/serializer.test.ts
@@ -99,5 +99,14 @@ describe('resultTransform', () => {
       const s = CSVSerializer(cols)
       expect(s.output()).toEqual('"{""name"":""John""}"')
     })
+    test('should escape newlines in values properly ', () => {
+      const cols = ['a\nb', 'b\nc']
+      const s = CSVSerializer(cols)
+      expect(s.output()).toEqual(
+        `"a
+b","b
+c"`
+      )
+    })
   })
 })

--- a/src/shared/services/serializer.test.ts
+++ b/src/shared/services/serializer.test.ts
@@ -108,5 +108,10 @@ b","b
 c"`
       )
     })
+    test('should escape newlines in values properly even with \r', () => {
+      const cols = ['a\r\nb', 'b\r\nc']
+      const s = CSVSerializer(cols)
+      expect(s.output()).toEqual(`"a\r\nb","b\r\nc"`)
+    })
   })
 })

--- a/src/shared/services/serializer.ts
+++ b/src/shared/services/serializer.ts
@@ -24,7 +24,7 @@ const csvNewline = '\n'
 const csvEscape = (str: any) => {
   if (!isString(str)) return str
   if (isEmptyString(str)) return '""'
-  if (hasQuotes(str) || hasDelimiterChars(str)) {
+  if (hasQuotes(str) || hasDelimiterChars(str) || hasNewLines(str)) {
     return `"${str.replace(/"/g, '""')}"`
   }
   return str
@@ -33,6 +33,7 @@ const serializeObject = (input: any) =>
   isObject(input) ? JSON.stringify(input) : input
 
 const hasDelimiterChars = (str: any) => str && str.indexOf(csvDelimiter) > -1
+const hasNewLines = (str: any) => str && str.indexOf(csvNewline) > -1
 const hasQuotes = (str: any) => str && str.indexOf('"') > -1
 const isString = (str: any) => typeof str === 'string'
 const isObject = (str: any) => typeof str === 'object' && str !== null


### PR DESCRIPTION
PR fixes the following issue.

`return "a\nb" as a,"b\nc" as b`

creates this csv

```csv
a,b
a
b,b
c
```

while it should have been

```csv
a,b
"a
b","b
c"
```

Preview at http://csv_export_fix.surge.sh
