### PR TITLE
Fixed consistent (*) count in default Overview panel as well

### DIFF
--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/DefaultPanelContent/DefaultOverviewPane.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/DefaultPanelContent/DefaultOverviewPane.tsx
@@ -118,6 +118,7 @@ function DefaultOverviewPane({
                 <NodeLabel
                   key={label}
                   graphStyle={graphStyle}
+                  allNodesCount={nodeCount}
                   selectedLabel={{
                     label,
                     propertyKeys: Object.keys(labels[label].properties),

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/DefaultPanelContent/NodeLabel.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/DefaultPanelContent/NodeLabel.tsx
@@ -30,15 +30,20 @@ export type NodeLabelProps = {
     count?: number
   }
   graphStyle: GraphStyleModel
+  /* The total number of nodes in returned graph */
+  allNodesCount?: number | null
 }
 export function NodeLabel({
   graphStyle,
-  selectedLabel
+  selectedLabel,
+  allNodesCount
 }: NodeLabelProps): JSX.Element {
   const labels = selectedLabel.label === '*' ? [] : [selectedLabel.label]
   const graphStyleForLabel = graphStyle.forNode({
     labels: labels
   })
+  const count =
+    selectedLabel.label === '*' ? allNodesCount : selectedLabel.count
 
   return (
     <NonClickableLabelChip
@@ -47,8 +52,8 @@ export function NodeLabel({
         color: graphStyleForLabel.get('text-color-internal')
       }}
     >
-      {selectedLabel.count !== undefined
-        ? `${selectedLabel.label} (${selectedLabel.count})`
+      {count !== undefined
+        ? `${selectedLabel.label} (${count})`
         : `${selectedLabel.label}`}
     </NonClickableLabelChip>
   )


### PR DESCRIPTION
Same fix as in [https://github.com/neo4j/neo4j-browser/pull/1754](https://github.com/neo4j/neo4j-browser/pull/1754), but for the default Node properties panel.
<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

