### PR TITLE
Add params to background explain query

### DIFF
--- a/src/browser/modules/Editor/MainEditor.tsx
+++ b/src/browser/modules/Editor/MainEditor.tsx
@@ -76,6 +76,7 @@ import {
 import { getUseDb } from 'shared/modules/connections/connectionsDuck'
 import { getHistory } from 'shared/modules/history/historyDuck'
 import { defaultNameFromDisplayContent } from 'browser-components/SavedScripts'
+import { getParams } from 'shared/modules/params/paramsDuck'
 
 type EditorFrameProps = {
   bus: Bus
@@ -86,6 +87,7 @@ type EditorFrameProps = {
   projectId: string
   updateFavorite: (id: string, value: string) => void
   useDb: null | string
+  params: Record<string, unknown>
 }
 
 type SavedScript = {
@@ -97,7 +99,7 @@ type SavedScript = {
   name?: string
 }
 
-export function EditorFrame({
+export function MainEditor({
   bus,
   codeFontLigatures,
   enableMultiStatementMode,
@@ -105,7 +107,8 @@ export function EditorFrame({
   history,
   projectId,
   updateFavorite,
-  useDb
+  useDb,
+  params
 }: EditorFrameProps): JSX.Element {
   const [addFile] = useMutation(ADD_PROJECT_FILE)
   const [unsaved, setUnsaved] = useState(false)
@@ -267,6 +270,7 @@ export function EditorFrame({
               onExecute={createRunCommandFunction(commandSources.editor)}
               ref={editorRef}
               useDb={useDb}
+              params={params}
             />
           </EditorContainer>
           {currentlyEditing && !currentlyEditing.isStatic && (
@@ -335,7 +339,8 @@ const mapStateToProps = (state: GlobalState) => {
     enableMultiStatementMode: shouldEnableMultiStatementMode(state),
     history: getHistory(state),
     projectId: getProjectId(state),
-    useDb: getUseDb(state)
+    useDb: getUseDb(state),
+    params: getParams(state)
   }
 }
 
@@ -350,6 +355,4 @@ const mapDispatchToProps = (dispatch: Dispatch<Action>) => {
   }
 }
 
-export default withBus(
-  connect(mapStateToProps, mapDispatchToProps)(EditorFrame)
-)
+export default withBus(connect(mapStateToProps, mapDispatchToProps)(MainEditor))

--- a/src/browser/modules/Editor/Monaco.test.tsx
+++ b/src/browser/modules/Editor/Monaco.test.tsx
@@ -37,6 +37,7 @@ describe('Monaco', () => {
         onExecute={noOp}
         toggleFullscreen={noOp}
         bus={{ self: noOp } as any}
+        params={{}}
         id="id"
       />
     )

--- a/src/browser/modules/Editor/Monaco.tsx
+++ b/src/browser/modules/Editor/Monaco.tsx
@@ -80,6 +80,7 @@ type MonacoProps = MonacoDefaultProps & {
   onExecute: (value: string) => void
   useDb: null | string
   toggleFullscreen: () => void
+  params: Record<string, unknown>
 }
 type MonacoState = { currentHistoryIndex: number; draft: string }
 const UNRUN_CMD_HISTORY_INDEX = -1
@@ -269,7 +270,8 @@ class Monaco extends React.Component<MonacoProps, MonacoState> {
         CYPHER_REQUEST,
         {
           query: EXPLAIN_QUERY_PREFIX + text,
-          queryType: NEO4J_BROWSER_USER_ACTION_QUERY
+          queryType: NEO4J_BROWSER_USER_ACTION_QUERY,
+          params: this.props.params
         },
         (response: { result: QueryResult; success?: boolean }) => {
           if (

--- a/src/browser/modules/Frame/FrameEditor.tsx
+++ b/src/browser/modules/Frame/FrameEditor.tsx
@@ -59,6 +59,7 @@ import {
   codeFontLigatures,
   shouldEnableMultiStatementMode
 } from 'shared/modules/settings/settingsDuck'
+import { getParams } from 'shared/modules/params/paramsDuck'
 
 type FrameTitleBarBaseProps = {
   frame: Frame
@@ -67,6 +68,7 @@ type FrameTitleBarBaseProps = {
   getRecords: () => any
   visElement: any
   bus: Bus
+  params: Record<string, unknown>
 }
 
 type FrameTitleBarProps = FrameTitleBarBaseProps & {
@@ -96,7 +98,8 @@ function FrameTitlebar({
   numRecords,
   getRecords,
   visElement,
-  bus
+  bus,
+  params
 }: FrameTitleBarProps) {
   const [editorValue, setEditorValue] = useState(frame.cmd)
   const [renderEditor, setRenderEditor] = useState(frame.isRerun)
@@ -212,6 +215,7 @@ function FrameTitlebar({
               fontLigatures={codeFontLigatures}
               id={`editor-${frame.id}`}
               bus={bus}
+              params={params}
               onChange={setEditorValue}
               onExecute={run}
               value={editorValue}
@@ -278,7 +282,8 @@ const mapStateToProps = (
     request,
     isRelateAvailable: app.isRelateAvailable(state),
     codeFontLigatures: codeFontLigatures(state),
-    enableMultiStatementMode: shouldEnableMultiStatementMode(state)
+    enableMultiStatementMode: shouldEnableMultiStatementMode(state),
+    params: getParams(state)
   }
 }
 


### PR DESCRIPTION
Our background explain query we do to get warnings, was not using the client side params we have. So it'll give warnings even as queries are correct. To reproduce 

1. Run `:param p => 1`
2. Type `RETURN $p`
3. Get warning on $p not being defined, although the query runs fine

I think there's a better way to solve this than passing the params down to the monaco component, but that's a change for when we get rid of the Bus