### PR TITLE
Make sure auto exec of play guide gets a new frame

### DIFF
--- a/src/browser/components/Directives.tsx
+++ b/src/browser/components/Directives.tsx
@@ -20,9 +20,11 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import { withBus } from 'react-suber'
+import { v4 } from 'uuid'
+
 import {
-  executeCommand,
-  commandSources
+  commandSources,
+  executeCommand
 } from 'shared/modules/commands/commandsDuck'
 import * as editor from 'shared/modules/editor/editorDuck'
 import { addClass, prependIcon } from 'shared/services/dom-helpers'
@@ -128,7 +130,7 @@ export const Directives = (props: any) => {
               props.onItemClick(
                 directive.valueExtractor(e),
                 true,
-                props.originFrameId
+                v4() /* new id, new frame */
               )
             })
           }


### PR DESCRIPTION
Prevents the annoying behaviour where the current guide is replaced by a query result. Preview @ http://michael_guide_fix.surge.sh

https://user-images.githubusercontent.com/10564538/150505899-30803f48-f14f-4a58-b89a-52fdf14c8995.mp4


