### PR TITLE
Make sure proper metadata is passed along with queries

### DIFF
--- a/src/shared/modules/commands/helpers/lambdas.ts
+++ b/src/shared/modules/commands/helpers/lambdas.ts
@@ -29,6 +29,7 @@ import {
 
 import bolt from '../../../services/bolt/bolt'
 import { recursivelyTypeGraphItems } from '../../../services/bolt/boltMappings'
+import { userDirectTxMetadata } from '../../../services/bolt/txMetadata'
 import arrayHasItems from '../../../utils/array-has-items'
 
 const FAT_ARROW = '=>'
@@ -83,7 +84,8 @@ export async function collectLambdaValues(
     {},
     {
       requestId,
-      cancelable: false
+      cancelable: false,
+      ...userDirectTxMetadata
     }
   )
 

--- a/src/shared/modules/cypher/cypherDuck.ts
+++ b/src/shared/modules/cypher/cypherDuck.ts
@@ -34,7 +34,10 @@ import {
 import { getCausalClusterAddresses } from './queriesProcedureHelper'
 import bolt from 'services/bolt/bolt'
 import { buildTxFunctionByMode } from 'services/bolt/boltHelpers'
-import { getUserTxMetadata } from 'services/bolt/txMetadata'
+import {
+  getUserTxMetadata,
+  userActionTxMetadata
+} from 'services/bolt/txMetadata'
 import { flatten } from 'services/utils'
 import {
   Connection,
@@ -53,6 +56,7 @@ const queryAndResolve = async (
   driver: any,
   action: any,
   host: any,
+  metadata: { type: string; app: string },
   useDb = {}
 ) => {
   return new Promise(resolve => {
@@ -62,7 +66,7 @@ const queryAndResolve = async (
     })
     const txFn = buildTxFunctionByMode(session)
     txFn &&
-      txFn((tx: any) => tx.run(action.query, action.parameters))
+      txFn((tx: any) => tx.run(action.query, action.parameters), { metadata })
         .then((r: any) => {
           session.close()
           resolve({
@@ -90,7 +94,12 @@ const callClusterMember = async (connection: any, action: any) => {
     bolt
       .directConnect(connection, undefined, undefined, false) // Ignore validation errors
       .then(async driver => {
-        const res = await queryAndResolve(driver, action, connection.host)
+        const res = await queryAndResolve(
+          driver,
+          action,
+          connection.host,
+          userActionTxMetadata.txMetadata
+        )
         driver.close()
         resolve(res)
       })
@@ -168,7 +177,7 @@ export const clusterCypherRequestEpic = (some$: any, store: any) =>
     .mergeMap((action: any) => {
       if (!action.$$responseChannel) return Rx.Observable.of(null)
       return bolt
-        .directTransaction(getCausalClusterAddresses, {})
+        .directTransaction(getCausalClusterAddresses, {}, userActionTxMetadata)
         .then((res: any) => {
           const addresses = flatten(
             res.records.map((record: any) => record.get('addresses'))
@@ -258,7 +267,8 @@ export const handleForcePasswordChangeEpic = (some$: any, store: any) =>
                 const versionRes: any = await queryAndResolve(
                   driver,
                   { ...action, query: serverInfoQuery, parameters: {} },
-                  undefined
+                  undefined,
+                  userActionTxMetadata.txMetadata
                 )
                 // What does the driver say, does the server support multidb?
                 const supportsMultiDb = await driver.supportsMultiDb()
@@ -289,6 +299,7 @@ export const handleForcePasswordChangeEpic = (some$: any, store: any) =>
                 driver,
                 { ...action, ...queryObj },
                 undefined,
+                userActionTxMetadata.txMetadata,
                 driverDatabaseSelection(store.getState(), 'system') // target system db if it has multi-db support
               )
               driver.close()

--- a/src/shared/services/bolt/boltConnection.ts
+++ b/src/shared/services/bolt/boltConnection.ts
@@ -30,6 +30,7 @@ import {
 } from './globalDrivers'
 import { buildTxFunctionByMode } from 'services/bolt/boltHelpers'
 import { Connection } from 'shared/modules/connections/connectionsDuck'
+import { backgroundTxMetadata } from './txMetadata'
 
 export const DIRECT_CONNECTION = 'DIRECT_CONNECTION'
 export const ROUTED_WRITE_CONNECTION = 'ROUTED_WRITE_CONNECTION'
@@ -68,9 +69,9 @@ export const validateConnection = (
       })
       const txFn = buildTxFunctionByMode(session)
       txFn &&
-        txFn((tx: { run: (query: string) => void }) =>
-          tx.run('CALL db.indexes()')
-        )
+        txFn(tx => tx.run('CALL db.indexes()'), {
+          metadata: backgroundTxMetadata.txMetadata
+        })
           .then(() => {
             session.close()
             res(driver)

--- a/src/shared/services/bolt/boltHelpers.test.ts
+++ b/src/shared/services/bolt/boltHelpers.test.ts
@@ -33,7 +33,7 @@ describe('buildTxFunctionByMode', () => {
 
     // When
     const txFn = buildTxFunctionByMode(fakeSession)
-    txFn()
+    txFn!(() => {})
 
     // Then
     expect(fakeSession.readTransaction).toHaveBeenCalledTimes(0)
@@ -49,7 +49,7 @@ describe('buildTxFunctionByMode', () => {
 
     // When
     const txFn = buildTxFunctionByMode(fakeSession)
-    txFn()
+    txFn!(() => {})
 
     // Then
     expect(fakeSession.readTransaction).toHaveBeenCalledTimes(1)
@@ -64,7 +64,7 @@ describe('buildTxFunctionByMode', () => {
 
     // When
     const txFn = buildTxFunctionByMode(fakeSession)
-    txFn()
+    txFn!(() => {})
 
     // Then
     expect(fakeSession.readTransaction).toHaveBeenCalledTimes(0)

--- a/src/shared/services/bolt/boltHelpers.ts
+++ b/src/shared/services/bolt/boltHelpers.ts
@@ -41,7 +41,7 @@ export const isConfigValTruthy = (val: boolean | string | number): boolean =>
 export const isConfigValFalsy = (val: boolean | string | number): boolean =>
   [false, 'false', 'no', 0, '0'].indexOf(val) > -1
 
-export const buildTxFunctionByMode = (session?: Session): any => {
+export const buildTxFunctionByMode = (session?: Session) => {
   if (!session) {
     return null
   }

--- a/src/shared/services/bolt/txMetadata.ts
+++ b/src/shared/services/bolt/txMetadata.ts
@@ -23,7 +23,7 @@ import { version } from 'project-root/package.json'
 export const NEO4J_BROWSER_BACKGROUND_QUERY = 'system'
 export const NEO4J_BROWSER_USER_QUERY = 'user-direct'
 export const NEO4J_BROWSER_USER_ACTION_QUERY = 'user-action'
-const UNKOWN_SOURCE = 'no-info'
+export const DEFAULT_QUERY_METADATA_TYPE = NEO4J_BROWSER_USER_ACTION_QUERY
 export const NEO4J_BROWSER_APP_ID = `neo4j-browser_v${version}`
 
 export const backgroundTxMetadata = {
@@ -39,8 +39,17 @@ export const userDirectTxMetadata = {
     app: NEO4J_BROWSER_APP_ID
   }
 }
+export const userActionTxMetadata = {
+  txMetadata: {
+    type: NEO4J_BROWSER_USER_QUERY,
+    app: NEO4J_BROWSER_APP_ID
+  }
+}
+export const defaultTxMetadata = userActionTxMetadata
 
-export const getUserTxMetadata = (type: string = UNKOWN_SOURCE) => ({
+export const getUserTxMetadata = (
+  type: string = DEFAULT_QUERY_METADATA_TYPE
+) => ({
   txMetadata: {
     type,
     app: NEO4J_BROWSER_APP_ID


### PR DESCRIPTION
I've gone through the cypher queries we send in browser and tagged them properly. I've added a default fallback in case something slipped through.