### PR TITLE
Bolt worker cleanup

### DIFF
--- a/src/shared/services/WorkPool.ts
+++ b/src/shared/services/WorkPool.ts
@@ -17,7 +17,81 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { QueryResult } from 'neo4j-driver'
 import { v4 as uuid } from 'uuid'
+
+import BoltWorkerModule from 'shared/services/bolt/boltWorker'
+
+export type WorkerMessageHandler = (message: {
+  data: {
+    type: string
+    error: Error
+    result: QueryResult
+  }
+}) => void
+
+class Work {
+  private executed = false
+  private finishFn?: (payload: any) => void = undefined
+  private worker?: Worker = undefined
+
+  constructor(
+    public readonly id: string,
+    private payload: any,
+    private onmessage: WorkerMessageHandler,
+    private removeFromQueue: (id: string) => void
+  ) {}
+
+  execute = (payload: any) => {
+    if (payload && this.worker) {
+      this.worker.worker.postMessage(payload)
+    }
+  }
+
+  onFinish = (fn: (payload: any) => void) => (this.finishFn = fn)
+
+  finish = () => {
+    if (!this.executed) {
+      this.removeFromQueue(this.id)
+    }
+    this.worker && this.worker.finish(this.id)
+    this.finishFn && this.finishFn({ executed: this.executed, id: this.id })
+  }
+
+  executeInitial = () => {
+    if (this.onmessage && this.worker) {
+      this.worker.worker.onmessage = this.onmessage
+    }
+
+    if (this.payload && this.worker) {
+      this.worker.worker.postMessage(this.payload)
+    }
+
+    this.executed = true
+  }
+
+  assignWorker = (worker: Worker) => {
+    worker.id = this.id
+    worker.state = WorkPool.workerStates.BUSY
+    worker.work = this
+    this.worker = worker
+  }
+}
+
+class Worker {
+  public work?: Work
+  public id?: string
+
+  constructor(
+    public readonly worker: BoltWorkerModule,
+    public state: any,
+    private unregisterWorker: (id: string) => void
+  ) {}
+
+  finish = (id: any) => {
+    this.unregisterWorker(id)
+  }
+}
 
 class WorkPool {
   static workerStates = {
@@ -25,163 +99,116 @@ class WorkPool {
     FREE: 'free'
   }
 
-  createWorker: any
-  maxPoolSize: any
-  q: any
-  register: any
+  createWorker: () => BoltWorkerModule
+  maxPoolSize: number
+  queue: Array<Work> = []
+  register: Array<Worker> = []
 
-  constructor(createWorker: any, maxPoolSize = 15) {
+  constructor(createWorker: () => BoltWorkerModule, maxPoolSize = 15) {
     this.createWorker = createWorker
     this.maxPoolSize = maxPoolSize
-    this.register = []
-    this.q = []
   }
 
   getPoolSize(state?: any) {
     if (!state) {
       return this.register.length
     }
-    return this.register.filter((w: any) => w.state === state).length
+    return this.register.filter(w => w.state === state).length
   }
 
   getQueueSize() {
-    return this.q.length
+    return this.queue.length
   }
 
-  getWorkById(id: any) {
-    for (let i = 0; i < this.q.length; i++) {
-      if (this.q[i].id === id) {
-        return this.q[i]
-      }
-    }
-    for (let i = 0; i < this.register.length; i++) {
-      if (this.register[i].id === id) {
-        return this.register[i].work
-      }
-    }
-    return null
+  getWorkById(id: string) {
+    return (
+      this.queue.find(work => work.id === id) ??
+      this.register.find(worker => worker.id === id)?.work ??
+      null
+    )
   }
 
-  doWork({ id, payload, onmessage }: any) {
-    const work = this._buildWorkObj({ id: id || uuid(), payload, onmessage })
-    this._addToQ(work)
-    this._next()
+  doWork({
+    id,
+    payload,
+    onmessage
+  }: {
+    id: string
+    payload: any
+    onmessage: WorkerMessageHandler
+  }) {
+    const work = new Work(
+      id || uuid(),
+      payload,
+      onmessage,
+      this.removeFromQueue
+    )
+    this.addToQueue(work)
+    this.next()
     return work
   }
 
   messageAllWorkers(msg: any) {
-    this.register.forEach((worker: any) => worker.worker.postMessage(msg))
+    this.register.forEach(worker => worker.worker.postMessage(msg))
   }
 
-  _getFreeWorker() {
-    const len = this.register.length
-    for (let i = len - 1; i >= 0; i--) {
-      if (this.register[i].state === WorkPool.workerStates.FREE) {
-        return this.register[i]
-      }
+  private getFreeWorker() {
+    const freeWorker = this.register.find(
+      worker => worker.state === WorkPool.workerStates.FREE
+    )
+    if (freeWorker) {
+      return freeWorker
     }
+
     const poolSize = this.getPoolSize()
     if (poolSize < this.maxPoolSize) {
-      const workerObj = this._buildWorkerObj(
+      const workerObj = new Worker(
         this.createWorker(),
-        WorkPool.workerStates.BUSY
+        WorkPool.workerStates.BUSY,
+        this.unregisterWorker
       )
       this.register.push(workerObj)
       return workerObj
     }
+
     return null
   }
 
-  _next() {
+  private next() {
     if (!this.getQueueSize()) {
       return
     }
-    const workerObj = this._getFreeWorker()
+    const workerObj = this.getFreeWorker()
     if (!workerObj) {
       return
     }
-    const work = this.q.shift()
-    workerObj.id = work.id
-    work._assignWorker(workerObj)
-    work._executeInitial()
+    const work = this.queue.shift()
+    if (!work) {
+      return
+    }
+
+    work.assignWorker(workerObj)
+    work.executeInitial()
   }
 
-  _addToQ(work: any) {
-    this.q.push(work)
+  private addToQueue(work: Work) {
+    this.queue.push(work)
   }
 
-  _removeFromQ(id: any) {
-    this.q.splice(
-      this.q.findIndex((el: any) => el.id === id),
+  private removeFromQueue(id: string) {
+    this.queue.splice(
+      this.queue.findIndex(el => el.id === id),
       1
     )
   }
 
-  _unregisterWorker = (id: any) => {
-    const worker = this._getWorkerById(id)
-    if (worker === null) {
+  private unregisterWorker = (id: string) => {
+    const worker = this.register.find(worker => worker.id === id)
+    if (!worker) {
       return
     }
     worker.state = WorkPool.workerStates.FREE
-    this._next()
-  }
-
-  _buildWorkObj({ id, payload, onmessage }: any) {
-    const obj: any = {
-      id,
-      _worker: undefined,
-      _executed: false,
-      _finishFn: undefined
-    }
-    obj.execute = (payload: any) => {
-      if (payload && obj._workerObj) {
-        obj._workerObj.worker.postMessage(payload)
-      }
-    }
-    obj.onFinish = (fn: any) => (obj._finishFn = fn)
-    obj.finish = () => {
-      if (!obj._executed) {
-        this._removeFromQ(id)
-      }
-      obj._workerObj && obj._workerObj.finish(id)
-      obj._finishFn && obj._finishFn({ executed: obj._executed, id })
-    }
-    obj._executeInitial = () => {
-      if (onmessage) {
-        obj._workerObj.worker.onmessage = onmessage
-      }
-      if (payload) {
-        obj._workerObj.worker.postMessage(payload)
-      }
-      obj._executed = true
-    }
-    obj._assignWorker = (workerObj: any) => {
-      workerObj.state = WorkPool.workerStates.BUSY
-      workerObj.work = obj
-      obj._workerObj = workerObj
-    }
-
-    return obj
-  }
-
-  _buildWorkerObj(worker: any, state: any) {
-    const obj: any = {
-      worker,
-      state
-    }
-    obj.finish = (id: any) => {
-      this._unregisterWorker(id)
-    }
-    return obj
-  }
-
-  _getWorkerById(id: any) {
-    for (let i = 0; i < this.register.length; i++) {
-      if (this.register[i].id === id) {
-        return this.register[i]
-      }
-    }
-    return null
+    this.next()
   }
 }
 

--- a/src/shared/services/WorkPool.ts
+++ b/src/shared/services/WorkPool.ts
@@ -122,7 +122,9 @@ class WorkPool {
 
   getWorkById(id: string) {
     return (
+      // search through undone work
       this.queue.find(work => work.id === id) ??
+      // search through work in progress
       this.register.find(worker => worker.id === id)?.work ??
       null
     )
@@ -196,10 +198,11 @@ class WorkPool {
   }
 
   private removeFromQueue(id: string) {
-    this.queue.splice(
-      this.queue.findIndex(el => el.id === id),
-      1
-    )
+    const workIndex = this.queue.findIndex(el => el.id === id)
+    if (workIndex === -1) {
+      return
+    }
+    this.queue.splice(workIndex, 1)
   }
 
   private unregisterWorker = (id: string) => {

--- a/src/shared/services/WorkPool.ts
+++ b/src/shared/services/WorkPool.ts
@@ -38,8 +38,8 @@ class Work {
   constructor(
     public readonly id: string,
     private payload: any,
-    private onmessage: WorkerMessageHandler,
-    private removeFromQueue: (id: string) => void
+    private removeFromQueue: (id: string) => void,
+    private onmessage?: WorkerMessageHandler
   ) {}
 
   execute = (payload: any) => {
@@ -134,14 +134,14 @@ class WorkPool {
     onmessage
   }: {
     id: string
-    payload: any
-    onmessage: WorkerMessageHandler
+    payload?: any
+    onmessage?: WorkerMessageHandler
   }) {
     const work = new Work(
       id || uuid(),
       payload,
-      onmessage,
-      this.removeFromQueue
+      this.removeFromQueue,
+      onmessage
     )
     this.addToQueue(work)
     this.next()

--- a/src/shared/services/bolt/bolt.ts
+++ b/src/shared/services/bolt/bolt.ts
@@ -224,7 +224,7 @@ export default {
   openConnection,
   closeConnection: () => {
     connectionProperties = null
-    boltConnection.closeConnection()
+    boltConnection.closeGlobalConnection()
     closeConnectionInWorkers()
   },
   directTransaction,

--- a/src/shared/services/bolt/bolt.ts
+++ b/src/shared/services/bolt/bolt.ts
@@ -94,7 +94,7 @@ function routedWriteTransaction(
   } = requestMetaData
   if (useCypherThread && window.Worker) {
     const id = requestId || v4()
-    const workFn = runCypherMessage(
+    const payload = runCypherMessage(
       input,
       mappings.recursivelyTypeGraphItems(parameters),
       boltConnection.ROUTED_WRITE_CONNECTION,
@@ -110,7 +110,7 @@ function routedWriteTransaction(
     const workerPromise = setupBoltWorker(
       boltWorkPool,
       id,
-      workFn,
+      payload,
       onLostConnection
     )
     return [id, workerPromise]
@@ -140,7 +140,7 @@ function routedReadTransaction(
   } = requestMetaData
   if (useCypherThread && window.Worker) {
     const id = requestId || v4()
-    const workFn = runCypherMessage(
+    const payload = runCypherMessage(
       input,
       mappings.recursivelyTypeGraphItems(parameters),
       boltConnection.ROUTED_READ_CONNECTION,
@@ -155,7 +155,7 @@ function routedReadTransaction(
     const workerPromise = setupBoltWorker(
       boltWorkPool,
       id,
-      workFn,
+      payload,
       onLostConnection
     )
     return workerPromise
@@ -184,7 +184,7 @@ function directTransaction(
   } = requestMetaData
   if (useCypherThread && window.Worker) {
     const id = requestId || v4()
-    const workFn = runCypherMessage(
+    const payload = runCypherMessage(
       input,
       mappings.recursivelyTypeGraphItems(parameters),
       boltConnection.DIRECT_CONNECTION,
@@ -199,7 +199,7 @@ function directTransaction(
     const workerPromise = setupBoltWorker(
       boltWorkPool,
       id,
-      workFn,
+      payload,
       onLostConnection
     )
     return workerPromise

--- a/src/shared/services/bolt/bolt.ts
+++ b/src/shared/services/bolt/bolt.ts
@@ -26,7 +26,7 @@ import * as mappings from './boltMappings'
 import {
   cancelTransactionMessage,
   closeConnectionMessage,
-  runCypherMessage
+  getWorkerPayloadForRunningCypherMessage
 } from './boltWorkerMessages'
 import { addTypesAsField, setupBoltWorker } from './setup-bolt-worker'
 import {
@@ -94,7 +94,7 @@ function routedWriteTransaction(
   } = requestMetaData
   if (useCypherThread && window.Worker) {
     const id = requestId || v4()
-    const payload = runCypherMessage(
+    const payload = getWorkerPayloadForRunningCypherMessage(
       input,
       mappings.recursivelyTypeGraphItems(parameters),
       boltConnection.ROUTED_WRITE_CONNECTION,
@@ -140,7 +140,7 @@ function routedReadTransaction(
   } = requestMetaData
   if (useCypherThread && window.Worker) {
     const id = requestId || v4()
-    const payload = runCypherMessage(
+    const payload = getWorkerPayloadForRunningCypherMessage(
       input,
       mappings.recursivelyTypeGraphItems(parameters),
       boltConnection.ROUTED_READ_CONNECTION,
@@ -184,7 +184,7 @@ function directTransaction(
   } = requestMetaData
   if (useCypherThread && window.Worker) {
     const id = requestId || v4()
-    const payload = runCypherMessage(
+    const payload = getWorkerPayloadForRunningCypherMessage(
       input,
       mappings.recursivelyTypeGraphItems(parameters),
       boltConnection.DIRECT_CONNECTION,

--- a/src/shared/services/bolt/boltConnection.ts
+++ b/src/shared/services/bolt/boltConnection.ts
@@ -143,7 +143,7 @@ export function openConnection(
   return p
 }
 
-export const closeConnection = (): void => {
+export const closeGlobalConnection = (): void => {
   const globalDrivers = getGlobalDrivers()
   if (globalDrivers) {
     globalDrivers.close()

--- a/src/shared/services/bolt/boltWorker.ts
+++ b/src/shared/services/bolt/boltWorker.ts
@@ -20,6 +20,7 @@
 
 /* eslint-env serviceworker */
 import 'core-js/stable'
+import { AnyAction } from 'redux'
 
 import { BoltConnectionError } from '../exceptions'
 import {
@@ -48,25 +49,8 @@ import {
 } from './transactions'
 import { applyGraphTypes } from 'services/bolt/boltMappings'
 
-const connectionTypeMap = {
-  [ROUTED_WRITE_CONNECTION]: {
-    create: routedWriteTransaction,
-    getPromise: (res: Promise<unknown>[]): Promise<unknown> => res[1]
-  },
-  [ROUTED_READ_CONNECTION]: {
-    create: routedReadTransaction,
-    getPromise: (res: Promise<unknown>): Promise<unknown> => res
-  },
-  [DIRECT_CONNECTION]: {
-    create: directTransaction,
-    getPromise: (res: Promise<unknown>): Promise<unknown> => res
-  }
-}
-
-let busy = false
-const workQue: { (): void }[] = []
-
-const onmessage = function (message: {
+declare const self: ServiceWorker
+type WorkerMessage = {
   data: {
     cancelable: boolean
     connectionProperties: {
@@ -88,80 +72,99 @@ const onmessage = function (message: {
     requestId: string
     type: string
   }
-}): void {
-  const messageType = message.data.type
+}
+
+// Something strange is going on here and it could be causing a bug. ALL of the
+// functions used here return an array `[string, Promise<any>]` WHEN they're
+// creating a tracked transaction. But here we assume that ONLY
+// routedWriteTransaction is ALWAYS returning an array.
+const connectionTypeMap = {
+  [ROUTED_WRITE_CONNECTION]: {
+    create: routedWriteTransaction,
+    getPromise: (res: Promise<unknown>[]): Promise<unknown> => res[1]
+  },
+  [ROUTED_READ_CONNECTION]: {
+    create: routedReadTransaction,
+    getPromise: (res: Promise<unknown>): Promise<unknown> => res
+  },
+  [DIRECT_CONNECTION]: {
+    create: directTransaction,
+    getPromise: (res: Promise<unknown>): Promise<unknown> => res
+  }
+}
+
+let busy = false
+const workQueue: { (): void }[] = []
+
+const maybeCypherErrorMessage = (error: any): AnyAction | undefined => {
+  if (isBoltConnectionErrorCode(error.code)) {
+    return boltConnectionErrorMessage({
+      ...error,
+      type: BOLT_CONNECTION_ERROR_MESSAGE
+    })
+  } else {
+    return cypherErrorMessage(error)
+  }
+}
+
+const runCypherMessage = async (data: WorkerMessage['data']) => {
+  const {
+    input,
+    parameters,
+    connectionType,
+    requestId,
+    cancelable,
+    connectionProperties
+  } = data
+
+  const { txMetadata, useDb, autoCommit } = connectionProperties
+  const onLostConnection = () =>
+    self.postMessage(boltConnectionErrorMessage(BoltConnectionError()))
+
+  await ensureConnection(
+    connectionProperties as any,
+    connectionProperties.opts,
+    onLostConnection
+  )
+
+  const transactionType = connectionTypeMap[connectionType]
+  const res: any = transactionType.create(input, applyGraphTypes(parameters), {
+    requestId,
+    cancelable,
+    txMetadata,
+    useDb,
+    autoCommit
+  })
+
+  return transactionType.getPromise(res)
+}
+
+const onmessage = function ({ data }: WorkerMessage): void {
+  const messageType = data.type
 
   if (messageType === RUN_CYPHER_MESSAGE) {
-    const {
-      input,
-      parameters,
-      connectionType,
-      requestId,
-      cancelable,
-      connectionProperties
-    } = message.data
-
-    const maybeCypherErrorMessage = (error: any) => {
-      if (isBoltConnectionErrorCode(error.code)) {
-        return boltConnectionErrorMessage({
-          ...error,
-          type: BOLT_CONNECTION_ERROR_MESSAGE
-        })
-      } else {
-        return cypherErrorMessage(error)
-      }
-    }
-
     beforeWork()
-    const { txMetadata, useDb, autoCommit } = connectionProperties
-    ensureConnection(
-      connectionProperties as any,
-      connectionProperties.opts,
-      () => {
-        ;(self as unknown as ServiceWorker).postMessage(
-          boltConnectionErrorMessage(BoltConnectionError())
-        )
-      }
-    )
-      .then(() => {
-        const res: any = connectionTypeMap[connectionType].create(
-          input,
-          applyGraphTypes(parameters),
-          { requestId, cancelable, txMetadata, useDb, autoCommit }
-        )
-        connectionTypeMap[connectionType]
-          .getPromise(res)
-          .then(r => {
-            afterWork()
-            ;(self as unknown as ServiceWorker).postMessage(
-              cypherResponseMessage(r)
-            )
-          })
-          .catch((e: { code: number; message: string }) => {
-            afterWork()
-            ;(self as unknown as ServiceWorker).postMessage(
-              maybeCypherErrorMessage({ code: e.code, message: e.message })
-            )
-          })
-      })
-      .catch(e => {
+    runCypherMessage(data)
+      .then(res => {
         afterWork()
-        ;(self as unknown as ServiceWorker).postMessage(
-          maybeCypherErrorMessage({ code: e.code, message: e.message })
+        self.postMessage(cypherResponseMessage(res))
+      })
+      .catch(err => {
+        afterWork()
+        self.postMessage(
+          maybeCypherErrorMessage({ code: err.code, message: err.message })
         )
       })
   } else if (messageType === CANCEL_TRANSACTION_MESSAGE) {
-    cancelTransaction(message.data.id, () => {
-      ;(self as unknown as ServiceWorker).postMessage(
-        postCancelTransactionMessage()
-      )
+    cancelTransaction(data.id, () => {
+      self.postMessage(postCancelTransactionMessage())
     })
   } else if (messageType === CLOSE_CONNECTION_MESSAGE) {
     queueWork(() => {
       closeConnection()
     })
   } else {
-    ;(self as unknown as ServiceWorker).postMessage(
+    self.postMessage(
       cypherErrorMessage({
         code: -1,
         message: `Unknown message to Bolt Worker: ${messageType}`
@@ -180,19 +183,23 @@ const afterWork = (): void => {
 }
 
 const queueWork = (fn: () => void): void => {
-  workQue.push(fn)
+  workQueue.push(fn)
   doWork()
 }
 const doWork = (): void => {
   if (busy) {
     return
   }
-  if (!workQue.length) {
+  if (!workQueue.length) {
     return
   }
-  const workFn = workQue.shift()
-  workFn && workFn()
+
+  const workFn = workQueue.shift()
+  if (workFn) {
+    workFn()
+  }
+
   doWork()
 }
 
-self.addEventListener('message', onmessage)
+self.addEventListener('message', onmessage as any)

--- a/src/shared/services/bolt/boltWorkerMessages.ts
+++ b/src/shared/services/bolt/boltWorkerMessages.ts
@@ -30,7 +30,7 @@ export const POST_CANCEL_TRANSACTION_MESSAGE = 'POST_CANCEL_TRANSACTION_MESSAGE'
 export const BOLT_CONNECTION_ERROR_MESSAGE = 'BOLT_CONNECTION_ERROR_MESSAGE'
 export const CLOSE_CONNECTION_MESSAGE = 'CLOSE_CONNECTION_MESSAGE'
 
-export const runCypherMessage = (
+export const getWorkerPayloadForRunningCypherMessage = (
   input: string,
   parameters: unknown,
   connectionType = ROUTED_WRITE_CONNECTION,

--- a/src/shared/services/bolt/setup-bolt-worker.ts
+++ b/src/shared/services/bolt/setup-bolt-worker.ts
@@ -56,6 +56,8 @@ export const setupBoltWorker = (
           case POST_CANCEL_TRANSACTION_MESSAGE:
             work.finish()
             break
+          default:
+            return
         }
       }
     })


### PR DESCRIPTION
The code around the bolt worker is not straightforward to read, and it doesn't help that it uses some old patterns (probably) from when Javascript didn't have classes. So here is some cleanup to make this code more readable. 

I didn't change any functionality, just moved things around, updated types, and renamed a few things to have more accurate names.

Preview: http://browser-bolt-worker-cleanup.surge.sh