### PR TITLE
Show links to documentation for both param and params

### DIFF
--- a/src/browser/modules/Stream/ParamsFrame.tsx
+++ b/src/browser/modules/Stream/ParamsFrame.tsx
@@ -39,7 +39,11 @@ const ParamsFrame = ({ frame, isCollapsed, isFullscreen }: any) => {
       )}
       <div style={{ marginTop: '20px' }}>
         See <AutoExecButton cmd="help param" /> for usage of the{' '}
-        <code>:param</code> command.
+        <code>:param</code> command (setting one parameter).
+      </div>
+      <div style={{ marginTop: '5px' }}>
+        See <AutoExecButton cmd="help params" /> for usage of the{' '}
+        <code>:params</code> command (setting multiple parameters).
       </div>
     </PaddedDiv>
   )


### PR DESCRIPTION
Now show doc links for both param and params when using either param or params.
<img width="957" alt="Screenshot 2022-02-10 at 10 49 20" src="https://user-images.githubusercontent.com/11065688/153381655-e7a22ada-67da-4ad8-a359-ffb51d2fff72.png">

<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

