### PR TITLE
Local storage guide retainment follow up

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,6 +209,7 @@
     "semver": "^5.5.0",
     "styled-components": "^4.0.0",
     "suber": "^5.0.1",
+    "typesafe-actions": "^5.1.0",
     "unist-util-visit": "^2.0.2",
     "url-parse": "^1.1.9",
     "uuid": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -209,7 +209,6 @@
     "semver": "^5.5.0",
     "styled-components": "^4.0.0",
     "suber": "^5.0.1",
-    "typesafe-actions": "^5.1.0",
     "unist-util-visit": "^2.0.2",
     "url-parse": "^1.1.9",
     "uuid": "^3.0.1"

--- a/src/browser/documentation/dynamic/cypher.tsx
+++ b/src/browser/documentation/dynamic/cypher.tsx
@@ -27,8 +27,8 @@ const filter = ['cypher']
 const description = (
   <>
     <p>
-      Cypher is Neo4j&apos;s graph query language. Working with a graph is all
-      about understanding patterns of data, which are central to Cypher queries.
+      {`Cypher is Neo4j's graph query language. Working with a graph is all
+      about understanding patterns of data, which are central to Cypher queries.`}
     </p>
     <p>
       Use

--- a/src/browser/documentation/index.ts
+++ b/src/browser/documentation/index.ts
@@ -125,17 +125,20 @@ type DocItem = {
   slides?: JSX.Element[]
 }
 
-type GuideItem = {
+export type Guide = {
+  currentSlide: number
   title: string
+  identifier: string
   slides: JSX.Element[]
+  isError?: boolean
 }
 
 type GuideDocs = {
   title: 'Built-in Browser guides'
-  chapters: Record<GuideChapter, GuideItem>
+  chapters: Record<BuiltInGuideIdentifier, Omit<Guide, 'currentSlide'>>
 }
 
-export type GuideChapter =
+export type BuiltInGuideIdentifier =
   | 'concepts'
   | 'cypher'
   | 'intro'
@@ -148,7 +151,7 @@ export type GuideChapter =
   | 'unfound'
 
 // TypeGuard function to ts to understand that a string is a valid key
-export function isGuideChapter(name: string): name is GuideChapter {
+export function isGuideChapter(name: string): name is BuiltInGuideIdentifier {
   return name in docs.guide.chapters
 }
 

--- a/src/browser/documentation/index.ts
+++ b/src/browser/documentation/index.ts
@@ -151,9 +151,8 @@ export type BuiltInGuideIdentifier =
   | 'unfound'
 
 // TypeGuard function to ts to understand that a string is a valid key
-export function isGuideChapter(name: string): name is BuiltInGuideIdentifier {
-  return name in docs.guide.chapters
-}
+export const isBuiltInGuide = (name: string): name is BuiltInGuideIdentifier =>
+  name in docs.guide.chapters
 
 type PlayDocs = {
   title: 'Guides & Examples'

--- a/src/browser/documentation/sidebar-guides/concepts.tsx
+++ b/src/browser/documentation/sidebar-guides/concepts.tsx
@@ -23,6 +23,7 @@ import { BuiltInGuideSidebarSlide } from '../../modules/Carousel/Slide'
 
 const title = 'Concepts Guide'
 const category = 'guides'
+const identifier = 'concepts'
 const slides = [
   <BuiltInGuideSidebarSlide key="s1">
     <h3>Property graph model concepts</h3>
@@ -200,4 +201,4 @@ const slides = [
   </BuiltInGuideSidebarSlide>
 ]
 
-export default { title, category, slides }
+export default { title, category, identifier, slides }

--- a/src/browser/documentation/sidebar-guides/concepts.tsx
+++ b/src/browser/documentation/sidebar-guides/concepts.tsx
@@ -83,10 +83,8 @@ const slides = [
       social graph, you label each node that represents a Person.
     </p>
     <ol>
-      <li>
-        Add the label &quot;Person&quot; to the node you created for Emil.
-      </li>
-      <li>Color the &quot;Person&quot; node red.</li>
+      <li>{`Add the label "Person" to the node you created for Emil.`}</li>
+      <li>{`Color the "Person" node red.`}</li>
     </ol>
     <br />
     <img src="./assets/images/labeled_node.png" className="img-responsive" />

--- a/src/browser/documentation/sidebar-guides/concepts.tsx
+++ b/src/browser/documentation/sidebar-guides/concepts.tsx
@@ -48,8 +48,8 @@ const slides = [
       <em>Neo4j stores data in a graph as nodes</em>
     </p>
     <p>
-      The simplest graph has just a single node with some named values called
-      properties. For example, let&apos;s draw a social graph:
+      {`The simplest graph has just a single node with some named values called
+      properties. For example, let's draw a social graph:`}
     </p>
     <ol>
       <li>Draw a circle for a node.</li>
@@ -179,9 +179,9 @@ const slides = [
       <em>Store information shared by two nodes</em>
     </p>
     <p>
-      In a property graph, relationships can also contain properties that
-      describe the relationship. Looking more closely at Emil&apos;s
-      relationships, note that:
+      {`In a property graph, relationships can also contain properties that
+      describe the relationship. Looking more closely at Emil's
+      relationships, note that:`}
     </p>
     <ul>
       <li>Emil has known Johan since 2001.</li>

--- a/src/browser/documentation/sidebar-guides/concepts.tsx
+++ b/src/browser/documentation/sidebar-guides/concepts.tsx
@@ -48,7 +48,7 @@ const slides = [
     </p>
     <p>
       The simplest graph has just a single node with some named values called
-      properties. For example, let's draw a social graph:
+      properties. For example, let&apos;s draw a social graph:
     </p>
     <ol>
       <li>Draw a circle for a node.</li>
@@ -82,8 +82,10 @@ const slides = [
       social graph, you label each node that represents a Person.
     </p>
     <ol>
-      <li>Add the label "Person" to the node you created for Emil.</li>
-      <li>Color the "Person" node red.</li>
+      <li>
+        Add the label &quot;Person&quot; to the node you created for Emil.
+      </li>
+      <li>Color the &quot;Person&quot; node red.</li>
     </ol>
     <br />
     <img src="./assets/images/labeled_node.png" className="img-responsive" />
@@ -177,8 +179,8 @@ const slides = [
     </p>
     <p>
       In a property graph, relationships can also contain properties that
-      describe the relationship. Looking more closely at Emil's relationships,
-      note that:
+      describe the relationship. Looking more closely at Emil&apos;s
+      relationships, note that:
     </p>
     <ul>
       <li>Emil has known Johan since 2001.</li>

--- a/src/browser/documentation/sidebar-guides/cypher.tsx
+++ b/src/browser/documentation/sidebar-guides/cypher.tsx
@@ -21,7 +21,8 @@
 import React from 'react'
 import { BuiltInGuideSidebarSlide } from '../../modules/Carousel/Slide'
 
-const title = 'Cypher Guide '
+const title = 'Cypher Guide'
+const identifier = 'cypher'
 const slides = [
   <BuiltInGuideSidebarSlide key="s1">
     <p className="lead">
@@ -196,4 +197,4 @@ WHERE ee.name = 'Emil' RETURN ee, friends`}
   </BuiltInGuideSidebarSlide>
 ]
 
-export default { title, slides }
+export default { title, identifier, slides }

--- a/src/browser/documentation/sidebar-guides/cypher.tsx
+++ b/src/browser/documentation/sidebar-guides/cypher.tsx
@@ -26,10 +26,10 @@ const identifier = 'cypher'
 const slides = [
   <BuiltInGuideSidebarSlide key="s1">
     <p className="lead">
-      <em>Neo4j&apos;s graph query language</em>
+      <em>{`Neo4j's graph query language`}</em>
     </p>
     <p>
-      Neo4j&apos;s Cypher language is purpose-built for working with graph data.
+      {`Neo4j's Cypher language is purpose-built for working with graph data.`}
     </p>
     <ul className="big">
       <li>Uses patterns to describe graph data.</li>
@@ -42,9 +42,10 @@ const slides = [
     <p className="lead">
       <em>Create a node</em>
     </p>
-    <p>Let&apos;s use Cypher to generate a small social graph.</p>
+    <p>{`Let's use Cypher to generate a small social graph.`}</p>
     <p>
-      <b>NOTE:</b> This guide assumes that you use an empty graph.{' '}
+      <b>NOTE:</b>
+      {` This guide assumes that you use an empty graph. `}
     </p>
     <ol>
       <li>
@@ -83,7 +84,7 @@ const slides = [
       <li>
         Click this code block and bring it into the Editor:
         <pre className="pre-scrollable code runnable">
-          MATCH (ee:Person) WHERE ee.name = &apos;Emil&apos; RETURN ee;
+          {`MATCH (ee:Person) WHERE ee.name = 'Emil' RETURN ee;`}
         </pre>
         <ul style={{ marginLeft: '10px', paddingLeft: '10px' }}>
           <li>
@@ -98,8 +99,8 @@ const slides = [
             <code>WHERE</code> filters the query.
           </li>
           <li>
-            <code>ee.name = &apos;Emil&apos;</code> compares name property to
-            the value <code>Emil</code>.
+            <code>{`ee.name = 'Emil'`}</code> compares name property to the
+            value <code>Emil</code>.
           </li>
           <li>
             <code>RETURN</code> returns particular results.
@@ -141,7 +142,7 @@ CREATE (js:Person { name: 'Johan', from: 'Sweden', learn: 'surfing' }),
       <em>Describe what to find in the graph</em>
     </p>
     <p className="summary">
-      For instance, a pattern can be used to find Emil&apos;s friends:
+      {`For instance, a pattern can be used to find Emil's friends:`}
     </p>
     <pre className="pre-scrollable code runnable">
       {`MATCH (ee:Person)-[:KNOWS]-(friends)
@@ -161,8 +162,8 @@ WHERE ee.name = 'Emil' RETURN ee, friends`}
         either direction) from <code>ee</code>.
       </li>
       <li>
-        <code>(friends)</code> represents the nodes that are Emil&apos;s
-        friends.
+        <code>(friends)</code>
+        {` represents the nodes that are Emil's friends.`}
       </li>
       <li>
         <code>RETURN</code> returns the node, referenced here by{' '}

--- a/src/browser/documentation/sidebar-guides/cypher.tsx
+++ b/src/browser/documentation/sidebar-guides/cypher.tsx
@@ -25,9 +25,11 @@ const title = 'Cypher Guide '
 const slides = [
   <BuiltInGuideSidebarSlide key="s1">
     <p className="lead">
-      <em>Neo4j's graph query language</em>
+      <em>Neo4j&apos;s graph query language</em>
     </p>
-    <p>Neo4j's Cypher language is purpose-built for working with graph data.</p>
+    <p>
+      Neo4j&apos;s Cypher language is purpose-built for working with graph data.
+    </p>
     <ul className="big">
       <li>Uses patterns to describe graph data.</li>
       <li>Familiar SQL-like clauses.</li>
@@ -39,7 +41,7 @@ const slides = [
     <p className="lead">
       <em>Create a node</em>
     </p>
-    <p>Let's use Cypher to generate a small social graph.</p>
+    <p>Let&apos;s use Cypher to generate a small social graph.</p>
     <p>
       <b>NOTE:</b> This guide assumes that you use an empty graph.{' '}
     </p>
@@ -80,7 +82,7 @@ const slides = [
       <li>
         Click this code block and bring it into the Editor:
         <pre className="pre-scrollable code runnable">
-          MATCH (ee:Person) WHERE ee.name = 'Emil' RETURN ee;
+          MATCH (ee:Person) WHERE ee.name = &apos;Emil&apos; RETURN ee;
         </pre>
         <ul style={{ marginLeft: '10px', paddingLeft: '10px' }}>
           <li>
@@ -95,8 +97,8 @@ const slides = [
             <code>WHERE</code> filters the query.
           </li>
           <li>
-            <code>ee.name = 'Emil'</code> compares name property to the value{' '}
-            <code>Emil</code>.
+            <code>ee.name = &apos;Emil&apos;</code> compares name property to
+            the value <code>Emil</code>.
           </li>
           <li>
             <code>RETURN</code> returns particular results.
@@ -138,7 +140,7 @@ CREATE (js:Person { name: 'Johan', from: 'Sweden', learn: 'surfing' }),
       <em>Describe what to find in the graph</em>
     </p>
     <p className="summary">
-      For instance, a pattern can be used to find Emil's friends:
+      For instance, a pattern can be used to find Emil&apos;s friends:
     </p>
     <pre className="pre-scrollable code runnable">
       {`MATCH (ee:Person)-[:KNOWS]-(friends)
@@ -158,7 +160,8 @@ WHERE ee.name = 'Emil' RETURN ee, friends`}
         either direction) from <code>ee</code>.
       </li>
       <li>
-        <code>(friends)</code> represents the nodes that are Emil's friends.
+        <code>(friends)</code> represents the nodes that are Emil&apos;s
+        friends.
       </li>
       <li>
         <code>RETURN</code> returns the node, referenced here by{' '}

--- a/src/browser/documentation/sidebar-guides/cypher.tsx
+++ b/src/browser/documentation/sidebar-guides/cypher.tsx
@@ -99,8 +99,10 @@ const slides = [
             <code>WHERE</code> filters the query.
           </li>
           <li>
-            <code>{`ee.name = 'Emil'`}</code> compares name property to the
-            value <code>Emil</code>.
+            <code>{`ee.name = 'Emil'`}</code>
+            {` compares name property to the
+            value `}
+            <code>Emil</code>.
           </li>
           <li>
             <code>RETURN</code> returns particular results.

--- a/src/browser/documentation/sidebar-guides/intro.tsx
+++ b/src/browser/documentation/sidebar-guides/intro.tsx
@@ -23,6 +23,7 @@ import { BuiltInGuideSidebarSlide } from '../../modules/Carousel/Slide'
 import { isMac } from 'browser/modules/App/keyboardShortcuts'
 
 const title = 'Intro Guide'
+const identifier = 'intro'
 const slides = [
   <BuiltInGuideSidebarSlide key="s1">
     <h3>Navigating Neo4j Browser</h3>
@@ -216,4 +217,4 @@ const slides = [
   </BuiltInGuideSidebarSlide>
 ]
 
-export default { title, slides }
+export default { title, identifier, slides }

--- a/src/browser/documentation/sidebar-guides/intro.tsx
+++ b/src/browser/documentation/sidebar-guides/intro.tsx
@@ -39,7 +39,7 @@ const slides = [
       <li>
         Graph visualization of query results containing nodes and relationships.
       </li>
-      <li>Convenient exploration of the Neo4j&apos;s HTTP API (REST).</li>
+      <li>{`Convenient exploration of the Neo4j's HTTP API (REST).`}</li>
     </ul>
   </BuiltInGuideSidebarSlide>,
   <BuiltInGuideSidebarSlide key="s2">

--- a/src/browser/documentation/sidebar-guides/intro.tsx
+++ b/src/browser/documentation/sidebar-guides/intro.tsx
@@ -38,7 +38,7 @@ const slides = [
       <li>
         Graph visualization of query results containing nodes and relationships.
       </li>
-      <li>Convenient exploration of the Neo4j's HTTP API (REST).</li>
+      <li>Convenient exploration of the Neo4j&apos;s HTTP API (REST).</li>
     </ul>
   </BuiltInGuideSidebarSlide>,
   <BuiltInGuideSidebarSlide key="s2">

--- a/src/browser/documentation/sidebar-guides/movie-graph.tsx
+++ b/src/browser/documentation/sidebar-guides/movie-graph.tsx
@@ -648,13 +648,13 @@ const slides = [
     <hr />
     <ul className="undecorated">
       <li>
-        Find the actor named &quot;Tom Hanks&quot;:
+        {`Find the actor named "Tom Hanks"`}:
         <pre className="pre-scrollable code runnable">
           {'MATCH (tom:Person {name: "Tom Hanks"}) RETURN tom'}
         </pre>
       </li>
       <li>
-        Find the movie with title &quot;Cloud Atlas&quot;:
+        {`Find the movie with title "Cloud Atlas":`}
         <pre className="pre-scrollable code runnable">
           {'MATCH (cloudAtlas:Movie {title: "Cloud Atlas"}) RETURN cloudAtlas'}
         </pre>
@@ -702,7 +702,7 @@ const slides = [
         </pre>
       </li>
       <li>
-        Who directed &quot;Cloud Atlas&quot;?
+        {`Who directed "Cloud Atlas"?`}
         <pre className="pre-scrollable code runnable">
           {
             'MATCH (cloudAtlas:Movie {title: "Cloud Atlas"})<-[:DIRECTED]-(directors) RETURN directors.name'
@@ -718,7 +718,7 @@ const slides = [
         </pre>
       </li>
       <li>
-        How people are related to &quot;Cloud Atlas&quot;?
+        {`How people are related to "Cloud Atlas"?`}
         <pre className="pre-scrollable code runnable">
           {
             'MATCH (people:Person)-[relatedTo]-(:Movie {title: "Cloud Atlas"}) RETURN people.name, Type(relatedTo), relatedTo.roles'
@@ -738,23 +738,21 @@ const slides = [
       <em>Six Degrees of Kevin Bacon</em>
     </p>
     <p>
-      You might have heard of the classic &quot;Six Degrees of Kevin
-      Bacon&quot;. That is simply the shortest path between two nodes, called
-      the &quot;Bacon Path&quot;.
+      {`You might have heard of the classic "Six Degrees of Kevin Bacon". That is simply the shortest path between two nodes, called the "Bacon Path".`}
     </p>
     <hr />
     <ul className="undecorated">
       <li>
-        Use variable length patterns to find movies and actors up to 4
-        &quot;hops&quot; away from Kevin Bacon.
+        {`Use variable length patterns to find movies and actors up to 4 "hops" away from Kevin Bacon.`}
         <pre className="pre-scrollable code runnable">
           {`MATCH (bacon:Person {name:"Kevin Bacon"})-[*1..4]-(hollywood)
 RETURN DISTINCT hollywood`}
         </pre>
       </li>
       <li>
-        Use the built-in <code>shortestPath()</code> algorithm to find the
-        &quot;Bacon Path&quot; to Meg Ryan.
+        Use the built-in <code>shortestPath()</code>
+        {` algorithm to find the
+        "Bacon Path" to Meg Ryan.`}
         <pre className="pre-scrollable code runnable">
           {`MATCH p=shortestPath(
 (bacon:Person {name:"Kevin Bacon"})-[*]-(meg:Person {name:"Meg Ryan"})

--- a/src/browser/documentation/sidebar-guides/movie-graph.tsx
+++ b/src/browser/documentation/sidebar-guides/movie-graph.tsx
@@ -25,6 +25,7 @@ import { DrawerExternalLink } from 'browser-components/drawer/drawer-styled'
 
 const title = 'Movie Graph Guide'
 const category = 'graphExamples'
+const identifier = 'movie-graph'
 const slides = [
   <BuiltInGuideSidebarSlide key="s1">
     <p>
@@ -871,4 +872,4 @@ RETURN tom, m, coActors, m2, cruise`}
   </BuiltInGuideSidebarSlide>
 ]
 
-export default { title, category, slides }
+export default { title, category, identifier, slides }

--- a/src/browser/documentation/sidebar-guides/movie-graph.tsx
+++ b/src/browser/documentation/sidebar-guides/movie-graph.tsx
@@ -710,7 +710,7 @@ const slides = [
         </pre>
       </li>
       <li>
-        Who were Tom Hanks&apos; co-actors?
+        {`Who were Tom Hanks' co-actors?`}
         <pre className="pre-scrollable code runnable">
           {
             'MATCH (tom:Person {name:"Tom Hanks"})-[:ACTED_IN]->(m)<-[:ACTED_IN]-(coActors) RETURN DISTINCT coActors.name'
@@ -775,9 +775,7 @@ RETURN p`}
       <em>Recommend new co-actors</em>
     </p>
     <p>
-      Let&apos;s recommend new co-actors for Tom Hanks. A basic recommendation
-      approach is to find connections past an immediate neighborhood that are
-      themselves well connected.
+      {`Let's recommend new co-actors for Tom Hanks. A basic recommendation approach is to find connections past an immediate neighborhood that are themselves well connected.`}
     </p>
     <hr />
     <p>For Tom Hanks, that means:</p>

--- a/src/browser/documentation/sidebar-guides/movie-graph.tsx
+++ b/src/browser/documentation/sidebar-guides/movie-graph.tsx
@@ -647,13 +647,13 @@ const slides = [
     <hr />
     <ul className="undecorated">
       <li>
-        Find the actor named "Tom Hanks":
+        Find the actor named &quot;Tom Hanks&quot;:
         <pre className="pre-scrollable code runnable">
           {'MATCH (tom:Person {name: "Tom Hanks"}) RETURN tom'}
         </pre>
       </li>
       <li>
-        Find the movie with title "Cloud Atlas":
+        Find the movie with title &quot;Cloud Atlas&quot;:
         <pre className="pre-scrollable code runnable">
           {'MATCH (cloudAtlas:Movie {title: "Cloud Atlas"}) RETURN cloudAtlas'}
         </pre>
@@ -701,7 +701,7 @@ const slides = [
         </pre>
       </li>
       <li>
-        Who directed "Cloud Atlas"?
+        Who directed &quot;Cloud Atlas&quot;?
         <pre className="pre-scrollable code runnable">
           {
             'MATCH (cloudAtlas:Movie {title: "Cloud Atlas"})<-[:DIRECTED]-(directors) RETURN directors.name'
@@ -709,7 +709,7 @@ const slides = [
         </pre>
       </li>
       <li>
-        Who were Tom Hanks' co-actors?
+        Who were Tom Hanks&apos; co-actors?
         <pre className="pre-scrollable code runnable">
           {
             'MATCH (tom:Person {name:"Tom Hanks"})-[:ACTED_IN]->(m)<-[:ACTED_IN]-(coActors) RETURN DISTINCT coActors.name'
@@ -717,7 +717,7 @@ const slides = [
         </pre>
       </li>
       <li>
-        How people are related to "Cloud Atlas"?
+        How people are related to &quot;Cloud Atlas&quot;?
         <pre className="pre-scrollable code runnable">
           {
             'MATCH (people:Person)-[relatedTo]-(:Movie {title: "Cloud Atlas"}) RETURN people.name, Type(relatedTo), relatedTo.roles'
@@ -737,14 +737,15 @@ const slides = [
       <em>Six Degrees of Kevin Bacon</em>
     </p>
     <p>
-      You might have heard of the classic "Six Degrees of Kevin Bacon". That is
-      simply the shortest path between two nodes, called the "Bacon Path".
+      You might have heard of the classic &quot;Six Degrees of Kevin
+      Bacon&quot;. That is simply the shortest path between two nodes, called
+      the &quot;Bacon Path&quot;.
     </p>
     <hr />
     <ul className="undecorated">
       <li>
-        Use variable length patterns to find movies and actors up to 4 "hops"
-        away from Kevin Bacon.
+        Use variable length patterns to find movies and actors up to 4
+        &quot;hops&quot; away from Kevin Bacon.
         <pre className="pre-scrollable code runnable">
           {`MATCH (bacon:Person {name:"Kevin Bacon"})-[*1..4]-(hollywood)
 RETURN DISTINCT hollywood`}
@@ -752,7 +753,7 @@ RETURN DISTINCT hollywood`}
       </li>
       <li>
         Use the built-in <code>shortestPath()</code> algorithm to find the
-        "Bacon Path" to Meg Ryan.
+        &quot;Bacon Path&quot; to Meg Ryan.
         <pre className="pre-scrollable code runnable">
           {`MATCH p=shortestPath(
 (bacon:Person {name:"Kevin Bacon"})-[*]-(meg:Person {name:"Meg Ryan"})
@@ -773,7 +774,7 @@ RETURN p`}
       <em>Recommend new co-actors</em>
     </p>
     <p>
-      Let's recommend new co-actors for Tom Hanks. A basic recommendation
+      Let&apos;s recommend new co-actors for Tom Hanks. A basic recommendation
       approach is to find connections past an immediate neighborhood that are
       themselves well connected.
     </p>

--- a/src/browser/documentation/sidebar-guides/northwind-graph.tsx
+++ b/src/browser/documentation/sidebar-guides/northwind-graph.tsx
@@ -59,8 +59,8 @@ const slides = [
       <em>Load the product catalog data from external CSV files</em>
     </p>
     <p>
-      Northwind sells food products in a few categories provided by suppliers.
-      Let&apos;s start by loading the product catalog tables.
+      {`Northwind sells food products in a few categories provided by suppliers.
+      Let's start by loading the product catalog tables.`}
     </p>
     <img
       src="./assets/images/northwind/product-category-supplier.png"
@@ -137,9 +137,9 @@ SET n = row`}
       <em>Transform foreign key references into data relationships</em>
     </p>
     <p>
-      The products, categories, and suppliers are related through foreign key
-      references. Let&apos;s promote those to data relationships to realize the
-      graph.
+      {`The products, categories, and suppliers are related through foreign key
+      references. Let's promote those to data relationships to realize the
+      graph.`}
     </p>
     <img
       src="./assets/images/northwind/product-graph.png"

--- a/src/browser/documentation/sidebar-guides/northwind-graph.tsx
+++ b/src/browser/documentation/sidebar-guides/northwind-graph.tsx
@@ -25,6 +25,7 @@ import { DrawerExternalLink } from 'browser-components/drawer/drawer-styled'
 
 const title = 'Northwind Graph Guide'
 const category = 'graphExamples'
+const identifier = 'northwind-graph'
 const slides = [
   <BuiltInGuideSidebarSlide key="s1">
     <p className="lead">
@@ -338,4 +339,4 @@ RETURN DISTINCT cust.contactName as CustomerName, SUM(o.quantity) AS TotalProduc
   </BuiltInGuideSidebarSlide>
 ]
 
-export default { title, category, slides }
+export default { title, category, identifier, slides }

--- a/src/browser/documentation/sidebar-guides/northwind-graph.tsx
+++ b/src/browser/documentation/sidebar-guides/northwind-graph.tsx
@@ -59,7 +59,7 @@ const slides = [
     </p>
     <p>
       Northwind sells food products in a few categories provided by suppliers.
-      Let's start by loading the product catalog tables.
+      Let&apos;s start by loading the product catalog tables.
     </p>
     <img
       src="./assets/images/northwind/product-category-supplier.png"
@@ -137,7 +137,7 @@ SET n = row`}
     </p>
     <p>
       The products, categories, and suppliers are related through foreign key
-      references. Let's promote those to data relationships to realize the
+      references. Let&apos;s promote those to data relationships to realize the
       graph.
     </p>
     <img

--- a/src/browser/documentation/sidebar-guides/unfound.tsx
+++ b/src/browser/documentation/sidebar-guides/unfound.tsx
@@ -24,7 +24,7 @@ const title = 'Not found'
 const identifier = 'unfound'
 const slides = [
   <BuiltInGuideSidebarSlide key="first">
-    <p>Apologies, but there doesn&apos;t seem to be any content about that.</p>
+    <p>{`Apologies, but there doesn't seem to be any content about that.`}</p>
     <h5>Try:</h5>
     <ul className="undecorated">
       <li>

--- a/src/browser/documentation/sidebar-guides/unfound.tsx
+++ b/src/browser/documentation/sidebar-guides/unfound.tsx
@@ -21,7 +21,7 @@
 import { BuiltInGuideSidebarSlide } from 'browser/modules/Carousel/Slide'
 import React from 'react'
 const title = 'Not found'
-
+const identifier = 'unfound'
 const slides = [
   <BuiltInGuideSidebarSlide key="first">
     <p>Apologies, but there doesn&apos;t seem to be any content about that.</p>
@@ -43,4 +43,4 @@ const slides = [
   </BuiltInGuideSidebarSlide>
 ]
 
-export default { title, slides, isError: true }
+export default { title, slides, identifier, isError: true }

--- a/src/browser/modules/Main/Main.tsx
+++ b/src/browser/modules/Main/Main.tsx
@@ -88,7 +88,7 @@ const Main = React.memo(function Main(props: MainProps) {
       )}
       {useDb && isDatabaseUnavailable && (
         <ErrorBanner>
-          Database &apos;{useDb}&apos; is unavailable. Run{' '}
+          {`Database '${useDb}' is unavailable. Run `}
           <AutoExecButton cmd="sysinfo" /> for more info.
         </ErrorBanner>
       )}
@@ -102,7 +102,7 @@ const Main = React.memo(function Main(props: MainProps) {
             cmd="server connect"
             data-testid="disconnectedBannerCode"
           />
-          &nbsp; to establish connection. There&apos;s a graph waiting for you.
+          {` to establish connection. There's a graph waiting for you.`}
         </NotAuthedBanner>
       )}
       {connectionState === PENDING_STATE && !past10Sec && (

--- a/src/browser/modules/Sidebar/About.tsx
+++ b/src/browser/modules/Sidebar/About.tsx
@@ -179,8 +179,7 @@ const About = ({ serverVersion, serverEdition }: AboutProps) => (
       <DrawerSection>
         <DrawerSubHeader>Thanks</DrawerSubHeader>
         <DrawerSectionBody>
-          Neo4j wouldn&apos;t be possible without a fantastic community. Thanks
-          for all the feedback, discussions and contributions.
+          {`Neo4j wouldn't be possible without a fantastic community. Thanks for all the feedback, discussions and contributions.`}
         </DrawerSectionBody>
       </DrawerSection>
     </DrawerBody>

--- a/src/browser/modules/Sidebar/GuideDrawer.test.tsx
+++ b/src/browser/modules/Sidebar/GuideDrawer.test.tsx
@@ -22,9 +22,9 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import { Provider } from 'react-redux'
 import configureMockStore, { MockStoreEnhanced } from 'redux-mock-store'
-
+import { Guide } from 'browser/documentation'
 import { GuideDrawerProps, GuideDrawer } from './GuideDrawer'
-import { Guide, RemoteGuide } from 'shared/modules/guides/guidesDuck'
+import { RemoteGuide } from 'shared/modules/guides/guidesDuck'
 
 const createProps = (
   currentGuide: Guide | null,

--- a/src/browser/modules/Sidebar/GuideDrawer.tsx
+++ b/src/browser/modules/Sidebar/GuideDrawer.tsx
@@ -23,7 +23,6 @@ import { Action, Dispatch } from 'redux'
 import { connect } from 'react-redux'
 
 import {
-  Guide,
   RemoteGuide,
   getCurrentGuide,
   getRemoteGuides,
@@ -34,6 +33,7 @@ import {
   updateRemoteGuides
 } from 'shared/modules/guides/guidesDuck'
 import { GlobalState } from 'shared/globalState'
+import { Guide } from 'browser/documentation'
 import GuideCarousel from '../GuideCarousel/GuideCarousel'
 import { BackIcon } from '../../components/icons/Icons'
 import {

--- a/src/browser/modules/Sidebar/GuidePicker.tsx
+++ b/src/browser/modules/Sidebar/GuidePicker.tsx
@@ -14,7 +14,7 @@ import {
   MarginBottomLi
 } from 'browser/documentation/sidebar-guides/styled'
 import { Guide, RemoteGuide } from 'shared/modules/guides/guidesDuck'
-import docs, { GuideChapter } from 'browser/documentation'
+import docs, { BuiltInGuideIdentifier } from 'browser/documentation'
 import { BinIcon } from 'browser-components/icons/Icons'
 
 type GuidePickerProps = {
@@ -24,7 +24,10 @@ type GuidePickerProps = {
   updateRemoteGuides: (newList: RemoteGuide[]) => void
 }
 
-const builtInGuides: { identifier: GuideChapter; description: string }[] = [
+const builtInGuides: {
+  identifier: BuiltInGuideIdentifier
+  description: string
+}[] = [
   { identifier: 'intro', description: 'Navigating Neo4j Browser' },
   { identifier: 'concepts', description: 'Property graph model concepts' },
   {

--- a/src/browser/modules/Sidebar/GuidePicker.tsx
+++ b/src/browser/modules/Sidebar/GuidePicker.tsx
@@ -13,8 +13,8 @@ import {
   GuideListEntry,
   MarginBottomLi
 } from 'browser/documentation/sidebar-guides/styled'
-import { Guide, RemoteGuide } from 'shared/modules/guides/guidesDuck'
-import docs, { BuiltInGuideIdentifier } from 'browser/documentation'
+import { RemoteGuide } from 'shared/modules/guides/guidesDuck'
+import docs, { BuiltInGuideIdentifier, Guide } from 'browser/documentation'
 import { BinIcon } from 'browser-components/icons/Icons'
 
 type GuidePickerProps = {

--- a/src/browser/modules/Stream/CypherScriptFrame/Summary.tsx
+++ b/src/browser/modules/Stream/CypherScriptFrame/Summary.tsx
@@ -60,8 +60,7 @@ const GenericSummary = ({
         <PaddedStatsBar>
           <StyledCypherInfoMessage>INFO</StyledCypherInfoMessage>
           <MessageArea>
-            This query is waiting for it&apos;s turn. The execution is serial
-            and will break on first error.
+            {`This query is waiting for it's turn. The execution is serial and will break on first error.`}
           </MessageArea>
         </PaddedStatsBar>
       )

--- a/src/shared/modules/guides/guidesDuck.ts
+++ b/src/shared/modules/guides/guidesDuck.ts
@@ -19,6 +19,7 @@
  */
 
 import { Observable } from 'rxjs'
+import { isOfType } from 'typesafe-actions'
 import { Epic } from 'redux-observable'
 import { GlobalState } from 'shared/globalState'
 import { tryGetRemoteInitialSlideFromUrl } from 'services/guideResolverHelper'
@@ -84,12 +85,10 @@ export const fetchRemoteGuideEpic: Epic<
   FetchGuideAction | SetGuideAction | OpenSidebarAction | AddRemoteGuideAction,
   GlobalState
 > = (action$, store$) =>
-  action$.ofType(FETCH_GUIDE).flatMap(action => {
-    const initialSlide = tryGetRemoteInitialSlideFromUrl(
-      (<FetchGuideAction>action).identifier
-    )
+  action$.filter(isOfType(FETCH_GUIDE)).flatMap(action => {
+    const initialSlide = tryGetRemoteInitialSlideFromUrl(action.identifier)
     return Observable.fromPromise(
-      resolveGuide((<FetchGuideAction>action).identifier, store$.getState())
+      resolveGuide(action.identifier, store$.getState())
     ).mergeMap(({ title, identifier, slides, isError }) => {
       const guide: RemoteGuide = {
         currentSlide: initialSlide,

--- a/src/shared/modules/guides/guidesDuck.ts
+++ b/src/shared/modules/guides/guidesDuck.ts
@@ -24,7 +24,7 @@ import { GlobalState } from 'shared/globalState'
 import { tryGetRemoteInitialSlideFromUrl } from 'services/guideResolverHelper'
 import { resolveGuide } from '../../services/guideResolverHelper'
 import { OpenSidebarAction, open } from '../sidebar/sidebarDuck'
-import { isGuideChapter } from 'browser/documentation'
+import { Guide, isBuiltInGuide } from 'browser/documentation'
 
 export const NAME = 'guides'
 export const FETCH_GUIDE = 'guides/FETCH_GUIDE'
@@ -38,12 +38,6 @@ export const getCurrentGuide = (state: GlobalState): Guide | null =>
 export const getRemoteGuides = (state: GlobalState): RemoteGuide[] =>
   state[NAME].remoteGuides
 
-export type Guide = {
-  currentSlide: number
-  title: string
-  identifier: string
-  slides: JSX.Element[]
-}
 export type RemoteGuide = Omit<Guide, 'slides'>
 export interface GuideState {
   currentGuide: Guide | null
@@ -139,7 +133,7 @@ export default function reducer(
         !!state.remoteGuides.find(
           remoteGuide => remoteGuide.identifier === action.guide.identifier
         ) ||
-        isGuideChapter(action.guide.identifier)
+        isBuiltInGuide(action.guide.identifier)
       ) {
         return state
       } else {

--- a/src/shared/modules/guides/guidesDuck.ts
+++ b/src/shared/modules/guides/guidesDuck.ts
@@ -81,21 +81,8 @@ interface AddRemoteGuideAction {
   guide: RemoteGuide
 }
 
-type TypeConstant = string
-
-function checkIsEmpty(arg: unknown) {
-  return arg == null
-}
-
-function throwIsEmpty(argPosition: number): never {
-  throw new Error(`Argument ${argPosition} is empty.`)
-}
-
-function checkInvalidActionTypeInArray(
-  arg: TypeConstant,
-  idx: number
-): void | never {
-  if (arg == null) {
+function checkInvalidActionTypeInArray(arg: string, idx: number): void | never {
+  if (!arg) {
     throw new Error(
       `Argument contains array with empty element at index ${idx}`
     )
@@ -129,8 +116,8 @@ function isOfType<T extends string, A extends { type: T }>(
   actionTypeOrTypes: T | T[],
   action?: A
 ) {
-  if (checkIsEmpty(actionTypeOrTypes)) {
-    throwIsEmpty(1)
+  if (!actionTypeOrTypes) {
+    throw new Error(`Argument 1 is empty.`)
   }
 
   const actionTypes = Array.isArray(actionTypeOrTypes)

--- a/src/shared/modules/guides/guidesDuck.ts
+++ b/src/shared/modules/guides/guidesDuck.ts
@@ -19,13 +19,13 @@
  */
 
 import { Observable } from 'rxjs'
-import { Action } from 'redux'
 import { Epic } from 'redux-observable'
 import { GlobalState } from 'shared/globalState'
 import { tryGetRemoteInitialSlideFromUrl } from 'services/guideResolverHelper'
 import { resolveGuide } from '../../services/guideResolverHelper'
 import { OpenSidebarAction, open } from '../sidebar/sidebarDuck'
 import { Guide, isBuiltInGuide } from 'browser/documentation'
+import { isOfType } from 'shared/utils/typeSafeActions'
 
 export const NAME = 'guides'
 export const FETCH_GUIDE = 'guides/FETCH_GUIDE'
@@ -79,61 +79,6 @@ export interface UpdateGuideAction {
 interface AddRemoteGuideAction {
   type: typeof ADD_REMOTE_GUIDE
   guide: RemoteGuide
-}
-
-function checkInvalidActionTypeInArray(arg: string, idx: number): void | never {
-  if (!arg) {
-    throw new Error(
-      `Argument contains array with empty element at index ${idx}`
-    )
-  } else if (typeof arg !== 'string' && typeof arg !== 'symbol') {
-    throw new Error(
-      `Argument contains array with invalid element at index ${idx}, it should be of type: string | symbol`
-    )
-  }
-}
-
-/**
- * @description (curried assert function) check if action type is equal given type-constant
- * @description it works with discriminated union types
- */
-function isOfType<T extends string, A extends { type: string }>(
-  type: T | T[],
-  action: A
-): action is A extends { type: T } ? A : never
-
-/**
- * @description (curried assert function) check if action type is equal given type-constant
- * @description it works with discriminated union types
- */
-function isOfType<T extends string>(
-  type: T | T[]
-): <A extends { type: string }>(
-  action: A
-) => action is A extends { type: T } ? A : never
-
-function isOfType<T extends string, A extends { type: T }>(
-  actionTypeOrTypes: T | T[],
-  action?: A
-) {
-  if (!actionTypeOrTypes) {
-    throw new Error(`Argument 1 is empty.`)
-  }
-
-  const actionTypes = Array.isArray(actionTypeOrTypes)
-    ? actionTypeOrTypes
-    : [actionTypeOrTypes]
-
-  actionTypes.forEach(checkInvalidActionTypeInArray)
-
-  const assertFn = (_action: A) => actionTypes.includes(_action.type)
-
-  // 1 arg case => return curried version
-  if (action === undefined) {
-    return assertFn
-  }
-  // 2 args case => invoke assertFn and return the result
-  return assertFn(action)
 }
 
 export const fetchRemoteGuideEpic: Epic<

--- a/src/shared/modules/udc/udcDuck.ts
+++ b/src/shared/modules/udc/udcDuck.ts
@@ -51,7 +51,7 @@ import {
 } from 'shared/modules/settings/settingsDuck'
 import cmdHelper from 'shared/services/commandInterpreterHelper'
 import { extractStatementsFromString } from 'services/commandUtils'
-import { isGuideChapter, isPlayChapter } from 'browser/documentation'
+import { isBuiltInGuide, isPlayChapter } from 'browser/documentation'
 import { v4 } from 'uuid'
 
 // Action types
@@ -256,7 +256,7 @@ export const trackCommandUsageEpic: Epic<Action, GlobalState> = action$ =>
       extraData.content = isPlayChapter(guideName) ? 'built-in' : 'non-built-in'
     } else if (type === 'guide') {
       const guideName = action.cmd.substr(':guide'.length).trim()
-      extraData.content = isGuideChapter(guideName)
+      extraData.content = isBuiltInGuide(guideName)
         ? 'built-in'
         : 'non-built-in'
     }

--- a/src/shared/services/guideResolverHelper.tsx
+++ b/src/shared/services/guideResolverHelper.tsx
@@ -117,7 +117,7 @@ async function resolveRemoteGuideByUrl(
   isError?: boolean
 }> {
   try {
-    // Construct URL probably throws exception and crashes the app
+    // URL constructor can throw would work as well
     const urlObject = new URL(url)
     urlObject.href = url
     const filenameExtension =

--- a/src/shared/services/guideResolverHelper.tsx
+++ b/src/shared/services/guideResolverHelper.tsx
@@ -23,7 +23,7 @@ import { includes, last, split, startsWith } from 'lodash-es'
 
 import MdxSlide from 'browser/modules/Docs/MDX/MdxSlide'
 import Slide from 'browser/modules/Carousel/Slide'
-import docs, { isGuideChapter } from 'browser/documentation'
+import docs, { isBuiltInGuide } from 'browser/documentation'
 import guideUnfound from 'browser/documentation/sidebar-guides/unfound'
 import {
   addProtocolsToUrlList,
@@ -73,7 +73,7 @@ export async function resolveGuide(
     return await resolveRemoteGuideByUrl(identifier, state)
   }
 
-  if (isGuideChapter(identifier)) {
+  if (isBuiltInGuide(identifier)) {
     return { ...chapters[identifier], identifier }
   }
 

--- a/src/shared/services/guideResolverHelper.tsx
+++ b/src/shared/services/guideResolverHelper.tsx
@@ -117,7 +117,7 @@ async function resolveRemoteGuideByUrl(
   isError?: boolean
 }> {
   try {
-    // URL constructor can throw would work as well
+    // URL constructor can throw
     const urlObject = new URL(url)
     urlObject.href = url
     const filenameExtension =

--- a/src/shared/services/localstorage.ts
+++ b/src/shared/services/localstorage.ts
@@ -20,7 +20,6 @@
 
 import { Middleware } from 'redux'
 import { GlobalState } from 'shared/globalState'
-import { GuideState } from 'shared/modules/guides/guidesDuck'
 import {
   shouldRetainConnectionCredentials,
   shouldRetainEditorHistory

--- a/src/shared/services/remote.ts
+++ b/src/shared/services/remote.ts
@@ -34,7 +34,7 @@ function request(method: any, url: any, data = null, extraHeaders = {}) {
   }).then(checkStatus)
 }
 
-function get(url: any, headers = {}) {
+function get(url: string, headers: HeadersInit = {}): Promise<string> {
   return fetch(url, {
     method: 'get',
     headers
@@ -58,13 +58,14 @@ export function getJSON(url: any) {
     })
 }
 
-function checkStatus(response: any) {
+function checkStatus(response: Response) {
   if (response.status >= 200 && response.status < 300) {
     return response
   } else {
-    const error: any = new Error(`${response.status} ${response.statusText}`)
-    error.response = response
-    throw error
+    throw {
+      ...new Error(`${response.status} ${response.statusText}`),
+      response
+    }
   }
 }
 

--- a/src/shared/utils/typeSafeActions.test.ts
+++ b/src/shared/utils/typeSafeActions.test.ts
@@ -1,0 +1,181 @@
+import { isOfType } from './typeSafeActions'
+
+const types = {
+  // String Literal Types
+  VERY_DEEP_WITH_TYPE_ONLY: 'VERY_DEEP_WITH_TYPE_ONLY',
+  WITH_TYPE_ONLY: 'WITH_TYPE_ONLY',
+  WITH_PAYLOAD: 'WITH_PAYLOAD',
+  WITH_OPTIONAL_PAYLOAD: 'WITH_OPTIONAL_PAYLOAD',
+  WITH_PAYLOAD_META: 'WITH_PAYLOAD_META',
+  WITH_MAPPED_PAYLOAD: 'WITH_MAPPED_PAYLOAD',
+  WITH_MAPPED_PAYLOAD_META: 'WITH_MAPPED_PAYLOAD_META'
+}
+
+const createAction = <P extends unknown, M extends unknown>(
+  type: string,
+  payload?: P,
+  meta?: M
+) => {
+  const action = { type }
+  if (payload) Object.assign(action, { payload })
+  if (meta) Object.assign(action, { meta })
+  return action
+}
+
+const actions = {
+  withTypeOnly: createAction(types.WITH_TYPE_ONLY),
+  withPayload: createAction(types.WITH_PAYLOAD, 2),
+  withPayloadMeta: createAction(types.WITH_PAYLOAD_META, 2, 'metaValue'),
+  withMappedPayload: createAction(types.WITH_MAPPED_PAYLOAD, 2),
+  withMappedPayloadMeta: createAction(
+    types.WITH_MAPPED_PAYLOAD_META,
+    2,
+    'metaValue'
+  )
+}
+
+/** HELPERS */
+
+const typeOnlyAction = actions.withTypeOnly
+const typeOnlyExpected = { type: 'WITH_TYPE_ONLY' }
+const payloadAction = actions.withPayload
+const payloadExpected = { type: 'WITH_PAYLOAD', payload: 2 }
+const payloadMetaAction = actions.withPayloadMeta
+const payloadMetaExpected = {
+  type: 'WITH_PAYLOAD_META',
+  payload: 2,
+  meta: 'metaValue'
+}
+const mappedPayloadAction = actions.withMappedPayload
+const mappedPayloadExpected = { type: 'WITH_MAPPED_PAYLOAD', payload: 2 }
+const mappedPayloadMetaAction = actions.withMappedPayloadMeta
+const mappedPayloadMetaExpected = {
+  type: 'WITH_MAPPED_PAYLOAD_META',
+  payload: 2,
+  meta: 'metaValue'
+}
+
+const $action = [
+  typeOnlyAction,
+  payloadAction,
+  payloadMetaAction,
+  mappedPayloadAction,
+  mappedPayloadMetaAction
+]
+
+/** TESTS */
+describe('isOfType', () => {
+  it('should work with single action-type arg', () => {
+    expect(isOfType(types.WITH_TYPE_ONLY)(typeOnlyAction)).toBe(true)
+    expect(isOfType(types.WITH_TYPE_ONLY, typeOnlyAction)).toBe(true)
+    expect(isOfType(types.WITH_TYPE_ONLY)(payloadAction)).toBe(false)
+    expect(isOfType(types.WITH_TYPE_ONLY, payloadAction)).toBe(false)
+    expect(isOfType([types.WITH_TYPE_ONLY])(typeOnlyAction)).toBe(true)
+    expect(isOfType([types.WITH_TYPE_ONLY], typeOnlyAction)).toBe(true)
+    expect(isOfType([types.WITH_TYPE_ONLY])(payloadAction)).toBe(false)
+    expect(isOfType([types.WITH_TYPE_ONLY], payloadAction)).toBe(false)
+  })
+
+  it('should work with multiple action-type args', () => {
+    expect(
+      isOfType([types.WITH_TYPE_ONLY, types.WITH_PAYLOAD])(typeOnlyAction)
+    ).toBe(true)
+    expect(
+      isOfType([types.WITH_TYPE_ONLY, types.WITH_PAYLOAD], typeOnlyAction)
+    ).toBe(true)
+    expect(
+      isOfType([types.WITH_TYPE_ONLY, types.WITH_PAYLOAD])(payloadAction)
+    ).toBe(true)
+    expect(
+      isOfType([types.WITH_TYPE_ONLY, types.WITH_PAYLOAD], payloadAction)
+    ).toBe(true)
+    expect(
+      isOfType([types.WITH_TYPE_ONLY, types.WITH_PAYLOAD])(mappedPayloadAction)
+    ).toBe(false)
+    expect(
+      isOfType([types.WITH_TYPE_ONLY, types.WITH_PAYLOAD], mappedPayloadAction)
+    ).toBe(false)
+  })
+
+  it('should correctly assert for an array with 1 arg', () => {
+    const actual = $action.filter(isOfType(types.WITH_TYPE_ONLY))
+    expect(actual).toEqual([typeOnlyExpected])
+  })
+
+  it('should correctly assert for an array with 2 args', () => {
+    const actual = $action.filter(
+      isOfType([types.WITH_TYPE_ONLY, types.WITH_PAYLOAD])
+    )
+    expect(actual).toEqual([typeOnlyExpected, payloadExpected])
+  })
+
+  it('should correctly assert for an array with 3 args', () => {
+    const actual = $action.filter(
+      isOfType([
+        types.WITH_TYPE_ONLY,
+        types.WITH_PAYLOAD,
+        types.WITH_PAYLOAD_META
+      ])
+    )
+    expect(actual).toEqual([
+      typeOnlyExpected,
+      payloadExpected,
+      payloadMetaExpected
+    ])
+  })
+
+  it('should correctly assert for an array with 4 args', () => {
+    const actual = $action.filter(
+      isOfType([
+        types.WITH_TYPE_ONLY,
+        types.WITH_PAYLOAD,
+        types.WITH_PAYLOAD_META,
+        types.WITH_MAPPED_PAYLOAD
+      ])
+    )
+    expect(actual).toEqual([
+      typeOnlyExpected,
+      payloadExpected,
+      payloadMetaExpected,
+      mappedPayloadExpected
+    ])
+  })
+
+  it('should correctly assert for an array with 4 args', () => {
+    const actual = $action.filter(
+      isOfType([
+        types.WITH_TYPE_ONLY,
+        types.WITH_PAYLOAD,
+        types.WITH_PAYLOAD_META,
+        types.WITH_MAPPED_PAYLOAD,
+        types.WITH_MAPPED_PAYLOAD_META
+      ])
+    )
+    expect(actual).toEqual([
+      typeOnlyExpected,
+      payloadExpected,
+      payloadMetaExpected,
+      mappedPayloadExpected,
+      mappedPayloadMetaExpected
+    ])
+  })
+
+  it('should correctly assert type with "any" action', () => {
+    const action: any = createAction(types.WITH_MAPPED_PAYLOAD, 1234)
+    if (
+      isOfType(
+        [types.WITH_MAPPED_PAYLOAD, types.WITH_MAPPED_PAYLOAD_META],
+        action
+      )
+    ) {
+      expect(action).toEqual({ payload: 1234, type: 'WITH_MAPPED_PAYLOAD' })
+    }
+    if (
+      isOfType([types.WITH_MAPPED_PAYLOAD, types.WITH_MAPPED_PAYLOAD_META])(
+        action
+      )
+    ) {
+      expect(action).toEqual({ payload: 1234, type: 'WITH_MAPPED_PAYLOAD' })
+    }
+  })
+})

--- a/src/shared/utils/typeSafeActions.ts
+++ b/src/shared/utils/typeSafeActions.ts
@@ -1,0 +1,54 @@
+function checkInvalidActionTypeInArray(arg: string, idx: number): void | never {
+  if (!arg) {
+    throw new Error(
+      `Argument contains array with empty element at index ${idx}`
+    )
+  } else if (typeof arg !== 'string' && typeof arg !== 'symbol') {
+    throw new Error(
+      `Argument contains array with invalid element at index ${idx}, it should be of type: string | symbol`
+    )
+  }
+}
+
+/**
+ * @description (curried assert function) check if action type is equal given type-constant
+ * @description it works with discriminated union types
+ */
+export function isOfType<T extends string, A extends { type: string }>(
+  type: T | T[],
+  action: A
+): action is A extends { type: T } ? A : never
+
+/**
+ * @description (curried assert function) check if action type is equal given type-constant
+ * @description it works with discriminated union types
+ */
+export function isOfType<T extends string>(
+  type: T | T[]
+): <A extends { type: string }>(
+  action: A
+) => action is A extends { type: T } ? A : never
+
+export function isOfType<T extends string, A extends { type: T }>(
+  actionTypeOrTypes: T | T[],
+  action?: A
+): unknown {
+  if (!actionTypeOrTypes) {
+    throw new Error(`Argument 1 is empty.`)
+  }
+
+  const actionTypes = Array.isArray(actionTypeOrTypes)
+    ? actionTypeOrTypes
+    : [actionTypeOrTypes]
+
+  actionTypes.forEach(checkInvalidActionTypeInArray)
+
+  const assertFn = (_action: A) => actionTypes.includes(_action.type)
+
+  // 1 arg case => return curried version
+  if (action === undefined) {
+    return assertFn
+  }
+  // 2 args case => invoke assertFn and return the result
+  return assertFn(action)
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13072,6 +13072,11 @@ typedarray@^0.0.6:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typesafe-actions@^5.1.0:
+  version "5.1.0"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/typesafe-actions/-/typesafe-actions-5.1.0.tgz#9afe8b1e6a323af1fd59e6a57b11b7dd6623d2f1"
+  integrity sha1-mv6LHmoyOvH9WealexG33WYj0vE=
+
 typescript-plugin-styled-components@^1.5.0:
   version "1.5.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/typescript-plugin-styled-components/-/typescript-plugin-styled-components-1.5.0.tgz#39d345102a236e304a4e9a37c7b1c8a752a46072"

--- a/yarn.lock
+++ b/yarn.lock
@@ -13072,11 +13072,6 @@ typedarray@^0.0.6:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typesafe-actions@^5.1.0:
-  version "5.1.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/typesafe-actions/-/typesafe-actions-5.1.0.tgz#9afe8b1e6a323af1fd59e6a57b11b7dd6623d2f1"
-  integrity sha1-mv6LHmoyOvH9WealexG33WYj0vE=
-
 typescript-plugin-styled-components@^1.5.0:
   version "1.5.0"
   resolved "https://neo.jfrog.io/neo/api/npm/npm/typescript-plugin-styled-components/-/typescript-plugin-styled-components-1.5.0.tgz#39d345102a236e304a4e9a37c7b1c8a752a46072"


### PR DESCRIPTION
Following #1607 , this PR continues code cleanup:
- [x] Consolidate `GuideItem` and `Guide` interface.
- [x] Include `identifier` to built-in guides. (https://github.com/neo4j/neo4j-browser/pull/1594#discussion_r750345119, https://github.com/neo4j/neo4j-browser/pull/1594#discussion_r750349801)
- [x] Clean up `TSlint` complain with `getResolverHelper`.
- [x] Make RxJS Epic type-safe. (https://github.com/neo4j/neo4j-browser/pull/1594#discussion_r750465038)