### PR TITLE
Rename causal cluster -> cluster 

### DIFF
--- a/src/browser/documentation/help/bolt-routing.tsx
+++ b/src/browser/documentation/help/bolt-routing.tsx
@@ -45,8 +45,8 @@ const content = (
       </ul>
     </p>
     <p>
-      If bolt+routing is on and the provided URI points to a Core Causal Cluster
-      member Neo4j Browser will:
+      If bolt+routing is on and the provided URI points to a Core Cluster member
+      Neo4j Browser will:
     </p>
     <ul className="topic-bullets">
       <li>
@@ -59,9 +59,9 @@ const content = (
       </li>
     </ul>
     <p>
-      If bolt+routing is off or the provided URI does not point to a Causal
-      Cluster member or the provided URI points to a Read-Replica Causal Cluster
-      member, Neo4j Browser will:
+      If bolt+routing is off or the provided URI does not point to a Cluster
+      member or the provided URI points to a Read-Replica Cluster member, Neo4j
+      Browser will:
     </p>
     <ul className="topic-bullets">
       <li>

--- a/src/browser/modules/Stream/Queries/LegacyQueriesFrame.test.tsx
+++ b/src/browser/modules/Stream/Queries/LegacyQueriesFrame.test.tsx
@@ -81,7 +81,7 @@ it('can list and kill queries', () => {
     neo4jVersion: '4.0.0',
     isFullscreen: false,
     isCollapsed: false,
-    isOnCausalCluster: false,
+    isOnCluster: false,
     hasListQueriesProcedure: true,
     versionOverFive: false,
     frame: null

--- a/src/browser/modules/Stream/Queries/LegacyQueriesFrame.tsx
+++ b/src/browser/modules/Stream/Queries/LegacyQueriesFrame.tsx
@@ -71,7 +71,7 @@ export type LegacyQueriesFrameProps = {
   isFullscreen: boolean
   versionOverFive: boolean
   isCollapsed: boolean
-  isOnCausalCluster: boolean
+  isOnCluster: boolean
 }
 export class LegacyQueriesFrame extends Component<
   LegacyQueriesFrameProps,
@@ -109,7 +109,7 @@ export class LegacyQueriesFrame extends Component<
       (this.props.frame &&
         this.props.frame.ts !== prevProps.frame.ts &&
         this.props.frame.isRerun) ||
-      this.props.isOnCausalCluster !== prevProps.isOnCausalCluster
+      this.props.isOnCluster !== prevProps.isOnCluster
     ) {
       this.getRunningQueries()
     }
@@ -117,7 +117,7 @@ export class LegacyQueriesFrame extends Component<
 
   getRunningQueries(suppressQuerySuccessMessage = false) {
     this.props.bus.self(
-      this.props.isOnCausalCluster ? CLUSTER_CYPHER_REQUEST : CYPHER_REQUEST,
+      this.props.isOnCluster ? CLUSTER_CYPHER_REQUEST : CYPHER_REQUEST,
       {
         query: listQueriesProcedure(),
         queryType: NEO4J_BROWSER_USER_ACTION_QUERY
@@ -158,7 +158,7 @@ export class LegacyQueriesFrame extends Component<
 
   killQueries(host: any, queryIdList: any) {
     this.props.bus.self(
-      this.props.isOnCausalCluster ? AD_HOC_CYPHER_REQUEST : CYPHER_REQUEST,
+      this.props.isOnCluster ? AD_HOC_CYPHER_REQUEST : CYPHER_REQUEST,
       { host, query: killQueriesProcedure(queryIdList) },
       (response: any) => {
         if (response.success) {

--- a/src/browser/modules/Stream/Queries/QueriesFrame.tsx
+++ b/src/browser/modules/Stream/Queries/QueriesFrame.tsx
@@ -55,7 +55,7 @@ import {
   getRawVersion,
   getSemanticVersion,
   hasProcedure,
-  isOnCausalCluster
+  isOnCluster
 } from 'shared/modules/dbMeta/dbMetaDuck'
 import { gte } from 'semver'
 
@@ -340,7 +340,7 @@ const mapStateToProps = (state: GlobalState) => {
     versionOverFive,
     connectionState: getConnectionState(state),
     neo4jVersion: getRawVersion(state),
-    isOnCausalCluster: isOnCausalCluster(state)
+    isOnCluster: isOnCluster(state)
   }
 }
 

--- a/src/browser/modules/Stream/SysInfoFrame/LegacySysInfoFrame/LegacySysInfoFrame.test.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/LegacySysInfoFrame/LegacySysInfoFrame.test.tsx
@@ -30,7 +30,7 @@ const baseProps = {
   frame: null as any,
   isFullscreen: false,
   isCollapsed: false,
-  isACausalCluster: false
+  isOnCluster: false
 }
 
 describe('LegacySysInfoFrame', () => {

--- a/src/browser/modules/Stream/SysInfoFrame/LegacySysInfoFrame/LegacySysInfoFrame.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/LegacySysInfoFrame/LegacySysInfoFrame.tsx
@@ -56,7 +56,7 @@ type LegacySysInfoProps = {
   isConnected: boolean
   isFullscreen: boolean
   isCollapsed: boolean
-  isACausalCluster: boolean
+  isOnCluster: boolean
 }
 
 export class LegacySysInfoFrame extends Component<
@@ -121,7 +121,7 @@ export class LegacySysInfoFrame extends Component<
         },
         legacyHelpers.responseHandler(this.setState.bind(this))
       )
-      if (this.props.isACausalCluster) {
+      if (this.props.isOnCluster) {
         this.props.bus.self(
           CYPHER_REQUEST,
           {
@@ -145,12 +145,11 @@ export class LegacySysInfoFrame extends Component<
   }
 
   render(): JSX.Element {
-    const { isFullscreen, isCollapsed, isConnected, isACausalCluster } =
-      this.props
+    const { isFullscreen, isCollapsed, isConnected, isOnCluster } = this.props
     const { error, success, lastFetch, autoRefresh } = this.state
 
     const content = isConnected ? (
-      <SysInfoDisplay {...this.state} isACausalCluster={isACausalCluster} />
+      <SysInfoDisplay {...this.state} isOnCluster={isOnCluster} />
     ) : (
       <ErrorsView
         result={{ code: 'No connection', message: 'No connection available' }}

--- a/src/browser/modules/Stream/SysInfoFrame/LegacySysInfoFrame/SysInfoDisplay.test.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/LegacySysInfoFrame/SysInfoDisplay.test.tsx
@@ -23,29 +23,27 @@ import React from 'react'
 import { SysInfoDisplay } from './SysInfoDisplay'
 
 describe('sysinfo component', () => {
-  test('should render causal cluster table', () => {
+  test('should render cluster table', () => {
     // Given
-    const props = { isACausalCluster: true, isConnected: true }
+    const props = { isOnCluster: true, isConnected: true }
 
     // When
     const { getByText, container } = render(<SysInfoDisplay {...props} />)
 
     // Then
-    expect(getByText('Causal Cluster Members')).not.toBeNull()
+    expect(getByText('Cluster Members')).not.toBeNull()
     expect(
-      container.querySelector(
-        '[data-testid="sysinfo-casual-cluster-members-title"]'
-      )
+      container.querySelector('[data-testid="sysinfo-cluster-members-title"]')
     ).not.toBeNull()
   })
-  test('should not render causal cluster table', () => {
+  test('should not render cluster table', () => {
     // Given
-    const props = { isACausalCluster: false, isConnected: true }
+    const props = { isOnCluster: false, isConnected: true }
 
     // When
     const { queryByTestId } = render(<SysInfoDisplay {...props} />)
 
     // Then
-    expect(queryByTestId('sysinfo-casual-cluster-members-title')).toBeNull()
+    expect(queryByTestId('sysinfo-cluster-members-title')).toBeNull()
   })
 })

--- a/src/browser/modules/Stream/SysInfoFrame/LegacySysInfoFrame/SysInfoDisplay.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/LegacySysInfoFrame/SysInfoDisplay.tsx
@@ -34,7 +34,7 @@ export const SysInfoDisplay = ({
   idAllocation,
   pageCache,
   transactions,
-  isACausalCluster,
+  isOnCluster,
   cc,
   ha,
   haInstances
@@ -53,12 +53,12 @@ export const SysInfoDisplay = ({
       <StyledSysInfoTable key="Transactionss" header="Transactions">
         {buildTableData(transactions)}
       </StyledSysInfoTable>
-      {isACausalCluster && (
+      {isOnCluster && (
         <StyledSysInfoTable
           key="cc-table"
           header={
-            <span data-testid="sysinfo-casual-cluster-members-title">
-              Causal Cluster Members{' '}
+            <span data-testid="sysinfo-cluster-members-title">
+              Cluster Members{' '}
               <QuestionIcon title="Values shown in `:sysinfo` may differ between cluster members" />
             </span>
           }

--- a/src/browser/modules/Stream/SysInfoFrame/LegacySysInfoFrame/sysinfoHelpers.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/LegacySysInfoFrame/sysinfoHelpers.tsx
@@ -173,7 +173,7 @@ export const responseHandler = (setState: any) =>
 export const clusterResponseHandler = (setState: any) =>
   function (res: any) {
     if (!res.success) {
-      setState({ error: 'No causal cluster results', success: false })
+      setState({ error: 'No cluster results', success: false })
       return
     }
     const mappedResult = mapLegacySysInfoRecords(res.result.records)

--- a/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.test.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.test.tsx
@@ -38,7 +38,7 @@ const baseProps = {
   useDb: 'neo4j',
   isFullscreen: false,
   isCollapsed: false,
-  isOnCausalCluster: true,
+  isOnCluster: true,
   namespacesEnabled: false,
   metricsPrefix: 'neo4j'
 }
@@ -54,15 +54,15 @@ const mountWithStore = (props: Partial<SysInfoFrameProps>) => {
 }
 
 describe('sysinfo component', () => {
-  test('should not render causal cluster table', () => {
+  test('should not render cluster table', () => {
     // Given
-    const props = { isACausalCluster: false, isConnected: true }
+    const props = { isOnCluster: false, isConnected: true }
 
     // When
     const { queryByTestId } = render(<SysInfoFrame {...baseProps} {...props} />)
 
     // Then
-    expect(queryByTestId('sysinfo-casual-cluster-members-title')).toBeNull()
+    expect(queryByTestId('sysinfo-cluster-members-title')).toBeNull()
   })
 
   test('should display error when there is no connection', () => {

--- a/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
@@ -49,7 +49,7 @@ import {
   getMetricsNamespacesEnabled,
   getMetricsPrefix,
   isEnterprise,
-  isOnCausalCluster
+  isOnCluster
 } from 'shared/modules/dbMeta/dbMetaDuck'
 import { hasMultiDbSupport } from 'shared/modules/features/versionedFeatures'
 import { Frame } from 'shared/modules/frames/framesDuck'
@@ -61,7 +61,7 @@ export type SysInfoFrameState = {
   idAllocation: DatabaseMetric[]
   pageCache: DatabaseMetric[]
   transactions: DatabaseMetric[]
-  casualClusterMembers: DatabaseMetric[]
+  clusterMembers: DatabaseMetric[]
   errorMessage: string | null
   results: boolean
   autoRefresh: boolean
@@ -78,7 +78,7 @@ export type SysInfoFrameProps = {
   useDb: string | null
   isFullscreen: boolean
   isCollapsed: boolean
-  isOnCausalCluster: boolean
+  isOnCluster: boolean
   namespacesEnabled: boolean
   metricsPrefix: string
 }
@@ -94,7 +94,7 @@ export class SysInfoFrame extends Component<
     idAllocation: [],
     pageCache: [],
     transactions: [],
-    casualClusterMembers: [],
+    clusterMembers: [],
     errorMessage: null,
     results: false,
     autoRefresh: false,
@@ -160,7 +160,7 @@ export class SysInfoFrame extends Component<
         },
         responseHandler
       )
-      if (this.props.isOnCausalCluster) {
+      if (this.props.isOnCluster) {
         this.props.bus.self(
           CYPHER_REQUEST,
           {
@@ -190,7 +190,7 @@ export class SysInfoFrame extends Component<
       pageCache,
       storeSizes,
       transactions,
-      casualClusterMembers
+      clusterMembers
     } = this.state
     const {
       databases,
@@ -208,7 +208,7 @@ export class SysInfoFrame extends Component<
         idAllocation={idAllocation}
         transactions={transactions}
         databases={databases}
-        casualClusterMembers={casualClusterMembers}
+        clusterMembers={clusterMembers}
         isEnterpriseEdition={isEnterprise}
         hasMultiDbSupport={hasMultiDbSupport}
       />
@@ -247,12 +247,7 @@ export class SysInfoFrame extends Component<
 }
 const FrameVersionPicker = (props: SysInfoFrameProps) => {
   if (props.isConnected && props.isEnterprise && !props.hasMultiDbSupport) {
-    return (
-      <LegacySysInfoFrame
-        {...props}
-        isACausalCluster={props.isOnCausalCluster}
-      />
-    )
+    return <LegacySysInfoFrame {...props} isOnCluster={props.isOnCluster} />
   } else {
     return <SysInfoFrame {...props} />
   }
@@ -264,7 +259,7 @@ const mapStateToProps = (state: GlobalState) => ({
   isConnected: isConnected(state),
   databases: getDatabases(state),
   useDb: getUseDb(state),
-  isOnCausalCluster: isOnCausalCluster(state),
+  isOnCluster: isOnCluster(state),
   namespacesEnabled: getMetricsNamespacesEnabled(state),
   metricsPrefix: getMetricsPrefix(state)
 })

--- a/src/browser/modules/Stream/SysInfoFrame/SysInfoTable.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/SysInfoTable.tsx
@@ -18,7 +18,7 @@ type SysInfoFrameProps = {
   idAllocation: DatabaseMetric[]
   pageCache: DatabaseMetric[]
   transactions: DatabaseMetric[]
-  casualClusterMembers: DatabaseMetric[]
+  clusterMembers: DatabaseMetric[]
   isEnterpriseEdition: boolean
   hasMultiDbSupport: boolean
 }
@@ -30,7 +30,7 @@ export const SysInfoTable = ({
   idAllocation,
   transactions,
   isEnterpriseEdition,
-  casualClusterMembers,
+  clusterMembers,
   hasMultiDbSupport
 }: SysInfoFrameProps): JSX.Element => {
   const mappedDatabases = [
@@ -63,12 +63,12 @@ export const SysInfoTable = ({
         {buildTableData(transactions)}
       </StyledSysInfoTable>
       {hasMultiDbSupport && buildDatabaseTable(mappedDatabases)}
-      {casualClusterMembers.length > 0 && (
+      {clusterMembers.length > 0 && (
         <StyledSysInfoTable
           key="cc-table"
           header={
-            <span data-testid="sysinfo-casual-cluster-members-title">
-              Causal Cluster Members{' '}
+            <span data-testid="sysinfo-cluster-members-title">
+              Cluster Members{' '}
               <QuestionIcon title="Values shown in `:sysinfo` may differ between cluster members" />
             </span>
           }
@@ -78,7 +78,7 @@ export const SysInfoTable = ({
             key="cc-entry"
             headers={['Roles', 'Addresses', 'Actions']}
           />
-          {buildTableData(casualClusterMembers)}
+          {buildTableData(clusterMembers)}
         </StyledSysInfoTable>
       )}
     </SysInfoTableContainer>

--- a/src/browser/modules/Stream/SysInfoFrame/sysinfoHelpers.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/sysinfoHelpers.tsx
@@ -278,7 +278,7 @@ export const responseHandler = (setState: (newState: any) => void) =>
 export const clusterResponseHandler = (setState: any) =>
   function (res: any) {
     if (!res.success) {
-      setState({ error: 'No causal cluster results', success: false })
+      setState({ error: 'No cluster results', success: false })
       return
     }
     const mappedResult = mapSysInfoRecords(res.result.records)
@@ -310,7 +310,7 @@ export const clusterResponseHandler = (setState: any) =>
       ]
     })
     setState({
-      casualClusterMembers: [{ value: mappedTableComponents }],
+      clusterMembers: [{ value: mappedTableComponents }],
       success: true
     })
   }

--- a/src/shared/modules/cypher/cypherDuck.ts
+++ b/src/shared/modules/cypher/cypherDuck.ts
@@ -31,7 +31,7 @@ import {
   changeUserPasswordQuery,
   driverDatabaseSelection
 } from '../features/versionedFeatures'
-import { getCausalClusterAddresses } from './queriesProcedureHelper'
+import { getClusterAddresses } from './queriesProcedureHelper'
 import bolt from 'services/bolt/bolt'
 import { buildTxFunctionByMode } from 'services/bolt/boltHelpers'
 import {
@@ -177,7 +177,7 @@ export const clusterCypherRequestEpic = (some$: any, store: any) =>
     .mergeMap((action: any) => {
       if (!action.$$responseChannel) return Rx.Observable.of(null)
       return bolt
-        .directTransaction(getCausalClusterAddresses, {}, userActionTxMetadata)
+        .directTransaction(getClusterAddresses, {}, userActionTxMetadata)
         .then((res: any) => {
           const addresses = flatten(
             res.records.map((record: any) => record.get('addresses'))

--- a/src/shared/modules/cypher/queriesProcedureHelper.ts
+++ b/src/shared/modules/cypher/queriesProcedureHelper.ts
@@ -18,8 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-export const getCausalClusterAddresses =
-  'CALL dbms.cluster.overview YIELD addresses'
+export const getClusterAddresses = 'CALL dbms.cluster.overview YIELD addresses'
 
 export function listQueriesProcedure() {
   return 'CALL dbms.listQueries'

--- a/src/shared/modules/dbMeta/dbMetaDuck.ts
+++ b/src/shared/modules/dbMeta/dbMetaDuck.ts
@@ -22,8 +22,7 @@ import { isConfigValFalsy } from 'services/bolt/boltHelpers'
 import { GlobalState } from 'shared/globalState'
 import { APP_START } from 'shared/modules/app/appDuck'
 import { extractServerInfo } from './utils'
-import { coerce, SemVer } from 'semver'
-import { gte } from 'lodash-es'
+import { coerce, SemVer, gte } from 'semver'
 
 export const UPDATE_META = 'meta/UPDATE_META'
 export const PARSE_META = 'meta/PARSE_META'
@@ -242,7 +241,7 @@ export const shouldRetainConnectionCredentials = (state: any) =>
 export const shouldRetainEditorHistory = (state: any) =>
   !supportsEditorHistorySetting(state) || getRetainEditorHistory(state)
 
-export const isOnCausalCluster = (state: GlobalState): boolean => {
+export const isOnCluster = (state: GlobalState): boolean => {
   const version = getSemanticVersion(state)
   if (!version) return false
 

--- a/src/shared/modules/dbMeta/dbMetaEpics.ts
+++ b/src/shared/modules/dbMeta/dbMetaEpics.ts
@@ -38,7 +38,7 @@ import {
   metaQuery,
   serverInfoQuery,
   VERSION_FOR_CLUSTER_ROLE_IN_SHOW_DB,
-  isOnCausalCluster
+  isOnCluster
 } from './dbMetaDuck'
 import {
   ClientSettings,
@@ -191,7 +191,7 @@ async function getFunctionsAndProcedures(store: any) {
 }
 
 async function clusterRole(store: any) {
-  if (!isOnCausalCluster(store.getState())) {
+  if (!isOnCluster(store.getState())) {
     return
   }
 


### PR DESCRIPTION
In the distant there was a distinction between "High Availability clusters" and "Causal clusters" but now we only use "causal cluster"s so the distinction is no longer needed.