### PR TITLE
Make max record setting user configurable

### DIFF
--- a/src/browser/modules/D3Visualization/components/OverviewPane.tsx
+++ b/src/browser/modules/D3Visualization/components/OverviewPane.tsx
@@ -162,8 +162,9 @@ function OverviewPane({
         <div style={{ paddingBottom: '10px' }}>
           {hasTruncatedFields && (
             <StyledTruncatedMessage>
-              <Icon name="warning sign" /> Record fields have been
-              truncated.&nbsp;
+              <Icon name="warning sign" />
+              Record fields have been truncated.&nbsp;
+              <br />
             </StyledTruncatedMessage>
           )}
           {infoMessage && (

--- a/src/browser/modules/Sidebar/UserSettings.tsx
+++ b/src/browser/modules/Sidebar/UserSettings.tsx
@@ -153,6 +153,12 @@ const visualSettings = [
         }
       },
       {
+        maxFieldItems: {
+          displayName: 'Max record fields',
+          tooltip: 'Limits the number of fields per returned record'
+        }
+      },
+      {
         autoComplete: {
           displayName: 'Connect result nodes',
           tooltip:


### PR DESCRIPTION
When a single returned "row" is a list we have a hardcoded limit in which we truncate it. This PR changes the setting to be user configureable. This video show it in action.
https://user-images.githubusercontent.com/10564538/153913900-eb69fa56-973e-4b32-9f19-2889833e2f2f.mp4

Also make sure our warning messages are shown on separate lines:
![CleanShot 2022-02-14 at 18 13 37](https://user-images.githubusercontent.com/10564538/153913544-422a5fbe-2dfb-4df3-8538-1816ed05e428.png)

A preview is up at http://expose_record_setting.surge.sh