### PR TITLE
Local storage guide retainment follow up

### DIFF
--- a/e2e_tests/integration/0.index.spec.ts
+++ b/e2e_tests/integration/0.index.spec.ts
@@ -67,7 +67,7 @@ describe('Neo4j Browser', () => {
           .should('have.class', 'Canny_Badge')
 
         // Click the navigation button to open the sidebar to show Documents drawer, and the badge should be shown in the changelog button
-        cy.get('[data-testid="drawerDocuments"]').click()
+        cy.get('[data-testid="navigationDocuments"]').click()
         cy.get('[data-testid="documentDrawerCanny"]')
           .children('div')
           .should('have.class', 'Canny_BadgeContainer')
@@ -102,7 +102,7 @@ describe('Neo4j Browser', () => {
           .and('match', /\bnone\b/)
 
         // Close sideber
-        cy.get('[data-testid="drawerDocuments"]').click()
+        cy.get('[data-testid="navigationDocuments"]').click()
       }
     })
   })
@@ -165,7 +165,7 @@ describe('Neo4j Browser', () => {
 
   it('can display meta items from side drawer', () => {
     cy.executeCommand(':clear')
-    cy.get('[data-testid="drawerDBMS"]').click()
+    cy.get('[data-testid="navigationDBMS"]').click()
 
     cy.executeCommand('MATCH (n) RETURN DISTINCT labels(n);')
     cy.contains('Movie')
@@ -173,12 +173,12 @@ describe('Neo4j Browser', () => {
       'have.length.above',
       17
     )
-    cy.get('[data-testid="drawerDBMS"]').click()
+    cy.get('[data-testid="navigationDBMS"]').click()
   })
 
   it('displays user info in sidebar (when connected)', () => {
     cy.executeCommand(':clear')
-    cy.get('[data-testid="drawerDBMS"]').click()
+    cy.get('[data-testid="navigationDBMS"]').click()
     cy.get('[data-testid="user-details-username"]').should('contain', 'neo4j')
     cy.get('[data-testid="user-details-roles"]', { timeout: 30000 }).should(
       'contain',
@@ -203,7 +203,7 @@ describe('Neo4j Browser', () => {
         ? 'admin'
         : '-'
     )
-    cy.get('[data-testid="drawerDBMS"]').click()
+    cy.get('[data-testid="navigationDBMS"]').click()
   })
 
   // Browser sync is disabled on Aura
@@ -218,17 +218,17 @@ describe('Neo4j Browser', () => {
         .first()
         .contains('RETURN 1')
 
-      cy.get('[data-testid="drawerSync"]').click()
+      cy.get('[data-testid="navigationSync"]').click()
       cy.get('[data-testid="clearLocalData"]').click()
       cy.wait(500)
 
       // confirm clear
       cy.get('[data-testid="clearLocalData"]').click()
 
-      cy.get('[data-testid="drawerFavorites"]').click()
+      cy.get('[data-testid="navigationFavorites"]').click()
 
       cy.get('[data-testid="savedScriptListItem"]').should('have.length', 0)
-      cy.get('[data-testid="drawerFavorites"]').click()
+      cy.get('[data-testid="navigationFavorites"]').click()
 
       // once data is cleared the user is logged out and the connect form is displayed
       cy.get('input[data-testid="boltaddress"]')
@@ -238,9 +238,9 @@ describe('Neo4j Browser', () => {
   it('displays no user info in sidebar (when not connected)', () => {
     cy.executeCommand(':server disconnect')
     cy.executeCommand(':clear')
-    cy.get('[data-testid="drawerDBMS"]').click()
+    cy.get('[data-testid="navigationDBMS"]').click()
     cy.get('[data-testid="user-details-username"]').should('have.length', 0)
     cy.get('[data-testid="user-details-roles"]').should('have.length', 0)
-    cy.get('[data-testid="drawerDBMS"]').click()
+    cy.get('[data-testid="navigationDBMS"]').click()
   })
 })

--- a/e2e_tests/integration/bolt.spec.ts
+++ b/e2e_tests/integration/bolt.spec.ts
@@ -88,7 +88,7 @@ describe('Bolt connections', () => {
       cy.connect('noroles', '.')
 
       // Check sidebar
-      cy.get('[data-testid="drawerDBMS"]').click()
+      cy.get('[data-testid="navigationDBMS"]').click()
       cy.get('[data-testid="user-details-username"]').should(
         'contain',
         'noroles'
@@ -99,7 +99,7 @@ describe('Bolt connections', () => {
       if (Cypress.config('serverVersion') === 4.1) {
         cy.get('[data-testid="user-details-roles"]').should('contain', 'PUBLIC')
       }
-      cy.get('[data-testid="drawerDBMS"]').click()
+      cy.get('[data-testid="navigationDBMS"]').click()
 
       cy.executeCommand(':server disconnect')
       cy.executeCommand(':server connect')

--- a/e2e_tests/integration/commands.spec.ts
+++ b/e2e_tests/integration/commands.spec.ts
@@ -60,8 +60,8 @@ describe('Commands', () => {
     cy.executeCommand(':help help')
     cy.get('[data-testid="frameCommand"]').contains(':help help')
     // lose focus
-    cy.get('[data-testid=drawerFavorites]').click()
-    cy.get('[data-testid=drawerFavorites]').click()
+    cy.get('[data-testid=navigationFavorites]').click()
+    cy.get('[data-testid=navigationFavorites]').click()
     cy.get('#monaco-main-editor > .monaco-editor').should(
       'not.have.class',
       'focused'

--- a/e2e_tests/integration/connect-form.spec.ts
+++ b/e2e_tests/integration/connect-form.spec.ts
@@ -143,11 +143,11 @@ describe('Connect form', () => {
         cy.get('[data-testid=password]')
           .type(Cypress.config('password'))
           .type('{enter}')
-        cy.get('[data-testid="drawerDBMS"]').click()
+        cy.get('[data-testid="navigationDBMS"]').click()
         cy.get('[data-testid="sidebarMetaItem"]', { timeout: 30000 }).contains(
           'TestLabel'
         )
-        cy.get('[data-testid="drawerDBMS"]').click()
+        cy.get('[data-testid="navigationDBMS"]').click()
 
         // unknown db leads to default db
         cy.executeCommand(':server disconnect')
@@ -160,11 +160,11 @@ describe('Connect form', () => {
         cy.get('[data-testid=password]')
           .type(Cypress.config('password'))
           .type('{enter}')
-        cy.get('[data-testid="drawerDBMS"]').click()
+        cy.get('[data-testid="navigationDBMS"]').click()
         cy.get('[data-testid="sidebarMetaItem"]', { timeout: 30000 }).contains(
           'MovieLabel'
         )
-        cy.get('[data-testid="drawerDBMS"]').click()
+        cy.get('[data-testid="navigationDBMS"]').click()
 
         cy.executeCommand('match (n:MovieLabel) delete n')
         cy.executeCommand(':use system')
@@ -187,7 +187,7 @@ describe('Connect form', () => {
           .type(Cypress.config('password'))
           .type('{enter}')
 
-        cy.get('[data-testid="drawerDBMS"]').click()
+        cy.get('[data-testid="navigationDBMS"]').click()
         cy.get('[data-testid="database-selection-list"]').contains('system')
         cy.executeCommand(':use neo4j')
       })

--- a/e2e_tests/integration/guide-command.spec.ts
+++ b/e2e_tests/integration/guide-command.spec.ts
@@ -32,11 +32,11 @@ describe('Guide command', () => {
     cy.executeCommand(':clear')
     cy.executeCommand(':guide not-found-guide-anywhere')
 
-    cy.get('[data-testid="guideDrawer"]').should('contain', 'Not found')
+    cy.get('[data-testid="guidesDrawer"]').should('contain', 'Not found')
 
     // reset state
     cy.executeCommand(':guide')
-    cy.get('[data-testid="guideDrawer"]').should('contain', ':guide movie')
+    cy.get('[data-testid="guidesDrawer"]').should('contain', ':guide movie')
     cy.get('[data-testid=navigationGuides]').click()
   })
 
@@ -44,22 +44,22 @@ describe('Guide command', () => {
     cy.executeCommand(':clear')
     // Open a guide from the sidebar
     cy.get('[data-testid=navigationGuides]').click()
-    cy.get('[data-testid="guideDrawer"]')
+    cy.get('[data-testid="guidesDrawer"]')
       .contains(':guide cypher')
       .click()
 
     // can progress slide
     cy.get('[data-testid=guideNextSlide]').click()
-    cy.get('[data-testid="guideDrawer"]').contains('CREATE')
+    cy.get('[data-testid="guidesDrawer"]').contains('CREATE')
 
     // remembers slide location
     cy.get('[data-testid=navigationGuides]').click()
     cy.get('[data-testid=navigationGuides]').click()
 
     // can go back
-    cy.get('[data-testid="guideDrawer"]').contains('CREATE')
+    cy.get('[data-testid="guidesDrawer"]').contains('CREATE')
     cy.get('[data-testid=guidePreviousSlide]').click()
-    cy.get('[data-testid="guideDrawer"]').contains('SQL-like clauses')
+    cy.get('[data-testid="guidesDrawer"]').contains('SQL-like clauses')
 
     // go to end
     cy.get('[data-testid=guideNextSlide]').click()
@@ -67,21 +67,21 @@ describe('Guide command', () => {
     cy.get('[data-testid=guideNextSlide]').click()
     cy.get('[data-testid=guideNextSlide]').click()
     cy.get('[data-testid=guideNextSlide]').click()
-    cy.get('[data-testid="guideDrawer"]').contains('Next steps')
+    cy.get('[data-testid="guidesDrawer"]').contains('Next steps')
 
     // switch guide via command
     cy.executeCommand(':guide northwind')
-    cy.get('[data-testid="guideDrawer"]').contains('From RDBMS to Graph')
+    cy.get('[data-testid="guidesDrawer"]').contains('From RDBMS to Graph')
 
     // Jump to end
     cy.get('[data-testid="pagination-11"]').click()
-    cy.get('[data-testid="guideDrawer"]').contains(
+    cy.get('[data-testid="guidesDrawer"]').contains(
       'Full Northwind import example'
     )
 
     // Can use back button
     cy.get('[data-testid="guidesBackButton"]').click()
-    cy.get('[data-testid="guideDrawer"]').contains(':guide cypher')
+    cy.get('[data-testid="guidesDrawer"]').contains(':guide cypher')
 
     cy.get('[data-testid=navigationGuides]').click()
   })

--- a/e2e_tests/integration/guide-command.spec.ts
+++ b/e2e_tests/integration/guide-command.spec.ts
@@ -94,7 +94,7 @@ describe('Guide command', () => {
   it('can load and persist a remote guide and can be deleted permanantly', () => {
     const guideUrl = 'https://guides.neo4j.com/sandbox/movies/index.html'
     cy.executeCommand(':clear')
-    cy.executeCommand(`:guide ${guideUrl}`)
+    cy.executeCommand(`:guide ${guideUrl}`, { timeout: 50000 })
     cy.get('[data-testid="guidesDrawer"]').should('contain', 'Movies Guide')
     cy.get('[data-testid="guidesDrawer"]').should('contain', 'What is Cypher?')
 

--- a/e2e_tests/integration/guide-command.spec.ts
+++ b/e2e_tests/integration/guide-command.spec.ts
@@ -37,13 +37,13 @@ describe('Guide command', () => {
     // reset state
     cy.executeCommand(':guide')
     cy.get('[data-testid="guideDrawer"]').should('contain', ':guide movie')
-    cy.get('[data-testid=drawerGuides]').click()
+    cy.get('[data-testid=navigationGuides]').click()
   })
 
-  it('can walk through a guides', () => {
+  it('can walk through a guide', () => {
     cy.executeCommand(':clear')
     // Open a guide from the sidebar
-    cy.get('[data-testid=drawerGuides]').click()
+    cy.get('[data-testid=navigationGuides]').click()
     cy.get('[data-testid="guideDrawer"]')
       .contains(':guide cypher')
       .click()
@@ -53,8 +53,8 @@ describe('Guide command', () => {
     cy.get('[data-testid="guideDrawer"]').contains('CREATE')
 
     // remembers slide location
-    cy.get('[data-testid=drawerGuides]').click()
-    cy.get('[data-testid=drawerGuides]').click()
+    cy.get('[data-testid=navigationGuides]').click()
+    cy.get('[data-testid=navigationGuides]').click()
 
     // can go back
     cy.get('[data-testid="guideDrawer"]').contains('CREATE')
@@ -83,6 +83,6 @@ describe('Guide command', () => {
     cy.get('[data-testid="guidesBackButton"]').click()
     cy.get('[data-testid="guideDrawer"]').contains(':guide cypher')
 
-    cy.get('[data-testid=drawerGuides]').click()
+    cy.get('[data-testid=navigationGuides]').click()
   })
 })

--- a/e2e_tests/integration/multi-db.spec.ts
+++ b/e2e_tests/integration/multi-db.spec.ts
@@ -87,9 +87,9 @@ describe('Multi database', () => {
 
     it('lists databases in sidebar', () => {
       cy.executeCommand(':clear')
-      cy.get('[data-testid="drawerDBMS"]').click()
+      cy.get('[data-testid="navigationDBMS"]').click()
       databaseOptionListOptions().should('have.length', 2)
-      cy.get('[data-testid="drawerDBMS"]').click()
+      cy.get('[data-testid="navigationDBMS"]').click()
     })
 
     if (isEnterpriseEdition()) {
@@ -101,7 +101,7 @@ describe('Multi database', () => {
         cy.executeCommand(':clear')
 
         // Count items in list
-        cy.get('[data-testid="drawerDBMS"]').click()
+        cy.get('[data-testid="navigationDBMS"]').click()
         databaseOptionListOptions().should('have.length', 3)
         databaseOptionListOptions().contains('system')
         databaseOptionListOptions().contains('neo4j')
@@ -131,7 +131,7 @@ describe('Multi database', () => {
         cy.executeCommand(':use system')
         cy.executeCommand('DROP DATABASE `name-with-dash`')
         databaseOptionListOptions().should('have.length', 2)
-        cy.get('[data-testid="drawerDBMS"]').click()
+        cy.get('[data-testid="navigationDBMS"]').click()
       })
     }
 

--- a/e2e_tests/integration/multistatements.spec.ts
+++ b/e2e_tests/integration/multistatements.spec.ts
@@ -57,9 +57,9 @@ describe('Multi statements', () => {
   it('can force run multiple statements to be executed as one statement', () => {
     // Given
     cy.executeCommand(':clear')
-    cy.get('[data-testid="drawerSettings"]').click()
+    cy.get('[data-testid="navigationSettings"]').click()
     cy.get('[data-testid="setting-enableMultiStatementMode"]').click()
-    cy.get('[data-testid="drawerSettings"]').click()
+    cy.get('[data-testid="navigationSettings"]').click()
 
     // When
     cy.executeCommand(validQuery)
@@ -74,9 +74,9 @@ describe('Multi statements', () => {
       .first()
       .should('contain', 'Error')
 
-    cy.get('[data-testid="drawerSettings"]').click()
+    cy.get('[data-testid="navigationSettings"]').click()
     cy.get('[data-testid="setting-enableMultiStatementMode"]').click()
-    cy.get('[data-testid="drawerSettings"]').click()
+    cy.get('[data-testid="navigationSettings"]').click()
   })
 
   it('can run multiple statements with error open', () => {
@@ -211,9 +211,9 @@ describe('Multi statements', () => {
           .contains('Test1')
 
         // Check sidebar for test1
-        cy.get('[data-testid="drawerDBMS"]').click()
+        cy.get('[data-testid="navigationDBMS"]').click()
         cy.get('[data-testid="sidebarMetaItem"]').contains('Test1')
-        cy.get('[data-testid="drawerDBMS"]').click()
+        cy.get('[data-testid="navigationDBMS"]').click()
 
         cy.executeCommand(':use test2')
         cy.executeCommand('MATCH (n) RETURN distinct labels(n);')
@@ -221,10 +221,10 @@ describe('Multi statements', () => {
           .first()
           .contains('Test2')
 
-        cy.get('[data-testid="drawerDBMS"]').click()
+        cy.get('[data-testid="navigationDBMS"]').click()
 
         cy.get('[data-testid="sidebarMetaItem"]').contains('Test2')
-        cy.get('[data-testid="drawerDBMS"]').click()
+        cy.get('[data-testid="navigationDBMS"]').click()
 
         cy.executeCommand(':use system')
         cy.executeCommand('DROP DATABASE test1')

--- a/e2e_tests/integration/saved-scripts.spec.ts
+++ b/e2e_tests/integration/saved-scripts.spec.ts
@@ -87,11 +87,11 @@ describe('Saved Scripts', () => {
     cy.get('[data-testid=navicon-fldr]').click({ force: true })
     cy.get('[data-testid=contextMenuRename]').click()
     cy.get('[data-testid=expandFolder-fldr]').should('not.exist')
-    cy.get('[data-testid=drawerFavorites]').click()
+    cy.get('[data-testid=navigationFavorites]').click()
   })
 
   it('it can use bulk delete', () => {
-    cy.get('[data-testid=drawerFavorites]').click()
+    cy.get('[data-testid=navigationFavorites]').click()
     cy.get('[data-testid=createNewFavorite]')
       .click()
       .click()

--- a/e2e_tests/integration/settings.spec.ts
+++ b/e2e_tests/integration/settings.spec.ts
@@ -35,12 +35,12 @@ describe('Settings', () => {
     cy.executeCommand('RETURN 3')
 
     // change settings to 1, make sure it is cut to 1
-    cy.get('[data-testid="drawerSettings"]').click()
+    cy.get('[data-testid="navigationSettings"]').click()
     cy.get('input[data-testid="setting-maxFrames"]')
       .clear()
       .type('1')
     // close settings again
-    cy.get('[data-testid="drawerSettings"]').click()
+    cy.get('[data-testid="navigationSettings"]').click()
 
     cy.get('[data-testid="frame"]').should('have.length', 1)
     cy.get('[data-testid="frame"]').should('contain', 'RETURN 3')
@@ -62,12 +62,12 @@ describe('Settings', () => {
     cy.get('[data-testid="frame"]').should('have.length', 1)
 
     // change settings to 3, then write commands and make sure it will be set to 3 frames at most
-    cy.get('[data-testid="drawerSettings"]').click()
+    cy.get('[data-testid="navigationSettings"]').click()
     cy.get('input[data-testid="setting-maxFrames"]')
       .clear()
       .type('3')
     // close settings again
-    cy.get('[data-testid="drawerSettings"]').click()
+    cy.get('[data-testid="navigationSettings"]').click()
     cy.executeCommand('RETURN 1')
     cy.executeCommand('RETURN 2')
     cy.executeCommand('RETURN 3')

--- a/e2e_tests/support/commands.ts
+++ b/e2e_tests/support/commands.ts
@@ -144,20 +144,20 @@ Cypress.Commands.add('addUser', (userName, password, role, force) => {
   cy.get('[data-testid="Add User"]').click()
 })
 Cypress.Commands.add('enableMultiStatement', () => {
-  cy.get('[data-testid="drawerSettings"]').click()
+  cy.get('[data-testid="navigationSettings"]').click()
   cy.get('[data-testid="setting-enableMultiStatementMode"]', {
     timeout: 30000
   }).check({
     force: true
   })
-  cy.get('[data-testid="drawerSettings"]').click()
+  cy.get('[data-testid="navigationSettings"]').click()
 })
 Cypress.Commands.add('disableMultiStatement', () => {
-  cy.get('[data-testid="drawerSettings"]').click()
+  cy.get('[data-testid="navigationSettings"]').click()
   cy.get('[data-testid="setting-enableMultiStatementMode"]', {
     timeout: 30000
   }).uncheck({ force: true })
-  cy.get('[data-testid="drawerSettings"]').click()
+  cy.get('[data-testid="navigationSettings"]').click()
 })
 Cypress.Commands.add('createUser', (username, password, forceChangePw) => {
   cy.dropUser(username)

--- a/src/browser/components/TabNavigation/Navigation.tsx
+++ b/src/browser/components/TabNavigation/Navigation.tsx
@@ -139,7 +139,7 @@ class Navigation extends Component<NavigationProps, NavigationState> {
             ) : null}
             <NavigationButtonContainer
               title={item.title}
-              data-testid={`drawer${item.name}`}
+              data-testid={`navigation${item.name}`}
               onClick={() => onNavClick(item.name.toLowerCase())}
               isOpen={isOpen}
             >

--- a/src/browser/modules/Sidebar/GuideDrawer.test.tsx
+++ b/src/browser/modules/Sidebar/GuideDrawer.test.tsx
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Network Engine for Objects in Lund AB [http://neotechnology.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { Provider } from 'react-redux'
+import configureMockStore, { MockStoreEnhanced } from 'redux-mock-store'
+
+import { GuideDrawerProps, GuideDrawer } from './GuideDrawer'
+import { Guide, RemoteGuide } from 'shared/modules/guides/guidesDuck'
+
+const createProps = (
+  currentGuide: Guide | null,
+  remoteGuides: RemoteGuide[]
+): GuideDrawerProps => ({
+  currentGuide: currentGuide,
+  remoteGuides: remoteGuides,
+  backToAllGuides: () => undefined,
+  gotoSlide: () => undefined,
+  setCurrentGuide: () => undefined,
+  fetchRemoteGuide: () => undefined,
+  updateRemoteGuides: () => undefined
+})
+
+const mockStore = configureMockStore()
+
+const renderWithRedux = (
+  store: MockStoreEnhanced<unknown>,
+  children: JSX.Element
+) => {
+  return render(<Provider store={store}>{children}</Provider>)
+}
+
+describe('GuideDrawer', () => {
+  const store = mockStore({
+    guides: {}
+  })
+
+  const remoteGuide: RemoteGuide = {
+    currentSlide: 0,
+    title: 'Title',
+    identifier: 'identifier'
+  }
+
+  it('renders list view without Remote Guides', () => {
+    const { container } = renderWithRedux(
+      store,
+      <GuideDrawer {...createProps(null, [])} />
+    )
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders list view including Remote Guides list', () => {
+    const { container } = renderWithRedux(
+      store,
+      <GuideDrawer {...createProps(null, [remoteGuide])} />
+    )
+
+    expect(container).toMatchSnapshot()
+    expect(screen.getByTestId('remoteGuidesTitle')).not.toBeNull()
+    expect(screen.getByText('Title')).not.toBeNull()
+  })
+
+  it('renders guide slide when a guide is selected', () => {
+    // scrollIntoView is not implemented in jsdom
+    // Avoid TypeError: scrollIntoView is not a function
+    window.HTMLElement.prototype.scrollIntoView = () => undefined
+
+    const { container } = renderWithRedux(
+      store,
+      <GuideDrawer
+        {...createProps(
+          { ...remoteGuide, slides: [<div key={1}>Test Slide</div>] },
+          [remoteGuide]
+        )}
+      />
+    )
+
+    expect(container).toMatchSnapshot()
+    expect(screen.getByText('Title')).not.toBeNull()
+    expect(screen.getByText('Test Slide')).not.toBeNull()
+  })
+})

--- a/src/browser/modules/Sidebar/GuideDrawer.tsx
+++ b/src/browser/modules/Sidebar/GuideDrawer.tsx
@@ -45,7 +45,7 @@ import {
 } from './styled'
 import GuidePicker from './GuidePicker'
 
-type GuideDrawerProps = {
+export type GuideDrawerProps = {
   currentGuide: Guide | null
   remoteGuides: RemoteGuide[]
   backToAllGuides: () => void
@@ -55,7 +55,7 @@ type GuideDrawerProps = {
   updateRemoteGuides: (newList: RemoteGuide[]) => void
 }
 
-function GuideDrawer({
+export const GuideDrawer = ({
   currentGuide,
   remoteGuides,
   backToAllGuides,
@@ -63,7 +63,7 @@ function GuideDrawer({
   setCurrentGuide,
   fetchRemoteGuide,
   updateRemoteGuides
-}: GuideDrawerProps): JSX.Element {
+}: GuideDrawerProps): JSX.Element => {
   const scrollRef = useRef<HTMLDivElement>(null)
 
   return (

--- a/src/browser/modules/Sidebar/GuideDrawer.tsx
+++ b/src/browser/modules/Sidebar/GuideDrawer.tsx
@@ -94,7 +94,7 @@ function GuideDrawer({
             {currentGuide.title}
           </GuideTitle>
           <GuideCarousel
-            slides={currentGuide.slides ?? []}
+            slides={currentGuide.slides}
             currentSlideIndex={currentGuide.currentSlide}
             gotoSlide={gotoSlide}
             scrollToTop={() =>

--- a/src/browser/modules/Sidebar/GuideDrawer.tsx
+++ b/src/browser/modules/Sidebar/GuideDrawer.tsx
@@ -69,7 +69,7 @@ function GuideDrawer({
   return (
     <StyledGuideDrawer
       id="guide-drawer"
-      data-testid="guideDrawer"
+      data-testid="guidesDrawer"
       ref={scrollRef}
     >
       <StyledGuideDrawerHeader onClick={backToAllGuides}>

--- a/src/browser/modules/Sidebar/GuidePicker.tsx
+++ b/src/browser/modules/Sidebar/GuidePicker.tsx
@@ -54,7 +54,9 @@ const GuidePicker = ({
     </DrawerBrowserCommand>
     in the code editor.
     <MarginTop pixels={25}>
-      <DrawerSubHeader as="div">Built-in guides</DrawerSubHeader>
+      <DrawerSubHeader as="div" /* prevents guide styling of h5*/>
+        Built-in guides
+      </DrawerSubHeader>
     </MarginTop>
     <NoBulletsUl>
       {builtInGuides.map(({ identifier, description }) => (
@@ -77,7 +79,10 @@ const GuidePicker = ({
     {remoteGuides.length !== 0 && (
       <>
         <MarginTop pixels={25}>
-          <DrawerSubHeader as="div" data-testid="remoteGuidesTitle">
+          <DrawerSubHeader
+            as="div" /* prevents guide styling of h5*/
+            data-testid="remoteGuidesTitle"
+          >
             Remote Guides
           </DrawerSubHeader>
         </MarginTop>

--- a/src/browser/modules/Sidebar/GuidePicker.tsx
+++ b/src/browser/modules/Sidebar/GuidePicker.tsx
@@ -54,9 +54,7 @@ const GuidePicker = ({
     </DrawerBrowserCommand>
     in the code editor.
     <MarginTop pixels={25}>
-      <DrawerSubHeader as="div" /* prevents guide styling of h5*/>
-        Built-in guides
-      </DrawerSubHeader>
+      <DrawerSubHeader as="div">Built-in guides</DrawerSubHeader>
     </MarginTop>
     <NoBulletsUl>
       {builtInGuides.map(({ identifier, description }) => (
@@ -79,10 +77,7 @@ const GuidePicker = ({
     {remoteGuides.length !== 0 && (
       <>
         <MarginTop pixels={25}>
-          <DrawerSubHeader
-            as="div"
-            data-testid="remoteGuidesTitle" /* prevents guide styling of h5*/
-          >
+          <DrawerSubHeader as="div" data-testid="remoteGuidesTitle">
             Remote Guides
           </DrawerSubHeader>
         </MarginTop>

--- a/src/browser/modules/Sidebar/GuidePicker.tsx
+++ b/src/browser/modules/Sidebar/GuidePicker.tsx
@@ -61,6 +61,7 @@ const GuidePicker = ({
     <NoBulletsUl>
       {builtInGuides.map(({ identifier, description }) => (
         <MarginBottomLi
+          data-testid={`builtInGuide${identifier}`}
           key={identifier}
           onClick={() =>
             setCurrentGuide({
@@ -78,22 +79,29 @@ const GuidePicker = ({
     {remoteGuides.length !== 0 && (
       <>
         <MarginTop pixels={25}>
-          <DrawerSubHeader as="div" /* prevents guide styling of h5*/>
+          <DrawerSubHeader
+            as="div"
+            data-testid="remoteGuidesTitle" /* prevents guide styling of h5*/
+          >
             Remote Guides
           </DrawerSubHeader>
         </MarginTop>
         <NoBulletsUl>
           {remoteGuides.map(guide => (
-            <GuideListEntry key={guide.title}>
+            <GuideListEntry key={guide.identifier}>
               <DrawerBrowserCommand
+                data-testid={`remoteGuide${guide.identifier}`}
                 onClick={() => fetchRemoteGuide(guide.identifier)}
               >
                 {guide.title}
               </DrawerBrowserCommand>
               <Clickable
+                data-testid={`removeGuide${guide.identifier}`}
                 onClick={() => {
                   updateRemoteGuides(
-                    remoteGuides.filter(({ title }) => title !== guide.title)
+                    remoteGuides.filter(
+                      ({ identifier }) => identifier !== guide.identifier
+                    )
                   )
                 }}
               >

--- a/src/browser/modules/Sidebar/__snapshots__/GuideDrawer.test.tsx.snap
+++ b/src/browser/modules/Sidebar/__snapshots__/GuideDrawer.test.tsx.snap
@@ -1,0 +1,381 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`GuideDrawer renders guide slide when a guide is selected 1`] = `
+<div>
+  <div
+    class="sc-cmthru fthsZk"
+    data-testid="guidesDrawer"
+    id="guide-drawer"
+  >
+    <h4
+      class="sc-hMFtBS bOgQOX"
+    >
+      <span
+        class="sc-gqPbQI gVcpvI"
+        data-testid="guidesBackButton"
+      >
+        <i
+          class="sc-fOKMvo gVZzMN"
+        >
+          <span
+            class="SVGInline SVGInline--cleaned"
+          >
+            <svg
+              class="SVGInline-svg SVGInline--cleaned-svg"
+              style="width: 16px;height: 16px;"
+            />
+          </span>
+        </i>
+      </span>
+      Neo4j Browser Guides
+       
+    </h4>
+    <div
+      class="sc-iujRgT CDjDu"
+    />
+    <div
+      class="sc-cLQEGU glkSyE"
+      title="Title"
+    >
+      Title
+    </div>
+    <div
+      class="sc-iuJeZd ktPSbN disable-font-ligatures"
+    >
+      <div>
+        <div>
+          Test Slide
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GuideDrawer renders list view including Remote Guides list 1`] = `
+<div>
+  <div
+    class="sc-cmthru fthsZk"
+    data-testid="guidesDrawer"
+    id="guide-drawer"
+  >
+    <h4
+      class="sc-hMFtBS bOgQOX"
+    >
+      Neo4j Browser Guides
+       
+    </h4>
+    <div
+      class="sc-iujRgT CDjDu"
+    />
+    <div
+      class="sc-gqjmRU gUGRcR slide"
+      style="padding: 0px 15px;"
+    >
+      You can also access Browser guides by running
+      <span
+        class="sc-jKJlTe gfgIxR remove-play-icon"
+        data-populate=":guide [guide name]"
+      >
+        :guide [guide name]
+      </span>
+      in the code editor.
+      <div
+        class="sc-lkqHmb eiwGIl"
+      >
+        <div
+          class="sc-chPdSV bPmcaA"
+        >
+          Built-in guides
+        </div>
+      </div>
+      <div
+        class="sc-gojNiO ikNDmz"
+      >
+        <li
+          class="sc-bXGyLb eUyJDI"
+          data-testid="builtInGuideintro"
+        >
+          <span
+            class="sc-jKJlTe gfgIxR remove-play-icon"
+          >
+            :guide 
+            intro
+          </span>
+          <div
+            class="sc-lkqHmb cSPHwa"
+          >
+             
+            Navigating Neo4j Browser
+             
+          </div>
+        </li>
+        <li
+          class="sc-bXGyLb eUyJDI"
+          data-testid="builtInGuideconcepts"
+        >
+          <span
+            class="sc-jKJlTe gfgIxR remove-play-icon"
+          >
+            :guide 
+            concepts
+          </span>
+          <div
+            class="sc-lkqHmb cSPHwa"
+          >
+             
+            Property graph model concepts
+             
+          </div>
+        </li>
+        <li
+          class="sc-bXGyLb eUyJDI"
+          data-testid="builtInGuidecypher"
+        >
+          <span
+            class="sc-jKJlTe gfgIxR remove-play-icon"
+          >
+            :guide 
+            cypher
+          </span>
+          <div
+            class="sc-lkqHmb cSPHwa"
+          >
+             
+            Cypher basics - create, match, delete
+             
+          </div>
+        </li>
+        <li
+          class="sc-bXGyLb eUyJDI"
+          data-testid="builtInGuidemovie-graph"
+        >
+          <span
+            class="sc-jKJlTe gfgIxR remove-play-icon"
+          >
+            :guide 
+            movie-graph
+          </span>
+          <div
+            class="sc-lkqHmb cSPHwa"
+          >
+             
+            Queries and recommendations with Cypher - movie use case}
+             
+          </div>
+        </li>
+        <li
+          class="sc-bXGyLb eUyJDI"
+          data-testid="builtInGuidenorthwind-graph"
+        >
+          <span
+            class="sc-jKJlTe gfgIxR remove-play-icon"
+          >
+            :guide 
+            northwind-graph
+          </span>
+          <div
+            class="sc-lkqHmb cSPHwa"
+          >
+             
+            Translate and import relation data into graph
+             
+          </div>
+        </li>
+      </div>
+      <div
+        class="sc-lkqHmb eiwGIl"
+      >
+        <div
+          class="sc-chPdSV bPmcaA"
+          data-testid="remoteGuidesTitle"
+        >
+          Remote Guides
+        </div>
+      </div>
+      <div
+        class="sc-gojNiO ikNDmz"
+      >
+        <li
+          class="sc-krvtoX HZOwu"
+        >
+          <span
+            class="sc-jKJlTe gfgIxR remove-play-icon"
+            data-testid="remoteGuideidentifier"
+          >
+            Title
+          </span>
+          <span
+            class="sc-cbkKFq hwlbJw"
+            data-testid="removeGuideidentifier"
+          >
+            <i
+              class="sc-fYiAbW giXALH sl-bin"
+            />
+          </span>
+        </li>
+      </div>
+      <div
+        class="sc-eLExRp dvdOkB"
+      >
+        <a
+          class="sc-ckVGcZ gpqute"
+          href="https://neo4j.com/graphgists/"
+          rel="noreferrer"
+          target="_blank"
+        >
+          More guides
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`GuideDrawer renders list view without Remote Guides 1`] = `
+<div>
+  <div
+    class="sc-cmthru fthsZk"
+    data-testid="guidesDrawer"
+    id="guide-drawer"
+  >
+    <h4
+      class="sc-hMFtBS bOgQOX"
+    >
+      Neo4j Browser Guides
+       
+    </h4>
+    <div
+      class="sc-iujRgT CDjDu"
+    />
+    <div
+      class="sc-gqjmRU gUGRcR slide"
+      style="padding: 0px 15px;"
+    >
+      You can also access Browser guides by running
+      <span
+        class="sc-jKJlTe gfgIxR remove-play-icon"
+        data-populate=":guide [guide name]"
+      >
+        :guide [guide name]
+      </span>
+      in the code editor.
+      <div
+        class="sc-lkqHmb eiwGIl"
+      >
+        <div
+          class="sc-chPdSV bPmcaA"
+        >
+          Built-in guides
+        </div>
+      </div>
+      <div
+        class="sc-gojNiO ikNDmz"
+      >
+        <li
+          class="sc-bXGyLb eUyJDI"
+          data-testid="builtInGuideintro"
+        >
+          <span
+            class="sc-jKJlTe gfgIxR remove-play-icon"
+          >
+            :guide 
+            intro
+          </span>
+          <div
+            class="sc-lkqHmb cSPHwa"
+          >
+             
+            Navigating Neo4j Browser
+             
+          </div>
+        </li>
+        <li
+          class="sc-bXGyLb eUyJDI"
+          data-testid="builtInGuideconcepts"
+        >
+          <span
+            class="sc-jKJlTe gfgIxR remove-play-icon"
+          >
+            :guide 
+            concepts
+          </span>
+          <div
+            class="sc-lkqHmb cSPHwa"
+          >
+             
+            Property graph model concepts
+             
+          </div>
+        </li>
+        <li
+          class="sc-bXGyLb eUyJDI"
+          data-testid="builtInGuidecypher"
+        >
+          <span
+            class="sc-jKJlTe gfgIxR remove-play-icon"
+          >
+            :guide 
+            cypher
+          </span>
+          <div
+            class="sc-lkqHmb cSPHwa"
+          >
+             
+            Cypher basics - create, match, delete
+             
+          </div>
+        </li>
+        <li
+          class="sc-bXGyLb eUyJDI"
+          data-testid="builtInGuidemovie-graph"
+        >
+          <span
+            class="sc-jKJlTe gfgIxR remove-play-icon"
+          >
+            :guide 
+            movie-graph
+          </span>
+          <div
+            class="sc-lkqHmb cSPHwa"
+          >
+             
+            Queries and recommendations with Cypher - movie use case}
+             
+          </div>
+        </li>
+        <li
+          class="sc-bXGyLb eUyJDI"
+          data-testid="builtInGuidenorthwind-graph"
+        >
+          <span
+            class="sc-jKJlTe gfgIxR remove-play-icon"
+          >
+            :guide 
+            northwind-graph
+          </span>
+          <div
+            class="sc-lkqHmb cSPHwa"
+          >
+             
+            Translate and import relation data into graph
+             
+          </div>
+        </li>
+      </div>
+      <div
+        class="sc-eLExRp dvdOkB"
+      >
+        <a
+          class="sc-ckVGcZ gpqute"
+          href="https://neo4j.com/graphgists/"
+          rel="noreferrer"
+          target="_blank"
+        >
+          More guides
+        </a>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/shared/modules/commands/helpers/config.ts
+++ b/src/shared/modules/commands/helpers/config.ts
@@ -27,7 +27,7 @@ import { splitStringOnFirst } from 'services/commandUtils'
 import { getRemoteContentHostnameAllowlist } from 'shared/modules/dbMeta/dbMetaDuck'
 import { hostIsAllowed } from 'services/utils'
 import { getJSON } from 'services/remote'
-import { isValidURL } from 'shared/modules/commands/helpers/http'
+import { isValidUrl } from 'shared/modules/commands/helpers/http'
 import jsonic from 'jsonic'
 
 export function handleGetConfigCommand(_action: any, store: any) {
@@ -42,7 +42,7 @@ export function handleUpdateConfigCommand(action: any, put: any, store: any) {
   const p = new Promise((resolve, reject) => {
     if (parts[1] === undefined || parts[1] === '') return resolve(true) // Nothing to do
     const param = parts[1].trim()
-    if (!isValidURL(param)) {
+    if (!isValidUrl(param)) {
       // Not an URL. Parse as command line params
       if (/^"?\{[^}]*\}"?$/.test(param)) {
         // JSON object string {"x": 2, "y":"string"}

--- a/src/shared/modules/commands/helpers/http.test.ts
+++ b/src/shared/modules/commands/helpers/http.test.ts
@@ -18,12 +18,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { isValidURL, parseHttpVerbCommand } from './http'
+import { isValidUrl, parseHttpVerbCommand } from './http'
 
 describe('isValidUrl', () => {
   it('finishes within a second when called with "EnableMultiStatement:true"', () => {
     const start = Date.now()
-    const result = isValidURL('EnableMultiStatement:true')
+    const result = isValidUrl('EnableMultiStatement:true')
     const end = Date.now()
 
     expect(result).toBe(false)

--- a/src/shared/modules/commands/helpers/http.ts
+++ b/src/shared/modules/commands/helpers/http.ts
@@ -49,14 +49,14 @@ export const parseHttpVerbCommand = (input: any) => {
 }
 
 // Check if valid url, from http://stackoverflow.com/questions/5717093/check-if-a-javascript-string-is-a-url
-export function isValidURL(string: any) {
-  let url
+export function isValidUrl(url: string): boolean {
+  let urlObject
 
   try {
-    url = new URL(string)
+    urlObject = new URL(url)
   } catch (_) {
     return false
   }
 
-  return url.protocol.startsWith('http')
+  return urlObject.protocol.startsWith('http')
 }

--- a/src/shared/modules/connections/connectionsDuck.ts
+++ b/src/shared/modules/connections/connectionsDuck.ts
@@ -451,7 +451,7 @@ export type DiscoverableData = {
   supportsMultiDb?: boolean
   host?: string
   encrypted?: string
-  hasForceURL?: boolean
+  hasForceUrl?: boolean
   SSOError?: string
   attemptSSOLogin?: boolean
   SSOProviders?: SSOProvider[]
@@ -505,7 +505,7 @@ export const startupConnectEpic = (action$: any, store: any) => {
       )
 
       if (
-        !(discovered && discovered.hasForceURL) && // If we have force url, don't try old connection data
+        !(discovered && discovered.hasForceUrl) && // If we have force url, don't try old connection data
         shouldTryAutoconnecting(savedConnection)
       ) {
         try {

--- a/src/shared/modules/discovery/discoveryDuck.test.ts
+++ b/src/shared/modules/discovery/discoveryDuck.test.ts
@@ -235,7 +235,7 @@ describe('discoveryOnStartupEpic', () => {
             host: expectedHost,
             SSOError: discovery.NO_SSO_PROVIDERS_ERROR_TEXT,
             SSOProviders: [],
-            hasForceURL: true,
+            hasForceUrl: true,
             supportsMultiDb: false
           }
         }
@@ -265,7 +265,7 @@ describe('discoveryOnStartupEpic', () => {
             SSOError: discovery.NO_SSO_PROVIDERS_ERROR_TEXT,
             SSOProviders: [],
             supportsMultiDb: false,
-            hasForceURL: true
+            hasForceUrl: true
           }
         }
       ])
@@ -292,7 +292,7 @@ describe('discoveryOnStartupEpic', () => {
           discovered: {
             host: expectedHost,
             requestedUseDb: 'test',
-            hasForceURL: true,
+            hasForceUrl: true,
             supportsMultiDb: true,
             SSOError: discovery.NO_SSO_PROVIDERS_ERROR_TEXT,
             SSOProviders: []
@@ -324,7 +324,7 @@ describe('discoveryOnStartupEpic', () => {
             SSOError: discovery.NO_SSO_PROVIDERS_ERROR_TEXT,
             SSOProviders: [],
             supportsMultiDb: false,
-            hasForceURL: true
+            hasForceUrl: true
           }
         }
       ])
@@ -355,7 +355,7 @@ describe('discoveryOnStartupEpic', () => {
             SSOError: discovery.NO_SSO_PROVIDERS_ERROR_TEXT,
             SSOProviders: [],
             supportsMultiDb: false,
-            hasForceURL: true
+            hasForceUrl: true
           }
         }
       ])

--- a/src/shared/modules/discovery/discoveryDuck.ts
+++ b/src/shared/modules/discovery/discoveryDuck.ts
@@ -111,7 +111,7 @@ const updateDiscoveryState = (action: any, store: any) => {
   ]
   const updateObj: any = keysToCopy.reduce(
     (accObj, key) => (action[key] ? { ...accObj, [key]: action[key] } : accObj),
-    { host: action.forceURL }
+    { host: action.forceUrl }
   )
 
   if (typeof action.encrypted !== 'undefined') {
@@ -134,7 +134,7 @@ export const injectDiscoveryEpic = (action$: any, store: any) =>
         ),
         action.host
       )
-      return updateDiscoveryState({ ...action, forceURL: connectUrl }, store)
+      return updateDiscoveryState({ ...action, forceUrl: connectUrl }, store)
     })
     .mapTo({ type: DONE })
 
@@ -145,20 +145,20 @@ export const discoveryOnStartupEpic = (some$: any, store: any) => {
       if (!action.url) return action
       const { searchParams } = new URL(action.url)
 
-      const passedURL =
+      const passedUrl =
         searchParams.get('dbms') || searchParams.get('connectURL')
 
       const passedDb = searchParams.get('db')
 
-      if (passedURL) {
-        action.forceURL = decodeURIComponent(passedURL)
+      if (passedUrl) {
+        action.forceUrl = decodeURIComponent(passedUrl)
         action.requestedUseDb = passedDb
       }
 
-      const discoveryURL = searchParams.get('discoveryURL')
+      const discoveryUrl = searchParams.get('discoveryURL')
 
-      if (discoveryURL) {
-        action.discoveryURL = discoveryURL
+      if (discoveryUrl) {
+        action.discoveryUrl = discoveryUrl
       }
 
       const sessionStorageHost = sessionStorage.getItem(
@@ -183,7 +183,7 @@ export const discoveryOnStartupEpic = (some$: any, store: any) => {
       }
       const discoveryData = await getAndMergeDiscoveryData({
         action,
-        hostedURL: getHostedUrl(store.getState()),
+        hostedUrl: getHostedUrl(store.getState()),
         hasDiscoveryEndpoint: hasDiscoveryEndpoint(store.getState()),
         generateBoltUrlWithAllowedScheme: (boltUrl: string) =>
           generateBoltUrl(

--- a/src/shared/modules/discovery/discoveryHelpers.test.ts
+++ b/src/shared/modules/discovery/discoveryHelpers.test.ts
@@ -29,13 +29,13 @@ const baseAction = {
   requestedUseDb: '',
   restApi: '',
   sessionStorageHost: '',
-  forceURL: '',
-  discoveryURL: ''
+  forceUrl: '',
+  discoveryUrl: ''
 }
 const sessionStorageHost = 'http://sessionStorageHost.com'
-const hostedURL = 'http://hostedURL.com'
-const forceURL = 'http://forceURL.com'
-const discoveryURL = 'http://discoveryURL.com'
+const hostedUrl = 'http://hostedURL.com'
+const forceUrl = 'http://forceURL.com'
+const discoveryUrl = 'http://discoveryURL.com'
 const generateBoltUrlWithAllowedScheme = (s: string) => s
 
 let logs = []
@@ -69,7 +69,7 @@ describe('getAndMergeDiscoveryData', () => {
     // When
     const discoveryData = await getAndMergeDiscoveryData({
       action: baseAction,
-      hostedURL: browserHost,
+      hostedUrl: browserHost,
       generateBoltUrlWithAllowedScheme,
       hasDiscoveryEndpoint: true
     })
@@ -98,7 +98,7 @@ describe('getAndMergeDiscoveryData', () => {
     // When
     const discoveryData = await getAndMergeDiscoveryData({
       action: baseAction,
-      hostedURL: browserHost,
+      hostedUrl: browserHost,
       generateBoltUrlWithAllowedScheme,
       hasDiscoveryEndpoint: true
     })
@@ -112,7 +112,7 @@ describe('getAndMergeDiscoveryData', () => {
 
   test('finds and priotises sso providers from session storage/connect form when all discovery sources are present, but doesnt merge when hosts differ', async () => {
     // Given
-    ;[hostedURL, forceURL, discoveryURL].forEach(host =>
+    ;[hostedUrl, forceUrl, discoveryUrl].forEach(host =>
       nock(host)
         .get('/')
         .reply(
@@ -133,15 +133,15 @@ describe('getAndMergeDiscoveryData', () => {
 
     const action = {
       ...baseAction,
-      discoveryURL,
-      forceURL,
+      discoveryUrl: discoveryUrl,
+      forceUrl: forceUrl,
       sessionStorageHost
     }
 
     // When
     const discoveryData = await getAndMergeDiscoveryData({
       action,
-      hostedURL,
+      hostedUrl: hostedUrl,
       generateBoltUrlWithAllowedScheme,
       hasDiscoveryEndpoint: true
     })
@@ -160,9 +160,9 @@ describe('getAndMergeDiscoveryData', () => {
     const hasDiscoveryEndpoint = true
     ;[
       { host: sessionStorageHost, providerIds: ['malmöstad'] },
-      { host: hostedURL, providerIds: ['trelleborg'] },
-      { host: forceURL, providerIds: ['göteborg'] },
-      { host: discoveryURL, providerIds: ['petalburg'] }
+      { host: hostedUrl, providerIds: ['trelleborg'] },
+      { host: forceUrl, providerIds: ['göteborg'] },
+      { host: discoveryUrl, providerIds: ['petalburg'] }
     ].forEach(({ host, providerIds }) => {
       nock(host)
         .get('/')
@@ -171,15 +171,15 @@ describe('getAndMergeDiscoveryData', () => {
 
     const action = {
       ...baseAction,
-      discoveryURL,
-      forceURL,
+      discoveryUrl: discoveryUrl,
+      forceUrl: forceUrl,
       sessionStorageHost
     }
 
     // When
     const discoveryData = await getAndMergeDiscoveryData({
       action,
-      hostedURL,
+      hostedUrl: hostedUrl,
       generateBoltUrlWithAllowedScheme,
       hasDiscoveryEndpoint
     })
@@ -202,9 +202,9 @@ test('finds sso providers from some providers and merges without overriding', as
   const hasDiscoveryEndpoint = true
   ;[
     { host: sessionStorageHost, providerIds: ['malmöstad'] },
-    { host: hostedURL, providerIds: ['trelleborg'] },
-    { host: forceURL, providerIds: ['göteborg'] },
-    { host: discoveryURL, providerIds: ['petalburg'] }
+    { host: hostedUrl, providerIds: ['trelleborg'] },
+    { host: forceUrl, providerIds: ['göteborg'] },
+    { host: discoveryUrl, providerIds: ['petalburg'] }
   ].forEach(({ host, providerIds }) => {
     nock(host)
       .get('/')
@@ -213,15 +213,15 @@ test('finds sso providers from some providers and merges without overriding', as
 
   const action = {
     ...baseAction,
-    discoveryURL,
-    forceURL,
+    discoveryUrl: discoveryUrl,
+    forceUrl: forceUrl,
     sessionStorageHost
   }
 
   // When
   const discoveryData = await getAndMergeDiscoveryData({
     action,
-    hostedURL,
+    hostedUrl: hostedUrl,
     generateBoltUrlWithAllowedScheme,
     hasDiscoveryEndpoint
   })

--- a/src/shared/modules/discovery/discoveryHelpers.ts
+++ b/src/shared/modules/discovery/discoveryHelpers.ts
@@ -74,8 +74,8 @@ export async function fetchBrowserDiscoveryDataFromUrl(
 }
 
 type DataFromPreviousAction = {
-  forceURL: string
-  discoveryURL: string
+  forceUrl: string
+  discoveryUrl: string
   sessionStorageHost: string | null
   requestedUseDb?: string
   encrypted?: boolean
@@ -85,7 +85,7 @@ type DataFromPreviousAction = {
 
 type GetAndMergeDiscoveryDataParams = {
   action: DataFromPreviousAction
-  hostedURL: string
+  hostedUrl: string
   hasDiscoveryEndpoint: boolean
   generateBoltUrlWithAllowedScheme: (boltUrl: string) => string
 }
@@ -98,8 +98,8 @@ type TaggedDiscoveryData = DiscoverableData & {
 
 type DiscoveryDataSource =
   | 'connectForm'
-  | 'discoveryURL'
-  | 'connectURL'
+  | 'discoveryUrl'
+  | 'connectUrl'
   | 'discoveryConnection'
   | 'discoveryEndpoint'
 export const CONNECT_FORM = 'connectForm'
@@ -115,17 +115,17 @@ const onlyTruthyValues = (obj: any) =>
 
 export async function getAndMergeDiscoveryData({
   action,
-  hostedURL,
+  hostedUrl,
   hasDiscoveryEndpoint,
   generateBoltUrlWithAllowedScheme
 }: GetAndMergeDiscoveryDataParams): Promise<DiscoverableData | null> {
-  const { sessionStorageHost, forceURL, discoveryConnection } = action
+  const { sessionStorageHost, forceUrl, discoveryConnection } = action
 
-  let dataFromForceURL: DiscoverableData = {}
+  let dataFromForceUrl: DiscoverableData = {}
   let dataFromConnection: DiscoverableData = {}
 
-  if (forceURL) {
-    const { username, protocol, host } = getUrlInfo(forceURL)
+  if (forceUrl) {
+    const { username, protocol, host } = getUrlInfo(forceUrl)
 
     const discovered = {
       username,
@@ -134,10 +134,10 @@ export async function getAndMergeDiscoveryData({
       supportsMultiDb: !!action.requestedUseDb,
       encrypted: action.encrypted,
       restApi: action.restApi,
-      hasForceURL: true
+      hasForceUrl: true
     }
 
-    dataFromForceURL = onlyTruthyValues(discovered)
+    dataFromForceUrl = onlyTruthyValues(discovered)
   } else if (discoveryConnection) {
     const discovered = {
       username: discoveryConnection.username,
@@ -155,9 +155,9 @@ export async function getAndMergeDiscoveryData({
       )
     : Promise.resolve(null)
 
-  const forceUrlHostPromise = dataFromForceURL.host
+  const forceUrlHostPromise = dataFromForceUrl.host
     ? fetchBrowserDiscoveryDataFromUrl(
-        boltToHttp(generateBoltUrlWithAllowedScheme(dataFromForceURL.host))
+        boltToHttp(generateBoltUrlWithAllowedScheme(dataFromForceUrl.host))
       )
     : Promise.resolve(null)
 
@@ -167,12 +167,12 @@ export async function getAndMergeDiscoveryData({
       )
     : Promise.resolve(null)
 
-  const discoveryUrlParamPromise = action.discoveryURL
-    ? fetchBrowserDiscoveryDataFromUrl(action.discoveryURL)
+  const discoveryUrlParamPromise = action.discoveryUrl
+    ? fetchBrowserDiscoveryDataFromUrl(action.discoveryUrl)
     : Promise.resolve(null)
 
   const discoveryEndpointPromise = hasDiscoveryEndpoint
-    ? fetchBrowserDiscoveryDataFromUrl(getDiscoveryEndpoint(hostedURL))
+    ? fetchBrowserDiscoveryDataFromUrl(getDiscoveryEndpoint(hostedUrl))
     : Promise.resolve(null)
 
   // Promise all is safe since fetchDataFromDiscoveryUrl never rejects
@@ -204,9 +204,9 @@ export async function getAndMergeDiscoveryData({
       // if we're dealing with a pre 4.4 server the disc request will fail even as there's a db present
       onlyCheckForHost: true,
       urlMissing: forceUrlHostData === null,
-      ...dataFromForceURL,
+      ...dataFromForceUrl,
       ...forceUrlHostData,
-      host: forceUrlHostData?.host || dataFromForceURL.host
+      host: forceUrlHostData?.host || dataFromForceUrl.host
     },
     {
       source: DISCOVERY_URL,
@@ -267,7 +267,7 @@ export async function getAndMergeDiscoveryData({
     'SSOError',
     'SSOProviders',
     'neo4jVersion',
-    'hasForceURL'
+    'hasForceUrl'
   ]
 
   let mergedDiscoveryData = pick(mainDiscoveryData, keysToCopy)

--- a/src/shared/modules/settings/settingsDuck.ts
+++ b/src/shared/modules/settings/settingsDuck.ts
@@ -77,7 +77,7 @@ const browserSyncConfig = (host = 'https://auth.neo4j.com') => ({
   logoutUrl: 'https://neo4j-sync.auth0.com/v2/logout',
   firebaseConfig: {
     apiKey: 'AIzaSyA1RwZMBWHxqRGyY3CK60leRkr56H6GHV4',
-    databaseURL: 'https://fiery-heat-7952.firebaseio.com',
+    databaseUrl: 'https://fiery-heat-7952.firebaseio.com',
     messagingSenderId: '352959348981'
   }
 })

--- a/src/shared/modules/settings/settingsDuck.ts
+++ b/src/shared/modules/settings/settingsDuck.ts
@@ -77,7 +77,7 @@ const browserSyncConfig = (host = 'https://auth.neo4j.com') => ({
   logoutUrl: 'https://neo4j-sync.auth0.com/v2/logout',
   firebaseConfig: {
     apiKey: 'AIzaSyA1RwZMBWHxqRGyY3CK60leRkr56H6GHV4',
-    databaseUrl: 'https://fiery-heat-7952.firebaseio.com',
+    databaseURL: 'https://fiery-heat-7952.firebaseio.com',
     messagingSenderId: '352959348981'
   }
 })

--- a/src/shared/services/commandInterpreterHelper.ts
+++ b/src/shared/services/commandInterpreterHelper.ts
@@ -80,7 +80,7 @@ import {
 import {
   UnknownCommandError,
   CouldNotFetchRemoteGuideError,
-  FetchURLError,
+  FetchUrlError,
   InvalidGrassError,
   UnsupportedError,
   DatabaseUnavailableError,
@@ -88,7 +88,7 @@ import {
 } from 'services/exceptions'
 import {
   parseHttpVerbCommand,
-  isValidURL
+  isValidUrl
 } from 'shared/modules/commands/helpers/http'
 import { fetchRemoteGrass } from 'shared/modules/commands/helpers/grass'
 import { parseGrass, objToCss } from 'shared/services/grassUtils'
@@ -730,7 +730,7 @@ const availableCommands = [
             }
           )
           const url =
-            !isValidURL(r.url) && connectionData.restApi
+            !isValidUrl(r.url) && connectionData.restApi
               ? `${connectionData.restApi}${r.url}`
               : r.url
           let authHeaders = {}
@@ -758,7 +758,7 @@ const availableCommands = [
               )
             })
             .catch(e => {
-              const error = FetchURLError({ error: e.message })
+              const error = FetchUrlError({ error: e.message })
               put(
                 frames.add({
                   useDb: getUseDb(store.getState()),
@@ -829,7 +829,7 @@ const availableCommands = [
       }
 
       if (
-        isValidURL(param) &&
+        isValidUrl(param) &&
         param.includes('.') /* isValid url considers words like rest an url*/
       ) {
         const url = param.startsWith('http') ? param : `http://${param}`

--- a/src/shared/services/exceptions.ts
+++ b/src/shared/services/exceptions.ts
@@ -25,7 +25,7 @@ type ErrorType =
   | 'UnknownCommandError'
   | 'UndefinedError'
   | 'CouldNotFetchRemoteGuideError'
-  | 'FetchURLError'
+  | 'FetchUrlError'
   | 'UnsupportedError'
   | 'NotFoundError'
   | 'InvalidGrassError'
@@ -92,8 +92,8 @@ export function CouldNotFetchRemoteGuideError(error: {
   }
 }
 
-export function FetchURLError(error: { error: string }): BrowserError {
-  const type = 'FetchURLError'
+export function FetchUrlError(error: { error: string }): BrowserError {
+  const type = 'FetchUrlError'
   return {
     type,
     code: type,
@@ -153,7 +153,7 @@ export function createErrorObject(type: ErrorType, args: any): BrowserError {
     UnknownCommandError,
     UndefinedError,
     CouldNotFetchRemoteGuideError,
-    FetchURLError,
+    FetchUrlError,
     UnsupportedError,
     NotFoundError,
     InvalidGrassError,


### PR DESCRIPTION
Followed #1594 , there are some fields still need to be done.

- [x] Add unit tests.
- [x] Add E2E tests (making sure existing guide won't be added twice).
- [x] As we created `RemoteGuide` type, we don't have to worry about if `slides` property is `undefined`. (https://github.com/neo4j/neo4j-browser/pull/1594#discussion_r752103434)
- [x] Convert `URL` to `Url`. (https://github.com/neo4j/neo4j-browser/pull/1594#discussion_r750344020)
- [ ] Consolidate `GuideItem` and `Guide` interface.
- [ ] Include `identifier` to built-in guides. (https://github.com/neo4j/neo4j-browser/pull/1594#discussion_r750345119, https://github.com/neo4j/neo4j-browser/pull/1594#discussion_r750349801)
- [ ] Make RxJS Epic type-safe. (https://github.com/neo4j/neo4j-browser/pull/1594#discussion_r750465038)