### PR TITLE
Add cursor pointer to context menu

### DIFF
--- a/src/browser/components/SavedScripts/styled.ts
+++ b/src/browser/components/SavedScripts/styled.ts
@@ -138,6 +138,7 @@ export const SavedScriptsInput = styled.input`
 
 export const ContextMenuContainer = styled.span`
   position: relative;
+  cursor: pointer;
 `
 
 export const ContextMenuHoverParent = styled.span<{ stayVisible?: boolean }>`


### PR DESCRIPTION
Fixes minor paper cut of the three dots in the favorites drawer not having cursor: pointer.

Preview: https://fix_favorite_cursor.surge.sh