### PR TITLE
Visualization: tweak interaction and positioning of nodes

### DIFF
--- a/src/browser/modules/D3Visualization/GraphEventHandler.ts
+++ b/src/browser/modules/D3Visualization/GraphEventHandler.ts
@@ -105,6 +105,8 @@ export class GraphEventHandler {
     if (!node) {
       return
     }
+    node.fx = node.x
+    node.fy = node.y
     if (!node.selected) {
       this.selectItem(node)
       this.onItemSelected({

--- a/src/browser/modules/D3Visualization/lib/visualization/components/Visualization.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/Visualization.ts
@@ -284,7 +284,7 @@ const vizFn = function (
     function dragHandler(simulation: Simulation<VizNode, Relationship>) {
       function dragstarted(event: D3DragEvent<SVGGElement, VizNode, any>) {
         clearSimulationTimeout()
-        if (!event.active) simulation.alphaTarget(0.3).restart()
+        if (!event.active) simulation.alphaTarget(0.3).alpha(1).restart()
       }
 
       function dragged(event: D3DragEvent<SVGGElement, VizNode, any>) {

--- a/src/browser/modules/D3Visualization/lib/visualization/components/Visualization.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/Visualization.ts
@@ -118,11 +118,23 @@ const vizFn = function (
     return viz.trigger('relationshipClicked', relationship)
   }
 
-  const onNodeMouseOver = (_event: Event, node: VizNode) =>
-    viz.trigger('nodeMouseOver', node)
+  const onNodeMouseOver = (_event: Event, node: VizNode) => {
+    if (!node.fx && !node.fy) {
+      node.hoverFixed = true
+      node.fx = node.x
+      node.fy = node.y
+    }
+    return viz.trigger('nodeMouseOver', node)
+  }
 
-  const onNodeMouseOut = (_event: Event, node: VizNode) =>
-    viz.trigger('nodeMouseOut', node)
+  const onNodeMouseOut = (_event: Event, node: VizNode) => {
+    if (node.hoverFixed) {
+      node.hoverFixed = false
+      node.fx = null
+      node.fy = null
+    }
+    return viz.trigger('nodeMouseOut', node)
+  }
 
   const onRelMouseOver = (_event: Event, rel: Relationship) =>
     viz.trigger('relMouseOver', rel)

--- a/src/browser/modules/D3Visualization/lib/visualization/components/VizNode.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/VizNode.ts
@@ -48,6 +48,7 @@ export default class VizNode {
   y: number
   fx: number | null = null
   fy: number | null = null
+  hoverFixed: boolean
   initialPositionCalculated: boolean
 
   constructor(
@@ -73,6 +74,7 @@ export default class VizNode {
     this.minified = false
     this.x = 0
     this.y = 0
+    this.hoverFixed = false
     this.initialPositionCalculated = false
   }
 

--- a/src/browser/modules/D3Visualization/lib/visualization/components/layout.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/layout.ts
@@ -71,8 +71,11 @@ const layout: AvailableLayouts = {
         )
 
       const simulation = forceSimulation<VizNode, Relationship>()
-        .force('charge', forceManyBody().strength(-300))
-        .on('tick', () => render())
+        .force('charge', forceManyBody().strength(-400))
+        .on('tick', () => {
+          simulation.tick(10)
+          render()
+        })
         .stop()
 
       const update = function (


### PR DESCRIPTION
Add some tweaks to get the updated visualization to behave closer to the older version:

- Lock nodes on hover and unlock them on mouse leave.  
- Increase the strength of the force repelling nodes.
- Accelerate simulation by running multiple ticks between each render (the difference here can mainly be seen when dragging nodes, the neighboring nodes follow more quickly than before). 