### PR TITLE
Sysinfo 3.x Fixes

### DIFF
--- a/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
@@ -216,7 +216,13 @@ export class SysInfoFrame extends Component<
       storeSizes,
       transactions
     } = this.state
-    const { databases, frame, isConnected, isEnterprise } = this.props
+    const {
+      databases,
+      frame,
+      isConnected,
+      isEnterprise,
+      hasMultiDbSupport
+    } = this.props
 
     const content = isConnected ? (
       <SysInfoTable
@@ -226,6 +232,7 @@ export class SysInfoFrame extends Component<
         transactions={transactions}
         databases={databases}
         isEnterpriseEdition={isEnterprise}
+        hasMultiDbSupport={hasMultiDbSupport}
       />
     ) : (
       <ErrorsView

--- a/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
@@ -161,24 +161,39 @@ export class SysInfoFrame extends Component<
 
   getSysInfo = (): void => {
     const { userConfiguredPrefix, namespacesEnabled } = this.state
-    const { bus, isConnected, useDb } = this.props
-    const { sysinfoQuery, responseHandler } = this.props.hasMultiDbSupport
-      ? helpers
-      : legacyHelpers
+    const { useDb, hasMultiDbSupport } = this.props
 
-    if (bus && isConnected && useDb) {
+    if (hasMultiDbSupport && useDb) {
+      this.runCypherQuery(
+        helpers.sysinfoQuery({
+          databaseName: useDb,
+          namespacesEnabled,
+          userConfiguredPrefix
+        }),
+        helpers.responseHandler(this.setState.bind(this))
+      )
+    } else if (!hasMultiDbSupport) {
+      this.runCypherQuery(
+        legacyHelpers.sysinfoQuery(),
+        legacyHelpers.responseHandler(this.setState.bind(this))
+      )
+    }
+  }
+
+  runCypherQuery = (
+    query: string,
+    responseHandler: (res: any) => void
+  ): void => {
+    const { bus, isConnected } = this.props
+    if (bus && isConnected) {
       this.setState({ lastFetch: Date.now() })
       bus.self(
         CYPHER_REQUEST,
         {
-          query: sysinfoQuery({
-            databaseName: useDb,
-            namespacesEnabled,
-            userConfiguredPrefix
-          }),
+          query,
           queryType: NEO4J_BROWSER_USER_ACTION_QUERY
         },
-        responseHandler(this.setState.bind(this))
+        responseHandler
       )
     }
   }

--- a/src/browser/modules/Stream/SysInfoFrame/SysInfoTable.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/SysInfoTable.tsx
@@ -15,6 +15,7 @@ type SysInfoFrameProps = {
   pageCache: DatabaseMetric[]
   transactions: DatabaseMetric[]
   isEnterpriseEdition: boolean
+  hasMultiDbSupport: boolean
 }
 
 export const SysInfoTable = ({
@@ -23,7 +24,8 @@ export const SysInfoTable = ({
   storeSizes,
   idAllocation,
   transactions,
-  isEnterpriseEdition
+  isEnterpriseEdition,
+  hasMultiDbSupport
 }: SysInfoFrameProps): JSX.Element => {
   const mappedDatabases = [
     {
@@ -54,7 +56,7 @@ export const SysInfoTable = ({
       <StyledSysInfoTable key="Transactions" header="Transactions">
         {buildTableData(transactions)}
       </StyledSysInfoTable>
-      {buildDatabaseTable(mappedDatabases)}
+      {hasMultiDbSupport && buildDatabaseTable(mappedDatabases)}
     </SysInfoTableContainer>
   ) : (
     <div>
@@ -62,7 +64,7 @@ export const SysInfoTable = ({
         Complete sysinfo is available only in Neo4j Enterprise Edition.
       </StyledInfoMessage>
       <SysInfoTableContainer>
-        {buildDatabaseTable(mappedDatabases)}
+        {hasMultiDbSupport && buildDatabaseTable(mappedDatabases)}
       </SysInfoTableContainer>
     </div>
   )


### PR DESCRIPTION
Changes:
- Fixes bug introduced in the :sysinfo frame refresh were we didn't fetch any metrics for 3.x databases
- No longer shows database table if server lacks multidb support