### PR TITLE
Fix sysinfo frame

### DIFF
--- a/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
@@ -123,11 +123,13 @@ export class SysInfoFrame extends Component<
                 resolve()
               })
             } else {
+              this.setState({ success: false })
               reject()
             }
           }
         )
       } else {
+        this.setState({ success: false })
         reject()
       }
     })
@@ -196,20 +198,21 @@ export class SysInfoFrame extends Component<
     } = this.state
     const { databases, frame, isConnected, isEnterprise } = this.props
 
-    const content = !isConnected ? (
-      <ErrorsView
-        result={{ code: 'No connection', message: 'No connection available' }}
-      />
-    ) : (
-      <SysInfoTable
-        pageCache={pageCache}
-        storeSizes={storeSizes}
-        idAllocation={idAllocation}
-        transactions={transactions}
-        databases={databases}
-        isEnterpriseEdition={isEnterprise}
-      />
-    )
+    const content =
+      !isConnected && success ? (
+        <ErrorsView
+          result={{ code: 'No connection', message: 'No connection available' }}
+        />
+      ) : (
+        <SysInfoTable
+          pageCache={pageCache}
+          storeSizes={storeSizes}
+          idAllocation={idAllocation}
+          transactions={transactions}
+          databases={databases}
+          isEnterpriseEdition={isEnterprise}
+        />
+      )
 
     return (
       <FrameTemplate

--- a/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
@@ -116,7 +116,7 @@ export class SysInfoFrame extends Component<
               result.records.forEach((record: any) => {
                 const name = record.get('name')
                 const value = record.get('value')
-                //if(name === "metrics.)
+                //if(name === "metrics.prefix")
                 //namespacesEnabled
                 //userConfiguredPrefix
                 //console.log(name, value)

--- a/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
@@ -45,6 +45,8 @@ import { SysInfoTable } from './SysInfoTable'
 import { Bus } from 'suber'
 import { GlobalState } from 'shared/globalState'
 import { Frame } from 'shared/modules/stream/streamDuck'
+import { ExclamationTriangleIcon } from '../../../components/icons/Icons'
+import styled from 'styled-components'
 
 export type DatabaseMetric = { label: string; value?: string }
 export type SysInfoFrameState = {
@@ -53,7 +55,7 @@ export type SysInfoFrameState = {
   idAllocation: DatabaseMetric[]
   pageCache: DatabaseMetric[]
   transactions: DatabaseMetric[]
-  error: string
+  errorMessage: string | null
   results: boolean
   success: boolean
   autoRefresh: boolean
@@ -81,7 +83,7 @@ export class SysInfoFrame extends Component<
     idAllocation: [],
     pageCache: [],
     transactions: [],
-    error: '',
+    errorMessage: null,
     results: false,
     success: false,
     autoRefresh: false,
@@ -184,7 +186,7 @@ export class SysInfoFrame extends Component<
   render(): ReactNode {
     const {
       autoRefresh,
-      error,
+      errorMessage,
       idAllocation,
       lastFetch,
       pageCache,
@@ -215,27 +217,31 @@ export class SysInfoFrame extends Component<
         contents={content}
         statusbar={
           <StatusbarWrapper>
-            {error && <FrameError message={error} />}
-            {success && (
-              <StyledStatusBar>
-                {lastFetch && `Updated: ${new Date(lastFetch).toISOString()}`}
-
-                {success}
-
-                <AutoRefreshSpan>
-                  <AutoRefreshToggle
-                    checked={autoRefresh}
-                    onChange={e => this.setAutoRefresh(e.target.checked)}
-                  />
-                </AutoRefreshSpan>
-              </StyledStatusBar>
-            )}
+            <StyledStatusBar>
+              {lastFetch && `Updated: ${new Date(lastFetch).toISOString()}`}
+              {errorMessage && (
+                <InlineError>
+                  <ExclamationTriangleIcon /> {errorMessage}
+                </InlineError>
+              )}
+              <AutoRefreshSpan>
+                <AutoRefreshToggle
+                  checked={autoRefresh}
+                  onChange={e => this.setAutoRefresh(e.target.checked)}
+                />
+              </AutoRefreshSpan>
+            </StyledStatusBar>
           </StatusbarWrapper>
         }
       />
     )
   }
 }
+
+const InlineError = styled.span`
+  color: ${props => props.theme.error};
+  padding-left: 15px;
+`
 
 const mapStateToProps = (state: GlobalState) => ({
   hasMultiDbSupport: hasMultiDbSupport(state),

--- a/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
@@ -87,10 +87,48 @@ export class SysInfoFrame extends Component<
     autoRefresh: false,
     autoRefreshInterval: 20 // seconds
   }
+  metricsSettings?: {
+    namespacesEnabled: boolean
+    userConfiguredPrefix: string
+    jmxDisabled: boolean
+    metricsDisabled: boolean
+  }
 
   componentDidMount(): void {
-    this.getSysInfo()
+    this.getSettings().then(this.getSysInfo.bind(this))
   }
+
+  getSettings = (): Promise<void> =>
+    new Promise((resolve, reject) => {
+      const { bus, isConnected } = this.props
+
+      if (bus && isConnected) {
+        bus.self(
+          CYPHER_REQUEST,
+          {
+            query: 'CALL dbms.listConfig("metrics.")',
+            queryType: NEO4J_BROWSER_USER_ACTION_QUERY
+          },
+          ({ success, result }) => {
+            if (success) {
+              result.records.forEach((record: any) => {
+                const name = record.get('name')
+                const value = record.get('value')
+                //if(name === "metrics.)
+                //namespacesEnabled
+                //userConfiguredPrefix
+                //console.log(name, value)
+                resolve()
+              })
+            } else {
+              reject()
+            }
+          }
+        )
+      } else {
+        reject()
+      }
+    })
 
   componentDidUpdate(
     prevProps: SysInfoFrameProps,
@@ -123,10 +161,14 @@ export class SysInfoFrame extends Component<
       bus.self(
         CYPHER_REQUEST,
         {
-          query: sysinfoQuery(useDb),
+          query: sysinfoQuery({
+            databaseName: useDb,
+            namespacesEnabled: false,
+            userConfiguredPrefix: 'neo4j'
+          }),
           queryType: NEO4J_BROWSER_USER_ACTION_QUERY
         },
-        responseHandler(this.setState.bind(this), useDb)
+        responseHandler(this.setState.bind(this))
       )
     }
   }

--- a/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
@@ -135,7 +135,7 @@ export class SysInfoFrame extends Component<
           }
         )
       } else {
-        reject('Connection error')
+        reject('Could not reach server')
       }
     })
 

--- a/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
@@ -56,7 +56,6 @@ export type SysInfoFrameState = {
   transactions: DatabaseMetric[]
   errorMessage: string | null
   results: boolean
-  success: boolean
   autoRefresh: boolean
   autoRefreshInterval: number
   namespacesEnabled: boolean
@@ -86,7 +85,6 @@ export class SysInfoFrame extends Component<
     transactions: [],
     errorMessage: null,
     results: false,
-    success: false,
     autoRefresh: false,
     autoRefreshInterval: 20, // seconds
     namespacesEnabled: false,
@@ -94,7 +92,9 @@ export class SysInfoFrame extends Component<
   }
 
   componentDidMount(): void {
-    this.getSettings().then(this.getSysInfo.bind(this))
+    this.getSettings()
+      .then(this.getSysInfo.bind(this))
+      .catch(() => this.setState({ errorMessage: "Couldn't fetch settings" }))
   }
 
   getSettings = (): Promise<void> =>
@@ -130,13 +130,11 @@ export class SysInfoFrame extends Component<
               this.setState(newState)
               resolve()
             } else {
-              this.setState({ success: false })
               reject()
             }
           }
         )
       } else {
-        this.setState({ success: false })
         reject()
       }
     })
@@ -201,26 +199,24 @@ export class SysInfoFrame extends Component<
       lastFetch,
       pageCache,
       storeSizes,
-      success,
       transactions
     } = this.state
     const { databases, frame, isConnected, isEnterprise } = this.props
 
-    const content =
-      !isConnected && success ? (
-        <ErrorsView
-          result={{ code: 'No connection', message: 'No connection available' }}
-        />
-      ) : (
-        <SysInfoTable
-          pageCache={pageCache}
-          storeSizes={storeSizes}
-          idAllocation={idAllocation}
-          transactions={transactions}
-          databases={databases}
-          isEnterpriseEdition={isEnterprise}
-        />
-      )
+    const content = isConnected ? (
+      <SysInfoTable
+        pageCache={pageCache}
+        storeSizes={storeSizes}
+        idAllocation={idAllocation}
+        transactions={transactions}
+        databases={databases}
+        isEnterpriseEdition={isEnterprise}
+      />
+    ) : (
+      <ErrorsView
+        result={{ code: 'No connection', message: 'No connection available' }}
+      />
+    )
 
     return (
       <FrameTemplate

--- a/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
@@ -45,7 +45,7 @@ import { Bus } from 'suber'
 import { GlobalState } from 'shared/globalState'
 import { Frame } from 'shared/modules/stream/streamDuck'
 import { ExclamationTriangleIcon } from '../../../components/icons/Icons'
-import styled from 'styled-components'
+import { InlineError } from './styled'
 
 export type DatabaseMetric = { label: string; value?: string }
 export type SysInfoFrameState = {
@@ -93,8 +93,8 @@ export class SysInfoFrame extends Component<
 
   componentDidMount(): void {
     this.getSettings()
-      .then(this.getSysInfo.bind(this))
-      .catch(() => this.setState({ errorMessage: "Couldn't fetch settings" }))
+      .then(this.getSysInfo)
+      .catch(errorMessage => this.setState({ errorMessage }))
   }
 
   getSettings = (): Promise<void> =>
@@ -130,12 +130,12 @@ export class SysInfoFrame extends Component<
               this.setState(newState)
               resolve()
             } else {
-              reject()
+              reject('Failed to run listConfig')
             }
           }
         )
       } else {
-        reject()
+        reject('Connection error')
       }
     })
 
@@ -146,7 +146,7 @@ export class SysInfoFrame extends Component<
     if (prevState.autoRefresh !== this.state.autoRefresh) {
       if (this.state.autoRefresh) {
         this.timer = setInterval(
-          this.getSysInfo.bind(this),
+          this.getSysInfo,
           this.state.autoRefreshInterval * 1000
         )
       } else {
@@ -159,7 +159,7 @@ export class SysInfoFrame extends Component<
     }
   }
 
-  getSysInfo(): void {
+  getSysInfo = (): void => {
     const { userConfiguredPrefix, namespacesEnabled } = this.state
     const { bus, isConnected, useDb } = this.props
     const { sysinfoQuery, responseHandler } = this.props.hasMultiDbSupport
@@ -183,7 +183,7 @@ export class SysInfoFrame extends Component<
     }
   }
 
-  setAutoRefresh(autoRefresh: boolean): void {
+  setAutoRefresh = (autoRefresh: boolean): void => {
     this.setState({ autoRefresh })
 
     if (autoRefresh) {
@@ -244,11 +244,6 @@ export class SysInfoFrame extends Component<
     )
   }
 }
-
-const InlineError = styled.span`
-  color: ${props => props.theme.error};
-  padding-left: 15px;
-`
 
 const mapStateToProps = (state: GlobalState) => ({
   hasMultiDbSupport: hasMultiDbSupport(state),

--- a/src/browser/modules/Stream/SysInfoFrame/helpers.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/helpers.tsx
@@ -186,7 +186,7 @@ export const responseHandler = (setState: (newState: any) => void) =>
     const storeSizes = [
       {
         label: 'Size',
-        value: toHumanReadableBytes(size.total)
+        value: size.total ? toHumanReadableBytes(size.total) : size.total
       }
     ]
 
@@ -243,9 +243,12 @@ export const responseHandler = (setState: (newState: any) => void) =>
       { label: 'Committed Write', value: tx.committed_write }
     ]
 
-    const valuesMissing = Object.values(intoGroups).some((group: any) =>
-      group.attributes.some((item: any) => !!item.value)
-    )
+    const valuesMissing = [
+      storeSizes,
+      pageCache,
+      idAllocation,
+      transactions
+    ].some(type => type.some((item: any) => !item.value))
 
     setState({
       pageCache,

--- a/src/browser/modules/Stream/SysInfoFrame/helpers.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/helpers.tsx
@@ -109,7 +109,7 @@ function constructQuery({
 }: ConstructorParams) {
   // Build full metric name of format:
   // <user-configured-prefix>.[namespace?].[databaseName?].<metric-name>
-  const parts = [userConfiguredPrefix]
+  const parts = []
   if (namespacesEnabled) {
     parts.push(type)
   }
@@ -119,9 +119,9 @@ function constructQuery({
   }
 
   parts.push(baseMetricName)
-  const fullMetricName = parts.join('.')
+  const metricName = parts.join('.')
 
-  return `CALL dbms.queryJmx("neo4j.metrics:name=${fullMetricName}") YIELD name, attributes RETURN "${group}" AS group, name, attributes`
+  return `CALL dbms.queryJmx("${userConfiguredPrefix}.metrics:name=${userConfiguredPrefix}.${metricName}") YIELD name, attributes RETURN "${group}" AS group, name, attributes`
 }
 
 export function sysinfoQuery({

--- a/src/browser/modules/Stream/SysInfoFrame/helpers.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/helpers.tsx
@@ -243,11 +243,18 @@ export const responseHandler = (setState: (newState: any) => void) =>
       { label: 'Committed Write', value: tx.committed_write }
     ]
 
+    const valuesMissing = Object.values(intoGroups).some((group: any) =>
+      group.attributes.some((item: any) => !!item.value)
+    )
+
     setState({
       pageCache,
       storeSizes,
       idAllocation,
       transactions,
-      success: true
+      success: true,
+      errorMessage: valuesMissing
+        ? 'Some metrics missing, check neo4j.conf'
+        : null
     })
   }

--- a/src/browser/modules/Stream/SysInfoFrame/helpers.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/helpers.tsx
@@ -20,7 +20,6 @@
 
 import { flattenAttributes } from './sysinfo-utils'
 import { toHumanReadableBytes } from 'services/utils'
-import { string } from 'browser/modules/Editor/cypher/functions'
 
 /*
 The database provides a number of ways to monitor it's health, we use JMX MBeans.
@@ -58,11 +57,10 @@ const sysInfoMetrics: SysInfoMetrics[] = [
     group: 'Page Cache',
     type: 'dbms',
     baseMetricNames: [
-      'page_cache.flushes',
-      'page_cache.evictions',
-      'page_cache.eviction_exceptions',
+      'page_cache.hits',
       'page_cache.hit_ratio',
-      'page_cache.usage_ratio'
+      'page_cache.usage_ratio',
+      'page_cache.page_faults'
     ]
   },
   {
@@ -80,10 +78,11 @@ const sysInfoMetrics: SysInfoMetrics[] = [
     type: 'database',
     baseMetricNames: [
       'transaction.last_committed_tx_id',
-      'transaction.active',
       'transaction.peak_concurrent',
-      'transaction.started',
-      'transaction.committed'
+      'transaction.active_read',
+      'transaction.active_write',
+      'transaction.committed_read',
+      'transaction.committed_write'
     ]
   }
 ]
@@ -193,12 +192,8 @@ export const responseHandler = (setState: (newState: any) => void) =>
 
     const cache = flattenAttributes(intoGroups['Page Cache'])
     const pageCache = [
-      { label: 'Flushes', value: cache.flushes },
-      { label: 'Evictions', value: cache.evictions },
-      {
-        label: 'Eviction Exceptions',
-        value: cache.eviction_exceptions
-      },
+      { label: 'Hits', value: cache.hits },
+      { label: 'Page Faults', value: cache.page_faults },
       {
         label: 'Hit Ratio',
         value: cache.hit_ratio,
@@ -238,13 +233,14 @@ export const responseHandler = (setState: (newState: any) => void) =>
         label: 'Last Tx Id',
         value: tx.last_committed_tx_id
       },
-      { label: 'Current', value: tx.active },
+      { label: 'Current Read', value: tx.active_read },
+      { label: 'Current Write', value: tx.active_write },
       {
-        label: 'Peak',
+        label: 'Peak Transactions',
         value: tx.peak_concurrent
       },
-      { label: 'Opened', value: tx.started },
-      { label: 'Committed', value: tx.committed }
+      { label: 'Committed Read', value: tx.committed_read },
+      { label: 'Committed Write', value: tx.committed_write }
     ]
 
     setState({

--- a/src/browser/modules/Stream/SysInfoFrame/helpers.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/helpers.tsx
@@ -154,7 +154,6 @@ function flatten<T>(acc: T[], curr: T[]): T[] {
 export const responseHandler = (setState: (newState: any) => void) =>
   function(res: any): void {
     if (!res || !res.result || !res.result.records) {
-      setState({ success: false })
       return
     }
 
@@ -255,7 +254,6 @@ export const responseHandler = (setState: (newState: any) => void) =>
       storeSizes,
       idAllocation,
       transactions,
-      success: true,
       errorMessage: valuesMissing
         ? 'Some metrics missing, check neo4j.conf'
         : null

--- a/src/browser/modules/Stream/SysInfoFrame/helpers.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/helpers.tsx
@@ -160,7 +160,7 @@ function flatten<T>(acc: T[], curr: T[]): T[] {
 export const responseHandler = (setState: (newState: any) => void) =>
   function(res: any): void {
     if (!res || !res.result || !res.result.records) {
-      setState({ errorMessage: 'Failed to call dbms.queryJmx' })
+      setState({ errorMessage: 'Call to dbms.queryJmx failed' })
       return
     }
 

--- a/src/browser/modules/Stream/SysInfoFrame/legacyHelpers.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/legacyHelpers.tsx
@@ -19,12 +19,8 @@
  */
 
 import React from 'react'
-import {
-  getTableDataFromRecords,
-  mapLegacySysInfoRecords,
-  buildTableData
-} from './sysinfo-utils'
-import { toHumanReadableBytes, toKeyString } from 'services/utils'
+import { getTableDataFromRecords, buildTableData } from './sysinfo-utils'
+import { toHumanReadableBytes } from 'services/utils'
 import arrayHasItems from 'shared/utils/array-has-items'
 import Render from 'browser-components/Render'
 import {

--- a/src/browser/modules/Stream/SysInfoFrame/styled.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/styled.tsx
@@ -1,0 +1,6 @@
+import styled from 'styled-components'
+
+export const InlineError = styled.span`
+  color: ${props => props.theme.error};
+  padding-left: 15px;
+`

--- a/src/browser/modules/Stream/__snapshots__/SchemaFrame.test.tsx.snap
+++ b/src/browser/modules/Stream/__snapshots__/SchemaFrame.test.tsx.snap
@@ -10,13 +10,13 @@ exports[`SchemaFrame renders empty 1`] = `
         class="sc-dqBHgY eVMXHH"
       >
         <table
-          class="sc-hgRTRy ldnbjm"
+          class="sc-iIHSe hPUsAM"
           data-testid="schemaFrameIndexesTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-gldTML jPArlV table-header"
+                class="sc-feryYK eLoFhR table-header"
               >
                 Indexes
               </th>
@@ -24,10 +24,10 @@ exports[`SchemaFrame renders empty 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-iIHSe bAdqZs table-row"
+              class="sc-gldTML fgQePp table-row"
             >
               <td
-                class="sc-feryYK iImUoj table-properties"
+                class="sc-cJOK cwWPhV table-properties"
               >
                 None
               </td>
@@ -35,13 +35,13 @@ exports[`SchemaFrame renders empty 1`] = `
           </tbody>
         </table>
         <table
-          class="sc-hgRTRy ldnbjm"
+          class="sc-iIHSe hPUsAM"
           data-testid="schemaFrameConstraintsTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-gldTML jPArlV table-header"
+                class="sc-feryYK eLoFhR table-header"
               >
                 Constraints
               </th>
@@ -49,10 +49,10 @@ exports[`SchemaFrame renders empty 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-iIHSe bAdqZs table-row"
+              class="sc-gldTML fgQePp table-row"
             >
               <td
-                class="sc-feryYK iImUoj table-properties"
+                class="sc-cJOK cwWPhV table-properties"
               >
                 None
               </td>
@@ -92,43 +92,43 @@ exports[`SchemaFrame renders empty for Neo4j >= 4.0 1`] = `
         class="sc-dqBHgY eVMXHH"
       >
         <table
-          class="sc-hgRTRy ldnbjm"
+          class="sc-iIHSe hPUsAM"
           data-testid="schemaFrameIndexesTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-gldTML jPArlV table-header"
+                class="sc-feryYK eLoFhR table-header"
               >
                 Index Name
               </th>
               <th
-                class="sc-gldTML jPArlV table-header"
+                class="sc-feryYK eLoFhR table-header"
               >
                 Type
               </th>
               <th
-                class="sc-gldTML jPArlV table-header"
+                class="sc-feryYK eLoFhR table-header"
               >
                 Uniqueness
               </th>
               <th
-                class="sc-gldTML jPArlV table-header"
+                class="sc-feryYK eLoFhR table-header"
               >
                 EntityType
               </th>
               <th
-                class="sc-gldTML jPArlV table-header"
+                class="sc-feryYK eLoFhR table-header"
               >
                 LabelsOrTypes
               </th>
               <th
-                class="sc-gldTML jPArlV table-header"
+                class="sc-feryYK eLoFhR table-header"
               >
                 Properties
               </th>
               <th
-                class="sc-gldTML jPArlV table-header"
+                class="sc-feryYK eLoFhR table-header"
               >
                 State
               </th>
@@ -136,42 +136,42 @@ exports[`SchemaFrame renders empty for Neo4j >= 4.0 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-iIHSe bAdqZs table-row"
+              class="sc-gldTML fgQePp table-row"
             >
               <td
-                class="sc-feryYK iImUoj table-properties"
+                class="sc-cJOK cwWPhV table-properties"
               >
                 None
               </td>
               <td
-                class="sc-feryYK iImUoj table-properties"
+                class="sc-cJOK cwWPhV table-properties"
               />
               <td
-                class="sc-feryYK iImUoj table-properties"
+                class="sc-cJOK cwWPhV table-properties"
               />
               <td
-                class="sc-feryYK iImUoj table-properties"
+                class="sc-cJOK cwWPhV table-properties"
               />
               <td
-                class="sc-feryYK iImUoj table-properties"
+                class="sc-cJOK cwWPhV table-properties"
               />
               <td
-                class="sc-feryYK iImUoj table-properties"
+                class="sc-cJOK cwWPhV table-properties"
               />
               <td
-                class="sc-feryYK iImUoj table-properties"
+                class="sc-cJOK cwWPhV table-properties"
               />
             </tr>
           </tbody>
         </table>
         <table
-          class="sc-hgRTRy ldnbjm"
+          class="sc-iIHSe hPUsAM"
           data-testid="schemaFrameConstraintsTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-gldTML jPArlV table-header"
+                class="sc-feryYK eLoFhR table-header"
               >
                 Constraints
               </th>
@@ -179,10 +179,10 @@ exports[`SchemaFrame renders empty for Neo4j >= 4.0 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-iIHSe bAdqZs table-row"
+              class="sc-gldTML fgQePp table-row"
             >
               <td
-                class="sc-feryYK iImUoj table-properties"
+                class="sc-cJOK cwWPhV table-properties"
               >
                 None
               </td>
@@ -222,13 +222,13 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
         class="sc-dqBHgY eVMXHH"
       >
         <table
-          class="sc-hgRTRy ldnbjm"
+          class="sc-iIHSe hPUsAM"
           data-testid="schemaFrameIndexesTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-gldTML jPArlV table-header"
+                class="sc-feryYK eLoFhR table-header"
               >
                 Indexes
               </th>
@@ -236,10 +236,10 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-iIHSe bAdqZs table-row"
+              class="sc-gldTML fgQePp table-row"
             >
               <td
-                class="sc-feryYK iImUoj table-properties"
+                class="sc-cJOK cwWPhV table-properties"
               >
                  ON :Movie(released) ONLINE 
               </td>
@@ -247,13 +247,13 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
           </tbody>
         </table>
         <table
-          class="sc-hgRTRy ldnbjm"
+          class="sc-iIHSe hPUsAM"
           data-testid="schemaFrameConstraintsTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-gldTML jPArlV table-header"
+                class="sc-feryYK eLoFhR table-header"
               >
                 Constraints
               </th>
@@ -261,10 +261,10 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-iIHSe bAdqZs table-row"
+              class="sc-gldTML fgQePp table-row"
             >
               <td
-                class="sc-feryYK iImUoj table-properties"
+                class="sc-cJOK cwWPhV table-properties"
               >
                  ON ( book:Book ) ASSERT book.isbn IS UNIQUE
               </td>

--- a/src/shared/modules/dbMeta/dbMetaDuck.ts
+++ b/src/shared/modules/dbMeta/dbMetaDuck.ts
@@ -259,7 +259,10 @@ export const initialState = {
     'browser.allow_outgoing_connections': false,
     'browser.remote_content_hostname_allowlist': 'guides.neo4j.com, localhost',
     'browser.retain_connection_credentials': false,
-    'browser.retain_editor_history': false
+    'browser.retain_editor_history': false,
+    'metrics.enabled': true,
+    'metrics.prefix': 'neo4j',
+    'metrics.namespaces.enabled': false
   }
 }
 

--- a/src/shared/modules/dbMeta/dbMetaDuck.ts
+++ b/src/shared/modules/dbMeta/dbMetaDuck.ts
@@ -259,10 +259,7 @@ export const initialState = {
     'browser.allow_outgoing_connections': false,
     'browser.remote_content_hostname_allowlist': 'guides.neo4j.com, localhost',
     'browser.retain_connection_credentials': false,
-    'browser.retain_editor_history': false,
-    'metrics.enabled': true,
-    'metrics.prefix': 'neo4j',
-    'metrics.namespaces.enabled': false
+    'browser.retain_editor_history': false
   }
 }
 


### PR DESCRIPTION
Depends on #1472 

Changelist:
- Fixes :sysinfo running before useDb has been set by rerunning the query when it's set.
- Adds docs on how the :sysinfo frame works
- Respects metrics.prefix
- Respect metrics.namespaces.enabled
- Adds error message on missing metrics to check the settings
- Changes default metrics to use metrics that aren't filtered out by default


This task quickly crept in scope and one of the issues I didn't have time to solve properly was collecting the settings through dbMetaDuck. Got a thumbs on from greg on the newly used metrics.


preview at http://blank_sysinfo_on_boot.surge.sh