### PR TITLE
Prevent 5.0 flakyness from async db creation

### DIFF
--- a/e2e_tests/integration/connect-form.spec.ts
+++ b/e2e_tests/integration/connect-form.spec.ts
@@ -113,7 +113,7 @@ describe('Connect form', () => {
       })
     }
   }
-  if (Cypress.config('serverVersion') >= 4.0) {
+  if (Cypress.config('serverVersion') >= 4.1) {
     it('can connect with the neo4j:// scheme', () => {
       cy.executeCommand(':clear')
       const boltUrl = 'neo4j://' + stripScheme(Cypress.config('boltUrl'))

--- a/e2e_tests/integration/connect-form.spec.ts
+++ b/e2e_tests/integration/connect-form.spec.ts
@@ -125,10 +125,7 @@ describe('Connect form', () => {
       it('shows correct metadata when using db field', () => {
         cy.connect('neo4j', Cypress.config('password'))
         cy.executeCommand(':use system')
-        cy.executeCommand('DROP DATABASE sidebartest IF EXISTS')
-        cy.executeCommand('CREATE DATABASE sidebartest')
-        cy.wait(10000) // Wait for db to come online
-        cy.contains('1 system update, no records')
+        cy.createDatabase('sidebartest')
         cy.executeCommand(':use sidebartest')
         cy.executeCommand('create (:TestLabel)')
         cy.executeCommand(':use neo4j')

--- a/e2e_tests/integration/multi-db.spec.ts
+++ b/e2e_tests/integration/multi-db.spec.ts
@@ -43,7 +43,7 @@ describe('Multi database', () => {
     cy.ensureConnection()
   })
 
-  if (Cypress.config('serverVersion') >= 4.0) {
+  if (Cypress.config('serverVersion') >= 4.1) {
     if (isEnterpriseEdition()) {
       it('shows a message indicating whether system updates have occurred', () => {
         cy.executeCommand('DROP DATABASE test1 IF EXISTS')

--- a/e2e_tests/integration/multi-db.spec.ts
+++ b/e2e_tests/integration/multi-db.spec.ts
@@ -40,14 +40,13 @@ describe('Multi database', () => {
   before(() => {
     cy.visit(Cypress.config('url')).title().should('include', 'Neo4j Browser')
     cy.wait(3000)
+    cy.ensureConnection()
   })
-  it('can connect', () => {
-    const password = Cypress.config('password')
-    cy.connect('neo4j', password)
-  })
+
   if (Cypress.config('serverVersion') >= 4.0) {
     if (isEnterpriseEdition()) {
       it('shows a message indicating whether system updates have occurred', () => {
+        cy.executeCommand('DROP DATABASE test1 IF EXISTS')
         cy.executeCommand(':clear')
 
         cy.executeCommand(':use system')
@@ -94,10 +93,7 @@ describe('Multi database', () => {
       it('adds databases to the sidebar and adds backticks to special db names', () => {
         // Add db
         cy.executeCommand(':use system')
-        cy.executeCommand('CREATE DATABASE `name-with-dash`')
-        cy.resultContains('1 system update')
-        cy.wait(10000) // wait for db to come online
-        cy.executeCommand(':clear')
+        cy.createDatabase('`name-with-dash`')
 
         // Count items in list
         cy.get('[data-testid="navigationDBMS"]').click()
@@ -178,11 +174,8 @@ describe('Multi database', () => {
 
     if (isEnterpriseEdition()) {
       it('lists new databases with :dbs command', () => {
-        cy.executeCommand('CREATE DATABASE sidebartest')
+        cy.createDatabase('sidebartest')
 
-        cy.wait(3000) // CREATE database can take a sec
-
-        cy.executeCommand(':clear')
         cy.executeCommand(':dbs')
         databaseList().should('have.length', 3)
         databaseList().contains('system')

--- a/e2e_tests/integration/multistatements.spec.ts
+++ b/e2e_tests/integration/multistatements.spec.ts
@@ -112,7 +112,7 @@ describe('Multi statements', () => {
       .first()
       .should('contain', 'ERROR')
   })
-  if (Cypress.config('serverVersion') >= 4.0) {
+  if (Cypress.config('serverVersion') >= 4.1) {
     if (isEnterpriseEdition()) {
       it('Can use :use command in multi-statements', () => {
         cy.executeCommand(':clear')

--- a/e2e_tests/integration/multistatements.spec.ts
+++ b/e2e_tests/integration/multistatements.spec.ts
@@ -122,25 +122,9 @@ describe('Multi statements', () => {
           'have.length',
           1
         )
-        cy.executeCommand('DROP DATABASE test1')
-        cy.executeCommand('DROP DATABASE test2')
-        cy.get('[data-testid="frame"]', { timeout: 10000 }).should(
-          'have.length',
-          3
-        )
-        cy.executeCommand(':clear')
 
-        cy.executeCommand('CREATE DATABASE test1')
-        cy.get('[data-testid="frame"]', { timeout: 10000 }).should(
-          'have.length',
-          1
-        )
-        cy.executeCommand('CREATE DATABASE test2')
-        cy.get('[data-testid="frame"]', { timeout: 10000 }).should(
-          'have.length',
-          2
-        )
-        cy.executeCommand(':clear')
+        cy.createDatabase('test1')
+        cy.createDatabase('test2')
 
         // Time to try it
         const query = ':use test1; CREATE(:Test1); :use test2; CREATE(:Test2);'

--- a/e2e_tests/support/global.d.ts
+++ b/e2e_tests/support/global.d.ts
@@ -45,6 +45,10 @@ declare global {
       ): Cypress.Chainable<void>
       waitForCommandResult(): Cypress.Chainable<void>
       /**
+       * Custom command to create a database and wait for it to come online
+       */
+      createDatabase(dbName: string): Cypress.Chainable<void>
+      /**
        * Custom command for testing content of frame
        */
       resultContains(str: string): Cypress.Chainable<boolean>


### PR DESCRIPTION
In neo4j 5.0 new databases are created asynchronously, so we'll need to wait until they are online before we try to use them. 