### PR TITLE
Prevent simulation running when entering/leaving frame fullscreen

### DIFF
--- a/src/browser/modules/D3Visualization/components/Graph.tsx
+++ b/src/browser/modules/D3Visualization/components/Graph.tsx
@@ -158,11 +158,6 @@ export class GraphComponent extends Component<GraphProps, GraphState> {
     }
     if (this.props.isFullscreen !== prevProps.isFullscreen) {
       this.graphView?.resize()
-      this.graphView?.update({
-        updateNodes: true,
-        updateRelationships: true,
-        precompute: true
-      })
     }
   }
 


### PR DESCRIPTION
It looks wierd that when entering and leaving frame fullscreen the nodes jumps to new positions (because the simulation is run and updated), prevent that by only calling resize.

<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

