### PR TITLE
Fix issue where fullscreen change didn't cause re-render

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/VisualizationView.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView.tsx
@@ -53,6 +53,7 @@ export class Visualization extends Component<any, VisualizationState> {
   shouldComponentUpdate(props: any, state: VisualizationState) {
     return (
       this.props.updated !== props.updated ||
+      this.props.fullscreen !== props.fullscreen ||
       !deepEquals(props.graphStyleData, this.props.graphStyleData) ||
       this.state.updated !== state.updated ||
       this.props.frameHeight !== props.frameHeight ||


### PR DESCRIPTION
A performance optimization caused the VisualizationView.tsx not to rerender as the fullscreen prop changed. Causing this issue:

https://user-images.githubusercontent.com/10564538/139863358-d61f4741-6a25-4f9f-aca8-cf91aa44fc5a.mp4

Preview of the fix @ http://zoombuttons_fullscreen_issue.surge.sh