### PR TITLE
Fix bug where panel expansion was not respected on first render

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/PlanView.tsx
+++ b/src/browser/modules/Stream/CypherFrame/PlanView.tsx
@@ -58,7 +58,10 @@ export class PlanView extends Component<PlanViewProps, PlanViewState> {
 
   componentDidMount() {
     this.extractPlan(this.props.result)
-      .then(() => this.props.setPlanExpand('EXPAND'))
+      .then(() => {
+        this.props.setPlanExpand('EXPAND')
+        this.toggleExpanded(true)
+      })
       .catch(() => {})
   }
 


### PR DESCRIPTION
The planview only collapses/expands when the planExpand prop changes. As planExpand is set to true by default, it doesn't count as a "change" in props, and the call to expand the svg doesn't fire