### PR TITLE
Remove unneeded listConfig call in sys info frame

### DIFF
--- a/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.test.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.test.tsx
@@ -38,7 +38,9 @@ const baseProps = {
   useDb: 'neo4j',
   isFullscreen: false,
   isCollapsed: false,
-  isOnCausalCluster: true
+  isOnCausalCluster: true,
+  namespacesEnabled: false,
+  metricsPrefix: 'neo4j'
 }
 
 const mountWithStore = (props: Partial<SysInfoFrameProps>) => {

--- a/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
@@ -119,7 +119,11 @@ export class SysInfoFrame extends Component<
       }
     }
 
-    if (prevProps.useDb !== this.props.useDb) {
+    if (
+      prevProps.useDb !== this.props.useDb ||
+      prevProps.namespacesEnabled !== this.props.namespacesEnabled ||
+      prevProps.metricsPrefix !== this.props.metricsPrefix
+    ) {
       this.getSysInfo()
     }
   }

--- a/src/browser/modules/Stream/SysInfoFrame/sysinfoHelpers.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/sysinfoHelpers.tsx
@@ -98,7 +98,7 @@ type MetricType = 'database' | 'dbms'
 type MetricSettings = {
   databaseName: string
   namespacesEnabled: boolean
-  userConfiguredPrefix: string
+  metricsPrefix: string
 }
 type ConstructorParams = MetricSettings & {
   baseMetricName: string
@@ -107,7 +107,7 @@ type ConstructorParams = MetricSettings & {
 }
 
 function constructQuery({
-  userConfiguredPrefix,
+  metricsPrefix,
   namespacesEnabled,
   databaseName,
   baseMetricName,
@@ -128,13 +128,13 @@ function constructQuery({
   parts.push(baseMetricName)
   const metricName = parts.join('.')
 
-  return `CALL dbms.queryJmx("${userConfiguredPrefix}.metrics:name=${userConfiguredPrefix}.${metricName}") YIELD name, attributes RETURN "${group}" AS group, name, attributes`
+  return `CALL dbms.queryJmx("${metricsPrefix}.metrics:name=${metricsPrefix}.${metricName}") YIELD name, attributes RETURN "${group}" AS group, name, attributes`
 }
 
 export function sysinfoQuery({
   databaseName,
   namespacesEnabled,
-  userConfiguredPrefix
+  metricsPrefix
 }: MetricSettings): string {
   const queries = sysInfoMetrics
     .map(({ group, type, baseMetricNames }) =>
@@ -142,7 +142,7 @@ export function sysinfoQuery({
         constructQuery({
           databaseName,
           namespacesEnabled,
-          userConfiguredPrefix,
+          metricsPrefix,
           baseMetricName,
           group,
           type

--- a/src/shared/modules/dbMeta/__snapshots__/dbMetaDuck.test.ts.snap
+++ b/src/shared/modules/dbMeta/__snapshots__/dbMetaDuck.test.ts.snap
@@ -24,6 +24,8 @@ Object {
     "browser.retain_connection_credentials": false,
     "browser.retain_editor_history": false,
     "clients.allow_telemetry": true,
+    "metrics.namespaces.enabled": false,
+    "metrics.prefix": "neo4j",
   },
 }
 `;
@@ -51,6 +53,8 @@ Object {
     "browser.retain_connection_credentials": false,
     "browser.retain_editor_history": false,
     "clients.allow_telemetry": true,
+    "metrics.namespaces.enabled": false,
+    "metrics.prefix": "neo4j",
   },
 }
 `;

--- a/src/shared/modules/dbMeta/epics.ts
+++ b/src/shared/modules/dbMeta/epics.ts
@@ -376,7 +376,14 @@ export const serverConfigEpic = (some$: any, store: any) =>
               }
               value = authEnabled
               store.dispatch(setAuthEnabled(authEnabled))
+            } else if (name === 'metrics.namespaces.enabled') {
+              let metricsNamespacesEnabled = true
+              if (typeof value !== 'undefined' && isConfigValFalsy(value)) {
+                metricsNamespacesEnabled = false
+              }
+              value = metricsNamespacesEnabled
             }
+
             all[name] = value
             return all
           }, {})

--- a/src/shared/modules/dbMeta/state.ts
+++ b/src/shared/modules/dbMeta/state.ts
@@ -54,7 +54,9 @@ export const initialState = {
     'browser.remote_content_hostname_allowlist': 'guides.neo4j.com, localhost',
     'browser.retain_connection_credentials': false,
     'browser.retain_editor_history': false,
-    'clients.allow_telemetry': true
+    'clients.allow_telemetry': true,
+    'metrics.namespaces.enabled': false,
+    'metrics.prefix': 'neo4j'
   }
 }
 
@@ -142,6 +144,10 @@ export const getRetainEditorHistory = (state: any) => {
   if (conf === null || typeof conf === 'undefined') return false
   return !isConfigValFalsy(conf)
 }
+export const getMetricsNamespacesEnabled = (state: GlobalState): boolean =>
+  getAvailableSettings(state)['metrics.namespaces.enabled']
+export const getMetricsPrefix = (state: GlobalState): string =>
+  getAvailableSettings(state)['metrics.prefix']
 
 export const getDatabases = (state: any): Database[] =>
   (state[NAME] || initialState).databases

--- a/src/shared/modules/features/featuresDuck.ts
+++ b/src/shared/modules/features/featuresDuck.ts
@@ -39,8 +39,6 @@ export const DETECTED_CLIENT_CONFIG = 'features/DETECTED_CLIENT_CONFIG'
 export const getAvailableProcedures = (state: any) =>
   state[NAME].availableProcedures
 
-// having this procedure used to indicate that we're on a cluster
-// but from 4.3 stand alone instances also have it
 export const isMultiDatabase = (state: any) =>
   getAvailableProcedures(state).includes('dbms.databases.overview')
 export const canAssignRolesToUser = (state: any) =>


### PR DESCRIPTION
After the `metrics.prefix` and `metrics.namespaces.enabled` settings were added to `clientConfig`, we no longer need the work-around of calling `listConfig` directly in the sysinfo frame since it's already called when loading the server metadata. 

I've made sure it works even if the settings haven't been read yet as well. Tested on `4.4.0` with settings: 
metrics.prefix=abc
metrics.namespaces.enabled=true

Preview at http://remove_listConfig_call.surge.sh