### PR TITLE
Improve connection validation performance

### DIFF
--- a/e2e_tests/integration/multistatements.spec.ts
+++ b/e2e_tests/integration/multistatements.spec.ts
@@ -41,6 +41,9 @@ describe('Multi statements', () => {
   })
 
   it('can run multiple statements (non open by default)', () => {
+    // Avoid the problem when executing the script under system database:
+    // Neo.DatabaseError.Statement.ExecutionFailed: Not a recognised system command or procedure. This Cypher command can only be executed in a user database: RETURN 1 AS `1`
+    cy.executeCommand(':use neo4j')
     cy.executeCommand(':clear')
     cy.executeCommand(validQuery)
     cy.get('[data-testid="frame"]', { timeout: 10000 }).should('have.length', 1)

--- a/e2e_tests/integration/multistatements.spec.ts
+++ b/e2e_tests/integration/multistatements.spec.ts
@@ -43,7 +43,7 @@ describe('Multi statements', () => {
   it('can run multiple statements (non open by default)', () => {
     // Avoid the problem when executing the script under system database:
     // Neo.DatabaseError.Statement.ExecutionFailed: Not a recognised system command or procedure. This Cypher command can only be executed in a user database: RETURN 1 AS `1`
-    cy.executeCommand(':use neo4j')
+    cy.useNeo4jDatabase()
     cy.executeCommand(':clear')
     cy.executeCommand(validQuery)
     cy.get('[data-testid="frame"]', { timeout: 10000 }).should('have.length', 1)

--- a/e2e_tests/integration/params.spec.ts
+++ b/e2e_tests/integration/params.spec.ts
@@ -51,7 +51,7 @@ function runTests() {
   // it(':param x => 1+1', () => {
   // Avoid the problem when executing the script under system database:
   // Syntax Error: Parameters cannot be declared when using system database.
-  cy.executeCommand(':use neo4j')
+  cy.useNeo4jDatabase()
   cy.executeCommand(':clear')
   // Set param
   setParamQ = ':param x => 1+1'

--- a/e2e_tests/integration/params.spec.ts
+++ b/e2e_tests/integration/params.spec.ts
@@ -49,8 +49,11 @@ function runTests() {
   cy.connect('neo4j', password)
   // })
   // it(':param x => 1+1', () => {
-  // Set param
+  // Avoid the problem when executing the script under system database:
+  // Syntax Error: Parameters cannot be declared when using system database.
+  cy.executeCommand(':use neo4j')
   cy.executeCommand(':clear')
+  // Set param
   setParamQ = ':param x => 1+1'
   cy.executeCommand(setParamQ)
   cy.resultContains('"x": 2')

--- a/e2e_tests/support/commands.ts
+++ b/e2e_tests/support/commands.ts
@@ -188,3 +188,6 @@ Cypress.Commands.add('dropUser', username => {
     cy.executeCommand(':clear')
   }
 })
+Cypress.Commands.add('useNeo4jDatabase', () => {
+  if (Cypress.config('serverVersion') >= 4.0) cy.executeCommand(':use neo4j')
+})

--- a/e2e_tests/support/global.d.ts
+++ b/e2e_tests/support/global.d.ts
@@ -62,6 +62,10 @@ declare global {
        * Custom command for dropping user on currently connected database
        */
       dropUser(username: string): Cypress.Chainable<void>
+      /**
+       * Use Neo4j database unser server >= 4.0
+       */
+      useNeo4jDatabase(): Cypress.Chainable<void>
       getEditor(): Cypress.Chainable<JQuery<HTMLElement>>
       getFrames(): Cypress.Chainable<JQuery<HTMLElement>>
       getPrevInFrameStackBtn(): Cypress.Chainable<JQuery<HTMLElement>>

--- a/src/shared/services/bolt/boltConnection.ts
+++ b/src/shared/services/bolt/boltConnection.ts
@@ -77,9 +77,7 @@ export const validateConnection = (
           })
           .catch((e: { code: string; message: string }) => {
             session.close()
-            // Only invalidate the connection if not available
-            // or not authed
-            // or credentials have expired
+            // Only invalidate bolt connection error
             if (!e.code || isBoltConnectionErrorCode(e.code)) {
               rej(e)
             } else {

--- a/src/shared/services/bolt/driverFactory.ts
+++ b/src/shared/services/bolt/driverFactory.ts
@@ -25,7 +25,7 @@ export const createDriverOrFailFn = (
   url: string,
   auth: AuthToken,
   opts: Config,
-  failFn: (error: Error) => void = () => {}
+  failFn: (error: Error) => void = () => undefined
 ): Driver | null => {
   // This is needed, I haven't figured out why. I don't find any mutations to
   // the object, so not sure what's going on.
@@ -34,7 +34,7 @@ export const createDriverOrFailFn = (
     const res = neo4j.driver(url, auth, spreadOpts)
     return res
   } catch (e) {
-    failFn(e)
+    failFn(<Error>e)
     return null
   }
 }


### PR DESCRIPTION
Previously, we used `CALL db.indexes` to verify that a connection is still valid. This can be expensive, so we replace the existing logic of `validateConnection` by calling `driver.verifyConnectivity()`. Also, this PR includes some type fixes.
More type fixes can be addressed via subsequent PRs to ensure this PR is small.

