### PR TITLE
format params for use with explain query

### DIFF
--- a/src/browser/modules/Editor/Monaco.tsx
+++ b/src/browser/modules/Editor/Monaco.tsx
@@ -36,6 +36,7 @@ import { Bus } from 'suber'
 import { NEO4J_BROWSER_USER_ACTION_QUERY } from 'services/bolt/txMetadata'
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
 import { QueryResult } from 'neo4j-driver'
+import { applyParamGraphTypes } from 'shared/modules/commands/helpers/cypher'
 
 const shouldCheckForHints = (code: string) =>
   code.trim().length > 0 &&
@@ -272,7 +273,7 @@ class Monaco extends React.Component<MonacoProps, MonacoState> {
         {
           query: EXPLAIN_QUERY_PREFIX + text,
           queryType: NEO4J_BROWSER_USER_ACTION_QUERY,
-          params: this.props.params
+          params: applyParamGraphTypes(this.props.params)
         },
         (response: { result: QueryResult; success?: boolean }) => {
           if (

--- a/src/shared/modules/commands/helpers/cypher.ts
+++ b/src/shared/modules/commands/helpers/cypher.ts
@@ -23,6 +23,13 @@ import { applyGraphTypes } from 'services/bolt/boltMappings'
 import { arrayToObject } from 'services/utils'
 import { send } from 'shared/modules/requests/requestsDuck'
 
+export const applyParamGraphTypes = (params = {} as any) =>
+  arrayToObject(
+    Object.keys(params).map(k => ({
+      [k]: applyGraphTypes(params[k])
+    }))
+  )
+
 export const handleCypherCommand = (
   action: any,
   put: any,
@@ -31,12 +38,9 @@ export const handleCypherCommand = (
   txMetadata = {},
   autoCommit = false
 ) => {
-  const paramsToNeo4jType = Object.keys(params).map(k => ({
-    [k]: applyGraphTypes(params[k])
-  }))
   const [id, request] = bolt.routedWriteTransaction(
     action.query,
-    arrayToObject(paramsToNeo4jType),
+    applyParamGraphTypes(params),
     {
       useCypherThread: shouldUseCypherThread,
       requestId: action.requestId,


### PR DESCRIPTION
Fixes an issue where params for explain queries were incorrectly formatted

Before:
<img width="647" alt="Screen Shot 2021-08-24 at 2 58 22 PM" src="https://user-images.githubusercontent.com/7042043/130949407-b83ef9b6-882a-4e25-80ec-5b96561f85a7.png">

After:
<img width="581" alt="Screen Shot 2021-08-24 at 2 59 01 PM" src="https://user-images.githubusercontent.com/7042043/130949436-3a88543c-40b8-48b5-92e7-df0e917b8120.png">
