### PR TITLE
Show hint about :auto on CALL {...} IN TRANSACTIONS

### DIFF
--- a/e2e_tests/integration/auto-prefix.spec.ts
+++ b/e2e_tests/integration/auto-prefix.spec.ts
@@ -36,13 +36,14 @@ describe(':auto prefix in browser', () => {
 
   it('adding :auto enables running periodic commit', () => {
     cy.executeCommand(':auto USING PERIODIC COMMIT RETURN "Laverre";')
-    cy.getFrames().contains('"Laverre"')
+    cy.getFrames().contains('ERROR')
+    cy.getFrames().contains('expected "LOAD"')
   })
 
   if (Cypress.config('serverVersion') >= 4.4) {
     it('shows help link when running CALL IN TRANSACTIONS without :auto', () => {
       cy.executeCommand(
-        'CALL { return "Dendemille" } IN TRANSACTIONS return "Dendemille";'
+        'CALL {{} return "Dendemille" } IN TRANSACTIONS return "Dendemille";'
       )
       cy.getFrames().contains('ERROR')
       cy.getFrames().contains(':auto')
@@ -50,8 +51,9 @@ describe(':auto prefix in browser', () => {
 
     it('adding :auto enables running CALL IN TRANSACTIONS', () => {
       cy.executeCommand(
-        'CALL { return "Undella" } IN TRANSACTIONS return "Undella";'
+        ':auto CALL {{} return "Undella" } IN TRANSACTIONS return "Undella";'
       )
+      cy.getFrames().should('not.contain', 'ERROR')
       cy.getFrames().contains('"Undella"')
     })
   }

--- a/e2e_tests/integration/auto-prefix.spec.ts
+++ b/e2e_tests/integration/auto-prefix.spec.ts
@@ -36,6 +36,8 @@ describe(':auto prefix in browser', () => {
 
   it('adding :auto enables running periodic commit', () => {
     cy.executeCommand(':auto USING PERIODIC COMMIT RETURN "Laverre";')
+    // the only valid PERIODIC COMMIT queries require csv files on
+    // the server, so as a shortcut we're just looking for a new error message
     cy.getFrames().contains('ERROR')
     cy.getFrames().contains(/LOAD/i)
   })

--- a/e2e_tests/integration/auto-prefix.spec.ts
+++ b/e2e_tests/integration/auto-prefix.spec.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2002-2021 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+describe(':auto prefix in browser', () => {
+  before(() => {
+    cy.visit(Cypress.config('url')).title().should('include', 'Neo4j Browser')
+    cy.wait(3000)
+    cy.ensureConnection()
+  })
+  beforeEach(() => {
+    cy.executeCommand(':clear')
+  })
+
+  it('shows help link when running period commit without :auto', () => {
+    cy.executeCommand('USING PERIODIC COMMIT RETURN "Verdanturf"')
+    cy.getFrames().contains('ERROR')
+    cy.getFrames().contains(':auto')
+  })
+
+  it('adding :auto enables running periodic commit', () => {
+    cy.executeCommand(':auto USING PERIODIC COMMIT RETURN "Laverre";')
+    cy.getFrames().contains('"Laverre"')
+  })
+
+  if (Cypress.config('serverVersion') >= 4.4) {
+    it('shows help link when running CALL IN TRANSACTIONS without :auto', () => {
+      cy.executeCommand(
+        'CALL { return "Dendemille" } IN TRANSACTIONS return "Dendemille";'
+      )
+      cy.getFrames().contains('ERROR')
+      cy.getFrames().contains(':auto')
+    })
+
+    it('adding :auto enables running CALL IN TRANSACTIONS', () => {
+      cy.executeCommand(
+        'CALL { return "Undella" } IN TRANSACTIONS return "Undella";'
+      )
+      cy.getFrames().contains('"Undella"')
+    })
+  }
+
+  it('can use :auto command in multi-statements', () => {
+    cy.executeCommand('create ();')
+    cy.executeCommand(':clear')
+    const query = `:auto CREATE (t:MultiStmtTest {{}name: "Pacifidlog"}) RETURN t;:auto CREATE (t:MultiStmtTest {{}name: "Wyndon"}) RETURN t;`
+    cy.executeCommand(query)
+    cy.get('[data-testid="frame"]', { timeout: 10000 }).should('have.length', 1)
+    const frame = cy.get('[data-testid="frame"]', { timeout: 10000 }).first()
+    frame.find('[data-testid="multi-statement-list"]').should('have.length', 1)
+    frame
+      .get('[data-testid="multi-statement-list-title"]')
+      .should('have.length', 2)
+    frame.get('[data-testid="multi-statement-list-title"]').eq(0).click()
+    frame
+      .get('[data-testid="multi-statement-list-content"]', { timeout: 10000 })
+      .contains('SUCCESS')
+    frame.get('[data-testid="multi-statement-list-title"]').eq(1).click()
+    frame
+      .get('[data-testid="multi-statement-list-content"]', { timeout: 10000 })
+      .contains('SUCCESS')
+    cy.executeCommand('match (n: MultiStmtTest) return n.name')
+    cy.get('[role="cell"]').contains('Pacifidlog')
+    cy.get('[role="cell"]').contains('Wyndon')
+    cy.executeCommand('match (n: MultiStmtTest) delete n')
+  })
+})

--- a/e2e_tests/integration/auto-prefix.spec.ts
+++ b/e2e_tests/integration/auto-prefix.spec.ts
@@ -37,7 +37,7 @@ describe(':auto prefix in browser', () => {
   it('adding :auto enables running periodic commit', () => {
     cy.executeCommand(':auto USING PERIODIC COMMIT RETURN "Laverre";')
     cy.getFrames().contains('ERROR')
-    cy.getFrames().contains(/LOAD/)
+    cy.getFrames().contains(/LOAD/i)
   })
 
   if (Cypress.config('serverVersion') >= 4.4) {

--- a/e2e_tests/integration/auto-prefix.spec.ts
+++ b/e2e_tests/integration/auto-prefix.spec.ts
@@ -37,7 +37,7 @@ describe(':auto prefix in browser', () => {
   it('adding :auto enables running periodic commit', () => {
     cy.executeCommand(':auto USING PERIODIC COMMIT RETURN "Laverre";')
     cy.getFrames().contains('ERROR')
-    cy.getFrames().contains('expected "LOAD"')
+    cy.getFrames().contains('LOAD')
   })
 
   if (Cypress.config('serverVersion') >= 4.4) {

--- a/e2e_tests/integration/auto-prefix.spec.ts
+++ b/e2e_tests/integration/auto-prefix.spec.ts
@@ -37,7 +37,7 @@ describe(':auto prefix in browser', () => {
   it('adding :auto enables running periodic commit', () => {
     cy.executeCommand(':auto USING PERIODIC COMMIT RETURN "Laverre";')
     cy.getFrames().contains('ERROR')
-    cy.getFrames().contains('LOAD')
+    cy.getFrames().contains(/LOAD/)
   })
 
   if (Cypress.config('serverVersion') >= 4.4) {

--- a/e2e_tests/integration/multistatements.spec.ts
+++ b/e2e_tests/integration/multistatements.spec.ts
@@ -17,7 +17,6 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 import { isEnterpriseEdition } from '../support/utils'
 
 /* global Cypress, cy, before, after */
@@ -26,9 +25,7 @@ describe('Multi statements', () => {
   const validQuery = 'RETURN 1; :config; RETURN 2;'
 
   before(() => {
-    cy.visit(Cypress.config('url'))
-      .title()
-      .should('include', 'Neo4j Browser')
+    cy.visit(Cypress.config('url')).title().should('include', 'Neo4j Browser')
     cy.wait(3000)
     cy.enableMultiStatement()
   })
@@ -115,38 +112,6 @@ describe('Multi statements', () => {
       .first()
       .should('contain', 'ERROR')
   })
-
-  it('can use :auto command in multi-statements', () => {
-    cy.executeCommand('create ();')
-    cy.executeCommand(':clear')
-    const query = `:auto CREATE (t:MultiStmtTest {{}name: "Pacifidlog"}) RETURN t;:auto CREATE (t:MultiStmtTest {{}name: "Wyndon"}) RETURN t;`
-    cy.executeCommand(query)
-    cy.get('[data-testid="frame"]', { timeout: 10000 }).should('have.length', 1)
-    const frame = cy.get('[data-testid="frame"]', { timeout: 10000 }).first()
-    frame.find('[data-testid="multi-statement-list"]').should('have.length', 1)
-    frame
-      .get('[data-testid="multi-statement-list-title"]')
-      .should('have.length', 2)
-    frame
-      .get('[data-testid="multi-statement-list-title"]')
-      .eq(0)
-      .click()
-    frame
-      .get('[data-testid="multi-statement-list-content"]', { timeout: 10000 })
-      .contains('SUCCESS')
-    frame
-      .get('[data-testid="multi-statement-list-title"]')
-      .eq(1)
-      .click()
-    frame
-      .get('[data-testid="multi-statement-list-content"]', { timeout: 10000 })
-      .contains('SUCCESS')
-    cy.executeCommand('match (n: MultiStmtTest) return n.name')
-    cy.get('[role="cell"]').contains('Pacifidlog')
-    cy.get('[role="cell"]').contains('Wyndon')
-    cy.executeCommand('match (n: MultiStmtTest) delete n')
-  })
-
   if (Cypress.config('serverVersion') >= 4.0) {
     if (isEnterpriseEdition()) {
       it('Can use :use command in multi-statements', () => {

--- a/e2e_tests/support/commands.ts
+++ b/e2e_tests/support/commands.ts
@@ -29,13 +29,9 @@ Cypress.Commands.add(
     cy.title().should('include', 'Neo4j Browser')
     cy.wait(3000)
 
-    cy.get('input[data-testid="boltaddress"]')
-      .clear()
-      .type(boltUrl)
+    cy.get('input[data-testid="boltaddress"]').clear().type(boltUrl)
 
-    cy.get('input[data-testid="username"]')
-      .clear()
-      .type(username)
+    cy.get('input[data-testid="username"]').clear().type(username)
     cy.get('input[data-testid="password"]').type(initialPassword)
 
     cy.get('button[data-testid="connect"]').click()
@@ -71,16 +67,10 @@ Cypress.Commands.add(
     cy.executeCommand(':clear')
     cy.executeCommand(':server connect')
 
-    cy.get('input[data-testid="boltaddress"]')
-      .clear()
-      .type(boltUrl)
+    cy.get('input[data-testid="boltaddress"]').clear().type(boltUrl)
 
-    cy.get('input[data-testid="username"]')
-      .clear()
-      .type(username)
-    cy.get('input[data-testid="password"]')
-      .clear()
-      .type(password)
+    cy.get('input[data-testid="username"]').clear().type(username)
+    cy.get('input[data-testid="password"]').clear().type(password)
 
     cy.get('button[data-testid="connect"]').click()
     if (makeAssertions) {
@@ -133,9 +123,7 @@ Cypress.Commands.add('resultContains', str => {
 Cypress.Commands.add('addUser', (userName, password, role, force) => {
   cy.get('[id*=username]')
   cy.get('[id*=username]').type(userName)
-  cy.get('[id*=password]')
-    .first()
-    .type(password)
+  cy.get('[id*=password]').first().type(password)
   cy.get('[id*=password-confirm]').type(password)
   cy.get('[id*=roles-selector]').select(role)
   if (force === true) {
@@ -188,3 +176,14 @@ Cypress.Commands.add('dropUser', username => {
     cy.executeCommand(':clear')
   }
 })
+
+Cypress.Commands.add(
+  'ensureConnection',
+  (creds = { username: 'neo4j', password: Cypress.config('password') }) => {
+    cy.contains('Database access not available').then(res => {
+      if (res) {
+        cy.connect(creds.username, creds.password)
+      }
+    })
+  }
+)

--- a/e2e_tests/support/global.d.ts
+++ b/e2e_tests/support/global.d.ts
@@ -14,6 +14,13 @@ declare global {
         makeAssertions?: boolean
       ): Cypress.Chainable<void>
       /**
+       * Custom command to run cy.connect if needed
+       */
+      ensureConnection(creds?: {
+        username: string
+        password: string
+      }): Cypress.Chainable<void>
+      /**
        * Custom command to disconnect from neo4j database
        */
       disconnect(): Cypress.Chainable<void>

--- a/src/browser/documentation/help/auto.tsx
+++ b/src/browser/documentation/help/auto.tsx
@@ -31,7 +31,8 @@ const content = (
       clusters.
       <br />
       Some query types do however need to be sent in auto-committing
-      transactions, <code>USING PERIODIC COMMIT</code> is the most notable one.
+      transactions, <code>CALL {'{...}'} IN TRANSACTIONS </code> is the most
+      notable one.
     </p>
     <table className="table-condensed table-help">
       <tbody>
@@ -47,8 +48,11 @@ const content = (
     </table>
     <section className="example">
       <figure>
-        <pre>{`:auto USING PERIODIC COMMIT
-LOAD CSV WITH HEADER FROM ... `}</pre>
+        <pre>{`:auto LOAD CSV FROM 'file:///artists.csv' AS line
+CALL {
+  WITH line
+  CREATE (:Artist {name: line[1], year: toInteger(line[2])})
+} IN TRANSACTIONS`}</pre>
         <figcaption>
           Example usage of the <em>:auto</em> command.
         </figcaption>

--- a/src/browser/modules/Stream/CypherFrame/ErrorsView.tsx
+++ b/src/browser/modules/Stream/CypherFrame/ErrorsView.tsx
@@ -39,8 +39,8 @@ import {
   PlayIcon
 } from 'browser-components/icons/Icons'
 import {
+  isImplicitTransactionError,
   isNoDbAccessError,
-  isPeriodicCommitError,
   isUnknownProcedureError
 } from 'services/cypherErrorsHelper'
 import { deepEquals } from 'services/utils'
@@ -93,7 +93,7 @@ export class ErrorsView extends Component<any> {
               </StyledLink>
             </StyledLinkContainer>
           )}
-          {isPeriodicCommitError(error) && (
+          {isImplicitTransactionError(error) && (
             <StyledLinkContainer>
               <StyledLink onClick={() => onItemClick(bus, `:help auto`)}>
                 <PlayIcon />

--- a/src/shared/services/cypherErrorsHelper.ts
+++ b/src/shared/services/cypherErrorsHelper.ts
@@ -5,6 +5,16 @@ export const isNoDbAccessError = ({ code, message }: any) =>
   code === 'Neo.ClientError.Security.Forbidden' &&
   /Database access is not allowed/i.test(message)
 
-export const isPeriodicCommitError = ({ code, message }: any) =>
+const isCallInTransactionError = ({ code, message }: any) =>
+  code === 'Neo.DatabaseError.Statement.ExecutionFailed' &&
+  /in an implicit transaction/.test(message)
+
+const isPeriodicCommitError = ({ code, message }: any) =>
   code === 'Neo.ClientError.Statement.SemanticError' &&
-  /in an open transaction is not possible/i.test(message)
+  [
+    /in an open transaction is not possible/i,
+    /tried to execute in an explicit transaction/i
+  ].some(reg => reg.test(message))
+
+export const isImplicitTransactionError = (error: any) =>
+  isPeriodicCommitError(error) || isCallInTransactionError(error)


### PR DESCRIPTION
We do a few regex checks on error messages to see if the error was caused by a missing `:auto` prefix, if so we add a hint to the error message.

This PR adds a check for if the error is the new `CALL IN {} TRANSACTIONS` which needs :auto and updates the check for `PERIODIC COMMIT` (that has the new error message`"A query with 'PERIODIC COMMIT' can only be executed in an implicit transaction but tried to execute in an explicit transaction."`).

I also add a few tests to verify the behaviour, updated the `:help auto` to use the new syntax and added a helper method to cypress for faster tests.

![CleanShot 2022-01-10 at 14 41 32](https://user-images.githubusercontent.com/10564538/148775879-934a0e0d-655b-4604-ad22-ea843b66e7c4.png)

URL for testing: update_warning.surge.sh
Do note that a 4.4 db is needed.