### PR TITLE
Export plan txt and make download dropdown context dependent

### DIFF
--- a/e2e_tests/integration/data-export.spec.ts
+++ b/e2e_tests/integration/data-export.spec.ts
@@ -21,10 +21,8 @@
 /* global Cypress, cy, before */
 
 describe('Data export', () => {
-  before(function() {
-    cy.visit(Cypress.config('url'))
-      .title()
-      .should('include', 'Neo4j Browser')
+  before(function () {
+    cy.visit(Cypress.config('url')).title().should('include', 'Neo4j Browser')
     cy.wait(3000)
   })
   it('can connect', () => {
@@ -32,7 +30,7 @@ describe('Data export', () => {
     cy.connect('neo4j', password)
   })
   context('export options', () => {
-    before(function() {
+    before(function () {
       cy.executeCommand(':clear')
       cy.executeCommand('PROFILE CREATE (n:ExportTest) RETURN n')
       cy.get('[data-testid="frame"]', { timeout: 10000 }).should(
@@ -40,32 +38,31 @@ describe('Data export', () => {
         1
       )
     })
-    after(function() {
+    after(function () {
       cy.executeCommand('MATCH (n:ExportTest) DETACH DELETE n')
     })
-    const exportOptionsConfig = [
-      {
-        names: ['Plan', 'Visualization', 'Table', 'Ascii', 'Code'],
-        order: ['CSV', 'JSON', 'PNG', 'SVG']
-      }
+    const tests = [
+      { panel: 'Visualization', expected: ['PNG', 'SVG'] },
+      { panel: 'Plan', expected: ['PNG', 'SVG'] }, // This test will fail in 5.0 -> one more option is enabled then
+      { panel: 'Table', expected: ['CSV', 'JSON'] },
+      { panel: 'Ascii', expected: ['CSV', 'JSON'] },
+      { panel: 'Code', expected: ['CSV', 'JSON'] }
     ]
-    exportOptionsConfig.forEach(config => {
-      config.names.forEach(name => {
-        it(`shows the correct export buttons for ${name} view`, () => {
-          cy.get(`[data-testid="cypherFrameSidebar${name}"]`, {
-            timeout: 10000
-          }).click()
-          cy.get('[data-testid="frame-export-dropdown"]').trigger('mouseover')
-          cy.get('[data-testid="frame-export-dropdown"]', {
-            timeout: 10000
-          }).within(() => {
-            cy.get('a').then(exportButtonsList => {
-              expect(exportButtonsList).to.have.length(config.order.length)
-              config.order.forEach((exportType, index) => {
-                expect(exportButtonsList.eq(index)).to.contain(
-                  `Export ${exportType}`
-                )
-              })
+    tests.forEach(({ panel, expected }) => {
+      it(`shows the correct export buttons for ${panel} view`, () => {
+        cy.get(`[data-testid="cypherFrameSidebar${panel}"]`, {
+          timeout: 10000
+        }).click()
+        cy.get('[data-testid="frame-export-dropdown"]').trigger('mouseover')
+        cy.get('[data-testid="frame-export-dropdown"]', {
+          timeout: 10000
+        }).within(() => {
+          cy.get('a').then(exportButtonsList => {
+            expect(exportButtonsList).to.have.length(expected.length)
+            expected.forEach((exportType, index) => {
+              expect(exportButtonsList.eq(index)).to.contain(
+                `Export ${exportType}`
+              )
             })
           })
         })

--- a/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
+++ b/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
@@ -177,15 +177,16 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
       { name: 'PNG', download: this.exportPNG },
       { name: 'SVG', download: this.exportSVG }
     ]
+
     this.props.setExportItems([
-      ...(this.getRecords().length > 0
+      ...(this.getRecords().length > 0 && this.state.openView !== ViewTypes.PLAN
         ? [{ name: 'CSV', download: this.exportCSV }]
         : []),
-      ...(this.getRecords().length > 0
+      ...(this.getRecords().length > 0 && this.state.openView !== ViewTypes.PLAN
         ? [{ name: 'JSON', download: this.exportJSON }]
         : []),
-      ...(this.hasStringPlan()
-        ? [{ name: 'PLAN.TXT', download: this.exportStringPlan }]
+      ...(this.hasStringPlan() && this.state.openView === ViewTypes.PLAN
+        ? [{ name: 'TXT', download: this.exportStringPlan }]
         : []),
       ...(this.visElement ? downloadGraphics : [])
     ])

--- a/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
+++ b/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
@@ -173,22 +173,32 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
       if (view) this.setState({ openView: view })
     }
 
+    const textDownloadEnabled = () =>
+      this.getRecords().length > 0 &&
+      this.state.openView &&
+      [ViewTypes.TEXT, ViewTypes.TABLE, ViewTypes.CODE].includes(
+        this.state.openView
+      )
+    const graphicsDownloadEnabled = () =>
+      this.visElement &&
+      this.state.openView &&
+      [ViewTypes.PLAN, ViewTypes.VISUALIZATION].includes(this.state.openView)
+
+    const downloadText = [
+      { name: 'CSV', download: this.exportCSV },
+      { name: 'JSON', download: this.exportJSON }
+    ]
     const downloadGraphics = [
       { name: 'PNG', download: this.exportPNG },
       { name: 'SVG', download: this.exportSVG }
     ]
 
     this.props.setExportItems([
-      ...(this.getRecords().length > 0 && this.state.openView !== ViewTypes.PLAN
-        ? [{ name: 'CSV', download: this.exportCSV }]
-        : []),
-      ...(this.getRecords().length > 0 && this.state.openView !== ViewTypes.PLAN
-        ? [{ name: 'JSON', download: this.exportJSON }]
-        : []),
+      ...(textDownloadEnabled() ? downloadText : []),
       ...(this.hasStringPlan() && this.state.openView === ViewTypes.PLAN
         ? [{ name: 'TXT', download: this.exportStringPlan }]
         : []),
-      ...(this.visElement ? downloadGraphics : [])
+      ...(graphicsDownloadEnabled() ? downloadGraphics : [])
     ])
   }
 

--- a/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
+++ b/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
@@ -178,18 +178,21 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
       { name: 'SVG', download: this.exportSVG }
     ]
     this.props.setExportItems([
-      { name: 'CSV', download: this.exportCSV },
-      { name: 'JSON', download: this.exportJSON },
+      ...(this.getRecords().length > 0
+        ? [{ name: 'CSV', download: this.exportCSV }]
+        : []),
+      ...(this.getRecords().length > 0
+        ? [{ name: 'JSON', download: this.exportJSON }]
+        : []),
+      ...(this.hasStringPlan()
+        ? [{ name: 'PLAN.TXT', download: this.exportStringPlan }]
+        : []),
       ...(this.visElement ? downloadGraphics : [])
     ])
   }
 
   componentDidMount(): void {
     const view = initialView(this.props, this.state)
-    this.props.setExportItems([
-      { name: 'CSV', download: this.exportCSV },
-      { name: 'JSON', download: this.exportJSON }
-    ])
     if (view) this.setState({ openView: view })
   }
 
@@ -427,6 +430,26 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
       type: 'text/plain;charset=utf-8'
     })
     saveAs(blob, 'records.json')
+  }
+
+  hasStringPlan = (): boolean =>
+    // @ts-ignore driver types don't have string-representation yet
+    !!this.props.request?.result?.summary?.plan?.arguments?.[
+      'string-representation'
+    ]
+
+  exportStringPlan = (): void => {
+    const data =
+      // @ts-ignore driver types don't have string-representation yet
+      this.props.request?.result?.summary?.plan?.arguments?.[
+        'string-representation'
+      ]
+    if (data) {
+      const blob = new Blob([data], {
+        type: 'text/plain;charset=utf-8'
+      })
+      saveAs(blob, 'plan.txt')
+    }
   }
 
   exportPNG = (): void => {


### PR DESCRIPTION
In the next version of neo4j there'll be an option to get query plan as a string representation. We're adding the option to download these. Since it's not released yet it's tricky to test, so no preview link.

This PR also makes sure you only see relevant download options for the panel you're currently viewing and makes sure we only allow downloading when there's data to download.