### PR TITLE
Color for * nodes sometimes not updated in property details

### DIFF
--- a/e2e_tests/integration/viz.spec.ts
+++ b/e2e_tests/integration/viz.spec.ts
@@ -44,4 +44,32 @@ describe('Viz rendering', () => {
     )
     cy.executeCommand('MATCH (a:TestLabel) DETACH DELETE a')
   })
+  it('can change default color of nodes', () => {
+    const selectorNodeLabelAll =
+      '[data-testid="property-details-overview-node-label-*"]'
+    const defaultColor = 'rgb(165, 171, 182)'
+    const orangeColor = 'rgb(247, 151, 103)'
+    cy.executeCommand(':clear')
+    cy.executeCommand(':style reset')
+    cy.executeCommand(
+      'CREATE (a:TestLabel)-[:CONNECTS]->(b:TestLabel) RETURN a, b'
+    )
+    // Check that default color is set
+    cy.get(selectorNodeLabelAll, { timeout: 5000 }).should(
+      'have.css',
+      'background-color',
+      defaultColor
+    )
+
+    // Change color and make sure color is changed
+    cy.get(selectorNodeLabelAll, { timeout: 5000 }).click()
+    cy.get('[data-testid="select-color-2"]').click()
+    cy.get('[data-testid="vizInspector"]') // Close grass editor
+
+    cy.get(selectorNodeLabelAll, { timeout: 5000 }).should(
+      'have.css',
+      'background-color',
+      orangeColor
+    )
+  })
 })

--- a/src/browser/modules/D3Visualization/components/GrassEditor.tsx
+++ b/src/browser/modules/D3Visualization/components/GrassEditor.tsx
@@ -78,6 +78,7 @@ export class GrassEditorComponent extends Component<GrassEditorProps> {
   }
 
   circleSelector(
+    type: 'color' | 'size',
     styleProps: any,
     styleProvider: any,
     activeProvider: any,
@@ -98,6 +99,7 @@ export class GrassEditorComponent extends Component<GrassEditorProps> {
         <StyledPickerListItem
           className={className}
           key={toKeyString('circle' + i)}
+          data-testid={`select-${type}-${i}`}
         >
           <StyledCircleSelector
             className={active ? 'active' : ''}
@@ -117,6 +119,7 @@ export class GrassEditorComponent extends Component<GrassEditorProps> {
         <StyledInlineList>
           <StyledInlineListItem>Color:</StyledInlineListItem>
           {this.circleSelector(
+            'color',
             this.graphStyle.defaultColors(),
             (color: any) => {
               return { backgroundColor: color.color }
@@ -138,6 +141,7 @@ export class GrassEditorComponent extends Component<GrassEditorProps> {
         <StyledInlineList data-testid="size-picker">
           <StyledInlineListItem>Size:</StyledInlineListItem>
           {this.circleSelector(
+            'size',
             this.graphStyle.defaultSizes(),
             (_size: any, index: any) => {
               return {

--- a/src/browser/modules/D3Visualization/components/StyleableNodeLabel.tsx
+++ b/src/browser/modules/D3Visualization/components/StyleableNodeLabel.tsx
@@ -40,8 +40,9 @@ export function StyleableNodeLabel({
   selectedLabel,
   onClick
 }: StyleableNodeLabelProps): JSX.Element {
+  const labels = selectedLabel.label === '*' ? [] : [selectedLabel.label]
   const graphStyleForLabel = graphStyle.forNode({
-    labels: [selectedLabel.label]
+    labels: labels
   })
 
   return (

--- a/src/browser/modules/D3Visualization/components/StyleableNodeLabel.tsx
+++ b/src/browser/modules/D3Visualization/components/StyleableNodeLabel.tsx
@@ -58,6 +58,7 @@ export function StyleableNodeLabel({
             backgroundColor: graphStyleForLabel.get('color'),
             color: graphStyleForLabel.get('text-color-internal')
           }}
+          data-testid={`property-details-overview-node-label-${selectedLabel.label}`}
         >
           {selectedLabel.count !== undefined
             ? `${selectedLabel.label} (${selectedLabel.count})`

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
@@ -140,12 +140,14 @@ exports[`Visualization renders with result and escapes any HTML 1`] = `
               >
                 <div
                   class="sc-RefOD sc-iQKALj dCvzLq"
+                  data-testid="property-details-overview-node-label-*"
                   style="background-color: rgb(165, 171, 182); color: rgb(255, 255, 255);"
                 >
                   * (1)
                 </div>
                 <div
                   class="sc-RefOD sc-iQKALj dCvzLq"
+                  data-testid="property-details-overview-node-label-Person"
                   style="background-color: rgb(201, 144, 192); color: rgb(255, 255, 255);"
                 >
                   Person (1)

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
@@ -140,7 +140,7 @@ exports[`Visualization renders with result and escapes any HTML 1`] = `
               >
                 <div
                   class="sc-RefOD sc-iQKALj dCvzLq"
-                  style="background-color: rgb(247, 151, 103); color: rgb(255, 255, 255);"
+                  style="background-color: rgb(165, 171, 182); color: rgb(255, 255, 255);"
                 >
                   * (1)
                 </div>


### PR DESCRIPTION
In property details the color of * are sometimes not updated when changing color, while it updates correctly in the sidebar.

![image](https://user-images.githubusercontent.com/11065688/144605648-1f308573-12c2-416b-8648-a9f55dae6e4a.png)

Steps to reproduce bug:
1. Do a style reset with command: ":style reset"
2. fetch not all but one or some nodes, for example: MATCH (n:Person_0) RETURN n LIMIT 25 (then after that first fetch of some, if fetching all after that it still not works, but if fetch all first after a style reset it is working)
3. then try to change color of * in node properties, the color is not updated in the property details view.
<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

