### PR TITLE
fix: Remove routing context when converts from neo4j to bolt protocol

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
@@ -5,10 +5,10 @@ exports[`Visualization renders 1`] = `<div />`;
 exports[`Visualization renders with result and escapes any HTML 1`] = `
 <div>
   <div
-    class="sc-ibxdXY dmclze"
+    class="sc-eXEjpC jwZnC"
   >
     <div
-      class="sc-jzJRlG eUKzrM"
+      class="sc-fjdhpX eoghYa"
       id="svg-vis"
     >
       <div
@@ -82,29 +82,29 @@ exports[`Visualization renders with result and escapes any HTML 1`] = `
             </g>
           </svg>
           <div
-            class="sc-cSHVUG gAlWnv"
+            class="sc-jzJRlG bmXesP"
             offset="296.57142857142856"
           >
             <button
-              class="sc-kAzzGY hrkFIX zoom-in"
+              class="sc-cSHVUG knJUXC zoom-in"
             >
               <i
-                class="sc-jtggT cxJBDr sl-zoom-in"
+                class="sc-dEoRIm bBgzgJ sl-zoom-in"
                 style="font-size: 1em;"
               />
             </button>
             <button
-              class="sc-kAzzGY hrkFIX zoom-out"
+              class="sc-cSHVUG knJUXC zoom-out"
             >
               <i
-                class="sc-ebFjAB bAowKS sl-zoom-out"
+                class="sc-jtggT cxJBDr sl-zoom-out"
                 style="font-size: 1em;"
               />
             </button>
           </div>
         </div>
         <div
-          class="sc-kgoBCf erHcgW"
+          class="sc-chPdSV dqKwfO"
         >
           <i
             aria-hidden="true"
@@ -113,58 +113,48 @@ exports[`Visualization renders with result and escapes any HTML 1`] = `
           />
         </div>
         <div
-          class="sc-chPdSV eCUJJ"
+          class="sc-kAzzGY eLmCiI"
           width="292.57142857142856"
         >
           <div
             class="react-resizable"
           >
             <div
-              class="sc-kGXeez hacloy"
+              class="sc-kgoBCf gXcNGy"
             >
               <div
-                class="sc-dxgOiQ iqpiQp"
+                class="sc-kpOJdX gHYrZk"
               >
                 Displaying NaN nodes, 0 relationships.
               </div>
               <div
-                class="sc-ckVGcZ cYUlXz"
+                class="sc-dxgOiQ jyxzCx"
               >
                 Node labels
                 <ul
                   class="sc-bxivhb sc-iwsKbI bfwfdz"
                 >
                   <li
-                    class="sc-EHOje sc-gZMcBi chSRLy"
-                    data-testid="viz-legend-labels"
+                    class="sc-EHOje sc-bZQynM sc-gzVnrw FEGBq"
+                    style="background-color: rgb(247, 151, 103); color: rgb(255, 255, 255);"
                   >
-                    <li
-                      class="sc-EHOje sc-bZQynM sc-gzVnrw fjTalv"
-                      style="background-color: rgb(247, 151, 103); color: rgb(255, 255, 255);"
+                    *
+                    <span
+                      class="sc-dnqmqq fFydjc"
                     >
-                      *
-                      <span
-                        class="sc-dnqmqq fFydjc"
-                      >
-                        (1)
-                      </span>
-                    </li>
+                      (1)
+                    </span>
                   </li>
                   <li
-                    class="sc-EHOje sc-gZMcBi chSRLy"
-                    data-testid="viz-legend-labels"
+                    class="sc-EHOje sc-bZQynM sc-gzVnrw FEGBq"
+                    style="background-color: rgb(201, 144, 192); color: rgb(255, 255, 255);"
                   >
-                    <li
-                      class="sc-EHOje sc-bZQynM sc-gzVnrw fjTalv"
-                      style="background-color: rgb(201, 144, 192); color: rgb(255, 255, 255);"
+                    Person
+                    <span
+                      class="sc-dnqmqq fFydjc"
                     >
-                      Person
-                      <span
-                        class="sc-dnqmqq fFydjc"
-                      >
-                        (1)
-                      </span>
-                    </li>
+                      (1)
+                    </span>
                   </li>
                 </ul>
                 Relationship Types

--- a/src/browser/modules/Stream/__snapshots__/SchemaFrame.test.tsx.snap
+++ b/src/browser/modules/Stream/__snapshots__/SchemaFrame.test.tsx.snap
@@ -10,13 +10,13 @@ exports[`SchemaFrame renders empty 1`] = `
         class="sc-dqBHgY eVMXHH"
       >
         <table
-          class="sc-eLdqWK gAQPXU"
+          class="sc-ejGVNB gIPBhr"
           data-testid="schemaFrameIndexesTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-hgRTRy jYMjDM table-header"
+                class="sc-iiUIRa edcYXE table-header"
               >
                 Indexes
               </th>
@@ -24,10 +24,10 @@ exports[`SchemaFrame renders empty 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-iiUIRa bUzelC table-row"
+              class="sc-eLdqWK eLPPkG table-row"
             >
               <td
-                class="sc-iIHSe dTEQLo table-properties"
+                class="sc-hgRTRy ezCOLT table-properties"
               >
                 None
               </td>
@@ -35,13 +35,13 @@ exports[`SchemaFrame renders empty 1`] = `
           </tbody>
         </table>
         <table
-          class="sc-eLdqWK gAQPXU"
+          class="sc-ejGVNB gIPBhr"
           data-testid="schemaFrameConstraintsTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-hgRTRy jYMjDM table-header"
+                class="sc-iiUIRa edcYXE table-header"
               >
                 Constraints
               </th>
@@ -49,10 +49,10 @@ exports[`SchemaFrame renders empty 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-iiUIRa bUzelC table-row"
+              class="sc-eLdqWK eLPPkG table-row"
             >
               <td
-                class="sc-iIHSe dTEQLo table-properties"
+                class="sc-hgRTRy ezCOLT table-properties"
               >
                 None
               </td>
@@ -92,43 +92,43 @@ exports[`SchemaFrame renders empty for Neo4j >= 4.0 1`] = `
         class="sc-dqBHgY eVMXHH"
       >
         <table
-          class="sc-eLdqWK gAQPXU"
+          class="sc-ejGVNB gIPBhr"
           data-testid="schemaFrameIndexesTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-hgRTRy jYMjDM table-header"
+                class="sc-iiUIRa edcYXE table-header"
               >
                 Index Name
               </th>
               <th
-                class="sc-hgRTRy jYMjDM table-header"
+                class="sc-iiUIRa edcYXE table-header"
               >
                 Type
               </th>
               <th
-                class="sc-hgRTRy jYMjDM table-header"
+                class="sc-iiUIRa edcYXE table-header"
               >
                 Uniqueness
               </th>
               <th
-                class="sc-hgRTRy jYMjDM table-header"
+                class="sc-iiUIRa edcYXE table-header"
               >
                 EntityType
               </th>
               <th
-                class="sc-hgRTRy jYMjDM table-header"
+                class="sc-iiUIRa edcYXE table-header"
               >
                 LabelsOrTypes
               </th>
               <th
-                class="sc-hgRTRy jYMjDM table-header"
+                class="sc-iiUIRa edcYXE table-header"
               >
                 Properties
               </th>
               <th
-                class="sc-hgRTRy jYMjDM table-header"
+                class="sc-iiUIRa edcYXE table-header"
               >
                 State
               </th>
@@ -136,42 +136,42 @@ exports[`SchemaFrame renders empty for Neo4j >= 4.0 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-iiUIRa bUzelC table-row"
+              class="sc-eLdqWK eLPPkG table-row"
             >
               <td
-                class="sc-iIHSe dTEQLo table-properties"
+                class="sc-hgRTRy ezCOLT table-properties"
               >
                 None
               </td>
               <td
-                class="sc-iIHSe dTEQLo table-properties"
+                class="sc-hgRTRy ezCOLT table-properties"
               />
               <td
-                class="sc-iIHSe dTEQLo table-properties"
+                class="sc-hgRTRy ezCOLT table-properties"
               />
               <td
-                class="sc-iIHSe dTEQLo table-properties"
+                class="sc-hgRTRy ezCOLT table-properties"
               />
               <td
-                class="sc-iIHSe dTEQLo table-properties"
+                class="sc-hgRTRy ezCOLT table-properties"
               />
               <td
-                class="sc-iIHSe dTEQLo table-properties"
+                class="sc-hgRTRy ezCOLT table-properties"
               />
               <td
-                class="sc-iIHSe dTEQLo table-properties"
+                class="sc-hgRTRy ezCOLT table-properties"
               />
             </tr>
           </tbody>
         </table>
         <table
-          class="sc-eLdqWK gAQPXU"
+          class="sc-ejGVNB gIPBhr"
           data-testid="schemaFrameConstraintsTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-hgRTRy jYMjDM table-header"
+                class="sc-iiUIRa edcYXE table-header"
               >
                 Constraints
               </th>
@@ -179,10 +179,10 @@ exports[`SchemaFrame renders empty for Neo4j >= 4.0 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-iiUIRa bUzelC table-row"
+              class="sc-eLdqWK eLPPkG table-row"
             >
               <td
-                class="sc-iIHSe dTEQLo table-properties"
+                class="sc-hgRTRy ezCOLT table-properties"
               >
                 None
               </td>
@@ -222,13 +222,13 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
         class="sc-dqBHgY eVMXHH"
       >
         <table
-          class="sc-eLdqWK gAQPXU"
+          class="sc-ejGVNB gIPBhr"
           data-testid="schemaFrameIndexesTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-hgRTRy jYMjDM table-header"
+                class="sc-iiUIRa edcYXE table-header"
               >
                 Indexes
               </th>
@@ -236,10 +236,10 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-iiUIRa bUzelC table-row"
+              class="sc-eLdqWK eLPPkG table-row"
             >
               <td
-                class="sc-iIHSe dTEQLo table-properties"
+                class="sc-hgRTRy ezCOLT table-properties"
               >
                  ON :Movie(released) ONLINE 
               </td>
@@ -247,13 +247,13 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
           </tbody>
         </table>
         <table
-          class="sc-eLdqWK gAQPXU"
+          class="sc-ejGVNB gIPBhr"
           data-testid="schemaFrameConstraintsTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-hgRTRy jYMjDM table-header"
+                class="sc-iiUIRa edcYXE table-header"
               >
                 Constraints
               </th>
@@ -261,10 +261,10 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-iiUIRa bUzelC table-row"
+              class="sc-eLdqWK eLPPkG table-row"
             >
               <td
-                class="sc-iIHSe dTEQLo table-properties"
+                class="sc-hgRTRy ezCOLT table-properties"
               >
                  ON ( book:Book ) ASSERT book.isbn IS UNIQUE
               </td>

--- a/src/shared/services/boltscheme.utils.ts
+++ b/src/shared/services/boltscheme.utils.ts
@@ -33,7 +33,9 @@ export const isNonRoutingScheme = (url = '') =>
 
 export const toNonRoutingScheme = (url: string) =>
   typeof url === 'string' &&
-  `${BOLT_DIRECT_SCHEME}${getSchemeFlag(url)}://${stripScheme(url)}`
+  `${BOLT_DIRECT_SCHEME}${getSchemeFlag(url)}://${stripQueryString(
+    stripScheme(url)
+  )}`
 
 export const getScheme = (url: string) => {
   if (!url) {
@@ -52,6 +54,11 @@ export const stripScheme = (url: string) => {
     return _scheme
   }
   return rest.join('://')
+}
+
+export const stripQueryString = (url: string) => {
+  const [_host] = (url || '').split('?')
+  return _host
 }
 
 export const isSecureBoltScheme = (url: string) => {


### PR DESCRIPTION
Browser during the loggin is creating direct connection to the informed `connect url`, but it's not removing the query string from the url. Because of this, browser is getting a `Parameters are not supported with none route scheme..` error. The routing context params are not support in direct connection by design.

The solution for this issue is removing the routing context (query string) from the url when transalate from `neo4j` to `bolt`.

<!--
BEFORE YOU SUBMIT make sure you've done the following:
[x] Done your work in a personal fork of the original repository
[x] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[x] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

