### PR TITLE
Support new alias feature from neo4j 4.4

### DIFF
--- a/e2e_tests/integration/multi-db.spec.ts
+++ b/e2e_tests/integration/multi-db.spec.ts
@@ -147,36 +147,38 @@ describe('Multi database', () => {
       cy.executeCommand(':use system')
     })
 
-    it('lists aliases with :dbs command', () => {
-      const password = Cypress.config('password')
-      cy.connect('neo4j', password)
-      cy.executeCommand(':clear')
-      // Drop alias in case it already exists
-      cy.executeCommand('drop alias `Mossdeep-24.` for database')
+    if (Cypress.config('serverVersion') >= 4.4) {
+      it('lists aliases with :dbs command', () => {
+        const password = Cypress.config('password')
+        cy.connect('neo4j', password)
+        cy.executeCommand(':clear')
+        // Drop alias in case it already exists
+        cy.executeCommand('drop alias `Mossdeep-24.` for database')
 
-      cy.executeCommand('create alias `Mossdeep-24.` for database neo4j')
-      cy.resultContains('1 system update, no records')
+        cy.executeCommand('create alias `Mossdeep-24.` for database neo4j')
+        cy.resultContains('1 system update, no records')
 
-      // Switch to system to see that using alias switches back to neo4j
-      cy.executeCommand(':use system')
-      editor().contains('system$')
+        // Switch to system to see that using alias switches back to neo4j
+        cy.executeCommand(':use system')
+        editor().contains('system$')
 
-      cy.executeCommand(':use `Mossdeep-24.`')
-      editor().contains('neo4j$')
+        cy.executeCommand(':use `Mossdeep-24.`')
+        editor().contains('neo4j$')
 
-      cy.executeCommand(':use system')
-      editor().contains('system$')
+        cy.executeCommand(':use system')
+        editor().contains('system$')
 
-      cy.executeCommand(':dbs')
-      cy.getFrames()
-        .eq(0)
-        .contains(':use `mossdeep-24.`')
-        .click()
-      editor().contains('neo4j$')
+        cy.executeCommand(':dbs')
+        cy.getFrames()
+          .eq(0)
+          .contains(':use `mossdeep-24.`')
+          .click()
+        editor().contains('neo4j$')
 
-      cy.executeCommand('drop alias `Mossdeep-24.` for database;')
-      cy.resultContains('1 system update, no records')
-    })
+        cy.executeCommand('drop alias `Mossdeep-24.` for database;')
+        cy.resultContains('1 system update, no records')
+      })
+    }
 
     if (isEnterpriseEdition()) {
       it('lists new databases with :dbs command', () => {

--- a/e2e_tests/integration/multi-db.spec.ts
+++ b/e2e_tests/integration/multi-db.spec.ts
@@ -91,6 +91,7 @@ describe('Multi database', () => {
       databaseOptionListOptions().should('have.length', 2)
       cy.get('[data-testid="drawerDBMS"]').click()
     })
+
     if (isEnterpriseEdition()) {
       it('adds databases to the sidebar and adds backticks to special db names', () => {
         // Add db
@@ -145,6 +146,7 @@ describe('Multi database', () => {
 
       cy.executeCommand(':use system')
     })
+
     if (isEnterpriseEdition()) {
       it('lists new databases with :dbs command', () => {
         cy.executeCommand('CREATE DATABASE sidebartest')

--- a/src/browser/modules/App/App.tsx
+++ b/src/browser/modules/App/App.tsx
@@ -34,8 +34,8 @@ import { utilizeBrowserSync } from 'shared/modules/features/featuresDuck'
 import { getOpenDrawer, open } from 'shared/modules/sidebar/sidebarDuck'
 import { getErrorMessage } from 'shared/modules/commands/commandsDuck'
 import {
-  shouldAllowOutgoingConnections,
-  getDatabases
+  findDatabaseByNameOrAlias,
+  shouldAllowOutgoingConnections
 } from 'shared/modules/dbMeta/dbMetaDuck'
 import {
   getActiveConnection,
@@ -154,7 +154,7 @@ export function App(props: any) {
     codeFontLigatures,
     connectionState,
     consentBannerShownCount,
-    databases,
+    databaseIsUnavailable,
     defaultConnectionData,
     drawer,
     errorMessage,
@@ -268,7 +268,7 @@ export function App(props: any) {
                       lastConnectionUpdate={lastConnectionUpdate}
                       errorMessage={errorMessage}
                       useDb={useDb}
-                      databases={databases}
+                      databaseIsUnavailable={databaseIsUnavailable}
                       showUdcConsentBanner={
                         telemetrySettings.source === 'BROWSER_SETTING' &&
                         consentBannerShownCount <= 5
@@ -291,6 +291,11 @@ export function App(props: any) {
 }
 
 const mapStateToProps = (state: GlobalState) => {
+  const useDb = getUseDb(state)
+  const databaseIsUnavailable =
+    useDb === null ||
+    findDatabaseByNameOrAlias(state, useDb)?.status !== 'online'
+
   const connectionData = getActiveConnectionData(state)
   return {
     experimentalFeatures: getExperimentalFeatures(state),
@@ -311,8 +316,8 @@ const mapStateToProps = (state: GlobalState) => {
     browserSyncAuthStatus: getUserAuthStatus(state),
     loadSync: utilizeBrowserSync(state),
     isWebEnv: inWebEnv(state),
-    useDb: getUseDb(state),
-    databases: getDatabases(state),
+    useDb,
+    databaseIsUnavailable,
     telemetrySettings: getTelemetrySettings(state),
     consentBannerShownCount: getConsentBannerShownCount(state)
   }

--- a/src/browser/modules/App/App.tsx
+++ b/src/browser/modules/App/App.tsx
@@ -263,7 +263,6 @@ export function App(props: any) {
                   </ErrorBoundary>
                   <StyledMainWrapper id={MAIN_WRAPPER_DOM_ID}>
                     <Main
-                      activeConnection={activeConnection}
                       connectionState={connectionState}
                       lastConnectionUpdate={lastConnectionUpdate}
                       errorMessage={errorMessage}

--- a/src/browser/modules/App/App.tsx
+++ b/src/browser/modules/App/App.tsx
@@ -146,7 +146,6 @@ export function App(props: any) {
   }, [props.bus])
 
   const {
-    activeConnection,
     browserSyncAuthStatus,
     browserSyncConfig,
     browserSyncMetadata,
@@ -154,7 +153,7 @@ export function App(props: any) {
     codeFontLigatures,
     connectionState,
     consentBannerShownCount,
-    databaseIsUnavailable,
+    isDatabaseUnavailable,
     defaultConnectionData,
     drawer,
     errorMessage,
@@ -267,7 +266,7 @@ export function App(props: any) {
                       lastConnectionUpdate={lastConnectionUpdate}
                       errorMessage={errorMessage}
                       useDb={useDb}
-                      databaseIsUnavailable={databaseIsUnavailable}
+                      isDatabaseUnavailable={isDatabaseUnavailable}
                       showUdcConsentBanner={
                         telemetrySettings.source === 'BROWSER_SETTING' &&
                         consentBannerShownCount <= 5
@@ -291,7 +290,7 @@ export function App(props: any) {
 
 const mapStateToProps = (state: GlobalState) => {
   const useDb = getUseDb(state)
-  const databaseIsUnavailable =
+  const isDatabaseUnavailable =
     useDb === null ||
     findDatabaseByNameOrAlias(state, useDb)?.status !== 'online'
 
@@ -316,7 +315,7 @@ const mapStateToProps = (state: GlobalState) => {
     loadSync: utilizeBrowserSync(state),
     isWebEnv: inWebEnv(state),
     useDb,
-    databaseIsUnavailable,
+    isDatabaseUnavailable,
     telemetrySettings: getTelemetrySettings(state),
     consentBannerShownCount: getConsentBannerShownCount(state)
   }

--- a/src/browser/modules/ClickToCode/__snapshots__/index.test.tsx.snap
+++ b/src/browser/modules/ClickToCode/__snapshots__/index.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ClickToCode does not render if no children 1`] = `<div />`;
 exports[`ClickToCode renders all children 1`] = `
 <div>
   <code
-    class="sc-hwwEjo ljXXxq"
+    class="sc-kPVwWT hLYRLx"
   >
     <div>
       <span>
@@ -20,7 +20,7 @@ exports[`ClickToCode renders all children 1`] = `
 exports[`ClickToCode renders children as code if no code is provided 1`] = `
 <div>
   <code
-    class="sc-hwwEjo ljXXxq"
+    class="sc-kPVwWT hLYRLx"
   >
     hellohi!
   </code>
@@ -30,7 +30,7 @@ exports[`ClickToCode renders children as code if no code is provided 1`] = `
 exports[`ClickToCode renders code as the code when code is available 1`] = `
 <div>
   <code
-    class="sc-hwwEjo ljXXxq"
+    class="sc-kPVwWT hLYRLx"
   >
     hello
   </code>

--- a/src/browser/modules/DBMSInfo/DatabaseSelector.test.tsx
+++ b/src/browser/modules/DBMSInfo/DatabaseSelector.test.tsx
@@ -21,13 +21,27 @@
 import React from 'react'
 import { render, fireEvent } from '@testing-library/react'
 import { DatabaseSelector } from './DatabaseSelector'
+import { Database } from 'shared/modules/dbMeta/dbMetaDuck'
 
 const testId = 'database-selection-list'
+
+const createDummyDb = (name: string, status = 'online'): Database => ({
+  name,
+  status,
+  address: 'bolt',
+  currentStatus: 'online',
+  default: false,
+  error: '',
+  requestedStatus: '',
+  role: 'LEADER',
+  aliases: [],
+  home: false
+})
 
 describe('DatabaseSelector', () => {
   it('renders empty if no databases in list', () => {
     // Given
-    const databases: any = []
+    const databases: Database[] = []
 
     // When
     const { container } = render(<DatabaseSelector databases={databases} />)
@@ -37,20 +51,12 @@ describe('DatabaseSelector', () => {
   })
   it('updates selection in list', () => {
     // Given
-    const databases = [
-      { name: 'stella', status: 'online' },
-      { name: 'molly', status: 'online' }
-    ]
-    const defaultDb = 'stella'
+    const databases = ['stella', 'molly'].map(n => createDummyDb(n))
     let selected = 'stella'
 
     // When
     const { getByDisplayValue, queryByDisplayValue, rerender } = render(
-      <DatabaseSelector
-        databases={databases}
-        selectedDb={selected}
-        defaultDb={defaultDb}
-      />
+      <DatabaseSelector databases={databases} selectedDb={selected} />
     )
 
     // Then
@@ -59,13 +65,7 @@ describe('DatabaseSelector', () => {
 
     // When
     selected = 'molly'
-    rerender(
-      <DatabaseSelector
-        databases={databases}
-        selectedDb={selected}
-        defaultDb={defaultDb}
-      />
-    )
+    rerender(<DatabaseSelector databases={databases} selectedDb={selected} />)
 
     // Then
     expect(getByDisplayValue(/molly/i)).toBeDefined()
@@ -73,25 +73,16 @@ describe('DatabaseSelector', () => {
 
     // When
     selected = ''
-    rerender(
-      <DatabaseSelector
-        databases={databases}
-        selectedDb={selected}
-        defaultDb={defaultDb}
-      />
-    )
+    rerender(<DatabaseSelector databases={databases} selectedDb={selected} />)
 
-    // Then default db should be selected
+    // Then select db text should be shown
     expect(getByDisplayValue(/select db/i)).toBeDefined()
     expect(queryByDisplayValue(/stella/i)).toBeDefined()
     expect(queryByDisplayValue(/molly/i)).toBeNull()
   })
   it('can handle selections', () => {
     // Given
-    const databases = [
-      { name: 'stella', status: 'online' },
-      { name: 'molly', status: 'online' }
-    ]
+    const databases = ['stella', 'molly'].map(n => createDummyDb(n))
     const onChange = jest.fn()
 
     // When
@@ -116,10 +107,7 @@ describe('DatabaseSelector', () => {
   })
   it('escapes db names when needed', () => {
     // Given
-    const databases = [
-      { name: 'regulardb', status: 'online' },
-      { name: 'db-with-dash', status: 'online' }
-    ]
+    const databases = ['regulardb', 'db-with-dash'].map(n => createDummyDb(n))
     const onChange = jest.fn()
 
     // When

--- a/src/browser/modules/DBMSInfo/DatabaseSelector.tsx
+++ b/src/browser/modules/DBMSInfo/DatabaseSelector.tsx
@@ -50,6 +50,9 @@ export const DatabaseSelector = ({
   selectedDb = '',
   onChange = () => undefined
 }: DatabaseSelectorProps): JSX.Element | null => {
+  if (databases.length === 0) {
+    return null
+  }
   const selectionChange = ({
     target
   }: React.ChangeEvent<HTMLSelectElement>) => {
@@ -58,7 +61,6 @@ export const DatabaseSelector = ({
     }
   }
 
-  // todo look into if the empty option is needed
   const databasesList: (Partial<Database> & {
     name: string
   })[] = databases

--- a/src/browser/modules/DBMSInfo/DatabaseSelector.tsx
+++ b/src/browser/modules/DBMSInfo/DatabaseSelector.tsx
@@ -63,12 +63,10 @@ export const DatabaseSelector = ({
 
   const databasesList: (Partial<Database> & {
     name: string
-  })[] = databases
-  if (!selectedDb) {
-    databasesList.unshift({ name: EMPTY_OPTION })
-  }
-  // When connected to a cluster, we get duplicates for each member
-  const uniqDatabases = uniqBy(databases, 'name')
+  })[] = selectedDb ? databases : [{ name: EMPTY_OPTION }, ...databases]
+
+  // When connected to a cluster, we get duplicate dbs for each member
+  const uniqDatabases = uniqBy(databasesList, 'name')
 
   const homeDb =
     uniqDatabases.find(db => db.home) || uniqDatabases.find(db => db.default)
@@ -78,7 +76,7 @@ export const DatabaseSelector = ({
       <DrawerSubHeader>Use database</DrawerSubHeader>
       <DrawerSectionBody>
         <Select
-          value={selectedDb || ''}
+          value={selectedDb}
           data-testid="database-selection-list"
           onChange={selectionChange}
         >

--- a/src/browser/modules/DBMSInfo/DatabaseSelector.tsx
+++ b/src/browser/modules/DBMSInfo/DatabaseSelector.tsx
@@ -25,7 +25,6 @@ import {
   DrawerSubHeader,
   DrawerSectionBody
 } from 'browser-components/drawer/drawer-styled'
-import { uniqBy } from 'lodash-es'
 import { escapeCypherIdentifier } from 'services/utils'
 import { Database } from 'shared/modules/dbMeta/dbMetaDuck'
 
@@ -85,9 +84,6 @@ export const DatabaseSelector = ({
               <option key={db.name} value={db.name}>
                 {db.name}
                 {db === homeDb ? NBSP_CHAR + HOUSE_EMOJI : ''}
-                {db.aliases &&
-                  db.aliases.length > 0 &&
-                  ` (${db.aliases.join(',')})`}
               </option>
             )
           })}

--- a/src/browser/modules/DBMSInfo/DatabaseSelector.tsx
+++ b/src/browser/modules/DBMSInfo/DatabaseSelector.tsx
@@ -27,6 +27,7 @@ import {
 } from 'browser-components/drawer/drawer-styled'
 import { escapeCypherIdentifier } from 'services/utils'
 import { Database } from 'shared/modules/dbMeta/dbMetaDuck'
+import { uniqBy } from 'lodash'
 
 const Select = styled.select`
   width: 100%;
@@ -66,9 +67,11 @@ export const DatabaseSelector = ({
   if (!selectedDb) {
     databasesList.unshift({ name: EMPTY_OPTION })
   }
+  // When connected to a cluster, we get duplicates for each member
+  const uniqDatabases = uniqBy(databases, 'name')
 
   const homeDb =
-    databasesList.find(db => db.home) || databasesList.find(db => db.default)
+    uniqDatabases.find(db => db.home) || uniqDatabases.find(db => db.default)
 
   return (
     <DrawerSection>
@@ -79,7 +82,7 @@ export const DatabaseSelector = ({
           data-testid="database-selection-list"
           onChange={selectionChange}
         >
-          {databasesList.map(db => {
+          {uniqDatabases.map(db => {
             return (
               <option key={db.name} value={db.name}>
                 {db.name}

--- a/src/browser/modules/Main/Main.test.tsx
+++ b/src/browser/modules/Main/Main.test.tsx
@@ -48,20 +48,23 @@ jest.mock(
       return <div />
     }
 )
+const useDb = 'some database'
+const noOp = () => undefined
+const mainBaseProps = {
+  useDb,
+  store,
+  connectionState: 2,
+  lastConnectionUpdate: 0,
+  showUdcConsentBanner: false,
+  dismissConsentBanner: noOp,
+  incrementConsentBannerShownCount: noOp,
+  openSettingsDrawer: noOp
+}
 
 describe('<Main />', () => {
-  it('should display an ErrorBanner when useDb is not in databases list', () => {
-    const useDb = 'some database'
-    const databases: any = []
-
+  it('should display an ErrorBanner when useDb is unavailable', () => {
     const { queryByText } = render(
-      <Main
-        {...{
-          databases,
-          useDb,
-          store
-        }}
-      />
+      <Main {...mainBaseProps} databaseIsUnavailable={true} />
     )
 
     expect(
@@ -69,22 +72,13 @@ describe('<Main />', () => {
     ).toBeTruthy()
   })
 
-  it('should display an ErrorBanner when useDb is not online in databases list', () => {
-    const useDb = 'some database'
-    const databases = [{ name: useDb, status: 'offline' }]
-
+  it('should not show Errorbanner before we have a useDb', () => {
     const { queryByText } = render(
-      <Main
-        {...{
-          databases,
-          useDb,
-          store
-        }}
-      />
+      <Main {...mainBaseProps} useDb={null} databaseIsUnavailable={true} />
     )
 
     expect(
       queryByText(`Database '${useDb}' is unavailable.`, { exact: false })
-    ).toBeTruthy()
+    ).toBeFalsy()
   })
 })

--- a/src/browser/modules/Main/Main.test.tsx
+++ b/src/browser/modules/Main/Main.test.tsx
@@ -64,7 +64,7 @@ const mainBaseProps = {
 describe('<Main />', () => {
   it('should display an ErrorBanner when useDb is unavailable', () => {
     const { queryByText } = render(
-      <Main {...mainBaseProps} databaseIsUnavailable={true} />
+      <Main {...mainBaseProps} isDatabaseUnavailable={true} />
     )
 
     expect(
@@ -74,7 +74,7 @@ describe('<Main />', () => {
 
   it('should not show Errorbanner before we have a useDb', () => {
     const { queryByText } = render(
-      <Main {...mainBaseProps} useDb={null} databaseIsUnavailable={true} />
+      <Main {...mainBaseProps} useDb={null} isDatabaseUnavailable={true} />
     )
 
     expect(

--- a/src/browser/modules/Main/Main.tsx
+++ b/src/browser/modules/Main/Main.tsx
@@ -41,7 +41,7 @@ import AutoExecButton from '../Stream/auto-exec-button'
 
 type MainProps = {
   connectionState: number
-  databaseIsUnavailable: boolean
+  isDatabaseUnavailable: boolean
   errorMessage?: string
   lastConnectionUpdate: number
   showUdcConsentBanner: boolean
@@ -55,7 +55,7 @@ const Main = React.memo(function Main(props: MainProps) {
   const [past5Sec, past10Sec] = useSlowConnectionState(props)
   const {
     connectionState,
-    databaseIsUnavailable,
+    isDatabaseUnavailable,
     errorMessage,
     showUdcConsentBanner,
     useDb,
@@ -86,7 +86,7 @@ const Main = React.memo(function Main(props: MainProps) {
           <DismissConsentBanner onClick={dismissConsentBanner} />
         </UdcConsentBanner>
       )}
-      {useDb && databaseIsUnavailable && (
+      {useDb && isDatabaseUnavailable && (
         <ErrorBanner>
           Database &apos;{useDb}&apos; is unavailable. Run{' '}
           <AutoExecButton cmd="sysinfo" /> for more info.

--- a/src/browser/modules/Main/Main.tsx
+++ b/src/browser/modules/Main/Main.tsx
@@ -42,17 +42,16 @@ import AutoExecButton from '../Stream/auto-exec-button'
 const Main = React.memo(function Main(props: any) {
   const [past5Sec, past10Sec] = useSlowConnectionState(props)
   const {
-    databases,
+    databaseIsUnavailable,
     useDb,
     showUdcConsentBanner,
     incrementConsentBannerShownCount,
     openSettingsDrawer
   } = props
-  const dbMeta = databases && databases.find((db: any) => db.name === useDb)
-  const dbIsUnavailable = useDb && (!dbMeta || dbMeta.status !== 'online')
+
   useEffect(() => {
     showUdcConsentBanner && incrementConsentBannerShownCount()
-  }, [showUdcConsentBanner])
+  }, [showUdcConsentBanner, incrementConsentBannerShownCount])
 
   return (
     <StyledMain data-testid="main">
@@ -72,7 +71,7 @@ const Main = React.memo(function Main(props: any) {
           <DismissConsentBanner onClick={props.dismissConsentBanner} />
         </UdcConsentBanner>
       )}
-      {dbIsUnavailable && (
+      {useDb && databaseIsUnavailable && (
         <ErrorBanner>
           Database '{useDb}' is unavailable. Run{' '}
           <AutoExecButton cmd="sysinfo" /> for more info.

--- a/src/browser/modules/Main/Main.tsx
+++ b/src/browser/modules/Main/Main.tsx
@@ -39,12 +39,27 @@ import ErrorBoundary from 'browser-components/ErrorBoundary'
 import { useSlowConnectionState } from './main.hooks'
 import AutoExecButton from '../Stream/auto-exec-button'
 
-const Main = React.memo(function Main(props: any) {
+type MainProps = {
+  connectionState: number
+  databaseIsUnavailable: boolean
+  errorMessage?: string
+  lastConnectionUpdate: number
+  showUdcConsentBanner: boolean
+  useDb: string | null
+  dismissConsentBanner: () => void
+  incrementConsentBannerShownCount: () => void
+  openSettingsDrawer: () => void
+}
+
+const Main = React.memo(function Main(props: MainProps) {
   const [past5Sec, past10Sec] = useSlowConnectionState(props)
   const {
+    connectionState,
     databaseIsUnavailable,
-    useDb,
+    errorMessage,
     showUdcConsentBanner,
+    useDb,
+    dismissConsentBanner,
     incrementConsentBannerShownCount,
     openSettingsDrawer
   } = props
@@ -58,7 +73,7 @@ const Main = React.memo(function Main(props: any) {
       <ErrorBoundary>
         <Editor />
       </ErrorBoundary>
-      {props.showUdcConsentBanner && (
+      {showUdcConsentBanner && (
         <UdcConsentBanner>
           <span>
             To help make Neo4j Browser better we collect information on product
@@ -68,36 +83,34 @@ const Main = React.memo(function Main(props: any) {
             </UnderlineClickable>{' '}
             at any time.
           </span>
-          <DismissConsentBanner onClick={props.dismissConsentBanner} />
+          <DismissConsentBanner onClick={dismissConsentBanner} />
         </UdcConsentBanner>
       )}
       {useDb && databaseIsUnavailable && (
         <ErrorBanner>
-          Database '{useDb}' is unavailable. Run{' '}
+          Database &apos;{useDb}&apos; is unavailable. Run{' '}
           <AutoExecButton cmd="sysinfo" /> for more info.
         </ErrorBanner>
       )}
-      {props.errorMessage && (
-        <ErrorBanner data-testid="errorBanner">
-          {props.errorMessage}
-        </ErrorBanner>
+      {errorMessage && (
+        <ErrorBanner data-testid="errorBanner">{errorMessage}</ErrorBanner>
       )}
-      {props.connectionState === DISCONNECTED_STATE && (
+      {connectionState === DISCONNECTED_STATE && (
         <NotAuthedBanner data-testid="disconnectedBanner">
           Database access not available. Please use&nbsp;
           <AutoExecButton
             cmd="server connect"
             data-testid="disconnectedBannerCode"
           />
-          &nbsp; to establish connection. There's a graph waiting for you.
+          &nbsp; to establish connection. There&apos;s a graph waiting for you.
         </NotAuthedBanner>
       )}
-      {props.connectionState === PENDING_STATE && !past10Sec && (
+      {connectionState === PENDING_STATE && !past10Sec && (
         <WarningBanner data-testid="reconnectBanner">
           Connection to server lost. Reconnecting...
         </WarningBanner>
       )}
-      {props.connectionState === CONNECTING_STATE && past5Sec && !past10Sec && (
+      {connectionState === CONNECTING_STATE && past5Sec && !past10Sec && (
         <NotAuthedBanner>Still connecting...</NotAuthedBanner>
       )}
       {past10Sec && (

--- a/src/browser/modules/Stream/Auth/DbsFrame.tsx
+++ b/src/browser/modules/Stream/Auth/DbsFrame.tsx
@@ -28,17 +28,18 @@ import {
 } from './styled'
 import { H3 } from 'browser-components/headers'
 import { toKeyString, escapeCypherIdentifier } from 'services/utils'
-import { UnstyledList } from '../styled'
+import { AliasText, UnstyledList } from '../styled'
 import { useDbCommand } from 'shared/modules/commands/commandsDuck'
 import TextCommand from 'browser/modules/DecoratedText/TextCommand'
 import ClickToCode from 'browser/modules/ClickToCode/index'
 import { StyledCodeBlockFrame } from 'browser/modules/Main/styled'
 import { uniqBy } from 'lodash-es'
+import { BaseFrameProps } from '../Stream'
 
-const DbsFrame = (props: any) => {
+const DbsFrame = (props: BaseFrameProps) => {
   const { frame } = props
   const { dbs = [] } = frame
-  const dbsToShow: any[] = uniqBy(dbs, 'name')
+  const dbsToShow = uniqBy(dbs, 'name')
 
   return (
     <>
@@ -52,7 +53,7 @@ const DbsFrame = (props: any) => {
       </StyledConnectionAside>
       <StyledConnectionBodyContainer>
         <StyledConnectionBody>
-          {Array.isArray(dbsToShow) && dbsToShow.length ? (
+          {dbsToShow.length ? (
             <>
               Click on one to start using it:
               <UnstyledList data-testid="dbs-command-list">
@@ -64,6 +65,19 @@ const DbsFrame = (props: any) => {
                           db.name
                         )}`}
                       />
+                      {db.aliases && db.aliases.length > 0 && (
+                        <AliasText>
+                          Configured aliases:{' '}
+                          {db.aliases.map(name => (
+                            <TextCommand
+                              key={name}
+                              command={`${useDbCommand} ${escapeCypherIdentifier(
+                                name
+                              )}`}
+                            />
+                          ))}
+                        </AliasText>
+                      )}
                     </StyledDbsRow>
                   )
                 })}
@@ -91,7 +105,7 @@ const DbsFrame = (props: any) => {
   )
 }
 
-const Frame = (props: any) => {
+const Frame = (props: BaseFrameProps): JSX.Element => {
   return (
     <FrameTemplate header={props.frame} contents={<DbsFrame {...props} />} />
   )

--- a/src/browser/modules/Stream/Auth/UseDbFrame.tsx
+++ b/src/browser/modules/Stream/Auth/UseDbFrame.tsx
@@ -29,8 +29,9 @@ import {
 import { H3 } from 'browser-components/headers'
 import TextCommand from 'browser/modules/DecoratedText/TextCommand'
 import { listDbsCommand } from 'shared/modules/commands/commandsDuck'
+import { BaseFrameProps } from '../Stream'
 
-const UseDbFrame = (props: any) => {
+const UseDbFrame = (props: BaseFrameProps) => {
   const { frame } = props
   const { useDb } = frame
   return (
@@ -63,7 +64,7 @@ const UseDbFrame = (props: any) => {
   )
 }
 
-const Frame = (props: any) => {
+const Frame = (props: BaseFrameProps): JSX.Element => {
   return (
     <FrameTemplate header={props.frame} contents={<UseDbFrame {...props} />} />
   )

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/CodeView.test.tsx.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/CodeView.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`CodeViews CodeStatusbar displays no statusBarMessage 1`] = `
     class="sc-jlyJG dMPRjC"
   >
     <div
-      class="sc-gGBfsJ hdpDrB"
+      class="sc-jnlKLf iTDaaZ"
     />
   </div>
 </div>
@@ -18,7 +18,7 @@ exports[`CodeViews CodeStatusbar displays statusBarMessage 1`] = `
     class="sc-jlyJG dMPRjC"
   >
     <div
-      class="sc-gGBfsJ hdpDrB"
+      class="sc-jnlKLf iTDaaZ"
     >
       Started streaming 1 records after 5 ms and completed after 10  ms.
     </div>

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/ErrorsView.test.tsx.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/ErrorsView.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`ErrorsViews ErrorsStatusbar displays error 1`] = `
       title="Test.Error: Test error description"
     >
       <i
-        class="sc-kIPQKe ezGIEH fa fa-exclamation-triangle"
+        class="sc-eXEjpC biJDBb fa fa-exclamation-triangle"
       />
        
       Test.Error: Test error description
@@ -61,7 +61,7 @@ exports[`ErrorsViews ErrorsView displays procedure link if unknown procedure 1`]
           class="sc-gisBJw imfIcQ"
         >
           <i
-            class="sc-kfGgVZ cavWqY fa fa-play-circle-o"
+            class="sc-esjQYD hZVCtC fa fa-play-circle-o"
           />
            List available procedures
         </a>

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`Visualization renders 1`] = `<div />`;
 exports[`Visualization renders with result and escapes any HTML 1`] = `
 <div>
   <div
-    class="sc-cMhqgX kLjcxD"
+    class="sc-iuJeZd fTWjas"
   >
     <div
       class="sc-jTzLTM bdhVYv"
@@ -86,7 +86,7 @@ exports[`Visualization renders with result and escapes any HTML 1`] = `
             class="sc-jzJRlG hPTWGK zoom-in"
           >
             <i
-              class="sc-dymIpo kVHyJW sl-zoom-in"
+              class="sc-bnXvFD bIRcfT sl-zoom-in"
               style="font-size: 1em;"
             />
           </button>
@@ -94,7 +94,7 @@ exports[`Visualization renders with result and escapes any HTML 1`] = `
             class="sc-jzJRlG hPTWGK zoom-out"
           >
             <i
-              class="sc-bnXvFD bIRcfT sl-zoom-out"
+              class="sc-gFaPwZ cMtXIT sl-zoom-out"
               style="font-size: 1em;"
             />
           </button>
@@ -139,13 +139,13 @@ exports[`Visualization renders with result and escapes any HTML 1`] = `
                 class="sc-htpNat sc-dnqmqq OaEcl"
               >
                 <div
-                  class="sc-ibxdXY sc-RefOD emwHTu"
+                  class="sc-RefOD sc-iQKALj dCvzLq"
                   style="background-color: rgb(247, 151, 103); color: rgb(255, 255, 255);"
                 >
                   * (1)
                 </div>
                 <div
-                  class="sc-ibxdXY sc-RefOD emwHTu"
+                  class="sc-RefOD sc-iQKALj dCvzLq"
                   style="background-color: rgb(201, 144, 192); color: rgb(255, 255, 255);"
                 >
                   Person (1)

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/relatable-view.test.tsx.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/relatable-view.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`RelatableViews RelatableView displays bodyMessage if no rows 1`] = `
     class="sc-Rmtcm keiynT"
   >
     <div
-      class="sc-gGBfsJ hdpDrB"
+      class="sc-jnlKLf iTDaaZ"
     >
       (no changes, no records)
     </div>
@@ -17,7 +17,7 @@ exports[`RelatableViews RelatableView displays bodyMessage if no rows 1`] = `
 exports[`RelatableViews RelatableView does not display bodyMessage if rows, and escapes HTML 1`] = `
 <div>
   <div
-    class="sc-jnlKLf ktwZlk"
+    class="sc-fYxtnH cQlhRi"
   >
     <div
       class="relatable css-1dne9dv"
@@ -73,7 +73,7 @@ exports[`RelatableViews RelatableView does not display bodyMessage if rows, and 
               role="cell"
             >
               <span
-                class="sc-tilXH fvcfTT"
+                class="sc-hEsumM cPMQJb"
               >
                 "String with HTML &lt;strong&gt;in&lt;/strong&gt; it"
               </span>
@@ -92,7 +92,7 @@ exports[`RelatableViews TableStatusbar displays no statusBarMessage 1`] = `
     class="sc-Rmtcm keiynT"
   >
     <div
-      class="sc-gGBfsJ hdpDrB"
+      class="sc-jnlKLf iTDaaZ"
     />
   </div>
 </div>
@@ -104,7 +104,7 @@ exports[`RelatableViews TableStatusbar displays statusBarMessage 1`] = `
     class="sc-Rmtcm keiynT"
   >
     <div
-      class="sc-gGBfsJ hdpDrB"
+      class="sc-jnlKLf iTDaaZ"
     >
       Started streaming 1 records after 5 ms and completed after 10  ms.
     </div>

--- a/src/browser/modules/Stream/__snapshots__/SchemaFrame.test.tsx.snap
+++ b/src/browser/modules/Stream/__snapshots__/SchemaFrame.test.tsx.snap
@@ -10,13 +10,13 @@ exports[`SchemaFrame renders empty 1`] = `
         class="sc-gZMcBi cnSkYm"
       >
         <table
-          class="sc-cTjmhe bGFmLD"
+          class="sc-cugefK jhgUTm"
           data-testid="schemaFrameIndexesTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-fnwBNb zVSNT table-header"
+                class="sc-iNhVCk beXLhl table-header"
               >
                 Indexes
               </th>
@@ -24,10 +24,10 @@ exports[`SchemaFrame renders empty 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-cugefK gwPANr table-row"
+              class="sc-fnwBNb gDjBsm table-row"
             >
               <td
-                class="sc-iNhVCk dCJRGV table-properties"
+                class="sc-eAKXzc fSOxNd table-properties"
               >
                 None
               </td>
@@ -35,13 +35,13 @@ exports[`SchemaFrame renders empty 1`] = `
           </tbody>
         </table>
         <table
-          class="sc-cTjmhe bGFmLD"
+          class="sc-cugefK jhgUTm"
           data-testid="schemaFrameConstraintsTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-fnwBNb zVSNT table-header"
+                class="sc-iNhVCk beXLhl table-header"
               >
                 Constraints
               </th>
@@ -49,10 +49,10 @@ exports[`SchemaFrame renders empty 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-cugefK gwPANr table-row"
+              class="sc-fnwBNb gDjBsm table-row"
             >
               <td
-                class="sc-iNhVCk dCJRGV table-properties"
+                class="sc-eAKXzc fSOxNd table-properties"
               >
                 None
               </td>
@@ -92,43 +92,43 @@ exports[`SchemaFrame renders empty for Neo4j >= 4.0 1`] = `
         class="sc-gZMcBi cnSkYm"
       >
         <table
-          class="sc-cTjmhe bGFmLD"
+          class="sc-cugefK jhgUTm"
           data-testid="schemaFrameIndexesTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-fnwBNb zVSNT table-header"
+                class="sc-iNhVCk beXLhl table-header"
               >
                 Index Name
               </th>
               <th
-                class="sc-fnwBNb zVSNT table-header"
+                class="sc-iNhVCk beXLhl table-header"
               >
                 Type
               </th>
               <th
-                class="sc-fnwBNb zVSNT table-header"
+                class="sc-iNhVCk beXLhl table-header"
               >
                 Uniqueness
               </th>
               <th
-                class="sc-fnwBNb zVSNT table-header"
+                class="sc-iNhVCk beXLhl table-header"
               >
                 EntityType
               </th>
               <th
-                class="sc-fnwBNb zVSNT table-header"
+                class="sc-iNhVCk beXLhl table-header"
               >
                 LabelsOrTypes
               </th>
               <th
-                class="sc-fnwBNb zVSNT table-header"
+                class="sc-iNhVCk beXLhl table-header"
               >
                 Properties
               </th>
               <th
-                class="sc-fnwBNb zVSNT table-header"
+                class="sc-iNhVCk beXLhl table-header"
               >
                 State
               </th>
@@ -136,42 +136,42 @@ exports[`SchemaFrame renders empty for Neo4j >= 4.0 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-cugefK gwPANr table-row"
+              class="sc-fnwBNb gDjBsm table-row"
             >
               <td
-                class="sc-iNhVCk dCJRGV table-properties"
+                class="sc-eAKXzc fSOxNd table-properties"
               >
                 None
               </td>
               <td
-                class="sc-iNhVCk dCJRGV table-properties"
+                class="sc-eAKXzc fSOxNd table-properties"
               />
               <td
-                class="sc-iNhVCk dCJRGV table-properties"
+                class="sc-eAKXzc fSOxNd table-properties"
               />
               <td
-                class="sc-iNhVCk dCJRGV table-properties"
+                class="sc-eAKXzc fSOxNd table-properties"
               />
               <td
-                class="sc-iNhVCk dCJRGV table-properties"
+                class="sc-eAKXzc fSOxNd table-properties"
               />
               <td
-                class="sc-iNhVCk dCJRGV table-properties"
+                class="sc-eAKXzc fSOxNd table-properties"
               />
               <td
-                class="sc-iNhVCk dCJRGV table-properties"
+                class="sc-eAKXzc fSOxNd table-properties"
               />
             </tr>
           </tbody>
         </table>
         <table
-          class="sc-cTjmhe bGFmLD"
+          class="sc-cugefK jhgUTm"
           data-testid="schemaFrameConstraintsTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-fnwBNb zVSNT table-header"
+                class="sc-iNhVCk beXLhl table-header"
               >
                 Constraints
               </th>
@@ -179,10 +179,10 @@ exports[`SchemaFrame renders empty for Neo4j >= 4.0 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-cugefK gwPANr table-row"
+              class="sc-fnwBNb gDjBsm table-row"
             >
               <td
-                class="sc-iNhVCk dCJRGV table-properties"
+                class="sc-eAKXzc fSOxNd table-properties"
               >
                 None
               </td>
@@ -222,13 +222,13 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
         class="sc-gZMcBi cnSkYm"
       >
         <table
-          class="sc-cTjmhe bGFmLD"
+          class="sc-cugefK jhgUTm"
           data-testid="schemaFrameIndexesTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-fnwBNb zVSNT table-header"
+                class="sc-iNhVCk beXLhl table-header"
               >
                 Indexes
               </th>
@@ -236,10 +236,10 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-cugefK gwPANr table-row"
+              class="sc-fnwBNb gDjBsm table-row"
             >
               <td
-                class="sc-iNhVCk dCJRGV table-properties"
+                class="sc-eAKXzc fSOxNd table-properties"
               >
                  ON :Movie(released) ONLINE 
               </td>
@@ -247,13 +247,13 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
           </tbody>
         </table>
         <table
-          class="sc-cTjmhe bGFmLD"
+          class="sc-cugefK jhgUTm"
           data-testid="schemaFrameConstraintsTable"
         >
           <thead>
             <tr>
               <th
-                class="sc-fnwBNb zVSNT table-header"
+                class="sc-iNhVCk beXLhl table-header"
               >
                 Constraints
               </th>
@@ -261,10 +261,10 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
           </thead>
           <tbody>
             <tr
-              class="sc-cugefK gwPANr table-row"
+              class="sc-fnwBNb gDjBsm table-row"
             >
               <td
-                class="sc-iNhVCk dCJRGV table-properties"
+                class="sc-eAKXzc fSOxNd table-properties"
               >
                  ON ( book:Book ) ASSERT book.isbn IS UNIQUE
               </td>

--- a/src/browser/modules/Stream/styled.tsx
+++ b/src/browser/modules/Stream/styled.tsx
@@ -390,3 +390,7 @@ export const AuraPromoLink = styled.a`
   text-decoration: none;
   margin-right: 5px;
 `
+
+export const AliasText = styled.span`
+  font-size: 13px;
+`

--- a/src/browser/modules/Stream/styled.tsx
+++ b/src/browser/modules/Stream/styled.tsx
@@ -392,5 +392,6 @@ export const AuraPromoLink = styled.a`
 `
 
 export const AliasText = styled.span`
-  font-size: 13px;
+  font-size: 1rem;
+  font-style: italic;
 `

--- a/src/shared/modules/connections/connectionsDuck.ts
+++ b/src/shared/modules/connections/connectionsDuck.ts
@@ -505,7 +505,6 @@ export const startupConnectEpic = (action$: any, store: any) => {
       )
 
       if (
-        //TODO Considder the SSO implications of this
         !(discovered && discovered.hasForceURL) && // If we have force url, don't try old connection data
         shouldTryAutoconnecting(savedConnection)
       ) {

--- a/src/shared/modules/dbMeta/dbMetaDuck.ts
+++ b/src/shared/modules/dbMeta/dbMetaDuck.ts
@@ -164,8 +164,6 @@ export type Database = {
   status: string
 }
 
-// TODO create a selector that gets a database by it's name or alias name
-
 export const getDatabases = (state: any): Database[] =>
   (state[NAME] || initialState).databases
 export const getActiveDbName = (state: any) =>
@@ -520,7 +518,6 @@ const clusterRole = (store: any) =>
 
 const switchToRequestedDb = (store: any) => {
   if (getUseDb(store.getState())) return Rx.Observable.of(null)
-  // needs to care about aliases
 
   const databases = getDatabases(store.getState())
   const activeConnection = getActiveConnectionData(store.getState())
@@ -528,18 +525,18 @@ const switchToRequestedDb = (store: any) => {
 
   const switchToLastUsedOrDefaultDb = () => {
     const lastUsedDb = getLastUseDb(store.getState())
-    if (lastUsedDb && databases.some((db: any) => db.name === lastUsedDb)) {
+    if (lastUsedDb && findDatabaseByNameOrAlias(store.getState(), lastUsedDb)) {
       store.dispatch(useDb(lastUsedDb))
     } else {
-      const homeDb = databases.find((db: any) => db.home)
+      const homeDb = databases.find(db => db.home)
       if (homeDb) {
         store.dispatch(useDb(homeDb.name))
       } else {
-        const defaultDb = databases.find((db: any) => db.default)
+        const defaultDb = databases.find(db => db.default)
         if (defaultDb) {
           store.dispatch(useDb(defaultDb.name))
         } else {
-          const systemDb = databases.find((db: any) => db.name === SYSTEM_DB)
+          const systemDb = databases.find(db => db.name === SYSTEM_DB)
           if (systemDb) {
             store.dispatch(useDb(systemDb.name))
           } else {

--- a/src/shared/modules/dbMeta/dbMetaDuck.ts
+++ b/src/shared/modules/dbMeta/dbMetaDuck.ts
@@ -79,6 +79,19 @@ export const SYSTEM_DB = 'system'
 /**
  * Selectors
  */
+
+export function findDatabaseByNameOrAlias(
+  state: GlobalState,
+  name: string
+): Database | undefined {
+  const lowerCaseName = name.toLowerCase()
+
+  return state[NAME].databases.find(
+    (db: Database) =>
+      db.name.toLowerCase() === lowerCaseName ||
+      db.aliases?.find(alias => alias.toLowerCase() === lowerCaseName)
+  )
+}
 export function getMetaInContext(state: any, context: any) {
   const inCurrentContext = (e: any) => e.context === context
 
@@ -146,9 +159,12 @@ export type Database = {
   currentStatus: string
   error: string
   default: boolean
-  home?: boolean
+  home?: boolean // introduced in neo4j 4.3
+  aliases?: string[] // introduced in neo4j 4.4
   status: string
 }
+
+// TODO create a selector that gets a database by it's name or alias name
 
 export const getDatabases = (state: any): Database[] =>
   (state[NAME] || initialState).databases
@@ -504,6 +520,7 @@ const clusterRole = (store: any) =>
 
 const switchToRequestedDb = (store: any) => {
   if (getUseDb(store.getState())) return Rx.Observable.of(null)
+  // needs to care about aliases
 
   const databases = getDatabases(store.getState())
   const activeConnection = getActiveConnectionData(store.getState())

--- a/src/shared/modules/discovery/discoveryHelpers.test.ts
+++ b/src/shared/modules/discovery/discoveryHelpers.test.ts
@@ -105,8 +105,6 @@ describe('getAndMergeDiscoveryData', () => {
     expect(discoveryData).toBeTruthy()
     expect(discoveryData?.host).toEqual(boltHost)
 
-    // expect(discoveryData?.source).toEqual(DISCOVERY_ENDPOINT)
-    // Todo test source via logs
     expect(discoveryData?.SSOProviders).toEqual([])
     expect(discoveryData?.SSOError).toEqual(undefined)
     expect(discoveryData?.neo4jVersion).toEqual(neo4jVersion)

--- a/src/shared/modules/frames/framesDuck.ts
+++ b/src/shared/modules/frames/framesDuck.ts
@@ -32,6 +32,7 @@ import { Epic } from 'redux-observable'
 import { Action } from 'redux'
 import { FrameView } from 'shared/modules/frames/frameViewTypes'
 import { GlobalState } from 'shared/globalState'
+import { Database } from '../dbMeta/dbMetaDuck'
 
 export const NAME = 'frames'
 export const ADD = 'frames/ADD'
@@ -250,6 +251,7 @@ export interface Frame {
   type: string
   useDb: string | null
   history?: string[]
+  dbs?: Database[]
 }
 
 export interface FrameStack {

--- a/src/shared/services/commandInterpreterHelper.ts
+++ b/src/shared/services/commandInterpreterHelper.ts
@@ -51,7 +51,8 @@ import {
   getDatabases,
   fetchMetaData,
   getAvailableSettings,
-  SYSTEM_DB
+  SYSTEM_DB,
+  Database
 } from 'shared/modules/dbMeta/dbMetaDuck'
 import { canSendTxMetadata } from 'shared/modules/features/versionedFeatures'
 import { fetchRemoteGuideAsync } from 'shared/modules/commands/helpers/playAndGuides'
@@ -219,7 +220,9 @@ const availableCommands = [
         const cleanDbName = unescapeCypherIdentifier(normalizedName)
 
         const dbMeta = getDatabases(store.getState()).find(
-          (db: any) => db.name.toLowerCase() === cleanDbName
+          (db: Database) =>
+            db.name.toLowerCase() === cleanDbName ||
+            db.aliases?.find(alias => alias.toLowerCase() === cleanDbName)
         )
 
         // Do we have a db with that name?
@@ -297,6 +300,7 @@ const availableCommands = [
         .hasMultiDbSupport()
         .then(supportsMultiDb => {
           if (supportsMultiDb) {
+            // TODO should also list aliases
             put(
               frames.add({
                 useDb: getUseDb(store.getState()),

--- a/src/shared/services/commandInterpreterHelper.ts
+++ b/src/shared/services/commandInterpreterHelper.ts
@@ -217,7 +217,7 @@ const availableCommands = [
 
         const normalizedName = dbName.toLowerCase()
         const cleanDbName = unescapeCypherIdentifier(normalizedName)
-        const dbMeta = findDatabaseByNameOrAlias(store, cleanDbName)
+        const dbMeta = findDatabaseByNameOrAlias(store.getState(), cleanDbName)
 
         if (!dbMeta) {
           throw DatabaseNotFoundError({ dbName })

--- a/src/shared/services/commandInterpreterHelper.ts
+++ b/src/shared/services/commandInterpreterHelper.ts
@@ -21,7 +21,6 @@
 import * as Sentry from '@sentry/react'
 import { v4 } from 'uuid'
 import { Dispatch, Action } from 'redux'
-import { GlobalState } from 'shared/globalState'
 import bolt from 'services/bolt/bolt'
 import * as frames from 'shared/modules/frames/framesDuck'
 import { getHostedUrl } from 'shared/modules/app/appDuck'
@@ -300,7 +299,6 @@ const availableCommands = [
         .hasMultiDbSupport()
         .then(supportsMultiDb => {
           if (supportsMultiDb) {
-            // TODO should also list aliases
             put(
               frames.add({
                 useDb: getUseDb(store.getState()),

--- a/src/shared/services/commandInterpreterHelper.ts
+++ b/src/shared/services/commandInterpreterHelper.ts
@@ -51,7 +51,7 @@ import {
   fetchMetaData,
   getAvailableSettings,
   SYSTEM_DB,
-  Database
+  findDatabaseByNameOrAlias
 } from 'shared/modules/dbMeta/dbMetaDuck'
 import { canSendTxMetadata } from 'shared/modules/features/versionedFeatures'
 import { fetchRemoteGuideAsync } from 'shared/modules/commands/helpers/playAndGuides'
@@ -217,12 +217,7 @@ const availableCommands = [
 
         const normalizedName = dbName.toLowerCase()
         const cleanDbName = unescapeCypherIdentifier(normalizedName)
-
-        const dbMeta = getDatabases(store.getState()).find(
-          (db: Database) =>
-            db.name.toLowerCase() === cleanDbName ||
-            db.aliases?.find(alias => alias.toLowerCase() === cleanDbName)
-        )
+        const dbMeta = findDatabaseByNameOrAlias(store, cleanDbName)
 
         if (!dbMeta) {
           throw DatabaseNotFoundError({ dbName })

--- a/src/shared/services/commandInterpreterHelper.ts
+++ b/src/shared/services/commandInterpreterHelper.ts
@@ -224,19 +224,18 @@ const availableCommands = [
             db.aliases?.find(alias => alias.toLowerCase() === cleanDbName)
         )
 
-        // Do we have a db with that name?
         if (!dbMeta) {
           throw DatabaseNotFoundError({ dbName })
         }
         if (dbMeta.status !== 'online') {
-          throw DatabaseUnavailableError({ dbName, dbMeta })
+          throw DatabaseUnavailableError({ dbName: dbMeta.name, dbMeta })
         }
-        put(useDb(cleanDbName))
+        put(useDb(dbMeta.name))
         put(
           frames.add({
             ...action,
             type: 'use-db',
-            useDb: cleanDbName
+            useDb: dbMeta.name
           })
         )
         if (action.requestId) {

--- a/src/shared/services/exceptions.ts
+++ b/src/shared/services/exceptions.ts
@@ -125,7 +125,7 @@ export function DatabaseNotFoundError({
   return {
     type,
     code: type,
-    message: `A database with the "${dbName}" name could not be found.`
+    message: `A database with the "${dbName}" name or alias could not be found.`
   }
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "noFallthroughCasesInSwitch": true,
     "jsx": "react",
     "outDir": "./build",
+    "noEmit": true,
     "allowJs": true,
     "resolveJsonModule": true,
     "baseUrl": "./src",


### PR DESCRIPTION
Adds support for the 4.4 concept of aliases. 
To create an alias run `create alias myAlias for database neo4j`. 

You should not be able to run `:use myAlias` and see your aliases when running `:dbs`. The "real" name should still be displaced in editor.

Preview @http://support_aliases.surge.sh