### PR TITLE
Fixed styles that were set in last release

### DIFF
--- a/src/browser/modules/Stream/styled.tsx
+++ b/src/browser/modules/Stream/styled.tsx
@@ -406,8 +406,8 @@ export const StyledMissingParamsTemplateLink = styled.div`
 
 export const StyledParamsTemplateClickableArea = styled.a`
   font-family: ${props => props.theme.codeBlockFont};
-  font-size: 1.2rem;
-  line-height: 1.8rem;
+  font-size: 12px;
+  line-height: 18px;
   background: ${props => props.theme.codeBlockBackground};
   color: ${props => props.theme.codeBlockTextColor};
   cursor: pointer;

--- a/src/graphVisualization/components/styled.tsx
+++ b/src/graphVisualization/components/styled.tsx
@@ -143,7 +143,7 @@ export const StyledZoomButton = styled.button`
 export const StyledZoomInfoOverlay = styled.div`
   position: absolute;
   width: 100%;
-  bottom: 2rem;
+  bottom: 20px;
   display: flex;
   flex-direction: row;
   pointer-events: none;
@@ -157,12 +157,12 @@ export const StyledZoomInfo = styled.div`
   box-shadow: ${props => props.theme.standardShadow}
   margin-left: auto;
   margin-right: auto;
-  padding: 1rem;
+  padding: 10px;
   flex: 0 0 auto;
   display: flex;
   flex-direction: column;
   align-items: baseline;
-  gap: 1rem;
+  gap: 10px;
   pointer-events: auto;
 `
 
@@ -170,11 +170,11 @@ export const StyledZoomInfoTextContainer = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 1rem;
+  gap: 10px;
 `
 
 export const StyledZoomInfoText = styled.span`
-  line-height: 1.5rem;
+  line-height: 15px;
 `
 
 export const StyledZoomInfoIconContainer = styled.div`
@@ -182,9 +182,9 @@ export const StyledZoomInfoIconContainer = styled.div`
 `
 
 export const StyledZoomInfoOverlayDoNotDisplayButton = styled.button`
-  padding: 0 3rem;
-  font-size: 1.2rem;
-  line-height: 1.5rem;
+  padding: 0 30px;
+  font-size: 12px;
+  line-height: 15px;
   border: none;
   outline: none;
   background-color: inherit;


### PR DESCRIPTION
Fixed styles that were set in last release when the css files were reordered hence the root font size was wrong, now when we have changed back the order the styles the root font size is different so the styles needs to be fixed. Set to px for now, until a complete change from px to rem is done all over the app.

PR where the order of the css styles imports was fixed: https://github.com/neo4j/neo4j-browser/pull/1689

<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

