### PR TITLE
Use cluster role from show databases if available

### DIFF
--- a/src/browser/modules/DBMSInfo/DatabaseKernelInfo.tsx
+++ b/src/browser/modules/DBMSInfo/DatabaseKernelInfo.tsx
@@ -41,7 +41,7 @@ import {
 } from 'shared/modules/commands/commandsDuck'
 import {
   Database,
-  getClusterRole,
+  getClusterRoleForDb,
   getDatabases,
   getEdition,
   getStoreSize,
@@ -133,12 +133,13 @@ export const DatabaseKernelInfo = ({
 }
 
 const mapStateToProps = (state: any) => {
+  const dbName = getUsedDbName(state)
   return {
     version: getRawVersion(state),
     edition: getEdition(state),
-    dbName: getUsedDbName(state),
+    dbName,
     storeSize: getStoreSize(state),
-    role: getClusterRole(state),
+    role: getClusterRoleForDb(state, dbName),
     databases: getDatabases(state)
   }
 }

--- a/src/browser/modules/Stream/Queries/QueriesFrame.tsx
+++ b/src/browser/modules/Stream/Queries/QueriesFrame.tsx
@@ -57,9 +57,12 @@ import {
   killQueriesProcedure,
   listQueriesProcedure
 } from 'shared/modules/cypher/queriesProcedureHelper'
-import { getRawVersion, hasProcedure } from 'shared/modules/dbMeta/dbMetaDuck'
+import {
+  getRawVersion,
+  hasProcedure,
+  isOnCausalCluster
+} from 'shared/modules/dbMeta/dbMetaDuck'
 import { getDefaultBoltScheme } from 'shared/modules/features/versionedFeatures'
-import { isOnCausalCluster } from 'shared/utils/selectors'
 
 type QueriesFrameState = {
   queries: any[]

--- a/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
@@ -48,11 +48,11 @@ import {
   getDatabases,
   getMetricsNamespacesEnabled,
   getMetricsPrefix,
-  isEnterprise
+  isEnterprise,
+  isOnCausalCluster
 } from 'shared/modules/dbMeta/dbMetaDuck'
 import { hasMultiDbSupport } from 'shared/modules/features/versionedFeatures'
 import { Frame } from 'shared/modules/frames/framesDuck'
-import { isOnCausalCluster } from 'shared/utils/selectors'
 
 export type DatabaseMetric = { label: string; value?: string }
 export type SysInfoFrameState = {

--- a/src/shared/modules/dbMeta/dbMetaEpics.ts
+++ b/src/shared/modules/dbMeta/dbMetaEpics.ts
@@ -37,7 +37,8 @@ import {
   SYSTEM_DB,
   metaQuery,
   serverInfoQuery,
-  VERSION_FOR_CLUSTER_ROLE_IN_SHOW_DB
+  VERSION_FOR_CLUSTER_ROLE_IN_SHOW_DB,
+  isOnCausalCluster
 } from './dbMetaDuck'
 import {
   Database,
@@ -71,7 +72,6 @@ import {
 } from 'shared/modules/connections/connectionsDuck'
 import { clearHistory } from 'shared/modules/history/historyDuck'
 import { backgroundTxMetadata } from 'shared/services/bolt/txMetadata'
-import { isOnCausalCluster } from 'shared/utils/selectors'
 import {
   getListFunctionQuery,
   getListProcedureQuery

--- a/src/shared/modules/features/versionedFeatures.ts
+++ b/src/shared/modules/features/versionedFeatures.ts
@@ -25,6 +25,7 @@ import { guessSemverVersion } from './featureDuck.utils'
 import { GlobalState } from 'project-root/src/shared/globalState'
 
 const NEO4J_4_0 = '4.0.0-alpha01'
+const NEO4J_5_0 = '4.0.0-alpha01'
 
 export const FIRST_MULTI_DB_SUPPORT = NEO4J_4_0
 // Keep the following as 3.4.0 as 3.5.X has a
@@ -49,6 +50,10 @@ export const getDbClusterRole = (state: GlobalState) => {
   const serverVersion = guessSemverVersion(getRawVersion(state))
   if (!semver.valid(serverVersion)) {
     return pre4
+  }
+  if (serverVersion && semver.gte(serverVersion, NEO4J_5_0)) {
+    const db = getUseDb(state)
+    return `SHOW DATABASES YIELD role, name WHERE name = "${db}"`
   }
   if (serverVersion && semver.gte(serverVersion, NEO4J_4_0)) {
     const db = getUseDb(state)

--- a/src/shared/modules/features/versionedFeatures.ts
+++ b/src/shared/modules/features/versionedFeatures.ts
@@ -25,7 +25,7 @@ import { guessSemverVersion } from './featureDuck.utils'
 import { GlobalState } from 'project-root/src/shared/globalState'
 
 const NEO4J_4_0 = '4.0.0-alpha01'
-const NEO4J_5_0 = '4.0.0-alpha01'
+const NEO4J_5_0 = '5.0.0-alpha01'
 
 export const FIRST_MULTI_DB_SUPPORT = NEO4J_4_0
 // Keep the following as 3.4.0 as 3.5.X has a

--- a/src/shared/rootEpic.ts
+++ b/src/shared/rootEpic.ts
@@ -59,7 +59,7 @@ import {
   clearMetaOnDisconnectEpic,
   dbMetaEpic,
   serverConfigEpic
-} from './modules/dbMeta/epics'
+} from './modules/dbMeta/dbMetaEpics'
 import {
   discoveryOnStartupEpic,
   injectDiscoveryEpic

--- a/src/shared/utils/selectors.ts
+++ b/src/shared/utils/selectors.ts
@@ -9,9 +9,6 @@ import {
 import {
   getAllowOutgoingConnections,
   getClientsAllowTelemetry,
-  getDatabases,
-  getRawVersion,
-  hasProcedure,
   isServerConfigDone,
   shouldAllowOutgoingConnections
 } from 'shared/modules/dbMeta/dbMetaDuck'
@@ -98,15 +95,4 @@ export const getTelemetrySettings = (state: GlobalState): TelemetrySettings => {
   }
 
   return { source, ...rules[source] }
-}
-
-export const isOnCausalCluster = (state: GlobalState): boolean => {
-  const version = semver.coerce(getRawVersion(state))
-  if (!version) return false
-
-  if (semver.gte(version, '4.3.0')) {
-    return getDatabases(state).some(database => database.role !== 'standalone')
-  } else {
-    return hasProcedure(state, 'dbms.cluster.overview')
-  }
 }


### PR DESCRIPTION
In modern version of neo4j the cluster role is available through `SHOW DATABASES` so we don't have to run `CALL dbms.cluster.role() YIELD role` to get it.