### PR TITLE
Fixed so possible to set params using multiline

### DIFF
--- a/e2e_tests/integration/params.spec.ts
+++ b/e2e_tests/integration/params.spec.ts
@@ -21,10 +21,8 @@
 /* global Cypress, cy, before */
 
 describe(':param in Browser', () => {
-  before(function() {
-    cy.visit(Cypress.config('url'))
-      .title()
-      .should('include', 'Neo4j Browser')
+  before(function () {
+    cy.visit(Cypress.config('url')).title().should('include', 'Neo4j Browser')
     cy.wait(3000)
   })
   it('handles :param without web worker', () => {
@@ -120,5 +118,18 @@ function runTests() {
     cy.waitForCommandResult()
     cy.resultContains('point({srid:4326, x:12.9082, y:57.7346})')
   }
+  // })
+
+  // :params
+  // it('can set :params with multiple lines syntax', () => {
+  cy.executeCommand(':clear')
+  setParamQ = `:params {{} x: 1,{shift}{enter}stringWithSpace:'with space',{shift}{enter}stringWithTab: 'with\ttab'{}}`
+  cy.executeCommand(setParamQ)
+  cy.get('[data-testid="rawParamData"]', { timeout: 20000 })
+    .first()
+    .should(
+      'contain',
+      '{\n  "x": 1.0,\n  "stringWithSpace": "with space",\n  "stringWithTab": "\'with\ttab\'"\n}'
+    )
   // })
 }

--- a/e2e_tests/integration/params.spec.ts
+++ b/e2e_tests/integration/params.spec.ts
@@ -131,5 +131,20 @@ function runTests() {
       'contain',
       '{\n  "x": 1.0,\n  "stringWithSpace": "with space",\n  "stringWithTab": "\'with\ttab\'"\n}'
     )
+  getParamQ = 'RETURN $stringWithSpace'
+  cy.executeCommand(getParamQ)
+  cy.waitForCommandResult()
+  cy.resultContains('"with space"')
+  // })
+  // it('can set :params where a new line is before the {', () => {
+  cy.executeCommand(':clear')
+  setParamQ = `:params{shift}{enter}{{} x: 1,{shift}{enter}stringWithSpace:'with space',{shift}{enter}stringWithTab: 'with\ttab'{}}`
+  cy.executeCommand(setParamQ)
+  cy.get('[data-testid="rawParamData"]', { timeout: 20000 })
+    .first()
+    .should(
+      'contain',
+      '{\n  "x": 1.0,\n  "stringWithSpace": "with space",\n  "stringWithTab": "\'with\ttab\'"\n}'
+    )
   // })
 }

--- a/src/shared/modules/commands/helpers/params.ts
+++ b/src/shared/modules/commands/helpers/params.ts
@@ -24,7 +24,7 @@ import { splitStringOnFirst } from 'services/commandUtils'
 import { SYSTEM_DB } from 'shared/modules/dbMeta/constants'
 import { replace, update } from 'shared/modules/params/paramsDuck'
 
-export const extractParams = (param: any) => {
+export const extractParams = (param: string) => {
   // early bail, now handled by parser
   if (param.includes('=>')) {
     return {

--- a/src/shared/modules/commands/helpers/params.ts
+++ b/src/shared/modules/commands/helpers/params.ts
@@ -83,7 +83,7 @@ export const handleParamsCommand = (action: any, put: any, targetDb?: any) => {
     )
   }
   const strippedCmd = action.cmd.substr(1)
-  const parts = splitStringOnFirst(strippedCmd, ' ')
+  const parts = splitStringOnFirst(strippedCmd, /\s/)
   const param = parts[1].trim()
 
   return Promise.resolve().then(() => {

--- a/src/shared/modules/commands/helpers/params.ts
+++ b/src/shared/modules/commands/helpers/params.ts
@@ -87,7 +87,7 @@ export const handleParamsCommand = (action: any, put: any, targetDb?: any) => {
   const param = parts[1].trim()
 
   return Promise.resolve().then(() => {
-    if (/^"?\{.*\}"?$/.test(param)) {
+    if (/^"?\{[\s\S]*\}"?$/.test(param)) {
       // JSON object string {"x": 2, "y":"string"}
       try {
         const res = jsonic(param.replace(/^"/, '').replace(/"$/, '')) // Remove any surrounding quotes

--- a/src/shared/services/commandUtils.test.ts
+++ b/src/shared/services/commandUtils.test.ts
@@ -74,6 +74,21 @@ RETURN 2
         str: 'test:"hello :space"',
         delimiter: ':',
         expect: ['test', '"hello :space"']
+      },
+      {
+        str: 'test:"hello :space"',
+        delimiter: /\s/,
+        expect: ['test:"hello', ':space"']
+      },
+      {
+        str: ' :config test:"hello :space"',
+        delimiter: /\s/,
+        expect: ['', ':config test:"hello :space"']
+      },
+      {
+        str: ':config',
+        delimiter: /\s/,
+        expect: [':config', '']
       }
     ]
     testStrs.forEach(obj => {
@@ -94,6 +109,26 @@ RETURN 2
         str: 'test:"hello :space"',
         delimiter: ':',
         expect: ['test:"hello ', 'space"']
+      },
+      {
+        str: ' test:hello',
+        delimiter: ' ',
+        expect: ['', 'test:hello']
+      },
+      {
+        str: 'test:hello ',
+        delimiter: ' ',
+        expect: ['test:hello', '']
+      },
+      {
+        str: 'test:hello',
+        delimiter: ' ',
+        expect: ['', 'test:hello']
+      },
+      {
+        str: 'test:"hello :space"',
+        delimiter: /\s/,
+        expect: ['test:"hello', ':space"']
       }
     ]
     testStrs.forEach(obj => {

--- a/src/shared/services/commandUtils.ts
+++ b/src/shared/services/commandUtils.ts
@@ -19,21 +19,20 @@
  */
 import { extractStatements } from 'cypher-editor-support'
 
-export function cleanCommand(cmd: any) {
+export function cleanCommand(cmd: string): string {
   const noComments = stripCommandComments(cmd)
-  const noEmptyLines = stripEmptyCommandLines(noComments)
-  return noEmptyLines
+  return stripEmptyCommandLines(noComments)
 }
 
-export function stripEmptyCommandLines(str: any) {
-  const skipEmptyLines = (e: any) => !/^\s*$/.test(e)
+export function stripEmptyCommandLines(str: string): string {
+  const skipEmptyLines = (e: string) => !/^\s*$/.test(e)
   return str.split('\n').filter(skipEmptyLines).join('\n')
 }
 
-export function stripCommandComments(str: any) {
+export function stripCommandComments(str: string): string {
   return str
     .split('\n')
-    .filter((line: any) => !line.trim().startsWith('//'))
+    .filter((line: string) => !line.trim().startsWith('//'))
     .join('\n')
 }
 
@@ -57,7 +56,7 @@ export function splitStringOnLast(
   return ([] as string[]).concat(stringWithoutLast, lastPart)
 }
 
-export const isCypherCommand = (cmd: any) => {
+export const isCypherCommand = (cmd: string): boolean => {
   const cleanCmd = cleanCommand(cmd)
   return cleanCmd[0] !== ':'
 }
@@ -67,38 +66,41 @@ export const buildCommandObject = (action: any, interpret: any) => {
   return { action, interpreted, useDb: action.useDb }
 }
 
-export const getInterpreter = (interpret: any, cmd: any, ignore = false) => {
+export const getInterpreter = (interpret: any, cmd: string, ignore = false) => {
   if (ignore) return interpret('noop')
   if (isCypherCommand(cmd)) return interpret('cypher')
   return interpret(cleanCommand(cmd).substr(1))
 }
 
-export const extractPostConnectCommandsFromServerConfig = (str: any) => {
+export const extractPostConnectCommandsFromServerConfig = (
+  str: string
+): string[] | undefined => {
   const substituteStr = '@@semicolon@@'
   const substituteRe = new RegExp(substituteStr, 'g')
-  const replaceFn = (m: any) => m.replace(/;/g, substituteStr)
+  const replaceFn = (m: string) => m.replace(/;/g, substituteStr)
   const qs = [/(`[^`]*?`)/g, /("[^"]*?")/g, /('[^']*?')/g]
   qs.forEach(q => (str = str.replace(q, replaceFn)))
   const splitted = str
     .split(';')
-    .map((item: any) => item.trim())
-    .map((item: any) => item.replace(substituteRe, ';'))
-    .filter((item: any) => item && item.length)
+    .map((item: string) => item.trim())
+    .map((item: string) => item.replace(substituteRe, ';'))
+    .filter((item: string) => item && item.length)
   return splitted && splitted.length ? splitted : undefined
 }
 
-const getHelpTopic = (str: any) => splitStringOnFirst(str, ' ')[1] || 'help' // Map empty input to :help help
-const stripPound = (str: any) => splitStringOnFirst(str, '#')[0]
-const lowerCase = (str: any) => str.toLowerCase()
-const trim = (str: any) => str.trim()
-const replaceSpaceWithDash = (str: any) => str.replace(/\s/g, '-')
-const snakeToCamel = (str: any) =>
-  str.replace(/(-\w)/g, (match: any) => match[1].toUpperCase())
-const camelToSnake = (name: any, separator: any) => {
+const getHelpTopic = (str: string) => splitStringOnFirst(str, ' ')[1] || 'help' // Map empty input to :help help
+const stripPound = (str: string) => splitStringOnFirst(str, '#')[0]
+const lowerCase = (str: string) => str.toLowerCase()
+const trim = (str: string) => str.trim()
+const replaceSpaceWithDash = (str: string) => str.replace(/\s/g, '-')
+const snakeToCamel = (str: string) =>
+  str.replace(/(-\w)/g, (match: string) => match[1].toUpperCase())
+const camelToSnake = (name: string, separator: string) => {
   return name
     .replace(
       /([a-z]|(?:[A-Z0-9]+))([A-Z0-9]|$)/g,
-      (_: any, $1: any, $2: any) => $1 + ($2 && (separator || '_') + $2)
+      (_: string, $1: string, $2: string) =>
+        $1 + ($2 && (separator || '_') + $2)
     )
     .toLowerCase()
 }
@@ -112,7 +114,7 @@ export const transformCommandToHelpTopic = (inputStr?: string): string =>
     .map(replaceSpaceWithDash)
     .map(snakeToCamel)[0]
 
-export const transformHelpTopicToCommand = (inputStr: any) => {
+export const transformHelpTopicToCommand = (inputStr: string): string => {
   if (inputStr.indexOf('-') > -1) {
     return inputStr
   }
@@ -122,7 +124,7 @@ export const transformHelpTopicToCommand = (inputStr: any) => {
 const quotedRegex = /^"(.*)"|'(.*)'/
 const arrowFunctionRegex = /^.*=>\s*([^$]*)$/
 
-export const mapParamToCypherStatement = (key: any, param: any) => {
+export const mapParamToCypherStatement = (key: any, param: any): string => {
   const quotedKey = key.match(quotedRegex)
   const cleanKey = quotedKey
     ? `\`${quotedKey[1]}\``
@@ -138,7 +140,7 @@ export const mapParamToCypherStatement = (key: any, param: any) => {
   return returnAs(param)
 }
 
-export const extractStatementsFromString = (str: any) => {
+export const extractStatementsFromString = (str: string) => {
   const cleanCmd = cleanCommand(str)
   const parsed = extractStatements(cleanCmd)
   const { statements } = parsed.referencesListener
@@ -148,7 +150,7 @@ export const extractStatementsFromString = (str: any) => {
     .filter((_: any) => _)
 }
 
-export const getCommandAndParam = (str: any) => {
+export const getCommandAndParam = (str: string): string[] => {
   const [serverCmd, props] = splitStringOnFirst(
     splitStringOnFirst(str, ' ')[1],
     ' '

--- a/src/shared/services/commandUtils.ts
+++ b/src/shared/services/commandUtils.ts
@@ -37,17 +37,24 @@ export function stripCommandComments(str: any) {
     .join('\n')
 }
 
-export function splitStringOnFirst(str: any, delimiter: any) {
+export function splitStringOnFirst(
+  str: string,
+  delimiter: string | RegExp
+): string[] {
   const parts = str.split(delimiter)
-  return ([] as any[]).concat(parts[0], parts.slice(1).join(delimiter))
+  const strWithoutFirst = str.slice(parts[0].length + 1)
+  return ([] as string[]).concat(parts[0], strWithoutFirst)
 }
 
-export function splitStringOnLast(str: any, delimiter: any) {
+export function splitStringOnLast(
+  str: string,
+  delimiter: string | RegExp
+): string[] {
   const parts = str.split(delimiter)
-  return [].concat(
-    parts.slice(0, parts.length - 1).join(delimiter),
-    parts[parts.length - 1]
-  )
+  const lastPart = parts[parts.length - 1]
+  const stringWithoutLast =
+    parts.length > 1 ? str.slice(0, str.length - lastPart.length - 1) : ''
+  return ([] as string[]).concat(stringWithoutLast, lastPart)
 }
 
 export const isCypherCommand = (cmd: any) => {


### PR DESCRIPTION
Now it is possible to use :params command with multiple lines <img width="1292" alt="Screenshot 2022-01-24 at 15 05 34" src="https://user-images.githubusercontent.com/11065688/150797419-01ba5609-83ac-4725-a355-eef2bc87eb29.png">
<!--

BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

