### PR TITLE
Make sure properties view are within frame when expanded

### DIFF
--- a/src/browser/modules/D3Visualization/components/DetailsPane.tsx
+++ b/src/browser/modules/D3Visualization/components/DetailsPane.tsx
@@ -91,7 +91,7 @@ export function DetailsPaneComponent({
             )
           })}
       </PaneHeader>
-      <PaneBody frameHeight={frameHeight}>
+      <PaneBody>
         <StyledInlineList>
           <AlternatingTable>
             <tbody>

--- a/src/browser/modules/D3Visualization/components/OverviewPane.tsx
+++ b/src/browser/modules/D3Visualization/components/OverviewPane.tsx
@@ -64,7 +64,7 @@ function OverviewPane({
   return (
     <>
       <PaneHeader>Overview</PaneHeader>
-      <PaneBody frameHeight={frameHeight}>
+      <PaneBody>
         {labels && Object.keys(labels).length !== 0 && (
           <>
             Node labels

--- a/src/browser/modules/D3Visualization/components/styled.tsx
+++ b/src/browser/modules/D3Visualization/components/styled.tsx
@@ -308,6 +308,8 @@ export const StyledNodeInspectorTopMenuChevron = styled.div<{
 export const PaneContainer = styled.div`
   padding: 0 14px;
   height: 100%;
+  display: flex;
+  flex-direction: column;
 `
 
 export const AlternatingTable = styled.table`
@@ -324,12 +326,13 @@ export const AlternatingTable = styled.table`
 export const PaneHeader = styled.div`
   font-size: 16px;
   margin-top: 10px;
+  flex: 0 0 auto;
 `
-const PANE_HEADER_HEIGHT = 50
-export const PaneBody = styled.div<{ frameHeight: number }>`
-  max-height: ${props => props.frameHeight - PANE_HEADER_HEIGHT}px;
+
+export const PaneBody = styled.div`
   overflow: auto;
-  margin-top: 14px;
+  margin: 14px 0;
+  flex: 0 1 auto;
 `
 export const KeyCell = styled.td`
   font-weight: 700;

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView.styled.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView.styled.tsx
@@ -25,7 +25,7 @@ export const StyledVisContainer = styled.div<{ fullscreen: boolean }>`
   width: 100%;
   height: ${props =>
     props.fullscreen
-      ? '100vh'
+      ? '100%'
       : dim.frameBodyHeight - dim.frameTitlebarHeight * 2 + 'px'};
   > svg {
     width: 100%;

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
@@ -115,15 +115,15 @@ exports[`Visualization renders with result and escapes any HTML 1`] = `
         width="204.8"
       >
         <div
-          class="sc-chPdSV kFlaMg react-resizable"
+          class="sc-chPdSV iEZMKC react-resizable"
         >
           <div
-            class="sc-kGXeez lhIkLB"
+            class="sc-kGXeez eoOSxY"
           >
             Overview
           </div>
           <div
-            class="sc-kpOJdX fyzTOa"
+            class="sc-kpOJdX buqxsO"
           >
             Node labels
             <ul


### PR DESCRIPTION
Also pane header was not of same size in Overview and Details, changed to using flex to auto take up space that are left instead

<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

