### PR TITLE
Fix issue with prettier and tsx files

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -9,8 +9,15 @@
   "jsxSingleQuote": false,
   "importOrderSeparation": true,
   "importOrderSortSpecifiers": true,
-  "importOrderParserPlugins": ["typescript"],
   "importOrder": [
     "^browser/(.*)$|^project-root/(.*)$|^browser-(.*)$|^shared/(.*)$|^services/(.*)$|^icons/(.*)$|^[./]"
-  ]
+  ],
+  "overrides": [
+      {
+        "files": "*.ts",
+        "options": {
+          "importOrderParserPlugins": ["typescript"]
+        }
+      }
+    ]
 }


### PR DESCRIPTION
Changing back to default for importOrderParserPlugins since not working on tsx files.
the default for importOrderParserPlugins is [typescript, jsx]. Without the jsx the tsx files are not working,
however for queryPlan.ts it is not working for some strange reason to include jsx so adding an override only for .ts-files without the jsx.

<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

