### PR TITLE
Visualization: reduce jiggling of nodes when interacting with graph

### DIFF
--- a/src/browser/modules/D3Visualization/lib/visualization/components/mouseEventHandlers.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/components/mouseEventHandlers.ts
@@ -1,11 +1,10 @@
 import { D3DragEvent, drag as d3Drag } from 'd3-drag'
 import { Simulation } from 'd3-force'
 import { BaseType, Selection } from 'd3-selection'
-import { ZoomBehavior } from 'd3-zoom'
 
 import {
-  DEFAULT_ALPHA,
   DEFAULT_ALPHA_TARGET,
+  DRAGGING_ALPHA,
   DRAGGING_ALPHA_TARGET
 } from '../constants'
 import Relationship from './Relationship'
@@ -69,7 +68,7 @@ export const nodeEventHandlers = (
       // isn't stopped while nodes are being dragged.
       simulation
         .alphaTarget(DRAGGING_ALPHA_TARGET)
-        .alpha(DEFAULT_ALPHA)
+        .alpha(DRAGGING_ALPHA)
         .restart()
       restartedSimulation = true
     }

--- a/src/browser/modules/D3Visualization/lib/visualization/constants.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/constants.ts
@@ -5,7 +5,7 @@ export const PRECOMPUTED_TICKS = 300
 export const TICKS_PER_RENDER = 10
 
 // Friction.
-export const VELOCITY_DECAY = 0.06
+export const VELOCITY_DECAY = 0.4
 // Temperature of the simulation. It's a value in the range [0,1] and it
 // decreases over time. Can be seen as the probability that a node will move.
 export const DEFAULT_ALPHA = 1

--- a/src/browser/modules/D3Visualization/lib/visualization/constants.ts
+++ b/src/browser/modules/D3Visualization/lib/visualization/constants.ts
@@ -13,6 +13,11 @@ export const DEFAULT_ALPHA = 1
 export const DEFAULT_ALPHA_TARGET = 0
 // Temperature at which the simulation is stopped.
 export const DEFAULT_ALPHA_MIN = 0.05
+// The lower this value, the lower the movement of nodes that aren't being
+// dragged. This also affects the perceived elasticity of relationships, a lower
+// value will cause neighboring nodes to take more time to follow the node that
+// is being dragged.
+export const DRAGGING_ALPHA = 0.8
 // When dragging we set alphaTarget to a value greater than alphaMin to prevent
 // the simulation from stopping.
 export const DRAGGING_ALPHA_TARGET = 0.09

--- a/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
+++ b/src/browser/modules/Stream/CypherFrame/__snapshots__/VisualizationView.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`Visualization renders with result and escapes any HTML 1`] = `
                 <g
                   aria-label="graph-node1"
                   class="node"
-                  transform="translate(0,0.030982068166081952)"
+                  transform="translate(0,0.9475741398926749)"
                 >
                   <circle
                     class="ring"


### PR DESCRIPTION
When dragging a node that has lots of neighbors, the neighboring nodes keep jiggling, making the visualization look worse than it did before. This PR is addressing this by increasing friction to make the nodes stabilize more quickly, and reducing the alpha value we use when dragging to reduce the movement of nodes that aren't being dragged.

The preview of this change is available here: http://browser-visualization-tweaks.surge.sh/