### PR TITLE
fix: graph is no simulation in initial rendering

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/VisualizationView/__snapshots__/VisualizationView.test.tsx.snap
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView/__snapshots__/VisualizationView.test.tsx.snap
@@ -39,7 +39,6 @@ exports[`Visualization renders with result and escapes any HTML 1`] = `
                 <g
                   aria-label="graph-node1"
                   class="node"
-                  transform="translate(0,0.9475741398926749)"
                 >
                   <circle
                     class="ring"

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/visualization/Visualization.ts
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/visualization/Visualization.ts
@@ -341,7 +341,7 @@ export class Visualization {
 
     this.updateNodes()
     this.updateRelationships()
-    this.forceSimulation.precompute()
+    this.forceSimulation.restart()
 
     this.adjustZoomMinScaleExtentToFitGraph()
   }

--- a/src/neo4j-arc/package.json
+++ b/src/neo4j-arc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo4j-devtools/arc",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "main": "dist/neo4j-arc.js",
   "author": "Neo4j Inc.",
   "license": "GPL-3.0",


### PR DESCRIPTION
Based on #1765 , a bug is identified that no simulation is triggered when the graph is initially rendered until the user's first interaction.

https://user-images.githubusercontent.com/26452483/177783591-ac2cbf1c-e292-4fbb-b4fd-cba9cc0510db.mov

Had dig into the root issue, I found that's due to the `forceSimulation.restart()` is not triggered when initialising the graph so  no simulation ticks and that's why `forceSimulation.endSimulationCallback()` is not triggered.
`forceSimulation.restart()` is only triggered when calling `visualization.update({restartSimulation: true})`. However, `visualization.update()` is not called if no "Connect to result nodes" option is toggled. In the current logic, when initialising the graph, the logic will be conditionally triggered".
```ts
    if (getAutoCompleteCallback) {
      getAutoCompleteCallback((internalRelationships: BasicRelationship[]) => {
        graph.addInternalRelationships(
          mapRelationships(internalRelationships, graph)
        )
        onGraphModelChange(getGraphStats(graph))
        this.visualization?.update({
          updateNodes: false,
          updateRelationships: true
        }) // this will trigger forceSimulation.restart() and then forceSimulation.endSimulationCallback()
        graphEventHandler.onItemMouseOut()
      })
    }
```
 
<img width="304" alt="Screenshot 2022-07-07 at 14 23 49" src="https://user-images.githubusercontent.com/26452483/177784416-3240ed59-20f4-4c75-8599-bbed016f2474.png">

The simplest fix is to `restart` simulation in initial render rather than `precompute`.