### PR TITLE
Remove viz limit of 1000

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
+++ b/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
@@ -60,7 +60,6 @@ import {
   VisualizationIcon
 } from 'browser-components/icons/Icons'
 import { StyledFrameBody } from 'browser/modules/Frame/styled'
-import { requestExceedsVisLimits } from 'browser/modules/Stream/CypherFrame/helpers'
 import RelatableView, {
   RelatableStatusbar
 } from 'browser/modules/Stream/CypherFrame/relatable-view'
@@ -201,9 +200,7 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
   }
 
   canShowViz = (): boolean =>
-    !requestExceedsVisLimits(this.props.request) &&
-    resultHasNodes(this.props.request) &&
-    !this.state.errors
+    resultHasNodes(this.props.request) && !this.state.errors
 
   sidebar = (): JSX.Element => (
     <FrameSidebar>

--- a/src/browser/modules/Stream/CypherFrame/helpers.ts
+++ b/src/browser/modules/Stream/CypherFrame/helpers.ts
@@ -30,7 +30,6 @@ import {
   some,
   take
 } from 'lodash-es'
-import { Duration } from 'luxon'
 import neo4j from 'neo4j-driver'
 
 import bolt from 'services/bolt/bolt'
@@ -135,12 +134,6 @@ export const flattenArrayDeep = (arr: any) => {
   return result
 }
 
-const VIS_MAX_SAFE_LIMIT = 1000
-
-export const requestExceedsVisLimits = ({ result }: any = {}) => {
-  return resultHasTruncatedFields(result, VIS_MAX_SAFE_LIMIT)
-}
-
 export const resultHasNodes = (request: any, types = neo4j.types) => {
   if (!request) return false
   const { result = {} } = request
@@ -222,8 +215,7 @@ export const initialView = (props: any, state: any = {}) => {
   }
   // No we don't care about the recentView
   // If the response have viz elements, we show the viz
-  if (!requestExceedsVisLimits(props.request) && resultHasNodes(props.request))
-    return viewTypes.VISUALIZATION
+  if (resultHasNodes(props.request)) return viewTypes.VISUALIZATION
   return viewTypes.TABLE
 }
 


### PR DESCRIPTION
Now it is possible to select the graph view even if the results contains more than a 1000 record fields. The other limit which truncates the record fields data is still there.
 
<img width="1722" alt="Screenshot 2022-02-10 at 14 14 06" src="https://user-images.githubusercontent.com/11065688/153419504-277f7630-6c5c-4528-8945-b9e0a2630b68.png">
<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

