### PR TITLE
Prevent animating when dragging

### DIFF
--- a/src/browser/modules/D3Visualization/components/NodeInspectorDrawer.tsx
+++ b/src/browser/modules/D3Visualization/components/NodeInspectorDrawer.tsx
@@ -69,18 +69,16 @@ export function NodeInspectorDrawer({
     }
   }
 
-  const drawerIsVisible = () => {
-    return (
-      transitionState === Opening ||
-      transitionState === Open ||
-      transitionState === Closing
-    )
-  }
+  const drawerIsVisible =
+    transitionState === Opening ||
+    transitionState === Open ||
+    transitionState === Closing
 
   return (
     <StyledNodeInspectorContainer
       width={!isOpen ? 0 : width}
       onTransitionEnd={onTransitionEnd}
+      shouldAnimate={transitionState !== Open}
     >
       {drawerIsVisible && children}
     </StyledNodeInspectorContainer>

--- a/src/browser/modules/D3Visualization/components/styled.tsx
+++ b/src/browser/modules/D3Visualization/components/styled.tsx
@@ -272,13 +272,14 @@ export const StyledZoomButton = styled.button`
 
 export const StyledNodeInspectorContainer = styled.div<{
   width: number
+  shouldAnimate: boolean
 }>`
   position: absolute;
   right: 0;
   top: 3px;
   z-index: 1;
   width: ${props => props.width}px;
-  transition: 0.2s ease-out;
+  ${props => props.shouldAnimate && 'transition: 0.2s ease-out;'}
   max-width: 95%;
   height: 100%;
   background: ${props => props.theme.editorBackground};

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`Visualization renders with result and escapes any HTML 1`] = `
         />
       </div>
       <div
-        class="sc-cSHVUG gCTDTC"
+        class="sc-cSHVUG hRkyWa"
         width="204.8"
       >
         <div


### PR DESCRIPTION
Our new animation of the Node properties makes the dragging of the panel look like it's lagging when it's actually just animating, luckily eija and I found a quick fix. 

Preview @ https://animation_lag_fix.surge.sh