### PR TITLE
Fix bug with incorrect version number & add git hash to overview

### DIFF
--- a/build_scripts/generate-manifest-helpers.js
+++ b/build_scripts/generate-manifest-helpers.js
@@ -44,13 +44,8 @@ function buildTargetObject(data, dataProp) {
   return out
 }
 
-function mergeObjects(source, target) {
-  return { ...target, ...source }
-}
-
 module.exports = {
   loadDataFromFile,
   writeDataToFile,
-  buildTargetObject,
-  mergeObjects
+  buildTargetObject
 }

--- a/build_scripts/webpack-plugins.js
+++ b/build_scripts/webpack-plugins.js
@@ -33,6 +33,10 @@ const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin')
 const manifestGeneration = require('./generate-manifest-helpers')
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin')
 
+const builtAt = new Date().toISOString()
+const buildNumber = process.env.BUILD_NUMBER
+const gitHash = process.env.GIT_HASH
+
 module.exports = () => {
   const plugins = [
     new webpack.DefinePlugin({
@@ -64,10 +68,9 @@ module.exports = () => {
             const mergedData = {
               ...JSON.parse(content),
               ...wantedData,
-              // This is so we can give better build info in the sidebar
-              builtAt: new Date().toISOString(),
-              buildNumber: process.env.BUILD_NUMBER,
-              gitHash: process.env.GIT_HASH
+              builtAt,
+              buildNumber,
+              gitHash
             }
             return JSON.stringify(mergedData, null, 2)
           }
@@ -77,6 +80,11 @@ module.exports = () => {
           to: helpers.assetsPath + '/images'
         }
       ]
+    }),
+    new webpack.DefinePlugin({
+      __BUILT_AT__: JSON.stringify(builtAt),
+      __BUILD_NUMBER__: JSON.stringify(buildNumber),
+      __GIT_HASH__: JSON.stringify(gitHash)
     }),
     new MiniCssExtractPlugin({
       // Options similar to the same options in webpackOptions.output

--- a/build_scripts/webpack-plugins.js
+++ b/build_scripts/webpack-plugins.js
@@ -62,11 +62,12 @@ module.exports = () => {
             )
 
             const mergedData = {
-              ...wantedData,
               ...JSON.parse(content),
+              ...wantedData,
               // This is so we can give better build info in the sidebar
               builtAt: new Date().toISOString(),
-              buildNumber: process.env.BUILD_NUMBER
+              buildNumber: process.env.BUILD_NUMBER,
+              gitHash: process.env.GIT_HASH
             }
             return JSON.stringify(mergedData, null, 2)
           }

--- a/src/browser/AppInit.tsx
+++ b/src/browser/AppInit.tsx
@@ -51,7 +51,7 @@ import { version } from 'project-root/package.json'
 import { applyKeys, createReduxMiddleware, getAll } from 'services/localstorage'
 import { detectRuntimeEnv, isRunningE2ETest } from 'services/utils'
 import { GlobalState } from 'shared/globalState'
-import { APP_START, updateBuildInfo } from 'shared/modules/app/appDuck'
+import { APP_START } from 'shared/modules/app/appDuck'
 import { NEO4J_CLOUD_DOMAINS } from 'shared/modules/settings/settingsDuck'
 import { getUuid, updateUdcData } from 'shared/modules/udc/udcDuck'
 import epics from 'shared/rootEpic'
@@ -240,15 +240,6 @@ if (auraNtId) {
   removeSearchParamsInBrowserHistory(['ntid'])
 }
 store.dispatch(updateUdcData({ auraNtId }))
-
-fetch('./manifest.json')
-  .then(res => res.json())
-  .then(json => {
-    if (json.buildNumber || json.gitHash || json.builtAt) {
-      store.dispatch(updateBuildInfo(json))
-    }
-  })
-  .catch(() => undefined)
 
 // typePolicies allow apollo cache to use these fields as 'id'
 // for automated cache updates when updating a single existing entity

--- a/src/browser/AppInit.tsx
+++ b/src/browser/AppInit.tsx
@@ -244,7 +244,7 @@ store.dispatch(updateUdcData({ auraNtId }))
 fetch('./manifest.json')
   .then(res => res.json())
   .then(json => {
-    if (json.buildNumber || json.builtAt) {
+    if (json.buildNumber || json.gitHash || json.builtAt) {
       store.dispatch(updateBuildInfo(json))
     }
   })

--- a/src/browser/modules/Sidebar/About.tsx
+++ b/src/browser/modules/Sidebar/About.tsx
@@ -31,7 +31,11 @@ import {
 } from 'browser-components/drawer/drawer-styled'
 import { version as browserVersion } from 'project-root/package.json'
 import { getEdition, getRawVersion } from 'shared/modules/dbMeta/dbMetaDuck'
-import { getBuiltAt, getBuildNumber } from 'shared/modules/app/appDuck'
+import {
+  getBuiltAt,
+  getBuildNumber,
+  getGitHash
+} from 'shared/modules/app/appDuck'
 import { copyToClipboard } from 'neo4j-arc/common'
 
 function asChangeLogUrl(serverVersion: string): string | undefined {
@@ -50,13 +54,15 @@ interface AboutProps {
   serverEdition: string | null
   builtAt: string | null
   buildNumber: string | null
+  gitHash: string | null
 }
 
 const About = ({
   serverVersion,
   serverEdition,
   builtAt,
-  buildNumber
+  buildNumber,
+  gitHash
 }: AboutProps) => (
   <Drawer id="db-about">
     <DrawerHeader>About Neo4j</DrawerHeader>
@@ -87,16 +93,6 @@ const About = ({
               {browserVersion}
             </a>
           </p>
-          {buildNumber && (
-            <div onClick={() => copyToClipboard(buildNumber)}>
-              Build number: {buildNumber}
-            </div>
-          )}
-          {builtAt && (
-            <div onClick={() => copyToClipboard(builtAt)}>
-              Build date: {new Date(builtAt).toLocaleDateString('se')}
-            </div>
-          )}
           {serverVersion && serverEdition && (
             <p>
               Neo4j Server version:{' '}
@@ -119,6 +115,21 @@ const About = ({
               Neo4j Browser Changelog
             </a>
           </p>
+          {buildNumber && (
+            <div onClick={() => copyToClipboard(buildNumber)}>
+              Build number: {buildNumber}
+            </div>
+          )}
+          {gitHash && (
+            <div onClick={() => copyToClipboard(gitHash)}>
+              Build hash: {gitHash.slice(0, 18)}
+            </div>
+          )}
+          {builtAt && (
+            <div onClick={() => copyToClipboard(builtAt)}>
+              Build date: {new Date(builtAt).toLocaleDateString('se')}
+            </div>
+          )}
         </DrawerSectionBody>
       </DrawerSection>
       <DrawerSection>
@@ -210,7 +221,8 @@ const mapStateToProps = (state: any) => {
     serverVersion: getRawVersion(state),
     serverEdition: getEdition(state),
     builtAt: getBuiltAt(state),
-    buildNumber: getBuildNumber(state)
+    buildNumber: getBuildNumber(state),
+    gitHash: getGitHash(state)
   }
 }
 

--- a/src/browser/modules/Sidebar/About.tsx
+++ b/src/browser/modules/Sidebar/About.tsx
@@ -31,12 +31,8 @@ import {
 } from 'browser-components/drawer/drawer-styled'
 import { version as browserVersion } from 'project-root/package.json'
 import { getEdition, getRawVersion } from 'shared/modules/dbMeta/dbMetaDuck'
-import {
-  getBuiltAt,
-  getBuildNumber,
-  getGitHash
-} from 'shared/modules/app/appDuck'
 import { copyToClipboard } from 'neo4j-arc/common'
+import { GlobalState } from 'shared/globalState'
 
 function asChangeLogUrl(serverVersion: string): string | undefined {
   if (!serverVersion) {
@@ -52,18 +48,14 @@ function asChangeLogUrl(serverVersion: string): string | undefined {
 interface AboutProps {
   serverVersion: string | null
   serverEdition: string | null
-  builtAt: string | null
-  buildNumber: string | null
-  gitHash: string | null
 }
 
-const About = ({
-  serverVersion,
-  serverEdition,
-  builtAt,
-  buildNumber,
-  gitHash
-}: AboutProps) => (
+// Injected by webpack
+declare const __GIT_HASH__: string | undefined
+declare const __BUILD_NUMBER__: string | undefined
+declare const __BUILT_AT__: string | undefined
+
+const About = ({ serverVersion, serverEdition }: AboutProps) => (
   <Drawer id="db-about">
     <DrawerHeader>About Neo4j</DrawerHeader>
     <DrawerBody>
@@ -115,19 +107,19 @@ const About = ({
               Neo4j Browser Changelog
             </a>
           </p>
-          {buildNumber && (
-            <div onClick={() => copyToClipboard(buildNumber)}>
-              Build number: {buildNumber}
+          {__BUILD_NUMBER__ && (
+            <div onClick={() => copyToClipboard(__BUILD_NUMBER__)}>
+              Build number: {__BUILD_NUMBER__}
             </div>
           )}
-          {gitHash && (
-            <div onClick={() => copyToClipboard(gitHash)}>
-              Build hash: {gitHash.slice(0, 18)}
+          {__GIT_HASH__ && (
+            <div onClick={() => copyToClipboard(__GIT_HASH__)}>
+              Build hash: {__GIT_HASH__.slice(0, 18)}
             </div>
           )}
-          {builtAt && (
-            <div onClick={() => copyToClipboard(builtAt)}>
-              Build date: {new Date(builtAt).toLocaleDateString('se')}
+          {__BUILT_AT__ && (
+            <div onClick={() => copyToClipboard(__BUILT_AT__)}>
+              Build date: {new Date(__BUILT_AT__).toLocaleDateString('se')}
             </div>
           )}
         </DrawerSectionBody>
@@ -216,14 +208,10 @@ const About = ({
     <DrawerFooter>With &#9829; from Sweden.</DrawerFooter>
   </Drawer>
 )
-const mapStateToProps = (state: any) => {
-  return {
-    serverVersion: getRawVersion(state),
-    serverEdition: getEdition(state),
-    builtAt: getBuiltAt(state),
-    buildNumber: getBuildNumber(state),
-    gitHash: getGitHash(state)
-  }
-}
+
+const mapStateToProps = (state: GlobalState) => ({
+  serverVersion: getRawVersion(state),
+  serverEdition: getEdition(state)
+})
 
 export default connect(mapStateToProps)(About)

--- a/src/shared/modules/app/appDuck.ts
+++ b/src/shared/modules/app/appDuck.ts
@@ -56,6 +56,8 @@ export const inDesktop = (state: GlobalState): boolean =>
   getEnv(state) === DESKTOP
 export const getBuildNumber = (state: GlobalState): string | null =>
   state[NAME].buildNumber ?? null
+export const getGitHash = (state: GlobalState): string | null =>
+  state[NAME].gitHash ?? null
 export const getBuiltAt = (state: GlobalState): string | null =>
   state[NAME].builtAt ?? null
 
@@ -87,10 +89,12 @@ export const getProjectId = (state: GlobalState): string | undefined =>
 export const updateBuildInfo = (action: {
   buildNumber?: string
   builtAt?: string
+  gitHash?: string
 }) => ({
   type: UPDATE_BUILD_INFO,
   buildNumber: action.buildNumber,
-  builtAt: action.builtAt
+  builtAt: action.builtAt,
+  gitHash: action.gitHash
 })
 
 export type AppState = {
@@ -102,6 +106,7 @@ export type AppState = {
   neo4jDesktopGraphAppId?: string
   builtAt?: string | null
   buildNumber?: string | null
+  gitHash?: string | null
 }
 
 // Reducer
@@ -124,7 +129,8 @@ export default function reducer(
       return {
         ...state,
         builtAt: action.builtAt,
-        buildNumber: action.buildNumber
+        buildNumber: action.buildNumber,
+        gitHash: action.gitHash
       }
     default:
       return state

--- a/src/shared/modules/app/appDuck.ts
+++ b/src/shared/modules/app/appDuck.ts
@@ -54,12 +54,6 @@ export const inWebBrowser = (state: GlobalState): boolean =>
   [WEB, CLOUD].includes(getEnv(state))
 export const inDesktop = (state: GlobalState): boolean =>
   getEnv(state) === DESKTOP
-export const getBuildNumber = (state: GlobalState): string | null =>
-  state[NAME].buildNumber ?? null
-export const getGitHash = (state: GlobalState): string | null =>
-  state[NAME].gitHash ?? null
-export const getBuiltAt = (state: GlobalState): string | null =>
-  state[NAME].builtAt ?? null
 
 export const getAllowedBoltSchemes = (
   state: GlobalState,
@@ -85,18 +79,6 @@ export const isRelateAvailable = (state: GlobalState): boolean =>
 export const getProjectId = (state: GlobalState): string | undefined =>
   state[NAME].relateProjectId
 
-// action creators
-export const updateBuildInfo = (action: {
-  buildNumber?: string
-  builtAt?: string
-  gitHash?: string
-}) => ({
-  type: UPDATE_BUILD_INFO,
-  buildNumber: action.buildNumber,
-  builtAt: action.builtAt,
-  gitHash: action.gitHash
-})
-
 export type AppState = {
   hostedUrl?: string | null
   env?: Environment
@@ -104,9 +86,6 @@ export type AppState = {
   relateApiToken?: string
   relateProjectId?: string
   neo4jDesktopGraphAppId?: string
-  builtAt?: string | null
-  buildNumber?: string | null
-  gitHash?: string | null
 }
 
 // Reducer
@@ -124,13 +103,6 @@ export default function reducer(
         relateApiToken: action.relateApiToken,
         relateProjectId: action.relateProjectId,
         neo4jDesktopGraphAppId: action.neo4jDesktopGraphAppId
-      }
-    case UPDATE_BUILD_INFO:
-      return {
-        ...state,
-        builtAt: action.builtAt,
-        buildNumber: action.buildNumber,
-        gitHash: action.gitHash
       }
     default:
       return state


### PR DESCRIPTION
The `mergeObjects` helper that was used before reversed the order properties were merged, causing the wrong version number to be used. I've also added the git hash to the manifest, to ease testing the stand-alone browser in the aura pipeline in the future.