### PR TITLE
Add eslint-plugin-json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,10 @@
 {
   "parser": "babel-eslint",
-  "extends": ["plugin:react/recommended", "prettier"],
+  "extends": [
+    "plugin:react/recommended",
+    "plugin:json/recommended",
+    "prettier"
+  ],
   "parserOptions": {
     "sourceType": "module"
   },

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "eslint": "^7.7.0",
     "eslint-config-prettier": "^6.7.0",
     "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-json": "^3.1.0",
     "eslint-plugin-jsx": "^0.1.0",
     "eslint-plugin-node": "^10.0.0",
     "eslint-plugin-promise": "^4.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5437,6 +5437,14 @@ eslint-plugin-import@^2.18.2:
     resolve "^1.17.0"
     tsconfig-paths "^3.9.0"
 
+eslint-plugin-json@^3.1.0:
+  version "3.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/eslint-plugin-json/-/eslint-plugin-json-3.1.0.tgz#251108ba1681c332e0a442ef9513bd293619de67"
+  integrity sha1-JREIuhaBwzLgpELvlRO9KTYZ3mc=
+  dependencies:
+    lodash "^4.17.21"
+    vscode-json-languageservice "^4.1.6"
+
 eslint-plugin-jsx@^0.1.0:
   version "0.1.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/eslint-plugin-jsx/-/eslint-plugin-jsx-0.1.0.tgz#6d0dc2a519d7102b17a9774a231b3548077f2a52"
@@ -8280,6 +8288,11 @@ json5@^1.0.1:
   integrity sha1-d5+wAYYE+oVOrL9iUhgNg1Q+Pb4=
   dependencies:
     minimist "^1.2.0"
+
+jsonc-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/jsonc-parser/-/jsonc-parser-3.0.0.tgz#abdd785701c7e7eaca8a9ec8cf070ca51a745a22"
+  integrity sha1-q914VwHH5+rKip7IzwcMpRp0WiI=
 
 jsonfile@^6.0.1:
   version "6.0.1"
@@ -13347,6 +13360,37 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha1-eGQcSIuObKkadfUR56OzKobl3aA=
+
+vscode-json-languageservice@^4.1.6:
+  version "4.1.9"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/vscode-json-languageservice/-/vscode-json-languageservice-4.1.9.tgz#fb48edc69e37167c3cafd447c3fa898052d87b61"
+  integrity sha1-+0jtxp43Fnw8r9RHw/qJgFLYe2E=
+  dependencies:
+    jsonc-parser "^3.0.0"
+    vscode-languageserver-textdocument "^1.0.1"
+    vscode-languageserver-types "^3.16.0"
+    vscode-nls "^5.0.0"
+    vscode-uri "^3.0.2"
+
+vscode-languageserver-textdocument@^1.0.1:
+  version "1.0.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.2.tgz#2f9f6bd5b5eb3d8e21424c0c367009216f016236"
+  integrity sha1-L59r1bXrPY4hQkwMNnAJIW8BYjY=
+
+vscode-languageserver-types@^3.16.0:
+  version "3.16.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz#ecf393fc121ec6974b2da3efb3155644c514e247"
+  integrity sha1-7POT/BIexpdLLaPvsxVWRMUU4kc=
+
+vscode-nls@^5.0.0:
+  version "5.0.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/vscode-nls/-/vscode-nls-5.0.0.tgz#99f0da0bd9ea7cda44e565a74c54b1f2bc257840"
+  integrity sha1-mfDaC9nqfNpE5WWnTFSx8rwleEA=
+
+vscode-uri@^3.0.2:
+  version "3.0.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/vscode-uri/-/vscode-uri-3.0.2.tgz#ecfd1d066cb8ef4c3a208decdbab9a8c23d055d0"
+  integrity sha1-7P0dBmy470w6II3s26uajCPQVdA=
 
 vue-eslint-parser@^2.0.2:
   version "2.0.3"


### PR DESCRIPTION
- [x] Done my work in a personal fork of the original repository
- [x] Created a branch with a useful name
- [ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
- [ ] Made sure the unit and e2e tests all pass
- [x] Read and sign our [CLA](https://neo4j.com/developer/cla)
- [x] Added a short explanation of what I've done and included a relevant screenshot if possible

#### Description
When opening a JSON file in an editor (i.e. VSCode), it shows an error: `Parsing error: Unexpected token, expected ";"`.
<img width="898" alt="Screenshot 2021-10-27 at 21 01 27" src="https://user-images.githubusercontent.com/26452483/139151061-bd983730-97e1-4d97-9d1c-20a30e152223.png">

This is due to the current ESLint being for validating JavaScript, not JSON.
To fix this, this PR introduces `eslint-plugin-json` to use ESLint on a JSON file.
After:
<img width="733" alt="Screenshot 2021-10-27 at 22 42 29" src="https://user-images.githubusercontent.com/26452483/139151568-918ec5f2-fec2-4319-9a50-561e692f2d5f.png">