### PR TITLE
Reduce icon size to avoid scroll on single line values in table

### DIFF
--- a/src/browser/components/ClipboardCopier.tsx
+++ b/src/browser/components/ClipboardCopier.tsx
@@ -1,5 +1,6 @@
-import styled from 'styled-components'
 import React, { useState } from 'react'
+import styled from 'styled-components'
+
 import { CopyIcon } from './icons/Icons'
 
 type ClipboardCopierProps = {
@@ -9,7 +10,7 @@ type ClipboardCopierProps = {
 }
 function ClipboardCopier({
   textToCopy: text,
-  iconSize = 20,
+  iconSize = 16,
   titleText = 'Copy to clipboard'
 }: ClipboardCopierProps): JSX.Element {
   const [messageToShow, setMessageToShow] = useState<string | null>(null)

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/relatable-view.test.tsx.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/relatable-view.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`RelatableViews RelatableView displays bodyMessage if no rows 1`] = `
 <div>
   <div
-    class="sc-Rmtcm keiynT"
+    class="sc-bRBYWo gXSQDz"
   >
     <div
-      class="sc-jnlKLf iTDaaZ"
+      class="sc-bxivhb jmjuqu"
     >
       (no changes, no records)
     </div>
@@ -89,10 +89,10 @@ exports[`RelatableViews RelatableView does not display bodyMessage if rows, and 
 exports[`RelatableViews TableStatusbar displays no statusBarMessage 1`] = `
 <div>
   <div
-    class="sc-Rmtcm keiynT"
+    class="sc-bRBYWo gXSQDz"
   >
     <div
-      class="sc-jnlKLf iTDaaZ"
+      class="sc-bxivhb jmjuqu"
     />
   </div>
 </div>
@@ -101,10 +101,10 @@ exports[`RelatableViews TableStatusbar displays no statusBarMessage 1`] = `
 exports[`RelatableViews TableStatusbar displays statusBarMessage 1`] = `
 <div>
   <div
-    class="sc-Rmtcm keiynT"
+    class="sc-bRBYWo gXSQDz"
   >
     <div
-      class="sc-jnlKLf iTDaaZ"
+      class="sc-bxivhb jmjuqu"
     >
       Started streaming 1 records after 5 ms and completed after 10  ms.
     </div>

--- a/src/browser/modules/Stream/CypherFrame/relatable-view.styled.ts
+++ b/src/browser/modules/Stream/CypherFrame/relatable-view.styled.ts
@@ -14,7 +14,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-
 import styled from 'styled-components'
 
 export const RelatableStyleWrapper = styled.div`
@@ -42,7 +41,7 @@ export const RelatableStyleWrapper = styled.div`
 export const StyledJsonPre = styled.pre`
   background-color: ${props => props.theme.preBackground};
   border-radius: 5px;
-  margin: 20px 10px;
+  margin: 0px 10px;
   border-bottom: none;
   color: ${props => props.theme.preText};
   line-height: 26px;
@@ -57,6 +56,6 @@ export const StyledPreSpan = styled.span`
 `
 export const CopyIconAbsolutePositioner = styled.span`
   position: absolute;
-  right: 15px;
-  top: 15px;
+  right: 10px;
+  top: 4px;
 `

--- a/src/browser/modules/Stream/CypherFrame/relatable-view.tsx
+++ b/src/browser/modules/Stream/CypherFrame/relatable-view.tsx
@@ -14,37 +14,36 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
-
-import React, { useMemo } from 'react'
-import { isInt, QueryResult, Record } from 'neo4j-driver'
 import Relatable from '@relate-by-ui/relatable'
 import { get, head, map, slice } from 'lodash-es'
-import { Icon } from 'semantic-ui-react'
+import { QueryResult, Record, isInt } from 'neo4j-driver'
+import React, { useMemo } from 'react'
 import { connect } from 'react-redux'
+import { Icon } from 'semantic-ui-react'
 
+import ClickableUrls from '../../../components/ClickableUrls'
+import ClipboardCopier from '../../../components/ClipboardCopier'
+import Ellipsis from '../../../components/Ellipsis'
+import { StyledStatsBar, StyledTruncatedMessage } from '../styled'
 import {
   getBodyAndStatusBarMessages,
   resultHasTruncatedFields
 } from './helpers'
-import arrayHasItems from 'shared/utils/array-has-items'
-import {
-  getMaxFieldItems,
-  getMaxRows
-} from 'shared/modules/settings/settingsDuck'
-import { stringModifier } from 'services/bolt/cypherTypesFormatting'
-import ClickableUrls from '../../../components/ClickableUrls'
-import ClipboardCopier from '../../../components/ClipboardCopier'
-import { StyledStatsBar, StyledTruncatedMessage } from '../styled'
-import Ellipsis from '../../../components/Ellipsis'
 import {
   CopyIconAbsolutePositioner,
   RelatableStyleWrapper,
   StyledJsonPre,
   StyledPreSpan
 } from './relatable-view.styled'
+import { BrowserRequestResult } from 'project-root/src/shared/modules/requests/requestsDuck'
+import { stringModifier } from 'services/bolt/cypherTypesFormatting'
 import { stringifyMod, unescapeDoubleQuotesForDisplay } from 'services/utils'
 import { GlobalState } from 'shared/globalState'
-import { BrowserRequestResult } from 'project-root/src/shared/modules/requests/requestsDuck'
+import {
+  getMaxFieldItems,
+  getMaxRows
+} from 'shared/modules/settings/settingsDuck'
+import arrayHasItems from 'shared/utils/array-has-items'
 
 const RelatableView = connect((state: GlobalState) => ({
   maxRows: getMaxRows(state),
@@ -69,10 +68,10 @@ export function RelatableViewComponent({
     [result]
   )
 
-  const columns = useMemo(() => getColumns(records, Number(maxFieldItems)), [
-    records,
-    maxFieldItems
-  ])
+  const columns = useMemo(
+    () => getColumns(records, Number(maxFieldItems)),
+    [records, maxFieldItems]
+  )
   const data = useMemo(() => slice(records, 0, maxRows), [records, maxRows])
 
   if (!arrayHasItems(columns)) {


### PR DESCRIPTION
- Fixed so single line object values will not have an unnecessary scroll by shrinking to copy icon
- Also, reduced the spacing around object values in tables
Before:
![before](https://user-images.githubusercontent.com/11065688/150163668-2b93492a-caa5-411f-a987-efcaa14247c7.png)
After:
![Screenshot 2022-01-20 at 10 05 26](https://user-images.githubusercontent.com/11065688/150310943-1f0548c8-e5e8-4500-9799-f37b16bf9e11.png)

<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

