### PR TITLE
Cleanup of svg dimensions

### DIFF
--- a/src/browser/modules/D3Visualization/components/Graph.tsx
+++ b/src/browser/modules/D3Visualization/components/Graph.tsx
@@ -106,7 +106,7 @@ export class GraphComponent extends Component<GraphProps, GraphState> {
     if (!this.graphView) {
       const NeoConstructor = GraphView
       const measureSize = () => ({
-        width: this.svgElement.offsetWidth,
+        width: this.svgElement?.parentElement.clientWidth,
         height: this.svgElement?.parentElement.clientHeight
       })
       this.graph = createGraph(this.props.nodes, this.props.relationships)

--- a/src/browser/modules/D3Visualization/lib/visualization/components/Visualization.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/Visualization.ts
@@ -80,11 +80,11 @@ const vizFn = function (
     .append('rect')
     .style('fill', 'none')
     .style('pointer-events', 'all')
-    // Make the rect cover the whole surface
-    .attr('x', '-2500')
-    .attr('y', '-2500')
-    .attr('width', '5000')
-    .attr('height', '5000')
+    // Make the rect cover the whole surface, center of the svg viewbox is in (0,0)
+    .attr('x', () => -Math.floor(measureSize().width / 2))
+    .attr('y', () => -Math.floor(measureSize().height / 2))
+    .attr('width', '100%')
+    .attr('height', '100%')
     .attr('transform', 'scale(1)')
 
   const container = baseGroup.append('g')
@@ -93,10 +93,6 @@ const vizFn = function (
   // This flags that a panning is ongoing and won't trigger
   // 'canvasClick' event when panning ends.
   let draw = false
-
-  // Arbitrary dimension used to keep force layout aligned with
-  // the centre of the svg view-port.
-  const layoutDimension = 200
 
   let updateViz = true
   let isZoomClick = false
@@ -325,11 +321,7 @@ const vizFn = function (
     }
 
     if (updateViz) {
-      force.update(
-        graph,
-        [layoutDimension, layoutDimension],
-        options.precompute
-      )
+      force.update(graph, options.precompute)
 
       viz.resize()
       viz.trigger('updated')
@@ -340,12 +332,15 @@ const vizFn = function (
 
   viz.resize = function () {
     const size = measureSize()
-    return root.attr(
+    rect
+      .attr('x', () => -Math.floor(size.width / 2))
+      .attr('y', () => -Math.floor(size.height / 2))
+    root.attr(
       'viewBox',
       [
-        0,
-        (layoutDimension - size.height) / 2,
-        layoutDimension,
+        -Math.floor(size.width / 2),
+        -Math.floor(size.height / 2),
+        size.width,
         size.height
       ].join(' ')
     )

--- a/src/browser/modules/D3Visualization/lib/visualization/components/layout.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/layout.ts
@@ -35,11 +35,7 @@ import Relationship from './Relationship'
 import VizNode from './VizNode'
 
 type ForceLayout = {
-  update: (
-    graph: Graph,
-    size: [number, number],
-    animate?: boolean
-  ) => Simulation<VizNode, Relationship>
+  update: (graph: Graph, animate?: boolean) => Simulation<VizNode, Relationship>
   simulation: Simulation<VizNode, Relationship>
 }
 export type Layout = { init: (render: () => void) => ForceLayout }
@@ -78,19 +74,15 @@ const layout: AvailableLayouts = {
         })
         .stop()
 
-      const update = function (
-        graph: Graph,
-        size: [number, number],
-        precompute = false
-      ) {
+      const update = function (graph: Graph, precompute = false) {
         clearSimulationTimeout()
         const nodes = cloneArray(graph.nodes())
         const relationships = oneRelationshipPerPairOfNodes(graph)
 
         const radius = (nodes.length * linkDistance) / (Math.PI * 2)
         const center = {
-          x: size[0] / 2,
-          y: size[1] / 2
+          x: 0,
+          y: 0
         }
         circularLayout(nodes, center, radius)
 

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
@@ -16,18 +16,18 @@ exports[`Visualization renders with result and escapes any HTML 1`] = `
       >
         <svg
           class="neod3viz"
-          viewBox="0 100 200 0"
+          viewBox="0 0 0 0"
         >
           <g
             transform="translate(0,0)"
           >
             <rect
-              height="5000"
+              height="100%"
               style="fill: none; pointer-events: all;"
               transform="scale(1)"
-              width="5000"
-              x="-2500"
-              y="-2500"
+              width="100%"
+              x="0"
+              y="0"
             />
             <g>
               <g
@@ -38,7 +38,7 @@ exports[`Visualization renders with result and escapes any HTML 1`] = `
               >
                 <g
                   class="node"
-                  transform="translate(100,100)"
+                  transform="translate(0,0)"
                 >
                   <circle
                     class="ring"


### PR DESCRIPTION
now both width and height are clearly defined to same as available space, and (0, 0) is in the center of the svg.

<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

