### PR TITLE
Fix export button for history and add tests

### DIFF
--- a/e2e_tests/integration/data-export.spec.ts
+++ b/e2e_tests/integration/data-export.spec.ts
@@ -80,7 +80,14 @@ describe('Data export', () => {
   it('can export history', () => {
     cy.executeCommand(':clear')
     cy.executeCommand(':history')
-    cy.get('[data-testid="exportGrassButton"]').should('not.exist')
-    cy.get('[data-testid="exportHistoryButton"]').should('not.exist')
+    cy.get('[data-testid="frame-export-dropdown"]').trigger('mouseover')
+    cy.get('[data-testid="frame-export-dropdown"]', {
+      timeout: 10000
+    }).within(() => {
+      cy.get('a').then(exportButtonsList => {
+        expect(exportButtonsList).to.have.length(1)
+        expect(exportButtonsList.eq(0)).to.contain('Export TXT')
+      })
+    })
   })
 })

--- a/e2e_tests/integration/data-export.spec.ts
+++ b/e2e_tests/integration/data-export.spec.ts
@@ -76,4 +76,11 @@ describe('Data export', () => {
       })
     })
   })
+
+  it('can export history', () => {
+    cy.executeCommand(':clear')
+    cy.executeCommand(':history')
+    cy.get('[data-testid="exportGrassButton"]').should('not.exist')
+    cy.get('[data-testid="exportHistoryButton"]').should('not.exist')
+  })
 })

--- a/e2e_tests/integration/style.spec.ts
+++ b/e2e_tests/integration/style.spec.ts
@@ -49,7 +49,8 @@ describe(':style', () => {
   it('can reset style with button', () => {
     cy.executeCommand(':clear')
     cy.executeCommand(':style')
-    cy.get('[data-testid="exportGrassButton"]', { timeout: 10000 })
+    // can't trigger hover with cypress so we can't know it's visible
+    cy.get('[data-testid="exportGrassButton"]').should('exist')
     cy.get('[data-testid="styleResetButton"]', { timeout: 10000 })
       .first()
       .click()

--- a/src/browser/modules/Frame/ExportButton.tsx
+++ b/src/browser/modules/Frame/ExportButton.tsx
@@ -63,10 +63,6 @@ function ExportButton({
   getRecords,
   visElement
 }: ExportButtonProps): JSX.Element {
-  function hasData() {
-    return numRecords > 0
-  }
-
   function exportCSV(records: any) {
     const exportData = stringifyResultArray(
       csvFormat,
@@ -129,60 +125,75 @@ function ExportButton({
     saveAs(blob, 'style.grass')
   }
 
+  const hasData = numRecords > 0
+  const canExportTXT = frame.type === 'history' && arrayHasItems(frame.result)
   // Quick reruns of cypher cause buttons to jump
-  function canExport() {
-    return (
-      canExportTXT() ||
-      (frame.type === 'cypher' && (hasData() || visElement)) ||
-      (frame.type === 'style' && hasData())
-    )
-  }
-
-  function canExportTXT() {
-    return frame.type === 'history' && arrayHasItems(frame.result)
-  }
+  const canExport =
+    canExportTXT ||
+    (frame.type === 'cypher' && (hasData || visElement)) ||
+    (frame.type === 'style' && hasData)
 
   return (
     <>
-      {canExport() && (
+      {canExport && (
         <DropdownButton title="Exports" data-testid="frame-export-dropdown">
           <DownloadIcon />
-          {hasData() && (
+          {canExport && (
             <DropdownList>
               <DropdownContent>
-                <Render if={isRelateAvailable}>
-                  <DropdownItem onClick={() => newProjectFile(frame.cmd)}>
-                    Save as project file
+                {isRelateAvailable && (
+                  <>
+                    <DropdownItem onClick={() => newProjectFile(frame.cmd)}>
+                      Save as project file
+                    </DropdownItem>
+                    <DropDownItemDivider />
+                  </>
+                )}
+                {hasData && frame.type === 'cypher' && (
+                  <>
+                    <DropdownItem
+                      data-testid="exportCsvButton"
+                      onClick={() => exportCSV(getRecords())}
+                    >
+                      Export CSV
+                    </DropdownItem>
+                    <DropdownItem onClick={() => exportJSON(getRecords())}>
+                      Export JSON
+                    </DropdownItem>
+                  </>
+                )}
+                {visElement && (
+                  <>
+                    <DropdownItem
+                      data-testid="exportPngButton"
+                      onClick={() => exportPNG()}
+                    >
+                      Export PNG
+                    </DropdownItem>
+                    <DropdownItem
+                      data-testid="exportSvgButton"
+                      onClick={() => exportSVG()}
+                    >
+                      Export SVG
+                    </DropdownItem>
+                  </>
+                )}
+                {canExportTXT && (
+                  <DropdownItem
+                    data-testid="exportTxtButton"
+                    onClick={exportTXT}
+                  >
+                    Export TXT
                   </DropdownItem>
-                  <DropDownItemDivider />
-                </Render>
-                <Render if={hasData() && frame.type === 'cypher'}>
-                  <DropdownItem onClick={() => exportCSV(getRecords())}>
-                    Export CSV
-                  </DropdownItem>
-                  <DropdownItem onClick={() => exportJSON(getRecords())}>
-                    Export JSON
-                  </DropdownItem>
-                </Render>
-                <Render if={visElement}>
-                  <DropdownItem onClick={() => exportPNG()}>
-                    Export PNG
-                  </DropdownItem>
-                  <DropdownItem onClick={() => exportSVG()}>
-                    Export SVG
-                  </DropdownItem>
-                </Render>
-                <Render if={canExportTXT()}>
-                  <DropdownItem onClick={exportTXT}>Export TXT</DropdownItem>
-                </Render>
-                <Render if={hasData() && frame.type === 'style'}>
+                )}
+                {hasData && frame.type === 'style' && (
                   <DropdownItem
                     data-testid="exportGrassButton"
                     onClick={() => exportGrass(getRecords())}
                   >
                     Export GraSS
                   </DropdownItem>
-                </Render>
+                )}
               </DropdownContent>
             </DropdownList>
           )}


### PR DESCRIPTION
Frame refactor in last release seemed to have broken exporting history. This PR fixes it, cleans up the file and adds tests to make sure it keeps working.

Preview @ http://export_history.surge.sh