### PR TITLE
feat: surface wheel zoom props and decouple with isFullscreen prop in graph visualisation

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/VisualizationView/VisualizationView.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView/VisualizationView.tsx
@@ -293,8 +293,10 @@ LIMIT ${maxNewNeighbours}`
           nodePropertiesExpandedByDefault={
             this.props.nodePropertiesExpandedByDefault
           }
-          wheelZoomRequired={!this.props.isFullscreen}
-          wheelZoomInfoMessageEnabled={this.props.wheelZoomInfoMessageEnabled}
+          wheelZoomRequiresModKey={!this.props.isFullscreen}
+          wheelZoomInfoMessageEnabled={
+            this.props.wheelZoomInfoMessageEnabled && !this.props.isFullscreen
+          }
           disableWheelZoomInfoMessage={this.props.disableWheelZoomInfoMessage}
           DetailsPaneOverride={DetailsPane}
           OverviewPaneOverride={OverviewPane}

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView/VisualizationView.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView/VisualizationView.tsx
@@ -293,6 +293,7 @@ LIMIT ${maxNewNeighbours}`
           nodePropertiesExpandedByDefault={
             this.props.nodePropertiesExpandedByDefault
           }
+          wheelZoomRequired={!this.props.isFullscreen}
           wheelZoomInfoMessageEnabled={this.props.wheelZoomInfoMessageEnabled}
           disableWheelZoomInfoMessage={this.props.disableWheelZoomInfoMessage}
           DetailsPaneOverride={DetailsPane}

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/Graph.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/Graph.tsx
@@ -57,7 +57,8 @@ export type GraphProps = {
   ) => void
   setGraph: (graph: GraphModel) => void
   offset: number
-  wheelZoomInfoMessageEnabled: boolean
+  wheelZoomRequired?: boolean
+  wheelZoomInfoMessageEnabled?: boolean
   disableWheelZoomInfoMessage: () => void
 }
 
@@ -93,7 +94,8 @@ export class Graph extends React.Component<GraphProps, GraphState> {
       setGraph,
       getAutoCompleteCallback,
       assignVisElement,
-      isFullscreen
+      isFullscreen,
+      wheelZoomRequired
     } = this.props
 
     if (!this.svgElement.current) return
@@ -111,7 +113,8 @@ export class Graph extends React.Component<GraphProps, GraphState> {
       this.handleDisplayZoomWheelInfoMessage,
       graph,
       graphStyle,
-      isFullscreen
+      isFullscreen,
+      wheelZoomRequired
     )
 
     const graphEventHandler = new GraphEventHandlerModel(
@@ -125,7 +128,7 @@ export class Graph extends React.Component<GraphProps, GraphState> {
     graphEventHandler.bindEventHandlers()
 
     onGraphModelChange(getGraphStats(graph))
-    this.visualization.resize(isFullscreen)
+    this.visualization.resize(isFullscreen, !!wheelZoomRequired)
     this.visualization.init()
 
     if (setGraph) {
@@ -151,7 +154,10 @@ export class Graph extends React.Component<GraphProps, GraphState> {
 
   componentDidUpdate(prevProps: GraphProps): void {
     if (this.props.isFullscreen !== prevProps.isFullscreen) {
-      this.visualization?.resize(this.props.isFullscreen)
+      this.visualization?.resize(
+        this.props.isFullscreen,
+        !!this.props.wheelZoomRequired
+      )
     }
 
     if (this.props.styleVersion !== prevProps.styleVersion) {
@@ -174,6 +180,7 @@ export class Graph extends React.Component<GraphProps, GraphState> {
   handleDisplayZoomWheelInfoMessage = (): void => {
     if (
       !this.state.displayingWheelZoomInfoMessage &&
+      this.props.wheelZoomRequired &&
       this.props.wheelZoomInfoMessageEnabled
     ) {
       this.displayZoomWheelInfoMessage(true)

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/Graph.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/Graph.tsx
@@ -246,13 +246,11 @@ export class Graph extends React.Component<GraphProps, GraphState> {
             <ZoomToFitIcon large={isFullscreen} />
           </StyledZoomButton>
         </StyledZoomHolder>
-        {wheelZoomInfoMessageEnabled &&
-          !isFullscreen &&
-          displayingWheelZoomInfoMessage && (
-            <WheelZoomInfoOverlay
-              onDisableWheelZoomInfoMessage={disableWheelZoomInfoMessage}
-            />
-          )}
+        {wheelZoomInfoMessageEnabled && displayingWheelZoomInfoMessage && (
+          <WheelZoomInfoOverlay
+            onDisableWheelZoomInfoMessage={disableWheelZoomInfoMessage}
+          />
+        )}
       </StyledSvgWrapper>
     )
   }

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/Graph.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/Graph.tsx
@@ -57,7 +57,7 @@ export type GraphProps = {
   ) => void
   setGraph: (graph: GraphModel) => void
   offset: number
-  wheelZoomRequired?: boolean
+  wheelZoomRequiresModKey?: boolean
   wheelZoomInfoMessageEnabled?: boolean
   disableWheelZoomInfoMessage: () => void
 }
@@ -95,7 +95,7 @@ export class Graph extends React.Component<GraphProps, GraphState> {
       getAutoCompleteCallback,
       assignVisElement,
       isFullscreen,
-      wheelZoomRequired
+      wheelZoomRequiresModKey
     } = this.props
 
     if (!this.svgElement.current) return
@@ -114,7 +114,7 @@ export class Graph extends React.Component<GraphProps, GraphState> {
       graph,
       graphStyle,
       isFullscreen,
-      wheelZoomRequired
+      wheelZoomRequiresModKey
     )
 
     const graphEventHandler = new GraphEventHandlerModel(
@@ -128,7 +128,7 @@ export class Graph extends React.Component<GraphProps, GraphState> {
     graphEventHandler.bindEventHandlers()
 
     onGraphModelChange(getGraphStats(graph))
-    this.visualization.resize(isFullscreen, !!wheelZoomRequired)
+    this.visualization.resize(isFullscreen, !!wheelZoomRequiresModKey)
     this.visualization.init()
 
     if (setGraph) {
@@ -156,7 +156,7 @@ export class Graph extends React.Component<GraphProps, GraphState> {
     if (this.props.isFullscreen !== prevProps.isFullscreen) {
       this.visualization?.resize(
         this.props.isFullscreen,
-        !!this.props.wheelZoomRequired
+        !!this.props.wheelZoomRequiresModKey
       )
     }
 
@@ -180,7 +180,7 @@ export class Graph extends React.Component<GraphProps, GraphState> {
   handleDisplayZoomWheelInfoMessage = (): void => {
     if (
       !this.state.displayingWheelZoomInfoMessage &&
-      this.props.wheelZoomRequired &&
+      this.props.wheelZoomRequiresModKey &&
       this.props.wheelZoomInfoMessageEnabled
     ) {
       this.displayZoomWheelInfoMessage(true)

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/visualization/Visualization.ts
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/visualization/Visualization.ts
@@ -79,12 +79,12 @@ export class Visualization {
     private graph: GraphModel,
     public style: GraphStyleModel,
     public isFullscreen: boolean,
-    public wheelZoomRequired?: boolean
+    public wheelZoomRequiresModKey?: boolean
   ) {
     this.root = d3Select(element)
 
     this.isFullscreen = isFullscreen
-    this.wheelZoomRequired = wheelZoomRequired
+    this.wheelZoomRequiresModKey = wheelZoomRequiresModKey
 
     // Remove the base group element when re-creating the visualization
     this.root.selectAll('g').remove()
@@ -137,7 +137,7 @@ export class Visualization {
     ) => {
       const handleZoomOnShiftScroll = (e: WheelEvent) => {
         const modKeySelected = e.metaKey || e.ctrlKey || e.shiftKey
-        if (modKeySelected || !this.wheelZoomRequired) {
+        if (modKeySelected || !this.wheelZoomRequiresModKey) {
           e.preventDefault()
 
           // This is the default implementation of wheelDelta function in d3-zoom v3.0.0
@@ -365,10 +365,10 @@ export class Visualization {
     return this.container.node()?.getBBox()
   }
 
-  resize(isFullscreen: boolean, wheelZoomRequired: boolean): void {
+  resize(isFullscreen: boolean, wheelZoomRequiresModKey: boolean): void {
     const size = this.measureSize()
     this.isFullscreen = isFullscreen
-    this.wheelZoomRequired = wheelZoomRequired
+    this.wheelZoomRequiresModKey = wheelZoomRequiresModKey
 
     this.rect
       .attr('x', () => -Math.floor(size.width / 2))

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/visualization/Visualization.ts
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/visualization/Visualization.ts
@@ -78,11 +78,13 @@ export class Visualization {
     private onDisplayZoomWheelInfoMessage: () => void,
     private graph: GraphModel,
     public style: GraphStyleModel,
-    public isFullscreen: boolean
+    public isFullscreen: boolean,
+    public wheelZoomRequired?: boolean
   ) {
     this.root = d3Select(element)
 
     this.isFullscreen = isFullscreen
+    this.wheelZoomRequired = wheelZoomRequired
 
     // Remove the base group element when re-creating the visualization
     this.root.selectAll('g').remove()
@@ -135,7 +137,7 @@ export class Visualization {
     ) => {
       const handleZoomOnShiftScroll = (e: WheelEvent) => {
         const modKeySelected = e.metaKey || e.ctrlKey || e.shiftKey
-        if (modKeySelected || this.isFullscreen) {
+        if (modKeySelected || !this.wheelZoomRequired) {
           e.preventDefault()
 
           // This is the default implementation of wheelDelta function in d3-zoom v3.0.0
@@ -363,9 +365,10 @@ export class Visualization {
     return this.container.node()?.getBBox()
   }
 
-  resize(isFullscreen: boolean): void {
+  resize(isFullscreen: boolean, wheelZoomRequired: boolean): void {
     const size = this.measureSize()
     this.isFullscreen = isFullscreen
+    this.wheelZoomRequired = wheelZoomRequired
 
     this.rect
       .attr('x', () => -Math.floor(size.width / 2))

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/GraphVisualizer.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/GraphVisualizer.tsx
@@ -74,7 +74,7 @@ type GraphVisualizerProps = GraphVisualizerDefaultProps & {
   nodeLimitHit?: boolean
   nodePropertiesExpandedByDefault?: boolean
   setNodePropertiesExpandedByDefault?: (expandedByDefault: boolean) => void
-  wheelZoomRequired?: boolean
+  wheelZoomRequiresModKey?: boolean
   wheelZoomInfoMessageEnabled?: boolean
   disableWheelZoomInfoMessage?: () => void
   DetailsPaneOverride?: React.FC<DetailsPaneProps>
@@ -263,7 +263,7 @@ export class GraphVisualizer extends Component<
           offset={
             (this.state.nodePropertiesExpanded ? this.state.width + 8 : 0) + 8
           }
-          wheelZoomRequired={this.props.wheelZoomRequired}
+          wheelZoomRequiresModKey={this.props.wheelZoomRequiresModKey}
           wheelZoomInfoMessageEnabled={this.props.wheelZoomInfoMessageEnabled}
           disableWheelZoomInfoMessage={this.props.disableWheelZoomInfoMessage}
         />

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/GraphVisualizer.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/GraphVisualizer.tsx
@@ -74,6 +74,7 @@ type GraphVisualizerProps = GraphVisualizerDefaultProps & {
   nodeLimitHit?: boolean
   nodePropertiesExpandedByDefault?: boolean
   setNodePropertiesExpandedByDefault?: (expandedByDefault: boolean) => void
+  wheelZoomRequired?: boolean
   wheelZoomInfoMessageEnabled?: boolean
   disableWheelZoomInfoMessage?: () => void
   DetailsPaneOverride?: React.FC<DetailsPaneProps>
@@ -262,6 +263,7 @@ export class GraphVisualizer extends Component<
           offset={
             (this.state.nodePropertiesExpanded ? this.state.width + 8 : 0) + 8
           }
+          wheelZoomRequired={this.props.wheelZoomRequired}
           wheelZoomInfoMessageEnabled={this.props.wheelZoomInfoMessageEnabled}
           disableWheelZoomInfoMessage={this.props.disableWheelZoomInfoMessage}
         />


### PR DESCRIPTION
This PR surfaces a new prop `wheelZoomRequired` prop for graph visualisation to dogfood load preview feature in Data Importer. Then, requiring modifier keys for scrolling to zoom and `isFullscreen` are decoupled.
To maintain the same behaviour with current Browser, you can simply pass `wheelZoomRequired={!isFullscreen}` to make it tie to `isFullscreen` state/prop.