### PR TITLE
Visualization: tweak duration of the simulation

### DIFF
--- a/src/browser/modules/D3Visualization/GraphEventHandler.ts
+++ b/src/browser/modules/D3Visualization/GraphEventHandler.ts
@@ -78,6 +78,12 @@ export class GraphEventHandler {
     if (this.selectedItem) {
       this.selectedItem.selected = false
       this.selectedItem = null
+
+      this.graphView.update({
+        updateNodes: true,
+        updateRelationships: true,
+        precompute: false
+      })
     }
     this.onItemSelected({
       type: 'canvas',
@@ -85,12 +91,6 @@ export class GraphEventHandler {
         nodeCount: this.graph.nodes().length,
         relationshipCount: this.graph.relationships().length
       }
-    })
-
-    this.graphView.update({
-      updateNodes: true,
-      updateRelationships: true,
-      precompute: false
     })
   }
 

--- a/src/browser/modules/D3Visualization/lib/visualization/components/Visualization.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/Visualization.ts
@@ -290,7 +290,10 @@ const vizFn = function (
         restartedSim = false
       }
 
-      function dragged(event: D3DragEvent<SVGGElement, VizNode, any>) {
+      function dragged(
+        event: D3DragEvent<SVGGElement, VizNode, any>,
+        node: VizNode
+      ) {
         // This is to prevent clicks/double clicks from restarting the simulation
         if (dist(initialPos, [event.x, event.y]) > tolerance && !restartedSim) {
           // Set alphaTarget to a value higher than alphaMin so the simulation
@@ -299,8 +302,9 @@ const vizFn = function (
           restartedSim = true
         }
 
-        event.subject.fx = event.x
-        event.subject.fy = event.y
+        node.hoverFixed = false
+        node.fx = event.x
+        node.fy = event.y
       }
 
       function dragended(_event: D3DragEvent<SVGGElement, VizNode, any>) {

--- a/src/browser/modules/D3Visualization/lib/visualization/components/layout.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/layout.ts
@@ -40,20 +40,7 @@ type ForceLayout = {
 export type Layout = { init: (render: () => void) => ForceLayout }
 export type AvailableLayouts = Record<'force', () => Layout>
 
-let simulationTimeout: null | number = null
-export const setSimulationTimeout = (
-  simulation: Simulation<VizNode, Relationship>
-) => {
-  simulationTimeout = setTimeout(() => simulation.stop(), 2000)
-}
-export const clearSimulationTimeout = () => {
-  if (simulationTimeout) {
-    clearTimeout(simulationTimeout)
-    simulationTimeout = null
-  }
-}
-
-const SIMULATION_STARTING_TICKS = 800
+const SIMULATION_STARTING_TICKS = 300
 
 const layout: AvailableLayouts = {
   force: () => ({
@@ -75,7 +62,6 @@ const layout: AvailableLayouts = {
         .stop()
 
       const update = function (graph: Graph, precompute = false) {
-        clearSimulationTimeout()
         const nodes = cloneArray(graph.nodes())
         const relationships = oneRelationshipPerPairOfNodes(graph)
 
@@ -111,11 +97,9 @@ const layout: AvailableLayouts = {
           // simulation with the animation and multiple re-renders
           simulation.tick(SIMULATION_STARTING_TICKS)
           render()
-        } else {
-          simulation.alpha(1).restart()
-          setSimulationTimeout(simulation)
         }
 
+        simulation.alphaMin(0.05).alpha(1).restart()
         return simulation
       }
 

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`Visualization renders with result and escapes any HTML 1`] = `
               >
                 <g
                   class="node"
-                  transform="translate(0,0.030003732090589447)"
+                  transform="translate(0,0.030982068166081952)"
                 >
                   <circle
                     class="ring"


### PR DESCRIPTION
- Remove the timeout that stops the simulation and adjust alpha values to make the simulation cool down on its own.
- Clicking on nodes no longer restarts the simulation.
- Reduce the number of precomputed ticks.
- Fixed a bug when dragging nodes, sometimes they would get unlocked when moving the cursor outside of the node.
- Remove re-render when clicking on the visualization background when no items are selected.

Preview available here: http://browser-visualization-tweaks.surge.sh