### PR TITLE
Cut long property values

### DIFF
--- a/src/browser/modules/D3Visualization/components/DetailsPane.tsx
+++ b/src/browser/modules/D3Visualization/components/DetailsPane.tsx
@@ -40,13 +40,17 @@ import { StyleableRelType } from './StyleableRelType'
 import { upperFirst } from 'services/utils'
 import { ShowMoreOrAll } from 'browser-components/ShowMoreOrAll/ShowMoreOrAll'
 
-const MAX_LENGTH = 150
+export const MAX_LENGTH_SMALL = 150
+export const MAX_LENGTH_LARGE = 300
 type ExpandableValueProps = {
   value: string
   type: string
+  wideMode: boolean
 }
-function ExpandableValue({ value }: ExpandableValueProps) {
+function ExpandableValue({ value, wideMode }: ExpandableValueProps) {
   const [expanded, setExpanded] = useState(false)
+
+  const maxLength = wideMode ? MAX_LENGTH_LARGE : MAX_LENGTH_SMALL
 
   const handleExpandClick = () => {
     setExpanded(true)
@@ -54,7 +58,7 @@ function ExpandableValue({ value }: ExpandableValueProps) {
 
   let valueShown = expanded
     ? value
-    : value.slice(0, Math.min(MAX_LENGTH, value.length))
+    : value.slice(0, Math.min(maxLength, value.length))
   const valueIsTrimmed = valueShown.length !== value.length
   valueShown += valueIsTrimmed ? '...' : ''
 
@@ -70,17 +74,20 @@ function ExpandableValue({ value }: ExpandableValueProps) {
   )
 }
 
+const WIDE_VIEW_THRESHOLD = 900
 type PropertiesViewProps = {
   visibleProperties: VizNodeProperty[]
   onMoreClick: (numMore: number) => void
   totalNumItems: number
   moreStep: number
+  nodeInspectorWidth: number
 }
 function PropertiesView({
   visibleProperties,
   totalNumItems,
   onMoreClick,
-  moreStep
+  moreStep,
+  nodeInspectorWidth
 }: PropertiesViewProps) {
   return (
     <>
@@ -93,7 +100,11 @@ function PropertiesView({
                   <ClickableUrls text={key} />
                 </KeyCell>
                 <ValueCell>
-                  <ExpandableValue value={value} type={type} />
+                  <ExpandableValue
+                    value={value}
+                    type={type}
+                    wideMode={nodeInspectorWidth > WIDE_VIEW_THRESHOLD}
+                  />
                 </ValueCell>
                 <CopyCell>
                   <ClipboardCopier
@@ -122,11 +133,13 @@ type DetailsPaneComponentProps = {
   vizItem: NodeItem | RelationshipItem
   graphStyle: GraphStyle
   frameHeight: number
+  nodeInspectorWidth: number
 }
 export function DetailsPaneComponent({
   vizItem,
   graphStyle,
-  frameHeight
+  frameHeight,
+  nodeInspectorWidth
 }: DetailsPaneComponentProps): JSX.Element {
   const [maxPropertiesCount, setMaxPropertiesCount] = useState(
     DETAILS_PANE_STEP_SIZE
@@ -186,6 +199,7 @@ export function DetailsPaneComponent({
           onMoreClick={handleMorePropertiesClick}
           moreStep={DETAILS_PANE_STEP_SIZE}
           totalNumItems={allItemProperties.length}
+          nodeInspectorWidth={nodeInspectorWidth}
         />
       </PaneBody>
     </>

--- a/src/browser/modules/D3Visualization/components/DetailsPane.tsx
+++ b/src/browser/modules/D3Visualization/components/DetailsPane.tsx
@@ -74,7 +74,7 @@ function ExpandableValue({ value, wideMode }: ExpandableValueProps) {
   )
 }
 
-const WIDE_VIEW_THRESHOLD = 900
+export const WIDE_VIEW_THRESHOLD = 900
 type PropertiesViewProps = {
   visibleProperties: VizNodeProperty[]
   onMoreClick: (numMore: number) => void

--- a/src/browser/modules/D3Visualization/components/DetailsPane.tsx
+++ b/src/browser/modules/D3Visualization/components/DetailsPane.tsx
@@ -23,6 +23,7 @@ import React, { useState } from 'react'
 import {
   AlternatingTable,
   CopyCell,
+  StyledExpandValueButton,
   KeyCell,
   PaneBody,
   PaneHeader,
@@ -38,6 +39,36 @@ import { StyleableNodeLabel } from './StyleableNodeLabel'
 import { StyleableRelType } from './StyleableRelType'
 import { upperFirst } from 'services/utils'
 import { ShowMoreOrAll } from 'browser-components/ShowMoreOrAll/ShowMoreOrAll'
+
+const MAX_LENGTH = 150
+type ExpandableValueProps = {
+  value: string
+  type: string
+}
+function ExpandableValue({ value }: ExpandableValueProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  const handleExpandClick = () => {
+    setExpanded(true)
+  }
+
+  let valueShown = expanded
+    ? value
+    : value.slice(0, Math.min(MAX_LENGTH, value.length))
+  const valueIsTrimmed = valueShown.length !== value.length
+  valueShown += valueIsTrimmed ? '...' : ''
+
+  return (
+    <>
+      <ClickableUrls text={valueShown} />
+      {valueIsTrimmed && (
+        <StyledExpandValueButton onClick={handleExpandClick}>
+          {' Show all'}
+        </StyledExpandValueButton>
+      )}
+    </>
+  )
+}
 
 type PropertiesViewProps = {
   visibleProperties: VizNodeProperty[]
@@ -62,7 +93,7 @@ function PropertiesView({
                   <ClickableUrls text={key} />
                 </KeyCell>
                 <ValueCell>
-                  <ClickableUrls text={value} />
+                  <ExpandableValue value={value} type={type} />
                 </ValueCell>
                 <CopyCell>
                   <ClipboardCopier

--- a/src/browser/modules/D3Visualization/components/NodeInspectorPanel.tsx
+++ b/src/browser/modules/D3Visualization/components/NodeInspectorPanel.tsx
@@ -81,6 +81,7 @@ export class NodeInspectorPanel extends Component<NodeInspectorPanelProps> {
                   vizItem={shownEl}
                   graphStyle={graphStyle}
                   frameHeight={frameHeight}
+                  nodeInspectorWidth={width}
                 />
               ) : (
                 <OverviewPane

--- a/src/browser/modules/D3Visualization/components/styled.tsx
+++ b/src/browser/modules/D3Visualization/components/styled.tsx
@@ -372,3 +372,10 @@ export const PaneBodySectionHeaderWrapper = styled.div`
   display: flex;
   flex-direction: column;
 `
+
+export const StyledExpandValueButton = styled.button`
+  border: none;
+  outline: none;
+  background-color: inherit;
+  color: ${props => props.theme.link};
+`

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Visualization renders 1`] = `<div />`;
 exports[`Visualization renders with result and escapes any HTML 1`] = `
 <div>
   <div
-    class="sc-hZSUBg kQEpqW"
+    class="sc-cMhqgX kLjcxD"
   >
     <div
       class="sc-jTzLTM bdhVYv"
@@ -86,7 +86,7 @@ exports[`Visualization renders with result and escapes any HTML 1`] = `
             class="sc-jzJRlG hPTWGK zoom-in"
           >
             <i
-              class="sc-cpmLhU gDDHKC sl-zoom-in"
+              class="sc-dymIpo kVHyJW sl-zoom-in"
               style="font-size: 1em;"
             />
           </button>
@@ -94,7 +94,7 @@ exports[`Visualization renders with result and escapes any HTML 1`] = `
             class="sc-jzJRlG hPTWGK zoom-out"
           >
             <i
-              class="sc-dymIpo kVHyJW sl-zoom-out"
+              class="sc-bnXvFD bIRcfT sl-zoom-out"
               style="font-size: 1em;"
             />
           </button>
@@ -139,13 +139,13 @@ exports[`Visualization renders with result and escapes any HTML 1`] = `
                 class="sc-htpNat sc-dnqmqq OaEcl"
               >
                 <div
-                  class="sc-eXEjpC sc-ibxdXY YDulL"
+                  class="sc-ibxdXY sc-RefOD emwHTu"
                   style="background-color: rgb(247, 151, 103); color: rgb(255, 255, 255);"
                 >
                   * (1)
                 </div>
                 <div
-                  class="sc-eXEjpC sc-ibxdXY YDulL"
+                  class="sc-ibxdXY sc-RefOD emwHTu"
                   style="background-color: rgb(201, 144, 192); color: rgb(255, 255, 255);"
                 >
                   Person (1)

--- a/src/browser/modules/Stream/__snapshots__/SchemaFrame.test.tsx.snap
+++ b/src/browser/modules/Stream/__snapshots__/SchemaFrame.test.tsx.snap
@@ -10,13 +10,13 @@ exports[`SchemaFrame renders empty 1`] = `
         class="sc-kGXeez cjmep"
       >
         <table
-          class="sc-cHSUfg oaTnP"
+          class="sc-cTjmhe bGFmLD"
           data-testid="schemaFrameIndexesTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-cugefK bHYQFR table-header"
+                class="sc-fnwBNb zVSNT table-header"
               >
                 Indexes
               </th>
@@ -24,10 +24,10 @@ exports[`SchemaFrame renders empty 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-cTjmhe hPoZfk table-row"
+              class="sc-cugefK gwPANr table-row"
             >
               <td
-                class="sc-fnwBNb gTkrTl table-properties"
+                class="sc-iNhVCk dCJRGV table-properties"
               >
                 None
               </td>
@@ -35,13 +35,13 @@ exports[`SchemaFrame renders empty 1`] = `
           </tbody>
         </table>
         <table
-          class="sc-cHSUfg oaTnP"
+          class="sc-cTjmhe bGFmLD"
           data-testid="schemaFrameConstraintsTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-cugefK bHYQFR table-header"
+                class="sc-fnwBNb zVSNT table-header"
               >
                 Constraints
               </th>
@@ -49,10 +49,10 @@ exports[`SchemaFrame renders empty 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-cTjmhe hPoZfk table-row"
+              class="sc-cugefK gwPANr table-row"
             >
               <td
-                class="sc-fnwBNb gTkrTl table-properties"
+                class="sc-iNhVCk dCJRGV table-properties"
               >
                 None
               </td>
@@ -92,43 +92,43 @@ exports[`SchemaFrame renders empty for Neo4j >= 4.0 1`] = `
         class="sc-kGXeez cjmep"
       >
         <table
-          class="sc-cHSUfg oaTnP"
+          class="sc-cTjmhe bGFmLD"
           data-testid="schemaFrameIndexesTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-cugefK bHYQFR table-header"
+                class="sc-fnwBNb zVSNT table-header"
               >
                 Index Name
               </th>
               <th
-                class="sc-cugefK bHYQFR table-header"
+                class="sc-fnwBNb zVSNT table-header"
               >
                 Type
               </th>
               <th
-                class="sc-cugefK bHYQFR table-header"
+                class="sc-fnwBNb zVSNT table-header"
               >
                 Uniqueness
               </th>
               <th
-                class="sc-cugefK bHYQFR table-header"
+                class="sc-fnwBNb zVSNT table-header"
               >
                 EntityType
               </th>
               <th
-                class="sc-cugefK bHYQFR table-header"
+                class="sc-fnwBNb zVSNT table-header"
               >
                 LabelsOrTypes
               </th>
               <th
-                class="sc-cugefK bHYQFR table-header"
+                class="sc-fnwBNb zVSNT table-header"
               >
                 Properties
               </th>
               <th
-                class="sc-cugefK bHYQFR table-header"
+                class="sc-fnwBNb zVSNT table-header"
               >
                 State
               </th>
@@ -136,42 +136,42 @@ exports[`SchemaFrame renders empty for Neo4j >= 4.0 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-cTjmhe hPoZfk table-row"
+              class="sc-cugefK gwPANr table-row"
             >
               <td
-                class="sc-fnwBNb gTkrTl table-properties"
+                class="sc-iNhVCk dCJRGV table-properties"
               >
                 None
               </td>
               <td
-                class="sc-fnwBNb gTkrTl table-properties"
+                class="sc-iNhVCk dCJRGV table-properties"
               />
               <td
-                class="sc-fnwBNb gTkrTl table-properties"
+                class="sc-iNhVCk dCJRGV table-properties"
               />
               <td
-                class="sc-fnwBNb gTkrTl table-properties"
+                class="sc-iNhVCk dCJRGV table-properties"
               />
               <td
-                class="sc-fnwBNb gTkrTl table-properties"
+                class="sc-iNhVCk dCJRGV table-properties"
               />
               <td
-                class="sc-fnwBNb gTkrTl table-properties"
+                class="sc-iNhVCk dCJRGV table-properties"
               />
               <td
-                class="sc-fnwBNb gTkrTl table-properties"
+                class="sc-iNhVCk dCJRGV table-properties"
               />
             </tr>
           </tbody>
         </table>
         <table
-          class="sc-cHSUfg oaTnP"
+          class="sc-cTjmhe bGFmLD"
           data-testid="schemaFrameConstraintsTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-cugefK bHYQFR table-header"
+                class="sc-fnwBNb zVSNT table-header"
               >
                 Constraints
               </th>
@@ -179,10 +179,10 @@ exports[`SchemaFrame renders empty for Neo4j >= 4.0 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-cTjmhe hPoZfk table-row"
+              class="sc-cugefK gwPANr table-row"
             >
               <td
-                class="sc-fnwBNb gTkrTl table-properties"
+                class="sc-iNhVCk dCJRGV table-properties"
               >
                 None
               </td>
@@ -222,13 +222,13 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
         class="sc-kGXeez cjmep"
       >
         <table
-          class="sc-cHSUfg oaTnP"
+          class="sc-cTjmhe bGFmLD"
           data-testid="schemaFrameIndexesTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-cugefK bHYQFR table-header"
+                class="sc-fnwBNb zVSNT table-header"
               >
                 Indexes
               </th>
@@ -236,10 +236,10 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-cTjmhe hPoZfk table-row"
+              class="sc-cugefK gwPANr table-row"
             >
               <td
-                class="sc-fnwBNb gTkrTl table-properties"
+                class="sc-iNhVCk dCJRGV table-properties"
               >
                  ON :Movie(released) ONLINE 
               </td>
@@ -247,13 +247,13 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
           </tbody>
         </table>
         <table
-          class="sc-cHSUfg oaTnP"
+          class="sc-cTjmhe bGFmLD"
           data-testid="schemaFrameConstraintsTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-cugefK bHYQFR table-header"
+                class="sc-fnwBNb zVSNT table-header"
               >
                 Constraints
               </th>
@@ -261,10 +261,10 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-cTjmhe hPoZfk table-row"
+              class="sc-cugefK gwPANr table-row"
             >
               <td
-                class="sc-fnwBNb gTkrTl table-properties"
+                class="sc-iNhVCk dCJRGV table-properties"
               >
                  ON ( book:Book ) ASSERT book.isbn IS UNIQUE
               </td>


### PR DESCRIPTION
Cut long property values in the Node properties panel and possible to expand by clicking 'Show all'.

<img width="813" alt="Screenshot 2021-11-17 at 14 57 21" src="https://user-images.githubusercontent.com/11065688/142224481-ed9e55b7-c59a-402d-b6e1-9bf7f6c881af.png">

<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

