### PR TITLE
Fix PNG exports font

### DIFF
--- a/src/shared/services/exporting/imageUtils.ts
+++ b/src/shared/services/exporting/imageUtils.ts
@@ -24,15 +24,25 @@ import { prepareForExport } from './svgUtils'
 
 export const downloadPNGFromSVG = (svg: any, graph: any, type: any) => {
   const svgObj = prepareForExport(svg, graph, type)
+  const svgDefaultWidth = parseInt(svgObj.attr('width'), 10)
+  const svgDefaultHeight = parseInt(svgObj.attr('height'), 10)
+
+  // Make PNGs a bit bigger than the default zoom (to lose less quality when resizing)
+  const EXTRA_SIZE = 1.5
+  // also adjust for screen resolutions (to avoid blurry text)
+  svgObj.attr('width', svgDefaultWidth * window.devicePixelRatio * EXTRA_SIZE)
+  svgObj.attr('height', svgDefaultHeight * window.devicePixelRatio * EXTRA_SIZE)
   const svgData = htmlCharacterRefToNumericalRef(svgObj.node())
 
   const canvas = document.createElement('canvas')
-  canvas.width = svgObj.attr('width') as any
-  canvas.height = svgObj.attr('height') as any
+  canvas.width = parseInt(svgObj.attr('width'), 10)
+  canvas.height = parseInt(svgObj.attr('height'), 10)
   const ctx = canvas.getContext('2d')
 
   if (ctx) {
     const v = canvg.fromString(ctx, svgData)
+    // Resize down to smaller canvas, but higher resolution
+    v.resize(canvas.width / devicePixelRatio, canvas.width / devicePixelRatio)
     v.render()
       .then(() =>
         downloadWithDataURI(`${type}.png`, canvas.toDataURL('image/png'))

--- a/src/shared/services/exporting/svgUtils.ts
+++ b/src/shared/services/exporting/svgUtils.ts
@@ -44,7 +44,9 @@ export const prepareForExport = (
 
   svg.selectAll('.overlay, .ring').remove()
   svg.selectAll('.context-menu-item').remove()
-  svg.selectAll('text').attr('font-family', 'sans-serif')
+  svg
+    .selectAll('text')
+    .attr('font-family', 'Helvetica Neue, Helvetica, Arial, sans-serif')
 
   svg.attr('width', dimensions.width)
   svg.attr('height', dimensions.height)


### PR DESCRIPTION
I set the correct font for export, increase the resolution of the PNG (less blurry text) and give it a little big extra size (since it's easy for a user to to make it smaller in for example photoshop, but look really bad when you make it bigger). (Code is also used for export of plan view) 

Before:
![graph(68)](https://user-images.githubusercontent.com/10564538/173026738-85da355b-f224-47ce-8eb6-cac3ee73f6a3.png)
 
After:
![graph(67)](https://user-images.githubusercontent.com/10564538/173026758-af797c76-e905-49fa-b72a-7e0bcf3a186a.png)
 