### PR TITLE
Changed show more links from span to button for accessibility

### DIFF
--- a/src/browser/components/ShowMoreOrAll/ShowMoreOrAll.tsx
+++ b/src/browser/components/ShowMoreOrAll/ShowMoreOrAll.tsx
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import React from 'react'
-import { StyledShowMoreLink } from './styled'
+import { StyledShowMoreButton } from './styled'
 
 type ShowMoreOrAllProps = {
   total: number
@@ -35,13 +35,13 @@ export const ShowMoreOrAll = ({
   const numMore = Math.min(moreStep, total - shown)
   return shown < total ? (
     <div>
-      <StyledShowMoreLink onClick={() => onMore(numMore)}>
+      <StyledShowMoreButton onClick={() => onMore(numMore)}>
         Show {numMore} more
-      </StyledShowMoreLink>
+      </StyledShowMoreButton>
       &nbsp;|&nbsp;
-      <StyledShowMoreLink onClick={() => onMore(total)}>
+      <StyledShowMoreButton onClick={() => onMore(total)}>
         Show all
-      </StyledShowMoreLink>
+      </StyledShowMoreButton>
     </div>
   ) : null
 }

--- a/src/browser/components/ShowMoreOrAll/styled.tsx
+++ b/src/browser/components/ShowMoreOrAll/styled.tsx
@@ -20,7 +20,9 @@
 
 import styled from 'styled-components'
 
-export const StyledShowMoreLink = styled.span`
-  cursor: pointer;
+export const StyledShowMoreButton = styled.button`
+  border: none;
+  outline: none;
+  background-color: inherit;
   color: ${props => props.theme.link};
 `

--- a/src/browser/modules/D3Visualization/components/DetailsPane.test.tsx
+++ b/src/browser/modules/D3Visualization/components/DetailsPane.test.tsx
@@ -85,32 +85,42 @@ describe('<DetailsPane />', () => {
   test('should handle show all properties', async () => {
     renderComponent({ properties: getMockProperties(1001) })
 
-    expect(screen.getByText('Show all')).toBeInTheDocument()
-    expect(screen.getByText('Show 2 more')).toBeInTheDocument() // id is added to list of properties so only showing 999
+    expect(screen.getByRole('button', { name: 'Show all' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Show 2 more' })
+    ).toBeInTheDocument() // id is added to list of properties so only showing 999
     expect(screen.queryByText('prop1000')).not.toBeInTheDocument()
 
     const showAllButton = screen.getByText('Show all')
     showAllButton.click()
 
     expect(screen.getByText('prop1000')).toBeInTheDocument()
-    expect(screen.queryByText('Show all')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Show all' })
+    ).not.toBeInTheDocument()
   })
 
   test('should handle show more properties', async () => {
     renderComponent({ properties: getMockProperties(2001) })
 
     expect(
-      screen.getByText(`Show ${DETAILS_PANE_STEP_SIZE} more`)
+      screen.getByRole('button', {
+        name: `Show ${DETAILS_PANE_STEP_SIZE} more`
+      })
     ).toBeInTheDocument()
     expect(screen.queryByText('prop1000')).not.toBeInTheDocument()
 
-    const showMoreButton = screen.getByText(
-      `Show ${DETAILS_PANE_STEP_SIZE} more`
-    )
+    const showMoreButton = screen.getByRole('button', {
+      name: `Show ${DETAILS_PANE_STEP_SIZE} more`
+    })
     showMoreButton.click()
 
     expect(screen.getByText('prop1000')).toBeInTheDocument()
-    expect(screen.queryByText('Show all')).toBeInTheDocument()
-    expect(screen.getByText('Show 2 more')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Show all' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Show 2 more' })
+    ).toBeInTheDocument()
   })
 })

--- a/src/browser/modules/D3Visualization/components/OverviewPane.test.tsx
+++ b/src/browser/modules/D3Visualization/components/OverviewPane.test.tsx
@@ -53,7 +53,7 @@ describe('<OverviewPane />', () => {
 
   const getRelTypes: (length: number) => GraphStatsRelationshipTypes = length =>
     Array.from({ length: length }).reduce(
-      (acc: GraphStatsLabels, _current, index) => {
+      (acc: GraphStatsRelationshipTypes, _current, index) => {
         return {
           ...acc,
           ['relType' + index]: { count: 1, properties: { key: 'abc' } }
@@ -96,15 +96,19 @@ describe('<OverviewPane />', () => {
     }
     renderComponent({ graphStats: stats })
 
-    expect(screen.getByText('Show all')).toBeInTheDocument()
-    expect(screen.getByText('Show 1 more')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Show all' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Show 1 more' })
+    ).toBeInTheDocument()
     expect(screen.queryByText('label50')).not.toBeInTheDocument()
 
-    const showAllButton = screen.getByText('Show all')
+    const showAllButton = screen.getByRole('button', { name: 'Show all' })
     showAllButton.click()
 
     expect(screen.getByText('label50')).toBeInTheDocument()
-    expect(screen.queryByText('Show all')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Show all' })
+    ).not.toBeInTheDocument()
   })
 
   test('should handle show more labels', () => {
@@ -114,18 +118,24 @@ describe('<OverviewPane />', () => {
     }
     renderComponent({ graphStats: stats })
 
-    expect(screen.getByText('Show all')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Show all' })).toBeInTheDocument()
     expect(
-      screen.getByText(`Show ${OVERVIEW_STEP_SIZE} more`)
+      screen.getByRole('button', { name: `Show ${OVERVIEW_STEP_SIZE} more` })
     ).toBeInTheDocument()
     expect(screen.queryByText('label50')).not.toBeInTheDocument()
 
-    const showMoreButton = screen.getByText(`Show ${OVERVIEW_STEP_SIZE} more`)
+    const showMoreButton = screen.getByRole('button', {
+      name: `Show ${OVERVIEW_STEP_SIZE} more`
+    })
     showMoreButton.click()
 
     expect(screen.getByText('label50')).toBeInTheDocument()
-    expect(screen.queryByText('Show all')).toBeInTheDocument()
-    expect(screen.getByText('Show 2 more')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Show all' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Show 2 more' })
+    ).toBeInTheDocument()
   })
 
   test('should handle show all rel types', () => {
@@ -135,15 +145,19 @@ describe('<OverviewPane />', () => {
     }
     renderComponent({ graphStats: stats })
 
-    expect(screen.getByText('Show all')).toBeInTheDocument()
-    expect(screen.getByText('Show 1 more')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Show all' })).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Show 1 more' })
+    ).toBeInTheDocument()
     expect(screen.queryByText('relType50')).not.toBeInTheDocument()
 
-    const showAllButton = screen.getByText('Show all')
+    const showAllButton = screen.getByRole('button', { name: 'Show all' })
     showAllButton.click()
 
     expect(screen.getByText('relType50')).toBeInTheDocument()
-    expect(screen.queryByText('Show all')).not.toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Show all' })
+    ).not.toBeInTheDocument()
   })
 
   test('should handle show more rel types', () => {
@@ -153,17 +167,23 @@ describe('<OverviewPane />', () => {
     }
     renderComponent({ graphStats: stats })
 
-    expect(screen.getByText('Show all')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Show all' })).toBeInTheDocument()
     expect(
-      screen.getByText(`Show ${OVERVIEW_STEP_SIZE} more`)
+      screen.getByRole('button', { name: `Show ${OVERVIEW_STEP_SIZE} more` })
     ).toBeInTheDocument()
     expect(screen.queryByText('relType50')).not.toBeInTheDocument()
 
-    const showMoreButton = screen.getByText(`Show ${OVERVIEW_STEP_SIZE} more`)
+    const showMoreButton = screen.getByRole('button', {
+      name: `Show ${OVERVIEW_STEP_SIZE} more`
+    })
     showMoreButton.click()
 
     expect(screen.getByText('relType50')).toBeInTheDocument()
-    expect(screen.queryByText('Show all')).toBeInTheDocument()
-    expect(screen.getByText('Show 2 more')).toBeInTheDocument()
+    expect(
+      screen.queryByRole('button', { name: 'Show all' })
+    ).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Show 2 more' })
+    ).toBeInTheDocument()
   })
 })

--- a/src/browser/modules/DBMSInfo/MetaItems.tsx
+++ b/src/browser/modules/DBMSInfo/MetaItems.tsx
@@ -31,6 +31,8 @@ import numberToUSLocale from 'shared/utils/number-to-US-locale'
 import neoGraphStyle from 'browser/modules/D3Visualization/graphStyle'
 import deepmerge from 'deepmerge'
 import { ShowMoreOrAll } from 'browser-components/ShowMoreOrAll/ShowMoreOrAll'
+import { ThemeProvider } from 'styled-components'
+import { dark } from 'browser-styles/themes'
 
 const wrapperStyle = (styles && styles.wrapper) || ''
 
@@ -152,12 +154,14 @@ const LabelItems = ({
       <DrawerSectionBody className={wrapperStyle}>
         {labelItems}
       </DrawerSectionBody>
-      <ShowMoreOrAll
-        total={totalNumItems}
-        shown={labels.length}
-        moreStep={moreStep}
-        onMore={onMoreClick}
-      />
+      <ThemeProvider theme={dark}>
+        <ShowMoreOrAll
+          total={totalNumItems}
+          shown={labels.length}
+          moreStep={moreStep}
+          onMore={onMoreClick}
+        />
+      </ThemeProvider>
     </DrawerSection>
   )
 }


### PR DESCRIPTION
also since drawer background is always dark no matter theme, then use dark theme on ShowAllOrMore to make sure link color has better visibility.

<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

