### PR TITLE
chore: move zoom to fit after pre-compute

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/VisualizationView/__snapshots__/VisualizationView.test.tsx.snap
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView/__snapshots__/VisualizationView.test.tsx.snap
@@ -39,6 +39,7 @@ exports[`Visualization renders with result and escapes any HTML 1`] = `
                 <g
                   aria-label="graph-node1"
                   class="node"
+                  transform="translate(0,0.9475741398926749)"
                 >
                   <circle
                     class="ring"

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/Graph.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/Graph.tsx
@@ -142,6 +142,13 @@ export class Graph extends React.Component<GraphProps, GraphState> {
 
     onGraphModelChange(getGraphStats(graph))
     this.visualization.resize(isFullscreen, !!wheelZoomRequiresModKey)
+    if (initialZoomToFit) {
+      this.visualization.endInitCallback = () => {
+        setTimeout(() => {
+          this.visualization?.zoomByType(ZoomType.FIT)
+        }, 150)
+      }
+    }
     this.visualization.init()
 
     if (setGraph) {
@@ -162,14 +169,6 @@ export class Graph extends React.Component<GraphProps, GraphState> {
     }
     if (assignVisElement) {
       assignVisElement(this.svgElement.current, this.visualization)
-    }
-
-    if (initialZoomToFit) {
-      this.visualization.endSimulationCallback = () => {
-        setTimeout(() => {
-          this.visualization?.zoomByType(ZoomType.FIT)
-        }, 150)
-      }
     }
   }
 

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/visualization/ForceSimulation.ts
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/visualization/ForceSimulation.ts
@@ -51,7 +51,6 @@ const oneRelationshipPerPairOfNodes = (graph: GraphModel) =>
 export class ForceSimulation {
   simulation: Simulation<NodeModel, RelationshipModel>
   simulationTimeout: null | number = null
-  endSimulationCallback: null | (() => void) = null
 
   constructor(private render: () => void) {
     this.simulation = forceSimulation<NodeModel, RelationshipModel>()
@@ -62,10 +61,6 @@ export class ForceSimulation {
       .on('tick', () => {
         this.simulation.tick(TICKS_PER_RENDER)
         render()
-      })
-      .on('end', () => {
-        this.endSimulationCallback && this.endSimulationCallback()
-        this.endSimulationCallback = null
       })
       .stop()
   }

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/visualization/Visualization.ts
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/visualization/Visualization.ts
@@ -70,6 +70,7 @@ export class Visualization {
   // 'canvasClick' event when panning ends.
   private draw = false
   private isZoomClick = false
+  public endInitCallback: null | (() => void) = null
 
   constructor(
     element: SVGElement,
@@ -167,10 +168,6 @@ export class Visualization {
       .on('click.zoom', () => (this.draw = false))
 
     this.forceSimulation = new ForceSimulation(this.render.bind(this))
-  }
-
-  set endSimulationCallback(cb: null | (() => void)) {
-    this.forceSimulation.endSimulationCallback = cb
   }
 
   private render() {
@@ -341,9 +338,12 @@ export class Visualization {
 
     this.updateNodes()
     this.updateRelationships()
-    this.forceSimulation.restart()
+    this.forceSimulation.precompute()
 
     this.adjustZoomMinScaleExtentToFitGraph()
+
+    this.endInitCallback && this.endInitCallback()
+    this.endInitCallback = null
   }
 
   update(options: {

--- a/src/neo4j-arc/package.json
+++ b/src/neo4j-arc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo4j-devtools/arc",
-  "version": "0.0.28",
+  "version": "0.0.29",
   "main": "dist/neo4j-arc.js",
   "author": "Neo4j Inc.",
   "license": "GPL-3.0",


### PR DESCRIPTION
Discussed with @OskarDamkjaer :

> We could run pre-compute only is the "connect result nodes" setting isn't on, then we'd get the best of both.

As Browser doesn't toggle zoom to fit by default so the issue I mentioned earlier today won't happen.

So I've moved the "zoom to fit" to run right after the visualisation is initialised, and brought back `precompute` when initialising the graph.

https://user-images.githubusercontent.com/26452483/178708360-b16a314a-10e8-4972-8dd8-06edaa36b3b6.mov
