### PR TITLE
Add brackets around array type in details properties view

### DIFF
--- a/src/browser/modules/D3Visualization/components/DetailsPane.tsx
+++ b/src/browser/modules/D3Visualization/components/DetailsPane.tsx
@@ -47,8 +47,9 @@ export const MAX_LENGTH_WIDE = 300
 type ExpandableValueProps = {
   value: string
   width: number
+  type: string
 }
-function ExpandableValue({ value, width }: ExpandableValueProps) {
+function ExpandableValue({ value, width, type }: ExpandableValueProps) {
   const [expanded, setExpanded] = useState(false)
 
   const maxLength =
@@ -64,12 +65,14 @@ function ExpandableValue({ value, width }: ExpandableValueProps) {
 
   return (
     <>
+      {type.startsWith('Array') && '['}
       <ClickableUrls text={valueShown} />
       {valueIsTrimmed && (
         <StyledExpandValueButton onClick={handleExpandClick}>
           {' Show all'}
         </StyledExpandValueButton>
       )}
+      {type.startsWith('Array') && ']'}
     </>
   )
 }
@@ -99,7 +102,11 @@ function PropertiesView({
                   <ClickableUrls text={key} />
                 </KeyCell>
                 <ValueCell>
-                  <ExpandableValue value={value} width={nodeInspectorWidth} />
+                  <ExpandableValue
+                    value={value}
+                    width={nodeInspectorWidth}
+                    type={type}
+                  />
                 </ValueCell>
                 <CopyCell>
                   <ClipboardCopier


### PR DESCRIPTION
<img width="416" alt="bracketsArray" src="https://user-images.githubusercontent.com/11065688/142858693-8487ecca-d633-4ab7-a8de-04eb7732577d.png">
<img width="455" alt="bracketsArrayShowAll" src="https://user-images.githubusercontent.com/11065688/142858690-4626184e-63e5-418c-a7a2-b77ccb956190.png">

<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

