### PR TITLE
Bump sso lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "luxon": "^2.0.2",
     "memoize-one": "^5.2.1",
     "monaco-editor": "0.23.0",
-    "neo4j-client-sso": "1.2.0",
+    "neo4j-client-sso": "1.2.2",
     "neo4j-driver": "^4.4.0",
     "react": "^17.0.2",
     "react-dnd": "^11.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10064,10 +10064,10 @@ neo-async@^2.5.0, neo-async@^2.6.1:
   resolved "https://neo.jfrog.io/neo/api/npm/npm/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha1-tKr7k+OustgXTKU88WOrfXMIMF8=
 
-neo4j-client-sso@1.2.0:
-  version "1.2.0"
-  resolved "https://neo.jfrog.io/neo/api/npm/npm/neo4j-client-sso/-/neo4j-client-sso-1.2.0.tgz#a3421e4bbe5dc5463c5c7416ca8c2580c12a4d27"
-  integrity sha1-o0IeS75dxUY8XHQWyowlgMEqTSc=
+neo4j-client-sso@1.2.2:
+  version "1.2.2"
+  resolved "https://neo.jfrog.io/neo/api/npm/npm/neo4j-client-sso/-/neo4j-client-sso-1.2.2.tgz#146f96ca8e23654c70e5bd5a7f98a3acb286ce2c"
+  integrity sha1-FG+Wyo4jZUxw5b1af5ijrLKGziw=
   dependencies:
     file-saver "^2.0.5"
     jwt-decode "^3.1.2"


### PR DESCRIPTION
`well_known_discovery_uri` was wrongly mandatory in the discovery data, this update fixes that