### PR TITLE
Improve performance of queries that return lots of nodes

### DIFF
--- a/src/browser/modules/D3Visualization/components/Explorer.tsx
+++ b/src/browser/modules/D3Visualization/components/Explorer.tsx
@@ -43,15 +43,15 @@ import { Action, Dispatch } from 'redux'
 const deduplicateNodes = (nodes: any) => {
   return nodes.reduce(
     (all: any, curr: any) => {
-      if (all.taken.indexOf(curr.id) > -1) {
+      if (all.taken[curr.id]) {
         return all
       } else {
         all.nodes.push(curr)
-        all.taken.push(curr.id)
+        all.taken[curr.id] = true
         return all
       }
     },
-    { nodes: [], taken: [] }
+    { nodes: [], taken: {} }
   ).nodes
 }
 


### PR DESCRIPTION
This change should improve the rendering time for query results that contain lots of nodes. I used the following query throughout my tests:

```cypher
WITH range(1,100000) as range 
UNWIND range as item 
CREATE (n:Stuff {iter: item}) 
RETURN n
```

and measured:

1. The time it takes from dispatching the `requests/SENT` to the `requests/UPDATED` actions in Redux. 
2. The time it takes to execute some snippets/functions that could be potential bottlenecks. 

### Before

1. **36.42s**

2. - **1ms** - commandInterpreterHelper.ts - exec - handleCypherCommand
   - **525ms** - boltWorker.ts - onmessage - cypherResponseMessage
   - **636ms** - setup-bolt-worker.ts - setupBoltWorker - addTypesAsField
   - **1ms** - boltWorker.ts - onmessage - cypherResponseMessage
   - **43790ms** - commandInterpreterHelp.ts - exec - updateQueryResult


### After

1. **03.60s**

2. - **4ms** - commandInterpreterHelper.ts - exec - handleCypherCommand
   - **517ms** - boltWorker.ts - onmessage - cypherResponseMessage
   - **295ms** - setup-bolt-worker.ts - setupBoltWorker - addTypesAsField
   - **0ms** - boltWorker.ts - onmessage - cypherResponseMessage
   - **944ms** - commandInterpreterHelp.ts - exec - updateQueryResult

### Notes

The time measurements can vary quite a lot between different runs, but even if they're not precise they can give an idea of the impact of each potential bottleneck.

Further improvements in this area could be achieved by optimizing the serialization of the results between the worker and main threads (eg. using shared memory), or the visualization/state management (more investigation would be needed for improving the visualization though). 