### PR TITLE
Handle null values in graph viz

### DIFF
--- a/src/browser/modules/D3Visualization/mapper.ts
+++ b/src/browser/modules/D3Visualization/mapper.ts
@@ -25,7 +25,9 @@ import { optionalToString } from 'services/utils'
 
 const mapProperties = (_: any) => Object.assign({}, ...stringifyValues(_))
 const stringifyValues = (obj: any) =>
-  Object.keys(obj).map(k => ({ [k]: optionalToString(obj[k]) }))
+  Object.keys(obj).map(k => ({
+    [k]: obj[k] === null ? 'null' : optionalToString(obj[k])
+  }))
 
 export function createGraph(
   nodes: BasicNode[],

--- a/src/shared/services/bolt/boltMappings.ts
+++ b/src/shared/services/bolt/boltMappings.ts
@@ -215,6 +215,10 @@ const getTypeDisplayName = (val: any): string => {
     return `Array(${val.length})`
   }
 
+  if (val === null) {
+    return 'null'
+  }
+
   return getDriverTypeName(val) || 'Unknown'
 }
 


### PR DESCRIPTION
We stringify all node property values except `null`, which causes crashes later on. This PR makes we handle null, and that the correct type hint show up as well. Preview at http://handle_null_properties.surge.sh, easiest way to trigger the crash is run `call apoc.create.vNode(['stuff'], {id:5, blah:null})` and hover the created node. 

Here's a screen shot of how it looks now: 
 
 ![CleanShot 2022-02-14 at 19 03 49](https://user-images.githubusercontent.com/10564538/153920993-c13acb15-dba4-43f0-89f3-82581147c778.png)