### PR TITLE
Prevent weird logic when maxFrames is not an integer

### DIFF
--- a/src/shared/modules/frames/framesDuck.ts
+++ b/src/shared/modules/frames/framesDuck.ts
@@ -197,7 +197,8 @@ function setRecentViewHelper(state: FramesState, recentView: FrameView) {
 }
 
 function ensureFrameLimit(state: FramesState, maxFrames: number) {
-  const limit = maxFrames > 0 ? maxFrames : settingsDefaultState.maxFrames
+  const limit =
+    maxFrames >= 1 ? Math.floor(maxFrames) : settingsDefaultState.maxFrames
   if (state.allIds.length <= limit) return state
   const numToRemove = state.allIds.length - limit
   const removeIds = state.allIds


### PR DESCRIPTION
if a number but not an integer, floor it down to nearest integer

if non number string or below 1 set limit to default value 15

<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

