### PR TITLE
Improve causal cluster detection

### DIFF
--- a/src/browser/modules/Stream/Queries/QueriesFrame.test.tsx
+++ b/src/browser/modules/Stream/Queries/QueriesFrame.test.tsx
@@ -82,7 +82,8 @@ it('can list and kill queries', () => {
     bus,
     neo4jVersion: '4.0.0',
     isFullscreen: false,
-    isCollapsed: false
+    isCollapsed: false,
+    isOnCausalCluster: false
   }
 
   const { getByText, getByTestId } = render(<QueriesFrame {...props} />)

--- a/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.test.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.test.tsx
@@ -38,7 +38,7 @@ const baseProps = {
   useDb: 'neo4j',
   isFullscreen: false,
   isCollapsed: false,
-  canCallClusterOverview: true
+  isOnCausalCluster: true
 }
 
 const mountWithStore = (props: Partial<SysInfoFrameProps>) => {

--- a/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
@@ -47,9 +47,9 @@ import {
   getDatabases,
   isEnterprise
 } from 'shared/modules/dbMeta/state'
-import { canCallDbmsClusterOverview } from 'shared/modules/features/featuresDuck'
 import { hasMultiDbSupport } from 'shared/modules/features/versionedFeatures'
 import { Frame } from 'shared/modules/frames/framesDuck'
+import { isOnCausalCluster } from 'shared/utils/selectors'
 
 export type DatabaseMetric = { label: string; value?: string }
 export type SysInfoFrameState = {
@@ -77,7 +77,7 @@ export type SysInfoFrameProps = {
   useDb: string | null
   isFullscreen: boolean
   isCollapsed: boolean
-  canCallClusterOverview: boolean
+  isOnCausalCluster: boolean
 }
 
 export class SysInfoFrame extends Component<
@@ -199,7 +199,7 @@ export class SysInfoFrame extends Component<
         },
         responseHandler
       )
-      if (this.props.canCallClusterOverview) {
+      if (this.props.isOnCausalCluster) {
         this.props.bus.self(
           CYPHER_REQUEST,
           {
@@ -289,7 +289,7 @@ const FrameVersionPicker = (props: SysInfoFrameProps) => {
     return (
       <LegacySysInfoFrame
         {...props}
-        isACausalCluster={props.canCallClusterOverview}
+        isACausalCluster={props.isOnCausalCluster}
       />
     )
   } else {
@@ -303,7 +303,7 @@ const mapStateToProps = (state: GlobalState) => ({
   isConnected: isConnected(state),
   databases: getDatabases(state),
   useDb: getUseDb(state),
-  canCallClusterOverview: canCallDbmsClusterOverview(state)
+  isOnCausalCluster: isOnCausalCluster(state)
 })
 
 export default withBus(connect(mapStateToProps)(FrameVersionPicker))

--- a/src/shared/modules/dbMeta/epics.ts
+++ b/src/shared/modules/dbMeta/epics.ts
@@ -23,7 +23,6 @@ import Rx from 'rxjs/Rx'
 import {
   FEATURE_DETECTION_DONE,
   USER_CAPABILITIES,
-  canCallDbmsClusterOverview,
   hasClientConfig,
   setClientConfig,
   updateUserCapability
@@ -72,6 +71,7 @@ import {
 } from 'shared/modules/connections/connectionsDuck'
 import { clearHistory } from 'shared/modules/history/historyDuck'
 import { getBackgroundTxMetadata } from 'shared/services/bolt/txMetadata'
+import { isOnCausalCluster } from 'shared/utils/selectors'
 
 const databaseList = (store: any) =>
   Rx.Observable.fromPromise(
@@ -155,7 +155,7 @@ const getLabelsAndTypes = (store: any) =>
 const clusterRole = (store: any) =>
   Rx.Observable.fromPromise(
     new Promise((resolve, reject) => {
-      if (!canCallDbmsClusterOverview(store.getState())) {
+      if (!isOnCausalCluster(store.getState())) {
         return resolve(null)
       }
       bolt

--- a/src/shared/modules/features/featuresDuck.test.ts
+++ b/src/shared/modules/features/featuresDuck.test.ts
@@ -70,21 +70,6 @@ describe('feature getters', () => {
       'foo.bar'
     )
   })
-  test('should not be a causal cluster', () => {
-    const nextState = reducer(undefined, { type: '' })
-    expect(features.canCallDbmsClusterOverview({ features: nextState })).toBe(
-      false
-    )
-  })
-  test('should be in a causal cluster', () => {
-    const nextState = reducer(
-      { availableProcedures: ['dbms.cluster.overview'] } as any,
-      { type: '' }
-    )
-    expect(features.canCallDbmsClusterOverview({ features: nextState })).toBe(
-      true
-    )
-  })
   test('should not be able to assign roles to user', () => {
     const nextState = reducer(undefined, { type: '' })
     expect(features.canAssignRolesToUser({ features: nextState })).toBe(false)

--- a/src/shared/modules/features/featuresDuck.ts
+++ b/src/shared/modules/features/featuresDuck.ts
@@ -41,8 +41,6 @@ export const getAvailableProcedures = (state: any) =>
 
 // having this procedure used to indicate that we're on a cluster
 // but from 4.3 stand alone instances also have it
-export const canCallDbmsClusterOverview = (state: any) =>
-  getAvailableProcedures(state).includes('dbms.cluster.overview')
 export const isMultiDatabase = (state: any) =>
   getAvailableProcedures(state).includes('dbms.databases.overview')
 export const canAssignRolesToUser = (state: any) =>


### PR DESCRIPTION
From 4.3 we can't use the presence of `dbms.cluster.overview` to know if we're connected to a cluster, but the same version added `SHOW DATABASES` which can.