### PR TITLE
Upgrade docs packages for Antora 3

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "npm run build && npm run serve & npm-watch build",
+    "start": "nodemon -e adoc --exec \"npm run build && npm run serve\"",
     "serve": "node server.js",
     "build": "antora --stacktrace preview.yml",
     "lint": "node scripts/lint-links.js"
@@ -22,23 +22,15 @@
   },
   "homepage": "https://github.com/neo4j/neo4j-browser/docs#readme",
   "dependencies": {
-    "@antora/cli": "^2.3.3",
-    "@antora/site-generator-default": "^2.3.3",
+    "@antora/cli": "^3.0.0",
+    "@antora/site-generator-default": "^3.0.0",
+    "@neo4j-antora/antora-add-notes": "^0.1.6",
+    "@neo4j-antora/antora-modify-sitemaps": "^0.4.2",
     "@neo4j-documentation/macros": "^1.0.0",
-    "@neo4j-documentation/remote-include": "^1.0.0",
-    "express": "^4.17.1",
-    "npm-watch": "^0.6.0"
-  },
-  "watch": {
-    "build": {
-      "patterns": [
-        "modules"
-      ],
-      "extensions": "adoc"
-    }
+    "@neo4j-documentation/remote-include": "^1.0.0"
   },
   "devDependencies": {
-    "cheerio": "^1.0.0-rc.3",
-    "hyperlink": "^4.6.0"
+    "express": "^4.17.1",
+    "nodemon": "^2.0.15"
   }
 }

--- a/docs/preview.yml
+++ b/docs/preview.yml
@@ -22,6 +22,13 @@ ui:
 urls:
   html_extension_style: indexify
 
+antora:
+  extensions:
+  - require: "@neo4j-antora/antora-modify-sitemaps"
+    sitemap_version: '4.4'
+    sitemap_loc_version: 'current'
+    move_sitemaps_to_components: true
+
 asciidoc:
   extensions:
   - "@neo4j-documentation/remote-include"

--- a/docs/publish.yml
+++ b/docs/publish.yml
@@ -23,6 +23,13 @@ ui:
 urls:
   html_extension_style: indexify
 
+antora:
+  extensions:
+  - require: "@neo4j-antora/antora-modify-sitemaps"
+    sitemap_version: '4.4'
+    sitemap_loc_version: 'current'
+    move_sitemaps_to_components: true
+
 asciidoc:
   extensions:
   - "@neo4j-documentation/remote-include"


### PR DESCRIPTION
## Description

Updates the docs package to the latest packages and versions, particularly upgrading from Antora 2.3 to Antora 3.0.

## Verification

In the _/docs/_ directory:

1. Remove node_modules
2. npm install
3. npm start

Verify there are no errors or warning from Antora / asciidoctor, and verify the output at localhost:8002 looks as expected

## Notes

From a docs contributor's perspective little is changed from the previous version of Antora. 

- If there are any errors or warnings in the log from the Antora build, they will be more informative than before, including full paths to relevant files.
- The **sitemap.xml** file is updated by the Antora extension `@neo4j-antora/antora-modify-sitemaps`, and will be output as _build/site/browser-manual/4.4/sitemap.xml after #1684 is merged. This is handled by the change to the playbook, **preview.yml**. (Previously, the sitemap had to be managed as part of the Gradle/TeamCity pipeline).
