### PR TITLE
bugfix center the graph on zoom to fit not always working

### DIFF
--- a/src/browser/modules/D3Visualization/lib/visualization/components/Visualization.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/Visualization.ts
@@ -267,6 +267,9 @@ export class Visualization {
       const graphWidth = graphSize.width
       const graphHeight = graphSize.height
 
+      const graphCenterX = graphSize.x + graphWidth / 2
+      const graphCenterY = graphSize.y + graphHeight / 2
+
       if (graphWidth === 0 || graphHeight === 0) return
 
       const scale =
@@ -275,7 +278,9 @@ export class Visualization {
 
       this.zoomBehavior.transform(
         this.root,
-        zoomIdentity.translate(0, 0).scale(Math.min(scale, ZOOM_MAX_SCALE))
+        zoomIdentity
+          .scale(Math.min(scale, ZOOM_MAX_SCALE))
+          .translate(-graphCenterX, -graphCenterY)
       )
     }
   }


### PR DESCRIPTION
Graphs that didn't have their midpoint in the centre (when no transforms are applied) didn't get centered when clicking zoom to fit. Now that is fixed by adjusting to have their mid point at the centre of the svg after zoom to fit is applied.

before:
<img width="1712" alt="Screenshot 2022-02-02 at 15 52 58" src="https://user-images.githubusercontent.com/11065688/152177934-9cff704e-ebd7-47da-bea9-2c062b0654dc.png">
after:
<img width="1710" alt="Screenshot 2022-02-02 at 15 52 32" src="https://user-images.githubusercontent.com/11065688/152178037-8bfcb71c-2f0b-411d-be0c-df0f24ab50f5.png">

and here is how the graph looks in both cases before any transforms are applied, you can see that there is more space above than below:
<img width="1720" alt="Screenshot 2022-02-02 at 15 56 33" src="https://user-images.githubusercontent.com/11065688/152178655-f20558b5-e200-427a-a91a-75db70100ccd.png">


<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

