### PR TITLE
Change so (*) also show number of nodes in graph instead of number of…

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/VisualizationView/PropertiesPanelContent/OverviewPane.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView/PropertiesPanelContent/OverviewPane.tsx
@@ -107,6 +107,7 @@ export default function OverviewPane({
                 <StyleableNodeLabel
                   key={label}
                   graphStyle={graphStyle}
+                  allNodesCount={nodeCount}
                   selectedLabel={{
                     label,
                     propertyKeys: Object.keys(labels[label].properties),

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView/PropertiesPanelContent/StyleableNodeLabel.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView/PropertiesPanelContent/StyleableNodeLabel.tsx
@@ -32,15 +32,20 @@ export type StyleableNodeLabelProps = {
     count?: number
   }
   graphStyle: GraphStyleModel
+  /* The total number of nodes in returned graph */
+  allNodesCount?: number | null
 }
 export function StyleableNodeLabel({
   graphStyle,
-  selectedLabel
+  selectedLabel,
+  allNodesCount
 }: StyleableNodeLabelProps): JSX.Element {
   const labels = selectedLabel.label === '*' ? [] : [selectedLabel.label]
   const graphStyleForLabel = graphStyle.forNode({
     labels: labels
   })
+  const count =
+    selectedLabel.label === '*' ? allNodesCount : selectedLabel.count
 
   return (
     <Popup
@@ -57,8 +62,8 @@ export function StyleableNodeLabel({
           }}
           data-testid={`property-details-overview-node-label-${selectedLabel.label}`}
         >
-          {selectedLabel.count !== undefined
-            ? `${selectedLabel.label} (${selectedLabel.count})`
+          {count !== undefined
+            ? `${selectedLabel.label} (${count})`
             : `${selectedLabel.label}`}
         </StyledLabelChip>
       }


### PR DESCRIPTION
… labels

Since a bit confusing for a user that the numbers are not representing the same as in the left side bar.

Before:
<img width="1080" alt="Screenshot 2022-06-13 at 16 46 49" src="https://user-images.githubusercontent.com/11065688/173380734-deec9ee1-7f32-4c1a-9497-9a12750fb93f.png">

After:
<img width="1071" alt="Screenshot 2022-06-13 at 16 42 03" src="https://user-images.githubusercontent.com/11065688/173380756-204124a9-6e2f-46cc-a26c-b7ddf1d93070.png">


<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

