### PR TITLE
Fix hidden type issues causing crashes

### DIFF
--- a/src/browser/modules/D3Visualization/GraphEventHandler.ts
+++ b/src/browser/modules/D3Visualization/GraphEventHandler.ts
@@ -17,14 +17,13 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-import { BasicNode, BasicNodesAndRels } from 'services/bolt/boltMappings'
 import { VizItem } from './components/types'
 import Graph from './lib/visualization/components/Graph'
 import GraphView from './lib/visualization/components/GraphView'
-import VizNode from './lib/visualization/components/Node'
 import Relationship from './lib/visualization/components/Relationship'
-import { mapNodes, mapRelationships, getGraphStats, GraphStats } from './mapper'
+import VizNode from './lib/visualization/components/VizNode'
+import { GraphStats, getGraphStats, mapNodes, mapRelationships } from './mapper'
+import { BasicNode, BasicNodesAndRels } from 'services/bolt/boltMappings'
 
 export type GetNodeNeighboursFn = (
   node: BasicNode | VizNode,
@@ -39,7 +38,7 @@ export class GraphEventHandler {
   onGraphModelChange: (stats: GraphStats) => void
   onItemMouseOver: (item: VizItem) => void
   onItemSelected: (item: VizItem) => void
-  selectedItem: VizItem
+  selectedItem: VizNode | Relationship | null
 
   constructor(
     graph: Graph,
@@ -62,7 +61,7 @@ export class GraphEventHandler {
     this.onGraphModelChange(getGraphStats(this.graph))
   }
 
-  selectItem(item: VizItem): void {
+  selectItem(item: VizNode | Relationship): void {
     if (this.selectedItem) {
       this.selectedItem.selected = false
     }
@@ -94,16 +93,16 @@ export class GraphEventHandler {
     this.graphModelChanged()
   }
 
-  nodeClicked(d: VizNode): void {
-    if (!d) {
+  nodeClicked(node: VizNode): void {
+    if (!node) {
       return
     }
-    d.fixed = true
-    if (!d.selected) {
-      this.selectItem(d)
+    node.fixed = true
+    if (!node.selected) {
+      this.selectItem(node)
       this.onItemSelected({
         type: 'node',
-        item: { id: d.id, labels: d.labels, properties: d.propertyList }
+        item: node
       })
     } else {
       this.deselectItem()
@@ -150,11 +149,7 @@ export class GraphEventHandler {
     if (!node.contextMenu) {
       this.onItemMouseOver({
         type: 'node',
-        item: {
-          id: node.id,
-          labels: node.labels,
-          properties: node.propertyList
-        }
+        item: node
       })
     }
   }
@@ -176,11 +171,7 @@ export class GraphEventHandler {
   onRelationshipMouseOver(relationship: Relationship): void {
     this.onItemMouseOver({
       type: 'relationship',
-      item: {
-        id: relationship.id,
-        type: relationship.type,
-        properties: relationship.propertyList
-      }
+      item: relationship
     })
   }
 
@@ -189,11 +180,7 @@ export class GraphEventHandler {
       this.selectItem(relationship)
       this.onItemSelected({
         type: 'relationship',
-        item: {
-          id: relationship.id,
-          type: relationship.type,
-          properties: relationship.propertyList
-        }
+        item: relationship
       })
     } else {
       this.deselectItem()

--- a/src/browser/modules/D3Visualization/components/DetailsPane.test.tsx
+++ b/src/browser/modules/D3Visualization/components/DetailsPane.test.tsx
@@ -17,24 +17,24 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-import React from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
+import React from 'react'
+
 import {
   DETAILS_PANE_STEP_SIZE,
   DetailsPaneComponent,
   ELLIPSIS,
-  MAX_LENGTH_WIDE,
   MAX_LENGTH_NARROW,
+  MAX_LENGTH_WIDE,
   WIDE_VIEW_THRESHOLD
 } from './DetailsPane'
-import { VizItem, VizNodeProperty } from './types'
+import { VizItem, VizItemProperty } from './types'
 import GraphStyle from 'project-root/src/browser/modules/D3Visualization/graphStyle'
 
 describe('<DetailsPane />', () => {
   const mockGraphStyle = new GraphStyle()
 
-  const getMockProperties: (length: number) => VizNodeProperty[] = length =>
+  const getMockProperties: (length: number) => VizItemProperty[] = length =>
     Array.from({ length: length }).map((_v, index) => {
       return {
         key: `prop${String(index).padStart(String(length).length, '0')}`,
@@ -44,13 +44,13 @@ describe('<DetailsPane />', () => {
     })
 
   type RenderComponentProps = {
-    properties?: VizItem[]
+    propertyList?: VizItemProperty[]
     labels?: string[]
     type?: 'node' | 'relationship'
     width?: number
   }
   const renderComponent = ({
-    properties = [],
+    propertyList = [],
     labels = [],
     type = 'node',
     width = 200
@@ -62,8 +62,8 @@ describe('<DetailsPane />', () => {
           type: type,
           item: {
             id: 'abc',
-            labels: labels,
-            properties: properties
+            labels,
+            propertyList
           }
         }
         break
@@ -72,7 +72,8 @@ describe('<DetailsPane />', () => {
           type: type,
           item: {
             id: 'abc',
-            properties: properties
+            type: 'abc2',
+            propertyList
           }
         }
     }
@@ -86,7 +87,7 @@ describe('<DetailsPane />', () => {
   }
 
   test('should handle show all properties', async () => {
-    renderComponent({ properties: getMockProperties(1001) })
+    renderComponent({ propertyList: getMockProperties(1001) })
 
     expect(screen.getByRole('button', { name: 'Show all' })).toBeInTheDocument()
     expect(
@@ -104,7 +105,7 @@ describe('<DetailsPane />', () => {
   })
 
   test('should handle show more properties', async () => {
-    renderComponent({ properties: getMockProperties(2001) })
+    renderComponent({ propertyList: getMockProperties(2001) })
 
     expect(
       screen.getByRole('button', {
@@ -135,7 +136,7 @@ describe('<DetailsPane />', () => {
       value: fullText
     }
     renderComponent({
-      properties: [mockProperty],
+      propertyList: [mockProperty],
       width: WIDE_VIEW_THRESHOLD - 1
     })
 
@@ -170,7 +171,7 @@ describe('<DetailsPane />', () => {
       value: fullText
     }
     renderComponent({
-      properties: [mockProperty],
+      propertyList: [mockProperty],
       width: WIDE_VIEW_THRESHOLD + 1
     })
 

--- a/src/browser/modules/D3Visualization/components/DetailsPane.tsx
+++ b/src/browser/modules/D3Visualization/components/DetailsPane.tsx
@@ -17,28 +17,27 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 import React, { useState } from 'react'
 
+import ClickableUrls from '../../../components/ClickableUrls'
+import { StyleableNodeLabel } from './StyleableNodeLabel'
+import { StyleableRelType } from './StyleableRelType'
 import {
   AlternatingTable,
   CopyCell,
-  StyledExpandValueButton,
   KeyCell,
   PaneBody,
   PaneHeader,
   PaneTitle,
+  StyledExpandValueButton,
   StyledInlineList,
   ValueCell
 } from './styled'
-import ClickableUrls from '../../../components/ClickableUrls'
+import { NodeItem, RelationshipItem, VizItemProperty } from './types'
 import ClipboardCopier from 'browser-components/ClipboardCopier'
-import { NodeItem, RelationshipItem, VizNodeProperty } from './types'
-import { StyleableNodeLabel } from './StyleableNodeLabel'
-import { StyleableRelType } from './StyleableRelType'
-import { upperFirst } from 'services/utils'
 import { ShowMoreOrAll } from 'browser-components/ShowMoreOrAll/ShowMoreOrAll'
 import { GraphStyle } from 'project-root/src/browser/modules/D3Visualization/graphStyle'
+import { upperFirst } from 'services/utils'
 
 export const ELLIPSIS = '\u2026'
 export const WIDE_VIEW_THRESHOLD = 900
@@ -78,7 +77,7 @@ function ExpandableValue({ value, width, type }: ExpandableValueProps) {
 }
 
 type PropertiesViewProps = {
-  visibleProperties: VizNodeProperty[]
+  visibleProperties: VizItemProperty[]
   onMoreClick: (numMore: number) => void
   totalNumItems: number
   moreStep: number
@@ -147,7 +146,7 @@ export function DetailsPaneComponent({
 
   const allItemProperties = [
     { key: '<id>', value: `${vizItem.item.id}`, type: 'String' },
-    ...vizItem.item.properties
+    ...vizItem.item.propertyList
   ].sort((a, b) => (a.key < b.key ? -1 : 1))
   const visibleItemProperties = allItemProperties.slice(0, maxPropertiesCount)
 
@@ -171,7 +170,7 @@ export function DetailsPaneComponent({
         {vizItem.type === 'relationship' && (
           <StyleableRelType
             selectedRelType={{
-              propertyKeys: vizItem.item.properties.map(p => p.key),
+              propertyKeys: vizItem.item.propertyList.map(p => p.key),
               relType: vizItem.item.type
             }}
             graphStyle={graphStyle}
@@ -185,7 +184,7 @@ export function DetailsPaneComponent({
                 graphStyle={graphStyle}
                 selectedLabel={{
                   label,
-                  propertyKeys: vizItem.item.properties.map(p => p.key)
+                  propertyKeys: vizItem.item.propertyList.map(p => p.key)
                 }}
               />
             )

--- a/src/browser/modules/D3Visualization/components/NodeInspectorPanel.tsx
+++ b/src/browser/modules/D3Visualization/components/NodeInspectorPanel.tsx
@@ -2,16 +2,16 @@ import React, { Component } from 'react'
 import { Resizable } from 'react-resizable'
 import { Icon } from 'semantic-ui-react'
 
-import OverviewPane from './OverviewPane'
-import { DetailsPaneComponent } from './DetailsPane'
 import { GraphStats } from '../mapper'
+import { DetailsPaneComponent } from './DetailsPane'
+import { NodeInspectorDrawer } from './NodeInspectorDrawer'
+import OverviewPane from './OverviewPane'
 import {
   PaneContainer,
   StyledNodeInspectorTopMenuChevron,
   panelMinWidth
 } from './styled'
 import { VizItem } from './types'
-import { NodeInspectorDrawer } from './NodeInspectorDrawer'
 import { GraphStyle } from 'project-root/src/browser/modules/D3Visualization/graphStyle'
 
 interface NodeInspectorPanelProps {

--- a/src/browser/modules/D3Visualization/components/types.d.ts
+++ b/src/browser/modules/D3Visualization/components/types.d.ts
@@ -1,20 +1,18 @@
+import Relationship from '../lib/visualization/components/Relationship'
+import VizNode from '../lib/visualization/components/VizNode'
+
 export type VizItem =
   | NodeItem
   | ContextMenuItem
   | RelationshipItem
   | CanvasItem
   | StatusItem
-  | LegendItem
 
-export type VizNodeProperty = { key: string; value: string; type: string }
+export type VizItemProperty = { key: string; value: string; type: string }
 
 type NodeItem = {
   type: 'node'
-  item: {
-    id: string
-    labels: string[]
-    properties: VizNodeProperty[]
-  }
+  item: Pick<VizNode, 'id' | 'labels' | 'propertyList'>
 }
 
 type ContextMenuItem = {
@@ -33,11 +31,7 @@ type StatusItem = {
 
 type RelationshipItem = {
   type: 'relationship'
-  item: {
-    id: string
-    type: string
-    properties: VizNodeProperty[]
-  }
+  item: Pick<Relationship, 'id' | 'type' | 'propertyList'>
 }
 
 type CanvasItem = {

--- a/src/browser/modules/D3Visualization/lib/visualization/components/Graph.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/Graph.ts
@@ -17,9 +17,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-import VizNode from './Node'
 import Relationship from './Relationship'
+import VizNode from './VizNode'
 
 type NodeMap = Record<string, string[]>
 function uniq<T>(list: T[]): T[] {
@@ -37,9 +36,8 @@ export default class Graph {
     this.addNodes = this.addNodes.bind(this)
     this.removeNode = this.removeNode.bind(this)
     this.updateNode = this.updateNode.bind(this)
-    this.removeConnectedRelationships = this.removeConnectedRelationships.bind(
-      this
-    )
+    this.removeConnectedRelationships =
+      this.removeConnectedRelationships.bind(this)
     this.addRelationships = this.addRelationships.bind(this)
     this.addInternalRelationships = this.addInternalRelationships.bind(this)
     this.pruneInternalRelationships = this.pruneInternalRelationships.bind(this)
@@ -189,7 +187,7 @@ export default class Graph {
       })
   }
 
-  findRelationship(id: string): Relationship {
+  findRelationship(id: string): Relationship | undefined {
     return this.relationshipMap[id]
   }
 

--- a/src/browser/modules/D3Visualization/lib/visualization/components/GraphGeometry.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/GraphGeometry.ts
@@ -17,13 +17,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-import GraphStyle from 'browser/modules/D3Visualization/graphStyle'
 import PairwiseArcsRelationshipRouting from '../utils/pairwiseArcsRelationshipRouting'
 import measureText from '../utils/textMeasurement'
 import Graph from './Graph'
-import VizNode, { NodeCaptionLine } from './Node'
 import Relationship from './Relationship'
+import VizNode, { NodeCaptionLine } from './VizNode'
+import GraphStyle from 'browser/modules/D3Visualization/graphStyle'
 
 export default class GraphGeometry {
   relationshipRouting: PairwiseArcsRelationshipRouting
@@ -133,17 +132,14 @@ const fitCaptionIntoCircle = (
     while (word.length > 2) {
       const newWord = `${word.substring(0, word.length - 2)}\u2026`
       if (measure(newWord) < line.remainingWidth) {
-        return `${line.text
-          .split(' ')
-          .slice(0, -1)
-          .join(' ')} ${newWord}`
+        return `${line.text.split(' ').slice(0, -1).join(' ')} ${newWord}`
       }
       word = word.substring(0, word.length - 1)
     }
     return `${word}\u2026`
   }
 
-  const fitOnFixedNumberOfLines = function(
+  const fitOnFixedNumberOfLines = function (
     lineCount: number
   ): [NodeCaptionLine[], number] {
     const lines = []

--- a/src/browser/modules/D3Visualization/lib/visualization/components/Relationship.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/Relationship.ts
@@ -17,17 +17,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 import ArcArrow from '../utils/ArcArrow'
 import LoopArrow from '../utils/LoopArrow'
 import StraightArrow from '../utils/StraightArrow'
-import Node from './Node'
+import Node from './VizNode'
+import { VizItemProperty } from 'browser/modules/D3Visualization/components/types'
 
 export type RelationShipCaptionLayout = 'internal' | 'external'
-type PropertyItem = { key: string; value: string; originalType: string }
 export default class Relationship {
   id: string
-  propertyList: PropertyItem[]
+  propertyList: VizItemProperty[]
   propertyMap: Record<string, string>
   source: Node
   target: Node
@@ -61,10 +60,8 @@ export default class Relationship {
     this.type = type
     this.propertyMap = properties
     this.propertyList = Object.keys(this.propertyMap || {}).reduce(
-      (acc: PropertyItem[], key) =>
-        acc.concat([
-          { key, originalType: propertyTypes[key], value: properties[key] }
-        ]),
+      (acc: VizItemProperty[], key) =>
+        acc.concat([{ key, type: propertyTypes[key], value: properties[key] }]),
       []
     )
 

--- a/src/browser/modules/D3Visualization/lib/visualization/components/Visualization.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/Visualization.ts
@@ -17,16 +17,16 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 import d3 from 'd3'
-import GraphGeometry from './GraphGeometry'
+
 import * as vizRenderers from '../renders/init'
 import { nodeMenuRenderer } from '../renders/menu'
 import vizClickHandler from '../utils/clickHandler'
-import GraphStyle from 'browser/modules/D3Visualization/graphStyle'
-import VizNode from './Node'
 import Graph from './Graph'
+import GraphGeometry from './GraphGeometry'
+import VizNode from './VizNode'
 import { Layout } from './layout'
+import GraphStyle from 'browser/modules/D3Visualization/graphStyle'
 
 type StatsBucket = {
   frameCount: number
@@ -56,7 +56,7 @@ export type VizObj = {
 }
 
 const noOp = () => undefined
-const vizFn = function(
+const vizFn = function (
   el: SVGElement,
   measureSize: MeasureSizeFn,
   graph: Graph,
@@ -132,7 +132,7 @@ const vizFn = function(
 
   let zoomLevel = null
 
-  const zoomed = function(): any {
+  const zoomed = function (): any {
     draw = true
     return container.attr(
       'transform',
@@ -155,7 +155,7 @@ const vizFn = function(
           translate
         )
         const s = d3.interpolate(zoomBehavior.scale(), scale)
-        return function(a: number) {
+        return function (a: number) {
           zoomBehavior.scale(s(a)).translate(t(a) as [number, number])
           return zoomed()
         }
@@ -163,17 +163,17 @@ const vizFn = function(
 
   let isZoomingIn = true
 
-  viz.zoomInClick = function() {
+  viz.zoomInClick = function () {
     isZoomingIn = true
     return zoomClick(this)
   }
 
-  viz.zoomOutClick = function() {
+  viz.zoomOutClick = function () {
     isZoomingIn = false
     return zoomClick(this)
   }
 
-  const zoomClick = function(_element: any) {
+  const zoomClick = function (_element: any) {
     draw = true
     const limitsReached = { zoomInLimit: false, zoomOutLimit: false }
 
@@ -213,7 +213,7 @@ const vizFn = function(
     .on('wheel.zoom', null as any)
     .on('mousewheel.zoom', null as any)
 
-  const newStatsBucket = function() {
+  const newStatsBucket = function () {
     const bucket: StatsBucket = {
       frameCount: 0,
       geometry: 0,
@@ -225,7 +225,7 @@ const vizFn = function(
       fps: () => ((1000 * bucket.frameCount) / bucket.duration()).toFixed(1),
       lps: () =>
         ((1000 * bucket.layout.layoutSteps) / bucket.duration()).toFixed(1),
-      top: function() {
+      top: function () {
         let time
         const renderers = []
         for (const name in bucket.relationshipRenderers) {
@@ -261,7 +261,7 @@ const vizFn = function(
       ? () => window.performance.now()
       : () => Date.now()
 
-  const render = function() {
+  const render = function () {
     if (!currentStats.firstFrame) {
       currentStats.firstFrame = now()
     }
@@ -283,8 +283,9 @@ const vizFn = function(
       .attr(
         'transform',
         d =>
-          `translate(${d.source.x} ${d.source.y}) rotate(${d.naturalAngle +
-            180})`
+          `translate(${d.source.x} ${d.source.y}) rotate(${
+            d.naturalAngle + 180
+          })`
       )
 
     for (const renderer of vizRenderers.relationship) {
@@ -305,14 +306,14 @@ const vizFn = function(
     // @ts-expect-error ts-migrate(2554) FIXME: Expected 1 arguments, but got 0.
     .on('dragend.node', () => onNodeDragToggle())
 
-  viz.collectStats = function(): StatsBucket {
+  viz.collectStats = function (): StatsBucket {
     const latestStats = currentStats
     latestStats.layout = force.collectStats()
     currentStats = newStatsBucket()
     return latestStats
   }
 
-  viz.update = function(options: {
+  viz.update = function (options: {
     updateNodes: boolean
     updateRelationships: boolean
   }) {
@@ -393,7 +394,7 @@ const vizFn = function(
     return (updateViz = true)
   }
 
-  viz.resize = function() {
+  viz.resize = function () {
     const size = measureSize()
     return root.attr(
       'viewBox',

--- a/src/browser/modules/D3Visualization/lib/visualization/components/VizNode.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/VizNode.ts
@@ -17,8 +17,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 import Graph from './Graph'
+import { VizItemProperty } from 'browser/modules/D3Visualization/components/types'
 
 type NodeProperties = { [key: string]: string }
 export type NodeCaptionLine = {
@@ -31,11 +31,7 @@ export type NodeCaptionLine = {
 export default class VizNode {
   id: string
   labels: string[]
-  propertyList: {
-    key: string
-    type: string
-    value: string
-  }[]
+  propertyList: VizItemProperty[]
   propertyMap: NodeProperties
   isNode = true
   isRelationship = false

--- a/src/browser/modules/D3Visualization/lib/visualization/components/collision.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/collision.ts
@@ -18,7 +18,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import d3 from 'd3'
-import VizNode from './Node'
+
+import VizNode from './VizNode'
 
 type D3MutatedNode = VizNode & d3.layout.force.Node
 const collision = {

--- a/src/browser/modules/D3Visualization/lib/visualization/renders/init.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/renders/init.ts
@@ -17,8 +17,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import VizNode, { NodeCaptionLine } from '../components/Node'
 import Renderer from '../components/Renderer'
+import VizNode, { NodeCaptionLine } from '../components/VizNode'
+
 const noop = () => undefined
 
 const nodeRingStrokeSize = 8
@@ -30,14 +31,10 @@ const nodeOutline = new Renderer({
       .selectAll('circle.outline')
       .data((node: VizNode) => [node])
 
-    circles
-      .enter()
-      .append('circle')
-      .classed('outline', true)
-      .attr({
-        cx: 0,
-        cy: 0
-      })
+    circles.enter().append('circle').classed('outline', true).attr({
+      cx: 0,
+      cy: 0
+    })
 
     circles.attr({
       r(node: VizNode) {
@@ -126,10 +123,7 @@ const arrowPath = new Renderer({
   onGraphChange(selection, viz) {
     const paths = selection.selectAll('path.outline').data((rel: any) => [rel])
 
-    paths
-      .enter()
-      .append('path')
-      .classed('outline', true)
+    paths.enter().append('path').classed('outline', true)
 
     paths
       .attr('fill', (rel: any) => viz.style.forRelationship(rel).get('color'))
@@ -195,10 +189,7 @@ const relationshipOverlay = new Renderer({
   onGraphChange(selection) {
     const rects = selection.selectAll('path.overlay').data(rel => [rel])
 
-    rects
-      .enter()
-      .append('path')
-      .classed('overlay', true)
+    rects.enter().append('path').classed('overlay', true)
 
     return rects.exit().remove()
   },

--- a/src/browser/modules/D3Visualization/lib/visualization/renders/menu.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/renders/menu.ts
@@ -17,18 +17,18 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 import d3 from 'd3'
-import VizNode from '../components/Node'
+
 import Renderer from '../components/Renderer'
 import { VizObj } from '../components/Visualization'
+import VizNode from '../components/VizNode'
 import icons from './d3Icons'
 
 const noOp = () => undefined
 
 const numberOfItemsInContextMenu = 3
 
-const drawArc = function(radius: number, itemNumber: number, width = 30) {
+const drawArc = function (radius: number, itemNumber: number, width = 30) {
   const startAngle =
     ((2 * Math.PI) / numberOfItemsInContextMenu) * (itemNumber - 1)
   const endAngle = startAngle + (2 * Math.PI) / numberOfItemsInContextMenu
@@ -73,7 +73,7 @@ const attachContextEvent = (
   })
 }
 
-const createMenuItem = function(
+const createMenuItem = function (
   selection: d3.Selection<any>,
   viz: VizObj,
   eventType: string,

--- a/src/browser/modules/D3Visualization/lib/visualization/utils/circularLayout.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/utils/circularLayout.ts
@@ -17,8 +17,7 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
-import VizNode from '../components/Node'
+import VizNode from '../components/VizNode'
 
 export default function circularLayout(
   nodes: VizNode[],

--- a/src/browser/modules/D3Visualization/lib/visualization/utils/clickHandler.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/utils/clickHandler.ts
@@ -18,6 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import d3 from 'd3'
+
 // euclidean distance
 const dist = (a: [number, number], b: [number, number]) =>
   Math.sqrt(Math.pow(a[0] - b[0], 2) + Math.pow(a[1] - b[1], 2))
@@ -26,8 +27,8 @@ const dist = (a: [number, number], b: [number, number]) =>
 drag a node, from triggering onclick events 
 */
 export default function clickHandler() {
-  const cc = function(selection: any) {
-    let down: [number, number]
+  const cc = function (selection: any) {
+    let down: [number, number] | undefined
     const tolerance = 5
     let wait: number | null = null
 
@@ -38,7 +39,7 @@ export default function clickHandler() {
     })
 
     return selection.on('mouseup', () => {
-      if (dist(down, d3.mouse(document.body)) > tolerance) {
+      if (down && dist(down, d3.mouse(document.body)) > tolerance) {
       } else {
         if (wait) {
           window.clearTimeout(wait)
@@ -47,7 +48,10 @@ export default function clickHandler() {
         } else {
           event.click((d3.event as any).target.__data__)
           return (wait = window.setTimeout(
-            (_e => () => (wait = null))(d3.event),
+            (
+              _e => () =>
+                (wait = null)
+            )(d3.event),
             250
           ))
         }

--- a/src/browser/modules/D3Visualization/mapper.ts
+++ b/src/browser/modules/D3Visualization/mapper.ts
@@ -17,12 +17,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+import Graph from './lib/visualization/components/Graph'
+import Relationship from './lib/visualization/components/Relationship'
+import VizNode from './lib/visualization/components/VizNode'
 import { BasicNode, BasicRelationship } from 'services/bolt/boltMappings'
 import { optionalToString } from 'services/utils'
-import Graph from './lib/visualization/components/Graph'
-import VizNode from './lib/visualization/components/Node'
-import Relationship from './lib/visualization/components/Relationship'
 
 const mapProperties = (_: any) => Object.assign({}, ...stringifyValues(_))
 const stringifyValues = (obj: any) =>

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
@@ -132,14 +132,14 @@ exports[`Visualization renders with result and escapes any HTML 1`] = `
                 class="sc-htpNat sc-dnqmqq OaEcl"
               >
                 <div
-                  class="sc-RefOD sc-iQKALj dCvzLq"
+                  class="sc-eHgmQL sc-cvbbAY gubsiZ"
                   data-testid="property-details-overview-node-label-*"
                   style="background-color: rgb(165, 171, 182); color: rgb(255, 255, 255);"
                 >
                   * (1)
                 </div>
                 <div
-                  class="sc-RefOD sc-iQKALj dCvzLq"
+                  class="sc-eHgmQL sc-cvbbAY gubsiZ"
                   data-testid="property-details-overview-node-label-Person"
                   style="background-color: rgb(201, 144, 192); color: rgb(255, 255, 255);"
                 >


### PR DESCRIPTION
One of the types that made up the `VizItem` type was not defined, which in turn made the `VizItem` type `any` which is fixed in this pr. 

There was also a bug where some relationships with only one node were not removed, which I've also fixed.
I've also renamed the Node.ts file to match the class it's containing "VizNode" 