### PR TITLE
Local Storage for retaining remote guides

### DIFF
--- a/src/browser/AppInit.tsx
+++ b/src/browser/AppInit.tsx
@@ -69,7 +69,8 @@ applyKeys(
   'grass',
   'syncConsent',
   'udc',
-  'experimentalFeatures'
+  'experimentalFeatures',
+  'guides'
 )
 
 // Create suber bus

--- a/src/browser/components/ProjectFiles/ProjectsFilesScripts.tsx
+++ b/src/browser/components/ProjectFiles/ProjectsFilesScripts.tsx
@@ -15,14 +15,15 @@
  *
  */
 import React from 'react'
-import { useEffect, useState, Dispatch } from 'react'
-import { Action } from 'redux'
+import { useEffect, useState } from 'react'
+import { Dispatch } from 'redux'
 import { connect } from 'react-redux'
 import { useQuery, useMutation, ApolloError } from '@apollo/client'
 import { flatMap } from 'lodash-es'
 
 import * as editor from 'shared/modules/editor/editorDuck'
 import {
+  ExecuteCommandAction,
   commandSources,
   executeCommand
 } from 'shared/modules/commands/commandsDuck'
@@ -168,7 +169,7 @@ const mapStateToProps = (state: any) => ({
   relateUrl: state.app.relateUrl
 })
 
-const mapDispatchToProps = (dispatch: Dispatch<Action>) => ({
+const mapDispatchToProps = (dispatch: Dispatch<ExecuteCommandAction>) => ({
   execScript: (cmd: string) => {
     dispatch(executeCommand(cmd, { source: commandSources.projectFile }))
   }

--- a/src/browser/documentation/sidebar-guides/unfound.tsx
+++ b/src/browser/documentation/sidebar-guides/unfound.tsx
@@ -24,7 +24,7 @@ const title = 'Not found'
 
 const slides = [
   <BuiltInGuideSidebarSlide key="first">
-    <p>Apologies, but there doesn't seem to be any content about that.</p>
+    <p>Apologies, but there doesn&apos;t seem to be any content about that.</p>
     <h5>Try:</h5>
     <ul className="undecorated">
       <li>

--- a/src/browser/modules/Sidebar/GuideDrawer.tsx
+++ b/src/browser/modules/Sidebar/GuideDrawer.tsx
@@ -29,9 +29,9 @@ import {
   FetchGuideAction,
   UpdateGuideAction,
   getCurrentGuide,
-  gotoSlide,
   getRemoteGuides,
   resetGuide,
+  gotoSlide,
   setCurrentGuide,
   fetchRemoteGuide,
   updateRemoteGuides
@@ -51,7 +51,7 @@ import GuidePicker from './GuidePicker'
 type GuideDrawerProps = {
   currentGuide: Guide | null
   remoteGuides: Guide[]
-  backToAllGuides: () => void
+  backToAllGuides: () => SetGuideAction
   gotoSlide: (slideIndex: number) => GotoSlideAction
   setCurrentGuide: (guide: Guide) => SetGuideAction
   fetchRemoteGuide: (identifier: string) => FetchGuideAction

--- a/src/browser/modules/Sidebar/GuideDrawer.tsx
+++ b/src/browser/modules/Sidebar/GuideDrawer.tsx
@@ -89,7 +89,7 @@ function GuideDrawer({
             {currentGuide.title}
           </GuideTitle>
           <GuideCarousel
-            slides={currentGuide.slides}
+            slides={currentGuide.slides ?? []}
             currentSlideIndex={currentGuide.currentSlide}
             gotoSlide={gotoSlide}
             scrollToTop={() =>

--- a/src/browser/modules/Sidebar/GuideDrawer.tsx
+++ b/src/browser/modules/Sidebar/GuideDrawer.tsx
@@ -24,6 +24,7 @@ import { connect } from 'react-redux'
 
 import {
   Guide,
+  RemoteGuide,
   getCurrentGuide,
   getRemoteGuides,
   resetGuide,
@@ -46,12 +47,12 @@ import GuidePicker from './GuidePicker'
 
 type GuideDrawerProps = {
   currentGuide: Guide | null
-  remoteGuides: Guide[]
+  remoteGuides: RemoteGuide[]
   backToAllGuides: () => void
   gotoSlide: (slideIndex: number) => void
   setCurrentGuide: (guide: Guide) => void
   fetchRemoteGuide: (identifier: string) => void
-  updateRemoteGuides: (newList: Guide[]) => void
+  updateRemoteGuides: (newList: RemoteGuide[]) => void
 }
 
 function GuideDrawer({
@@ -116,7 +117,7 @@ const mapDispatchToProps = (dispatch: Dispatch<Action>) => ({
   setCurrentGuide: (guide: Guide) => dispatch(setCurrentGuide(guide)),
   fetchRemoteGuide: (identifier: string) =>
     dispatch(fetchRemoteGuide(identifier)),
-  updateRemoteGuides: (updatedList: Guide[]) =>
+  updateRemoteGuides: (updatedList: RemoteGuide[]) =>
     dispatch(updateRemoteGuides(updatedList))
 })
 const ConnectedGuideDrawer = connect(

--- a/src/browser/modules/Sidebar/GuideDrawer.tsx
+++ b/src/browser/modules/Sidebar/GuideDrawer.tsx
@@ -18,17 +18,22 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import React, { Dispatch, useRef } from 'react'
-import { Action } from 'redux'
+import React, { useRef } from 'react'
+import { Action, Dispatch } from 'redux'
 import { connect } from 'react-redux'
 
 import {
-  getCurrentGuide,
   Guide,
+  GotoSlideAction,
+  SetGuideAction,
+  FetchGuideAction,
+  UpdateGuideAction,
+  getCurrentGuide,
   gotoSlide,
   getRemoteGuides,
   resetGuide,
   setCurrentGuide,
+  fetchRemoteGuide,
   updateRemoteGuides
 } from 'shared/modules/guides/guidesDuck'
 import { GlobalState } from 'shared/globalState'
@@ -45,19 +50,21 @@ import GuidePicker from './GuidePicker'
 
 type GuideDrawerProps = {
   currentGuide: Guide | null
-  backToAllGuides: () => void
-  gotoSlide: (slideIndex: number) => void
   remoteGuides: Guide[]
-  setCurrentGuide: (guide: Guide) => void
-  updateRemoteGuides: (newList: Guide[]) => void
+  backToAllGuides: () => void
+  gotoSlide: (slideIndex: number) => GotoSlideAction
+  setCurrentGuide: (guide: Guide) => SetGuideAction
+  fetchRemoteGuide: (identifier: string) => FetchGuideAction
+  updateRemoteGuides: (newList: Guide[]) => UpdateGuideAction
 }
 
 function GuideDrawer({
   currentGuide,
+  remoteGuides,
   backToAllGuides,
   gotoSlide,
-  remoteGuides,
   setCurrentGuide,
+  fetchRemoteGuide,
   updateRemoteGuides
 }: GuideDrawerProps): JSX.Element {
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -81,6 +88,7 @@ function GuideDrawer({
         <GuidePicker
           remoteGuides={remoteGuides}
           setCurrentGuide={setCurrentGuide}
+          fetchRemoteGuide={fetchRemoteGuide}
           updateRemoteGuides={updateRemoteGuides}
         />
       ) : (
@@ -110,6 +118,8 @@ const mapDispatchToProps = (dispatch: Dispatch<Action>) => ({
   backToAllGuides: () => dispatch(resetGuide()),
   gotoSlide: (slideIndex: number) => dispatch(gotoSlide(slideIndex)),
   setCurrentGuide: (guide: Guide) => dispatch(setCurrentGuide(guide)),
+  fetchRemoteGuide: (identifier: string) =>
+    dispatch(fetchRemoteGuide(identifier)),
   updateRemoteGuides: (updatedList: Guide[]) =>
     dispatch(updateRemoteGuides(updatedList))
 })

--- a/src/browser/modules/Sidebar/GuideDrawer.tsx
+++ b/src/browser/modules/Sidebar/GuideDrawer.tsx
@@ -24,10 +24,6 @@ import { connect } from 'react-redux'
 
 import {
   Guide,
-  GotoSlideAction,
-  SetGuideAction,
-  FetchGuideAction,
-  UpdateGuideAction,
   getCurrentGuide,
   getRemoteGuides,
   resetGuide,
@@ -51,11 +47,11 @@ import GuidePicker from './GuidePicker'
 type GuideDrawerProps = {
   currentGuide: Guide | null
   remoteGuides: Guide[]
-  backToAllGuides: () => SetGuideAction
-  gotoSlide: (slideIndex: number) => GotoSlideAction
-  setCurrentGuide: (guide: Guide) => SetGuideAction
-  fetchRemoteGuide: (identifier: string) => FetchGuideAction
-  updateRemoteGuides: (newList: Guide[]) => UpdateGuideAction
+  backToAllGuides: () => void
+  gotoSlide: (slideIndex: number) => void
+  setCurrentGuide: (guide: Guide) => void
+  fetchRemoteGuide: (identifier: string) => void
+  updateRemoteGuides: (newList: Guide[]) => void
 }
 
 function GuideDrawer({

--- a/src/browser/modules/Sidebar/GuidePicker.tsx
+++ b/src/browser/modules/Sidebar/GuidePicker.tsx
@@ -13,14 +13,20 @@ import {
   GuideListEntry,
   MarginBottomLi
 } from 'browser/documentation/sidebar-guides/styled'
-import { Guide } from 'shared/modules/guides/guidesDuck'
+import {
+  Guide,
+  SetGuideAction,
+  FetchGuideAction,
+  UpdateGuideAction
+} from 'shared/modules/guides/guidesDuck'
 import docs, { GuideChapter } from 'browser/documentation'
 import { BinIcon } from 'browser-components/icons/Icons'
 
 type GuidePickerProps = {
   remoteGuides: Guide[]
-  setCurrentGuide: (guide: Guide) => void
-  updateRemoteGuides: (newList: Guide[]) => void
+  setCurrentGuide: (guide: Guide) => SetGuideAction
+  fetchRemoteGuide: (identifier: string) => FetchGuideAction
+  updateRemoteGuides: (newList: Guide[]) => UpdateGuideAction
 }
 
 const builtInGuides: { identifier: GuideChapter; description: string }[] = [
@@ -43,6 +49,7 @@ const builtInGuides: { identifier: GuideChapter; description: string }[] = [
 const GuidePicker = ({
   remoteGuides,
   setCurrentGuide,
+  // fetchRemoteGuide,
   updateRemoteGuides
 }: GuidePickerProps): JSX.Element => (
   <BuiltInGuideSidebarSlide>

--- a/src/browser/modules/Sidebar/GuidePicker.tsx
+++ b/src/browser/modules/Sidebar/GuidePicker.tsx
@@ -49,7 +49,7 @@ const builtInGuides: { identifier: GuideChapter; description: string }[] = [
 const GuidePicker = ({
   remoteGuides,
   setCurrentGuide,
-  // fetchRemoteGuide,
+  fetchRemoteGuide,
   updateRemoteGuides
 }: GuidePickerProps): JSX.Element => (
   <BuiltInGuideSidebarSlide>
@@ -90,7 +90,9 @@ const GuidePicker = ({
         <NoBulletsUl>
           {remoteGuides.map(guide => (
             <GuideListEntry key={guide.title}>
-              <DrawerBrowserCommand onClick={() => setCurrentGuide(guide)}>
+              <DrawerBrowserCommand
+                onClick={() => fetchRemoteGuide(guide.identifier)}
+              >
                 {guide.title}
               </DrawerBrowserCommand>
               <Clickable

--- a/src/browser/modules/Sidebar/GuidePicker.tsx
+++ b/src/browser/modules/Sidebar/GuidePicker.tsx
@@ -13,15 +13,15 @@ import {
   GuideListEntry,
   MarginBottomLi
 } from 'browser/documentation/sidebar-guides/styled'
-import { Guide } from 'shared/modules/guides/guidesDuck'
+import { Guide, RemoteGuide } from 'shared/modules/guides/guidesDuck'
 import docs, { GuideChapter } from 'browser/documentation'
 import { BinIcon } from 'browser-components/icons/Icons'
 
 type GuidePickerProps = {
-  remoteGuides: Guide[]
+  remoteGuides: RemoteGuide[]
   setCurrentGuide: (guide: Guide) => void
   fetchRemoteGuide: (identifier: string) => void
-  updateRemoteGuides: (newList: Guide[]) => void
+  updateRemoteGuides: (newList: RemoteGuide[]) => void
 }
 
 const builtInGuides: { identifier: GuideChapter; description: string }[] = [

--- a/src/browser/modules/Sidebar/GuidePicker.tsx
+++ b/src/browser/modules/Sidebar/GuidePicker.tsx
@@ -23,16 +23,19 @@ type GuidePickerProps = {
   updateRemoteGuides: (newList: Guide[]) => void
 }
 
-const builtInGuides: { name: GuideChapter; description: string }[] = [
-  { name: 'intro', description: 'Navigating Neo4j Browser' },
-  { name: 'concepts', description: 'Property graph model concepts' },
-  { name: 'cypher', description: 'Cypher basics - create, match, delete' },
+const builtInGuides: { identifier: GuideChapter; description: string }[] = [
+  { identifier: 'intro', description: 'Navigating Neo4j Browser' },
+  { identifier: 'concepts', description: 'Property graph model concepts' },
   {
-    name: 'movie-graph',
+    identifier: 'cypher',
+    description: 'Cypher basics - create, match, delete'
+  },
+  {
+    identifier: 'movie-graph',
     description: 'Queries and recommendations with Cypher - movie use case}'
   },
   {
-    name: 'northwind-graph',
+    identifier: 'northwind-graph',
     description: 'Translate and import relation data into graph'
   }
 ]
@@ -54,14 +57,18 @@ const GuidePicker = ({
       </DrawerSubHeader>
     </MarginTop>
     <NoBulletsUl>
-      {builtInGuides.map(({ name, description }) => (
+      {builtInGuides.map(({ identifier, description }) => (
         <MarginBottomLi
-          key={name}
+          key={identifier}
           onClick={() =>
-            setCurrentGuide({ ...docs.guide.chapters[name], currentSlide: 0 })
+            setCurrentGuide({
+              ...docs.guide.chapters[identifier],
+              identifier,
+              currentSlide: 0
+            })
           }
         >
-          <DrawerBrowserCommand>:guide {name}</DrawerBrowserCommand>
+          <DrawerBrowserCommand>:guide {identifier}</DrawerBrowserCommand>
           <MarginTop> {description} </MarginTop>
         </MarginBottomLi>
       ))}

--- a/src/browser/modules/Sidebar/GuidePicker.tsx
+++ b/src/browser/modules/Sidebar/GuidePicker.tsx
@@ -13,20 +13,15 @@ import {
   GuideListEntry,
   MarginBottomLi
 } from 'browser/documentation/sidebar-guides/styled'
-import {
-  Guide,
-  SetGuideAction,
-  FetchGuideAction,
-  UpdateGuideAction
-} from 'shared/modules/guides/guidesDuck'
+import { Guide } from 'shared/modules/guides/guidesDuck'
 import docs, { GuideChapter } from 'browser/documentation'
 import { BinIcon } from 'browser-components/icons/Icons'
 
 type GuidePickerProps = {
   remoteGuides: Guide[]
-  setCurrentGuide: (guide: Guide) => SetGuideAction
-  fetchRemoteGuide: (identifier: string) => FetchGuideAction
-  updateRemoteGuides: (newList: Guide[]) => UpdateGuideAction
+  setCurrentGuide: (guide: Guide) => void
+  fetchRemoteGuide: (identifier: string) => void
+  updateRemoteGuides: (newList: Guide[]) => void
 }
 
 const builtInGuides: { identifier: GuideChapter; description: string }[] = [

--- a/src/browser/modules/Sidebar/ProjectFiles.tsx
+++ b/src/browser/modules/Sidebar/ProjectFiles.tsx
@@ -17,8 +17,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import React, { Dispatch } from 'react'
-import { Action } from 'redux'
+import React from 'react'
+import { Action, Dispatch } from 'redux'
 import { connect } from 'react-redux'
 import { useMutation } from '@apollo/client'
 import { getProjectId } from 'shared/modules/app/appDuck'
@@ -33,7 +33,10 @@ import {
   updateCacheAddProjectFile
 } from '../../components/ProjectFiles/projectFilesUtils'
 import { ADD_PROJECT_FILE } from '../../components/ProjectFiles/projectFilesConstants'
-import { setDraftScript } from 'shared/modules/sidebar/sidebarDuck'
+import {
+  SetDraftScriptAction,
+  setDraftScript
+} from 'shared/modules/sidebar/sidebarDuck'
 import { CYPHER_FILE_EXTENSION } from 'services/exporting/favoriteUtils'
 
 interface ProjectFilesProps {
@@ -91,7 +94,7 @@ const mapStateToProps = (state: any) => ({
   projectId: getProjectId(state)
 })
 
-const mapDispatchToProps = (dispatch: Dispatch<Action>) => ({
+const mapDispatchToProps = (dispatch: Dispatch<SetDraftScriptAction>) => ({
   resetDraft: () => {
     dispatch(setDraftScript(null, 'project files'))
   }

--- a/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
+++ b/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
@@ -18,9 +18,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { Record as Neo4jRecord } from 'neo4j-driver'
+import React, { Component } from 'react'
+import { Dispatch } from 'redux'
 import { connect } from 'react-redux'
-import React, { Component, Dispatch } from 'react'
+
+import { Record as Neo4jRecord } from 'neo4j-driver'
+
 import FrameTemplate from '../../Frame/FrameTemplate'
 import { CypherFrameButton } from 'browser-components/buttons'
 import Centered from 'browser-components/Centered'
@@ -51,7 +54,7 @@ import { PlanView, PlanStatusbar } from './PlanView'
 import { VisualizationConnectedBus } from './VisualizationView'
 
 import Display from 'browser-components/Display'
-import * as viewTypes from 'shared/modules/frames/frameViewTypes'
+import * as ViewTypes from 'shared/modules/frames/frameViewTypes'
 import {
   resultHasRows,
   resultHasWarnings,
@@ -91,11 +94,11 @@ type CypherFrameProps = CypherFrameBaseProps & {
   maxNeighbours: number
   maxRows: number
   request: BrowserRequest
-  onRecentViewChanged: (view: viewTypes.FrameView) => void
+  onRecentViewChanged: (view: ViewTypes.FrameView) => void
 }
 
 type CypherFrameState = {
-  openView?: viewTypes.FrameView
+  openView?: ViewTypes.FrameView
   fullscreen: boolean
   collapse: boolean
   frameHeight: number
@@ -124,7 +127,7 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
     planExpand: 'EXPAND'
   }
 
-  changeView(view: viewTypes.FrameView): void {
+  changeView(view: ViewTypes.FrameView): void {
     this.setState({ openView: view })
     if (this.props.onRecentViewChanged) {
       this.props.onRecentViewChanged(view)
@@ -167,7 +170,7 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
     if (this.props.request.status !== REQUEST_STATUS_PENDING) {
       const openView = initialView(this.props, this.state)
       if (openView !== this.state.openView) {
-        const hasVis = openView === viewTypes.ERRORS ? false : this.state.hasVis
+        const hasVis = openView === ViewTypes.ERRORS ? false : this.state.hasVis
         this.setState({ openView, hasVis })
       }
     } else {
@@ -177,7 +180,7 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
 
     // When frame re-use leads to result without visualization
     const doneLoading = this.props.request.status === REQUEST_STATUS_SUCCESS
-    const currentlyShowingViz = this.state.openView === viewTypes.VISUALIZATION
+    const currentlyShowingViz = this.state.openView === ViewTypes.VISUALIZATION
     if (doneLoading && currentlyShowingViz && !this.canShowViz()) {
       const view = initialView(this.props, {
         ...this.state,
@@ -209,9 +212,9 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
       {this.canShowViz() && (
         <CypherFrameButton
           data-testid="cypherFrameSidebarVisualization"
-          selected={this.state.openView === viewTypes.VISUALIZATION}
+          selected={this.state.openView === ViewTypes.VISUALIZATION}
           onClick={() => {
-            this.changeView(viewTypes.VISUALIZATION)
+            this.changeView(ViewTypes.VISUALIZATION)
           }}
         >
           <VisualizationIcon />
@@ -220,9 +223,9 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
       {!resultIsError(this.props.request) && (
         <CypherFrameButton
           data-testid="cypherFrameSidebarTable"
-          selected={this.state.openView === viewTypes.TABLE}
+          selected={this.state.openView === ViewTypes.TABLE}
           onClick={() => {
-            this.changeView(viewTypes.TABLE)
+            this.changeView(ViewTypes.TABLE)
           }}
         >
           <TableIcon />
@@ -231,9 +234,9 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
       {resultHasRows(this.props.request) && !resultIsError(this.props.request) && (
         <CypherFrameButton
           data-testid="cypherFrameSidebarAscii"
-          selected={this.state.openView === viewTypes.TEXT}
+          selected={this.state.openView === ViewTypes.TEXT}
           onClick={() => {
-            this.changeView(viewTypes.TEXT)
+            this.changeView(ViewTypes.TEXT)
           }}
         >
           <AsciiIcon />
@@ -242,17 +245,17 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
       {resultHasPlan(this.props.request) && (
         <CypherFrameButton
           data-testid="cypherFrameSidebarPlan"
-          selected={this.state.openView === viewTypes.PLAN}
-          onClick={() => this.changeView(viewTypes.PLAN)}
+          selected={this.state.openView === ViewTypes.PLAN}
+          onClick={() => this.changeView(ViewTypes.PLAN)}
         >
           <PlanIcon />
         </CypherFrameButton>
       )}
       {resultHasWarnings(this.props.request) && (
         <CypherFrameButton
-          selected={this.state.openView === viewTypes.WARNINGS}
+          selected={this.state.openView === ViewTypes.WARNINGS}
           onClick={() => {
-            this.changeView(viewTypes.WARNINGS)
+            this.changeView(ViewTypes.WARNINGS)
           }}
         >
           <AlertIcon />
@@ -260,9 +263,9 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
       )}
       {resultIsError(this.props.request) ? (
         <CypherFrameButton
-          selected={this.state.openView === viewTypes.ERRORS}
+          selected={this.state.openView === ViewTypes.ERRORS}
           onClick={() => {
-            this.changeView(viewTypes.ERRORS)
+            this.changeView(ViewTypes.ERRORS)
           }}
         >
           <ErrorIcon />
@@ -270,9 +273,9 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
       ) : (
         <CypherFrameButton
           data-testid="cypherFrameSidebarCode"
-          selected={this.state.openView === viewTypes.CODE}
+          selected={this.state.openView === ViewTypes.CODE}
           onClick={() => {
-            this.changeView(viewTypes.CODE)
+            this.changeView(ViewTypes.CODE)
           }}
         >
           <CodeIcon />
@@ -301,9 +304,9 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
         data-testid="frame-loaded-contents"
         fullscreen={this.state.fullscreen}
         collapsed={this.state.collapse}
-        preventOverflow={this.state.openView === viewTypes.VISUALIZATION}
+        preventOverflow={this.state.openView === ViewTypes.VISUALIZATION}
       >
-        <Display if={this.state.openView === viewTypes.TEXT} lazy>
+        <Display if={this.state.openView === ViewTypes.TEXT} lazy>
           <AsciiView
             asciiSetColWidth={this.state.asciiSetColWidth}
             maxRows={this.props.maxRows}
@@ -314,19 +317,19 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
             }
           />
         </Display>
-        <Display if={this.state.openView === viewTypes.TABLE} lazy>
+        <Display if={this.state.openView === ViewTypes.TABLE} lazy>
           <RelatableView updated={this.props.request.updated} result={result} />
         </Display>
-        <Display if={this.state.openView === viewTypes.CODE} lazy>
+        <Display if={this.state.openView === ViewTypes.CODE} lazy>
           <CodeView result={result} request={request} query={query} />
         </Display>
-        <Display if={this.state.openView === viewTypes.ERRORS} lazy>
+        <Display if={this.state.openView === ViewTypes.ERRORS} lazy>
           <ErrorsView result={result} updated={this.props.request.updated} />
         </Display>
-        <Display if={this.state.openView === viewTypes.WARNINGS} lazy>
+        <Display if={this.state.openView === ViewTypes.WARNINGS} lazy>
           <WarningsView result={result} updated={this.props.request.updated} />
         </Display>
-        <Display if={this.state.openView === viewTypes.PLAN} lazy>
+        <Display if={this.state.openView === ViewTypes.PLAN} lazy>
           <PlanView
             planExpand={this.state.planExpand}
             result={result}
@@ -341,7 +344,7 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
             }
           />
         </Display>
-        <Display if={this.state.openView === viewTypes.VISUALIZATION} lazy>
+        <Display if={this.state.openView === ViewTypes.VISUALIZATION} lazy>
           <VisualizationConnectedBus
             fullscreen={this.state.fullscreen}
             result={result}
@@ -363,7 +366,7 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
   getStatusbar(result: BrowserRequestResult): JSX.Element {
     return (
       <StyledStatsBarContainer>
-        <Display if={this.state.openView === viewTypes.TEXT} lazy>
+        <Display if={this.state.openView === ViewTypes.TEXT} lazy>
           <AsciiStatusbar
             asciiMaxColWidth={this.state.asciiMaxColWidth}
             asciiSetColWidth={this.state.asciiSetColWidth}
@@ -375,25 +378,25 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
             }
           />
         </Display>
-        <Display if={this.state.openView === viewTypes.TABLE} lazy>
+        <Display if={this.state.openView === ViewTypes.TABLE} lazy>
           <RelatableStatusbar
             updated={this.props.request.updated}
             result={result}
           />
         </Display>
-        <Display if={this.state.openView === viewTypes.CODE} lazy>
+        <Display if={this.state.openView === ViewTypes.CODE} lazy>
           <CodeStatusbar result={result} />
         </Display>
-        <Display if={this.state.openView === viewTypes.ERRORS} lazy>
+        <Display if={this.state.openView === ViewTypes.ERRORS} lazy>
           <ErrorsStatusbar result={result} />
         </Display>
-        <Display if={this.state.openView === viewTypes.WARNINGS} lazy>
+        <Display if={this.state.openView === ViewTypes.WARNINGS} lazy>
           <WarningsStatusbar
             result={result}
             updated={this.props.request.updated}
           />
         </Display>
-        <Display if={this.state.openView === viewTypes.PLAN} lazy>
+        <Display if={this.state.openView === ViewTypes.PLAN} lazy>
           <PlanStatusbar
             result={result}
             setPlanExpand={(planExpand: PlanExpand) =>
@@ -422,7 +425,7 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
         this.getFrameContents(request, result, query)
       )
     const statusBar =
-      this.state.openView !== viewTypes.VISUALIZATION &&
+      this.state.openView !== ViewTypes.VISUALIZATION &&
       requestStatus !== 'error'
         ? this.getStatusbar(result)
         : null
@@ -439,8 +442,8 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
         onResize={this.onResize}
         visElement={
           this.state.hasVis &&
-          (this.state.openView === viewTypes.VISUALIZATION ||
-            this.state.openView === viewTypes.PLAN)
+          (this.state.openView === ViewTypes.VISUALIZATION ||
+            this.state.openView === ViewTypes.PLAN)
             ? this.visElement
             : null
         }
@@ -462,7 +465,7 @@ const mapStateToProps = (
 })
 
 const mapDispatchToProps = (dispatch: Dispatch<SetRecentViewAction>) => ({
-  onRecentViewChanged: (view: viewTypes.FrameView) => {
+  onRecentViewChanged: (view: ViewTypes.FrameView) => {
     dispatch(setRecentView(view))
   }
 })

--- a/src/browser/modules/Stream/__snapshots__/SchemaFrame.test.tsx.snap
+++ b/src/browser/modules/Stream/__snapshots__/SchemaFrame.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`SchemaFrame renders empty 1`] = `
   >
     <div>
       <div
-        class="sc-kGXeez cjmep"
+        class="sc-gZMcBi cnSkYm"
       >
         <table
           class="sc-cTjmhe bGFmLD"
@@ -89,7 +89,7 @@ exports[`SchemaFrame renders empty for Neo4j >= 4.0 1`] = `
   >
     <div>
       <div
-        class="sc-kGXeez cjmep"
+        class="sc-gZMcBi cnSkYm"
       >
         <table
           class="sc-cTjmhe bGFmLD"
@@ -219,7 +219,7 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
   >
     <div>
       <div
-        class="sc-kGXeez cjmep"
+        class="sc-gZMcBi cnSkYm"
       >
         <table
           class="sc-cTjmhe bGFmLD"

--- a/src/shared/modules/commands/commandsDuck.ts
+++ b/src/shared/modules/commands/commandsDuck.ts
@@ -40,7 +40,7 @@ import {
   getPlayImplicitInitCommands,
   shouldEnableMultiStatementMode
 } from '../settings/settingsDuck'
-import { fetchRemoteGuideAsync } from './helpers/play'
+import { fetchRemoteGuideAsync } from './helpers/playAndGuides'
 import { CONNECTION_SUCCESS } from '../connections/connectionsDuck'
 import {
   UPDATE_SETTINGS,

--- a/src/shared/modules/commands/commandsDuck.ts
+++ b/src/shared/modules/commands/commandsDuck.ts
@@ -40,7 +40,7 @@ import {
   getPlayImplicitInitCommands,
   shouldEnableMultiStatementMode
 } from '../settings/settingsDuck'
-import { fetchRemoteGuide } from './helpers/play'
+import { fetchRemoteGuideAsync } from './helpers/play'
 import { CONNECTION_SUCCESS } from '../connections/connectionsDuck'
 import {
   UPDATE_SETTINGS,
@@ -88,6 +88,21 @@ export default function reducer(state = initialState, action: any) {
 
 // Action creators
 
+export interface ExecuteSingleCommandAction {
+  type: typeof SINGLE_COMMAND_QUEUED
+  cmd: string
+  id?: number | string
+  requestId?: string
+  useDb?: string | null
+  isRerun?: boolean
+}
+
+export interface ExecuteCommandAction extends ExecuteSingleCommandAction {
+  type: typeof COMMAND_QUEUED
+  parentId?: string
+  source?: string
+}
+
 export const commandSources = {
   button: 'BUTTON',
   playButton: 'PLAY-BUTTON',
@@ -99,8 +114,33 @@ export const commandSources = {
   sidebar: 'SIDEBAR',
   url: 'URL'
 }
+
+export const executeSingleCommand = (
+  cmd: string,
+  {
+    id,
+    requestId,
+    useDb,
+    isRerun = false
+  }: {
+    id?: number | string
+    requestId?: string
+    useDb?: string | null
+    isRerun?: boolean
+  } = {}
+): ExecuteSingleCommandAction => {
+  return {
+    type: SINGLE_COMMAND_QUEUED,
+    cmd,
+    id,
+    requestId,
+    useDb,
+    isRerun
+  }
+}
+
 export const executeCommand = (
-  cmd: any,
+  cmd: string,
   {
     id = undefined,
     requestId = undefined,
@@ -108,8 +148,15 @@ export const executeCommand = (
     useDb = undefined,
     isRerun = false,
     source = undefined
-  }: any = {}
-) => {
+  }: {
+    id?: number | string
+    requestId?: string
+    parentId?: string
+    useDb?: string | null
+    isRerun?: boolean
+    source?: string
+  } = {}
+): ExecuteCommandAction => {
   return {
     type: COMMAND_QUEUED,
     cmd,
@@ -119,20 +166,6 @@ export const executeCommand = (
     useDb,
     isRerun,
     source
-  }
-}
-
-export const executeSingleCommand = (
-  cmd: any,
-  { id, requestId, useDb, isRerun = false }: any = {}
-) => {
-  return {
-    type: SINGLE_COMMAND_QUEUED,
-    cmd,
-    id,
-    requestId,
-    useDb,
-    isRerun
   }
 }
 
@@ -318,7 +351,7 @@ export const fetchGuideFromAllowlistEpic = (some$: any, store: any) =>
 
     return firstSuccessPromise(guidesUrls, (url: any) => {
       // Get first successful fetch
-      return fetchRemoteGuide(url, allowlistStr).then(r => ({
+      return fetchRemoteGuideAsync(url, allowlistStr).then(r => ({
         type: action.$$responseChannel,
         success: true,
         result: r

--- a/src/shared/modules/commands/helpers/grass.ts
+++ b/src/shared/modules/commands/helpers/grass.ts
@@ -21,8 +21,8 @@
 import { hostIsAllowed } from 'services/utils'
 import remote from 'services/remote'
 
-export const fetchRemoteGrass = (url: any, allowlist = null) => {
-  return new Promise((resolve, reject) => {
+export const fetchRemoteGrass = (url: any, allowlist?: string) => {
+  return new Promise<void>((resolve, reject) => {
     if (!hostIsAllowed(url, allowlist)) {
       return reject(
         new Error('Hostname is not allowed according to server allowlist')

--- a/src/shared/modules/commands/helpers/play.ts
+++ b/src/shared/modules/commands/helpers/play.ts
@@ -18,11 +18,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+// Need to refactor
 import { hostIsAllowed } from 'services/utils'
 import { cleanHtml } from 'services/remoteUtils'
 import remote from 'services/remote'
 
-export const fetchRemoteGuide = (url: any, allowlist = null) => {
+export const fetchRemoteGuideAsync = (url: any, allowlist = null) => {
   return new Promise<void>((resolve, reject) => {
     if (!hostIsAllowed(url, allowlist)) {
       return reject(

--- a/src/shared/modules/commands/helpers/play.ts
+++ b/src/shared/modules/commands/helpers/play.ts
@@ -23,15 +23,18 @@ import { hostIsAllowed } from 'services/utils'
 import { cleanHtml } from 'services/remoteUtils'
 import remote from 'services/remote'
 
-export const fetchRemoteGuideAsync = (url: any, allowlist = null) => {
+export const fetchRemoteGuideAsync = async (
+  url: string,
+  allowlistStr?: string
+): Promise<string> => {
   return new Promise<void>((resolve, reject) => {
-    if (!hostIsAllowed(url, allowlist)) {
+    if (!hostIsAllowed(url, allowlistStr)) {
       return reject(
         new Error('Hostname is not allowed according to server allowlist')
       )
     }
     resolve()
-  }).then(() => {
+  }).then(async () => {
     return remote
       .get(url, { pragma: 'no-cache', 'cache-control': 'no-cache' })
       .then(r => {

--- a/src/shared/modules/commands/helpers/playAndGuides.ts
+++ b/src/shared/modules/commands/helpers/playAndGuides.ts
@@ -33,11 +33,11 @@ export const fetchRemoteGuideAsync = async (
       )
     }
     resolve()
-  }).then(async () => {
-    return remote
+  }).then(() =>
+    remote
       .get(url, { pragma: 'no-cache', 'cache-control': 'no-cache' })
       .then(r => {
         return cleanHtml(r)
       })
-  })
+  )
 }

--- a/src/shared/modules/commands/helpers/playAndGuides.ts
+++ b/src/shared/modules/commands/helpers/playAndGuides.ts
@@ -18,7 +18,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// Need to refactor
 import { hostIsAllowed } from 'services/utils'
 import { cleanHtml } from 'services/remoteUtils'
 import remote from 'services/remote'

--- a/src/shared/modules/dbMeta/dbMetaDuck.ts
+++ b/src/shared/modules/dbMeta/dbMetaDuck.ts
@@ -121,9 +121,9 @@ export const getClientsAllowTelemetry = (state: GlobalState): boolean =>
   initialState.settings['clients.allow_telemetry']
 export const credentialsTimeout = (state: any) =>
   getAvailableSettings(state)['browser.credential_timeout'] || 0
-export const getRemoteContentHostnameAllowlist = (state: any) =>
+export const getRemoteContentHostnameAllowlist = (state: GlobalState): string =>
   getAvailableSettings(state)['browser.remote_content_hostname_allowlist']
-export const getDefaultRemoteContentHostnameAllowlist = () =>
+export const getDefaultRemoteContentHostnameAllowlist = (): string =>
   initialState.settings['browser.remote_content_hostname_allowlist']
 export const getRetainConnectionCredentials = (state: any) => {
   const settings = getAvailableSettings(state)

--- a/src/shared/modules/guides/guidesDuck.ts
+++ b/src/shared/modules/guides/guidesDuck.ts
@@ -18,10 +18,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import { Epic } from 'redux-observable'
 import docs from 'browser/documentation'
 import { GlobalState } from 'shared/globalState'
+import { resolveGuide } from '../../services/guideResolverHelper'
 
 export const NAME = 'guides'
+export const FETCH_GUIDE = 'guides/FETCH_GUIDE'
 export const SET_GUIDE = 'sidebar/SET_GUIDE'
 export const GOTO_SLIDE = 'sidebar/GOTO_SLIDE'
 export const UPDATE_REMOTE_GUIDES = 'sidebar/UPDATE_REMOTE_GUIDES'
@@ -50,22 +53,29 @@ const initialState: GuideState = {
   remoteGuides: []
 }
 
-type GuideAction =
-  | SetAction
+export type GuideAction =
+  | FetchGuideAction
+  | SetGuideAction
   | GotoSlideAction
   | UpdateGuideAction
   | AddGuideAction
 
-interface SetAction {
+export interface SetGuideAction {
   type: typeof SET_GUIDE
   guide: Guide | null
 }
 
-interface GotoSlideAction {
+export interface GotoSlideAction {
   type: typeof GOTO_SLIDE
   slideIndex: number
 }
-interface UpdateGuideAction {
+
+export interface FetchGuideAction {
+  type: typeof FETCH_GUIDE
+  identifier: string
+}
+
+export interface UpdateGuideAction {
   type: typeof UPDATE_REMOTE_GUIDES
   updatedGuides: Guide[]
 }
@@ -73,6 +83,18 @@ interface AddGuideAction {
   type: typeof ADD_GUIDE
   guide: Guide
 }
+
+export const fetchRemoteGuideEpic: Epic<GuideAction, GlobalState> = action$ =>
+  action$
+    .ofType(FETCH_GUIDE)
+    .map(() =>
+      setCurrentGuide({
+        currentSlide: 0,
+        identifier: 'test',
+        title: 'test',
+        slides: []
+      })
+    )
 
 export default function reducer(
   state = initialState,
@@ -134,11 +156,15 @@ export function addRemoteGuide(guide: Guide): AddGuideAction {
   return { type: ADD_GUIDE, guide }
 }
 
-export function setCurrentGuide(guide: Guide): SetAction {
+export function fetchRemoteGuide(identifier: string): FetchGuideAction {
+  return { type: FETCH_GUIDE, identifier }
+}
+
+export function setCurrentGuide(guide: Guide): SetGuideAction {
   return { type: SET_GUIDE, guide }
 }
 
-export function resetGuide(): SetAction {
+export function resetGuide(): SetGuideAction {
   return { type: SET_GUIDE, guide: null }
 }
 

--- a/src/shared/modules/guides/guidesDuck.ts
+++ b/src/shared/modules/guides/guidesDuck.ts
@@ -140,7 +140,6 @@ export default function reducer(
       const builtInGuidesTitles = Object.values(docs.guide.chapters).map(
         guide => guide.title
       )
-      console.log(builtInGuidesTitles)
 
       const alreadyAdded = remoteGuideTitles
         .concat(builtInGuidesTitles)

--- a/src/shared/modules/guides/guidesDuck.ts
+++ b/src/shared/modules/guides/guidesDuck.ts
@@ -100,13 +100,13 @@ export const fetchRemoteGuideEpic: Epic<
       const guide: Guide = {
         currentSlide: initialSlide,
         title,
-        identifier,
-        slides
+        identifier
       }
 
       const streamActions: Array<
         SetGuideAction | OpenAction | AddGuideAction
-      > = [setCurrentGuide(guide), open('guides')]
+      > = [setCurrentGuide({ ...guide, slides }), open('guides')]
+      // To keep Redux store as small as possible, we don't save slides into it
       if (!isError) streamActions.push(addRemoteGuide(guide))
       return streamActions
     })

--- a/src/shared/modules/guides/guidesDuck.ts
+++ b/src/shared/modules/guides/guidesDuck.ts
@@ -24,6 +24,7 @@ import { GlobalState } from 'shared/globalState'
 import { tryGetRemoteInitialSlideFromUrl } from 'services/guideResolverHelper'
 import { resolveGuide } from '../../services/guideResolverHelper'
 import { OpenSidebarAction, open } from '../sidebar/sidebarDuck'
+import { isGuideChapter } from 'browser/documentation'
 
 export const NAME = 'guides'
 export const FETCH_GUIDE = 'guides/FETCH_GUIDE'
@@ -134,11 +135,12 @@ export default function reducer(
       return { ...state, remoteGuides: action.updatedGuides }
 
     case ADD_REMOTE_GUIDE:
-      const remoteGuideTitles = state.remoteGuides.map(g => g.identifier)
-
-      const alreadyAdded = remoteGuideTitles.includes(action.guide.identifier)
-
-      if (alreadyAdded) {
+      if (
+        !!state.remoteGuides.find(
+          remoteGuide => remoteGuide.identifier === action.guide.identifier
+        ) ||
+        isGuideChapter(action.guide.identifier)
+      ) {
         return state
       } else {
         return {

--- a/src/shared/modules/guides/guidesDuck.ts
+++ b/src/shared/modules/guides/guidesDuck.ts
@@ -24,7 +24,7 @@ import docs from 'browser/documentation'
 import { GlobalState } from 'shared/globalState'
 import { tryGetRemoteInitialSlideFromUrl } from 'services/guideResolverHelper'
 import { resolveGuide } from '../../services/guideResolverHelper'
-import { OpenAction, open } from '../sidebar/sidebarDuck'
+import { OpenSidebarAction, open } from '../sidebar/sidebarDuck'
 
 export const NAME = 'guides'
 export const FETCH_GUIDE = 'guides/FETCH_GUIDE'
@@ -87,7 +87,7 @@ interface AddGuideAction {
 }
 
 export const fetchRemoteGuideEpic: Epic<
-  FetchGuideAction | SetGuideAction | OpenAction | AddGuideAction,
+  FetchGuideAction | SetGuideAction | OpenSidebarAction | AddGuideAction,
   GlobalState
 > = (action$, store$) =>
   action$.ofType(FETCH_GUIDE).flatMap(action => {
@@ -104,7 +104,7 @@ export const fetchRemoteGuideEpic: Epic<
       }
 
       const streamActions: Array<
-        SetGuideAction | OpenAction | AddGuideAction
+        SetGuideAction | OpenSidebarAction | AddGuideAction
       > = [setCurrentGuide({ ...guide, slides }), open('guides')]
       // To keep Redux store as small as possible, we don't save slides into it
       if (!isError) streamActions.push(addRemoteGuide(guide))

--- a/src/shared/modules/guides/guidesDuck.ts
+++ b/src/shared/modules/guides/guidesDuck.ts
@@ -22,7 +22,7 @@ import { Observable } from 'rxjs'
 import { Epic } from 'redux-observable'
 import docs from 'browser/documentation'
 import { GlobalState } from 'shared/globalState'
-import { tryGetRemoteInitialSlideFromUrl } from 'services/commandUtils'
+import { tryGetRemoteInitialSlideFromUrl } from 'services/guideResolverHelper'
 import { resolveGuide } from '../../services/guideResolverHelper'
 import { OpenAction, open } from '../sidebar/sidebarDuck'
 

--- a/src/shared/modules/guides/guidesDuck.ts
+++ b/src/shared/modules/guides/guidesDuck.ts
@@ -35,7 +35,9 @@ export const getRemoteGuides = (state: GlobalState): Guide[] =>
 export type Guide = {
   currentSlide: number
   title: string
-  slides: JSX.Element[]
+  identifier: string
+  isRemote?: boolean
+  slides?: JSX.Element[]
 }
 
 export interface GuideState {
@@ -95,10 +97,12 @@ export default function reducer(
       return { ...state, remoteGuides: action.updatedGuides }
 
     case ADD_GUIDE:
+      // Use title as the unique identifier doesn't seem correct
       const remoteGuideTitles = state.remoteGuides.map(g => g.title)
       const builtInGuidesTitles = Object.values(docs.guide.chapters).map(
         guide => guide.title
       )
+      console.log(builtInGuidesTitles)
 
       const alreadyAdded = remoteGuideTitles
         .concat(builtInGuidesTitles)
@@ -126,7 +130,7 @@ export function clearRemoteGuides(): UpdateGuideAction {
   return updateRemoteGuides([])
 }
 
-export function addGuideIfExternal(guide: Guide): AddGuideAction {
+export function addRemoteGuide(guide: Guide): AddGuideAction {
   return { type: ADD_GUIDE, guide }
 }
 

--- a/src/shared/modules/sidebar/sidebarDuck.ts
+++ b/src/shared/modules/sidebar/sidebarDuck.ts
@@ -86,7 +86,7 @@ export interface OpenAction {
   drawerId: DrawerId
 }
 
-interface SetDraftScriptAction {
+export interface SetDraftScriptAction {
   type: typeof SET_DRAFT_SCRIPT
   cmd: string | null
   scriptId: string | null

--- a/src/shared/modules/sidebar/sidebarDuck.ts
+++ b/src/shared/modules/sidebar/sidebarDuck.ts
@@ -74,14 +74,14 @@ function toggleDrawer(state: SidebarState, drawer: DrawerId): SidebarState {
   return { draftScript: null, drawer, scriptId: null }
 }
 
-type SidebarAction = ToggleAction | SetDraftScriptAction | OpenAction
+type SidebarAction = ToggleAction | SetDraftScriptAction | OpenSidebarAction
 
 interface ToggleAction {
   type: typeof TOGGLE
   drawerId: DrawerId
 }
 
-export interface OpenAction {
+export interface OpenSidebarAction {
   type: typeof OPEN
   drawerId: DrawerId
 }
@@ -116,7 +116,7 @@ export function toggle(drawerId: DrawerId): ToggleAction {
   return { type: TOGGLE, drawerId }
 }
 
-export function open(drawerId: DrawerId): OpenAction {
+export function open(drawerId: DrawerId): OpenSidebarAction {
   return { type: OPEN, drawerId }
 }
 

--- a/src/shared/modules/sidebar/sidebarDuck.ts
+++ b/src/shared/modules/sidebar/sidebarDuck.ts
@@ -81,7 +81,7 @@ interface ToggleAction {
   drawerId: DrawerId
 }
 
-interface OpenAction {
+export interface OpenAction {
   type: typeof OPEN
   drawerId: DrawerId
 }

--- a/src/shared/rootEpic.ts
+++ b/src/shared/rootEpic.ts
@@ -93,6 +93,7 @@ import {
   getCurrentUserEpic,
   clearCurrentUserOnDisconnectEpic
 } from './modules/currentUser/currentUserDuck'
+import { fetchRemoteGuideEpic } from './modules/guides/guidesDuck'
 
 export default combineEpics(
   handleCommandEpic,
@@ -148,5 +149,6 @@ export default combineEpics(
   trackErrorFramesEpic,
   trackReduxActionsEpic,
   initializeCypherEditorEpic,
-  updateEditorSupportSchemaEpic
+  updateEditorSupportSchemaEpic,
+  fetchRemoteGuideEpic
 )

--- a/src/shared/services/commandInterpreterHelper.ts
+++ b/src/shared/services/commandInterpreterHelper.ts
@@ -38,7 +38,7 @@ import {
 } from 'shared/modules/connections/connectionsDuck'
 import { open } from 'shared/modules/sidebar/sidebarDuck'
 import {
-  addGuideIfExternal,
+  addRemoteGuide,
   resetGuide,
   setCurrentGuide
 } from 'shared/modules/guides/guidesDuck'
@@ -506,29 +506,30 @@ const availableCommands = [
   {
     name: 'guide',
     match: (cmd: any) => /^guide(\s|$)/.test(cmd),
-    exec(action: any, put: any, store: any) {
-      const guideName = action.cmd.substr(':guide'.length).trim()
-      if (!guideName) {
-        put(resetGuide())
-        put(open('guides'))
+    exec(action: any, dispatch: any, store: any) {
+      const guideLink = action.cmd.substr(':guide'.length).trim()
+      if (!guideLink) {
+        dispatch(resetGuide())
+        dispatch(open('guides'))
         return
       }
 
       const initialSlide = tryGetRemoteInitialSlideFromUrl(action.cmd)
-      resolveGuide(guideName, store.getState()).then(
-        ({ slides, title, isError }) => {
+      resolveGuide(guideLink, store.getState()).then(
+        ({ slides, title, identifier, isError }) => {
           const guide = {
             currentSlide: initialSlide,
             title,
+            identifier,
             slides,
             isError
           }
-          put(setCurrentGuide(guide))
+          dispatch(setCurrentGuide(guide))
           if (!guide.isError) {
-            put(addGuideIfExternal(guide))
+            dispatch(addRemoteGuide(guide))
           }
 
-          put(open('guides'))
+          dispatch(open('guides'))
         }
       )
     }

--- a/src/shared/services/commandInterpreterHelper.ts
+++ b/src/shared/services/commandInterpreterHelper.ts
@@ -54,7 +54,7 @@ import {
   SYSTEM_DB
 } from 'shared/modules/dbMeta/dbMetaDuck'
 import { canSendTxMetadata } from 'shared/modules/features/versionedFeatures'
-import { fetchRemoteGuideAsync } from 'shared/modules/commands/helpers/play'
+import { fetchRemoteGuideAsync } from 'shared/modules/commands/helpers/playAndGuides'
 import remote from 'services/remote'
 import { isLocalRequest, authHeaderFromCredentials } from 'services/remoteUtils'
 import { handleServerCommand } from 'shared/modules/commands/helpers/server'

--- a/src/shared/services/commandInterpreterHelper.ts
+++ b/src/shared/services/commandInterpreterHelper.ts
@@ -20,7 +20,7 @@
 
 import * as Sentry from '@sentry/react'
 import { v4 } from 'uuid'
-import { Store, Dispatch } from 'redux'
+import { Dispatch, Action } from 'redux'
 import { GlobalState } from 'shared/globalState'
 import bolt from 'services/bolt/bolt'
 import * as frames from 'shared/modules/frames/framesDuck'
@@ -61,7 +61,7 @@ import { handleServerCommand } from 'shared/modules/commands/helpers/server'
 import { handleCypherCommand } from 'shared/modules/commands/helpers/cypher'
 import {
   SINGLE_COMMAND_QUEUED,
-  ExecuteCommandAction,
+  ExecuteSingleCommandAction,
   showErrorMessage,
   successfulCypher,
   unsuccessfulCypher,
@@ -505,7 +505,7 @@ const availableCommands = [
   {
     name: 'guide',
     match: (cmd: string) => /^guide(\s|$)/.test(cmd),
-    exec(action: ExecuteCommandAction, dispatch: Dispatch<GlobalState>) {
+    exec(action: ExecuteSingleCommandAction, dispatch: Dispatch<Action>) {
       const guideIdentifier = action.cmd.substr(':guide'.length).trim()
       if (!guideIdentifier) {
         dispatch(resetGuide())

--- a/src/shared/services/commandInterpreterHelper.ts
+++ b/src/shared/services/commandInterpreterHelper.ts
@@ -100,13 +100,10 @@ import {
   getUserDirectTxMetadata,
   getBackgroundTxMetadata
 } from 'shared/services/bolt/txMetadata'
-import {
-  getCommandAndParam,
-  tryGetRemoteInitialSlideFromUrl
-} from './commandUtils'
+import { getCommandAndParam } from './commandUtils'
 import { unescapeCypherIdentifier } from './utils'
 import { getLatestFromFrameStack } from 'browser/modules/Stream/stream.utils'
-import { resolveGuide } from './guideResolverHelper'
+import { tryGetRemoteInitialSlideFromUrl } from './guideResolverHelper'
 import { AUTH_STORAGE_LOGS } from 'neo4j-client-sso'
 
 const PLAY_FRAME_TYPES = ['play', 'play-remote']

--- a/src/shared/services/commandUtils.test.ts
+++ b/src/shared/services/commandUtils.test.ts
@@ -255,29 +255,4 @@ RETURN n`
       })
     })
   })
-
-  describe('tryGetRemoteInitialSlideFromUrl', () => {
-    it('extracts initial slide hashbangs from a string', () => {
-      expect(utils.tryGetRemoteInitialSlideFromUrl('foo#slide-1')).toEqual(1)
-      expect(
-        utils.tryGetRemoteInitialSlideFromUrl('http://foo.com#slide-2')
-      ).toEqual(2)
-      expect(
-        utils.tryGetRemoteInitialSlideFromUrl(
-          'http://www.google.com/yarr/#slide-21'
-        )
-      ).toEqual(21)
-    })
-    it('returns 0 when no valid hashbang found', () => {
-      expect(utils.tryGetRemoteInitialSlideFromUrl('foo')).toEqual(0)
-      expect(
-        utils.tryGetRemoteInitialSlideFromUrl('http://foo.com#sloide-2')
-      ).toEqual(0)
-      expect(
-        utils.tryGetRemoteInitialSlideFromUrl(
-          'http://www.google.com/yarr/#slide-fooo'
-        )
-      ).toEqual(0)
-    })
-  })
 })

--- a/src/shared/services/commandUtils.ts
+++ b/src/shared/services/commandUtils.ts
@@ -153,7 +153,7 @@ export const getCommandAndParam = (str: any) => {
   return [serverCmd, props]
 }
 
-export function tryGetRemoteInitialSlideFromUrl(url: any) {
+export function tryGetRemoteInitialSlideFromUrl(url: string): number {
   const hashBang = includes(url, '#') ? last(split(url, '#')) : ''
 
   if (!startsWith(hashBang, 'slide-')) return 0

--- a/src/shared/services/commandUtils.ts
+++ b/src/shared/services/commandUtils.ts
@@ -17,7 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { includes, last, split, startsWith } from 'lodash-es'
+
 import { extractStatements } from 'cypher-editor-support'
 
 export function cleanCommand(cmd: any) {
@@ -151,15 +151,4 @@ export const getCommandAndParam = (str: any) => {
     ' '
   )
   return [serverCmd, props]
-}
-
-// Consider to move this method to guideResolverHelper
-export function tryGetRemoteInitialSlideFromUrl(url: string): number {
-  const hashBang = includes(url, '#') ? last(split(url, '#')) : ''
-
-  if (!startsWith(hashBang, 'slide-')) return 0
-
-  const slideIndex = Number(last(split(hashBang, 'slide-')))
-
-  return !isNaN(slideIndex) ? slideIndex : 0
 }

--- a/src/shared/services/commandUtils.ts
+++ b/src/shared/services/commandUtils.ts
@@ -153,6 +153,7 @@ export const getCommandAndParam = (str: any) => {
   return [serverCmd, props]
 }
 
+// Consider to move this method to guideResolverHelper
 export function tryGetRemoteInitialSlideFromUrl(url: string): number {
   const hashBang = includes(url, '#') ? last(split(url, '#')) : ''
 

--- a/src/shared/services/guideResolverHelper.test.ts
+++ b/src/shared/services/guideResolverHelper.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import * as guideResolverHelper from './guideResolverHelper'
+
+describe('tryGetRemoteInitialSlideFromUrl', () => {
+  it('extracts initial slide hashbangs from a string', () => {
+    expect(
+      guideResolverHelper.tryGetRemoteInitialSlideFromUrl('foo#slide-1')
+    ).toEqual(1)
+    expect(
+      guideResolverHelper.tryGetRemoteInitialSlideFromUrl(
+        'http://foo.com#slide-2'
+      )
+    ).toEqual(2)
+    expect(
+      guideResolverHelper.tryGetRemoteInitialSlideFromUrl(
+        'http://www.google.com/yarr/#slide-21'
+      )
+    ).toEqual(21)
+  })
+  it('returns 0 when no valid hashbang found', () => {
+    expect(guideResolverHelper.tryGetRemoteInitialSlideFromUrl('foo')).toEqual(
+      0
+    )
+    expect(
+      guideResolverHelper.tryGetRemoteInitialSlideFromUrl(
+        'http://foo.com#sloide-2'
+      )
+    ).toEqual(0)
+    expect(
+      guideResolverHelper.tryGetRemoteInitialSlideFromUrl(
+        'http://www.google.com/yarr/#slide-fooo'
+      )
+    ).toEqual(0)
+  })
+})

--- a/src/shared/services/guideResolverHelper.tsx
+++ b/src/shared/services/guideResolverHelper.tsx
@@ -58,7 +58,7 @@ export async function resolveGuide(
   console.log('link', identifier)
   const isUrl = identifier.startsWith('http')
   if (isUrl) {
-    return await resolveRemoteGuideFromURL(identifier, state)
+    return await resolveRemoteGuideByUrl(identifier, state)
   }
 
   if (isGuideChapter(identifier)) {
@@ -91,7 +91,7 @@ function htmlTextToSlides(html: string): JSX.Element[] {
   return [<Slide key="first" html={html} isSidebarSlide />]
 }
 
-async function resolveRemoteGuideFromURL(
+async function resolveRemoteGuideByUrl(
   url: string,
   state: any
 ): Promise<{

--- a/src/shared/services/guideResolverHelper.tsx
+++ b/src/shared/services/guideResolverHelper.tsx
@@ -30,7 +30,7 @@ import {
   extractAllowlistFromConfigString,
   resolveAllowlistWildcard
 } from './utils'
-import { fetchRemoteGuideAsync } from 'shared/modules/commands/helpers/play'
+import { fetchRemoteGuideAsync } from 'shared/modules/commands/helpers/playAndGuides'
 import {
   getDefaultRemoteContentHostnameAllowlist,
   getRemoteContentHostnameAllowlist

--- a/src/shared/services/guideResolverHelper.tsx
+++ b/src/shared/services/guideResolverHelper.tsx
@@ -19,6 +19,8 @@
  */
 
 import React from 'react'
+import { includes, last, split, startsWith } from 'lodash-es'
+
 import MdxSlide from 'browser/modules/Docs/MDX/MdxSlide'
 import Slide from 'browser/modules/Carousel/Slide'
 import docs, { isGuideChapter } from 'browser/documentation'
@@ -46,6 +48,16 @@ import {
 import { GlobalState } from 'shared/globalState'
 
 const { chapters } = docs.guide
+
+export function tryGetRemoteInitialSlideFromUrl(url: string): number {
+  const hashBang = includes(url, '#') ? last(split(url, '#')) : ''
+
+  if (!startsWith(hashBang, 'slide-')) return 0
+
+  const slideIndex = Number(last(split(hashBang, 'slide-')))
+
+  return !isNaN(slideIndex) ? slideIndex : 0
+}
 
 export async function resolveGuide(
   identifier: string,

--- a/src/shared/services/guideResolverHelper.tsx
+++ b/src/shared/services/guideResolverHelper.tsx
@@ -28,7 +28,7 @@ import {
   extractAllowlistFromConfigString,
   resolveAllowlistWildcard
 } from './utils'
-import { fetchRemoteGuide } from 'shared/modules/commands/helpers/play'
+import { fetchRemoteGuideAsync } from 'shared/modules/commands/helpers/play'
 import {
   getDefaultRemoteContentHostnameAllowlist,
   getRemoteContentHostnameAllowlist
@@ -43,19 +43,20 @@ import {
   StyledHelpFrame,
   StyledPreformattedArea
 } from 'browser/modules/Stream/styled'
+import { GlobalState } from 'shared/globalState'
 
 const { chapters } = docs.guide
 
 export async function resolveGuide(
   identifier: string,
-  state: any
+  state: GlobalState
 ): Promise<{
   slides: JSX.Element[]
   title: string
   identifier: string
   isError?: boolean
 }> {
-  console.log('link', identifier)
+  console.log('id', identifier)
   const isUrl = identifier.startsWith('http')
   if (isUrl) {
     return await resolveRemoteGuideByUrl(identifier, state)
@@ -93,7 +94,7 @@ function htmlTextToSlides(html: string): JSX.Element[] {
 
 async function resolveRemoteGuideByUrl(
   url: string,
-  state: any
+  state: GlobalState
 ): Promise<{
   slides: JSX.Element[]
   title: string
@@ -108,7 +109,7 @@ async function resolveRemoteGuideByUrl(
   const allowlist = getRemoteContentHostnameAllowlist(state)
 
   try {
-    const remoteGuide = await fetchRemoteGuide(url, allowlist)
+    const remoteGuide = await fetchRemoteGuideAsync(url, allowlist)
     const titleRegexMatch = remoteGuide.match(/<title>(.*?)<\/title>/)
     const title = (titleRegexMatch && titleRegexMatch[1])?.trim() || url
     if (['md', 'mdx'].includes(filenameExtension)) {
@@ -175,7 +176,7 @@ async function resolveRemoteGuideByName(
     .reduce(
       (promiseChain: Promise<any>, currentUrl: string) =>
         promiseChain
-          .catch(() => fetchRemoteGuide(currentUrl, allowlistStr))
+          .catch(() => fetchRemoteGuideAsync(currentUrl, allowlistStr))
           .then(r => Promise.resolve(r)),
       Promise.reject(new Error())
     )

--- a/src/shared/services/guideResolverHelper.tsx
+++ b/src/shared/services/guideResolverHelper.tsx
@@ -56,7 +56,6 @@ export async function resolveGuide(
   identifier: string
   isError?: boolean
 }> {
-  console.log('id', identifier)
   const isUrl = identifier.startsWith('http')
   if (isUrl) {
     return await resolveRemoteGuideByUrl(identifier, state)
@@ -156,7 +155,7 @@ async function resolveRemoteGuideByUrl(
 
 async function resolveRemoteGuideByName(
   guideName: string,
-  state: any
+  state: GlobalState
 ): Promise<{ slides: JSX.Element[]; title: string; identifier: string }> {
   const allowlistStr = getRemoteContentHostnameAllowlist(state)
   const allowlist = extractAllowlistFromConfigString(allowlistStr)
@@ -168,13 +167,13 @@ async function resolveRemoteGuideByName(
     defaultAllowlist
   )
   const urlAllowlist = addProtocolsToUrlList(resolvedWildcardAllowlist)
-  const possibleGuidesUrls: string[] = urlAllowlist.map(
+  const possibleGuidesUrls = urlAllowlist.map(
     (url: string) => `${url}/${guideName}`
   )
 
   return possibleGuidesUrls
     .reduce(
-      (promiseChain: Promise<any>, currentUrl: string) =>
+      (promiseChain: Promise<string>, currentUrl: string) =>
         promiseChain
           .catch(() => fetchRemoteGuideAsync(currentUrl, allowlistStr))
           .then(r => Promise.resolve(r)),

--- a/src/shared/services/localstorage.test.ts
+++ b/src/shared/services/localstorage.test.ts
@@ -23,7 +23,7 @@ import * as ls from './localstorage'
 describe('localstorage', () => {
   test('getItem return items', () => {
     // Given
-    const givenKey = 'myKey' as ls.key
+    const givenKey = 'myKey' as ls.LocalStorageKey
     const givenVal = 'myVal'
     const storage = {
       getItem: (key: string) => {
@@ -61,7 +61,7 @@ describe('localstorage', () => {
 
   test('should fetch items from storage based on key input', () => {
     // Given
-    const keys = (['key1', 'key2', 'key3'] as unknown) as ls.key[]
+    const keys = (['key1', 'key2', 'key3'] as unknown) as ls.LocalStorageKey[]
     const vals = {
       key1: 'hello',
       key2: [1, 2, 3]

--- a/src/shared/services/localstorage.ts
+++ b/src/shared/services/localstorage.ts
@@ -76,8 +76,6 @@ export function getAll(): Partial<GlobalState> {
           ...(current as typeof settingsInitialState),
           playImplicitInitCommands: true
         }
-      } else if (key === 'guides') {
-        out[key] = { ...(current as GuideState), currentGuide: null }
       } else {
         Object.assign(out, { [key]: current })
       }
@@ -110,6 +108,8 @@ export function createReduxMiddleware(): Middleware {
         })
       } else if (key === 'history' && !shouldRetainEditorHistory(state)) {
         setItem(key, [])
+      } else if (key === 'guides') {
+        setItem(key, { ...state[key], currentGuide: null })
       } else {
         setItem(key, state[key])
       }

--- a/src/shared/services/localstorage.ts
+++ b/src/shared/services/localstorage.ts
@@ -20,6 +20,7 @@
 
 import { Middleware } from 'redux'
 import { GlobalState } from 'shared/globalState'
+import { GuideState } from 'shared/modules/guides/guidesDuck'
 import {
   shouldRetainConnectionCredentials,
   shouldRetainEditorHistory
@@ -29,7 +30,7 @@ import { initialState as settingsInitialState } from '../modules/settings/settin
 export const keyPrefix = 'neo4j.'
 let storage = window.localStorage
 
-export type key =
+export type LocalStorageKey =
   | 'connections'
   | 'settings'
   | 'history'
@@ -39,9 +40,12 @@ export type key =
   | 'syncConsent'
   | 'udc'
   | 'experimentalFeatures'
-const keys: key[] = []
+  | 'guides'
+const keys: LocalStorageKey[] = []
 
-export function getItem(key: key): GlobalState[key] | undefined {
+export function getItem(
+  key: LocalStorageKey
+): GlobalState[LocalStorageKey] | undefined {
   try {
     const serializedVal = storage.getItem(keyPrefix + key)
     if (serializedVal === null) return undefined
@@ -72,8 +76,10 @@ export function getAll(): Partial<GlobalState> {
           ...(current as typeof settingsInitialState),
           playImplicitInitCommands: true
         }
+      } else if (key === 'guides') {
+        out[key] = { ...(current as GuideState), currentGuide: null }
       } else {
-        out[key] = current as any
+        Object.assign(out, { [key]: current })
       }
     }
   })
@@ -112,7 +118,7 @@ export function createReduxMiddleware(): Middleware {
   }
 }
 
-export function applyKeys(...newKeys: key[]): void {
+export function applyKeys(...newKeys: LocalStorageKey[]): void {
   keys.push(...newKeys)
 }
 export const setStorage = (s: Storage): void => {

--- a/src/shared/services/utils.test.ts
+++ b/src/shared/services/utils.test.ts
@@ -226,7 +226,7 @@ describe('utils', () => {
       hostname: 'anything.com',
       port: '',
       pathname: '',
-      search: '',
+      query: '',
       hash: '',
       username: '',
       password: ''
@@ -237,7 +237,7 @@ describe('utils', () => {
       hostname: 'anything.com',
       port: '',
       pathname: '',
-      search: '',
+      query: '',
       hash: '',
       username: '',
       password: ''
@@ -248,7 +248,7 @@ describe('utils', () => {
       hostname: 'anything.com',
       port: '8080',
       pathname: '/index.html',
-      search: '',
+      query: '',
       hash: '',
       username: '',
       password: ''
@@ -259,7 +259,7 @@ describe('utils', () => {
       hostname: 'guides.neo4j.com',
       port: '',
       pathname: '',
-      search: '',
+      query: '',
       hash: '',
       username: '',
       password: ''
@@ -270,7 +270,7 @@ describe('utils', () => {
       hostname: 'localhost',
       port: '',
       pathname: '',
-      search: '',
+      query: '',
       hash: '',
       username: '',
       password: ''
@@ -285,7 +285,7 @@ describe('utils', () => {
       hostname: 'guides.neo4j.com',
       port: '1111',
       pathname: '/path',
-      search: '?arg1=a&arg2=2',
+      query: '?arg1=a&arg2=2',
       hash: '',
       username: 'neo',
       password: 'neoPass'


### PR DESCRIPTION
We are able to load remote guides. However, when reloading the Browser, added remote guides are lost. Thus, we need to retain remote guides in `localStorage`. 
Also, to keep the size of cache small, we aim not to store contents of guides. Same with Redux states. Instead, when we click the remote guide, we fetch from remote server.
This PR also involves some code clean up in relevant areas.

Test links:
- https://guides.neo4j.com/got
- https://guides.neo4j.com/restaurant_recommendation
- https://guides.neo4j.com/sandbox/movies/index.html

More guide links:
https://neo4j.com/developer/guide-create-neo4j-browser-guide/

Further code cleanup around the affected area and relevant unit tests and E2E tests will be handled in subsequent PRs.