### PR TITLE
Show what command was unknown

### DIFF
--- a/src/shared/modules/commands/helpers/server.ts
+++ b/src/shared/modules/commands/helpers/server.ts
@@ -48,7 +48,7 @@ export function handleServerCommand(action: any, put: any, store: any) {
   return {
     ...action,
     type: 'error',
-    error: { message: UnknownCommandError(action.cmd).message }
+    error: UnknownCommandError({ cmd: action.cmd })
   }
 }
 


### PR DESCRIPTION
Solves error not being created properly. 

Before:
![image](https://user-images.githubusercontent.com/10564538/124785424-20bf1d80-df47-11eb-8b4e-cdf33dd3dca0.png)

After: ![image](https://user-images.githubusercontent.com/10564538/124785365-156bf200-df47-11eb-9cea-fe2ed52aaa99.png)

Preview at http://name_unknown_command.surge.sh