### PR TITLE
chore: change some titles to sentence case

### DIFF
--- a/src/browser/modules/DBMSInfo/MetaItems.tsx
+++ b/src/browser/modules/DBMSInfo/MetaItems.tsx
@@ -155,7 +155,7 @@ const LabelItems = ({
   }
   return (
     <DrawerSection>
-      <DrawerSubHeader>Node Labels</DrawerSubHeader>
+      <DrawerSubHeader>Node labels</DrawerSubHeader>
       <DrawerSectionBody className={wrapperStyle}>
         {labelItems}
       </DrawerSectionBody>
@@ -211,7 +211,7 @@ const RelationshipItems = ({
   }
   return (
     <DrawerSection>
-      <DrawerSubHeader>Relationship Types</DrawerSubHeader>
+      <DrawerSubHeader>Relationship types</DrawerSubHeader>
       <DrawerSectionBody className={wrapperStyle}>
         {relationshipItems}
       </DrawerSectionBody>
@@ -262,7 +262,7 @@ RETURN DISTINCT "relationship" AS entity, r.${escapeCypherIdentifier(
   }
   return (
     <DrawerSection>
-      <DrawerSubHeader>Property Keys</DrawerSubHeader>
+      <DrawerSubHeader>Property keys</DrawerSubHeader>
       <DrawerSectionBody className={wrapperStyle}>
         {propertyItems}
       </DrawerSectionBody>

--- a/src/browser/modules/DBMSInfo/__snapshots__/MetaItems.test.tsx.snap
+++ b/src/browser/modules/DBMSInfo/__snapshots__/MetaItems.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`LabelItems renders empty 1`] = `
     <h5
       class="sc-iUKqMP kWpjPs"
     >
-      Node Labels
+      Node labels
     </h5>
     <div
       class="sc-efQSVx ka-Dmgl"
@@ -29,7 +29,7 @@ exports[`LabelItems renders labels 1`] = `
     <h5
       class="sc-iUKqMP kWpjPs"
     >
-      Node Labels
+      Node labels
     </h5>
     <div
       class="sc-efQSVx ka-Dmgl"
@@ -65,7 +65,7 @@ exports[`PropertyItems renders empty 1`] = `
     <h5
       class="sc-iUKqMP kWpjPs"
     >
-      Property Keys
+      Property keys
     </h5>
     <div
       class="sc-efQSVx ka-Dmgl"
@@ -86,7 +86,7 @@ exports[`PropertyItems renders properties 1`] = `
     <h5
       class="sc-iUKqMP kWpjPs"
     >
-      Property Keys
+      Property keys
     </h5>
     <div
       class="sc-efQSVx ka-Dmgl"
@@ -116,7 +116,7 @@ exports[`RelationshipItems renders empty 1`] = `
     <h5
       class="sc-iUKqMP kWpjPs"
     >
-      Relationship Types
+      Relationship types
     </h5>
     <div
       class="sc-efQSVx ka-Dmgl"
@@ -137,7 +137,7 @@ exports[`RelationshipItems renders relationshipTypes 1`] = `
     <h5
       class="sc-iUKqMP kWpjPs"
     >
-      Relationship Types
+      Relationship types
     </h5>
     <div
       class="sc-efQSVx ka-Dmgl"

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView/PropertiesPanelContent/DetailsPane.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView/PropertiesPanelContent/DetailsPane.tsx
@@ -54,7 +54,7 @@ export function DetailsPane({
     <>
       <PaneHeader>
         <PaneTitle>
-          <span>{`${upperFirst(vizItem.type)} Properties`}</span>
+          <span>{`${upperFirst(vizItem.type)} properties`}</span>
           <ClipboardCopier
             textToCopy={allItemProperties
               .map(prop => `${prop.key}: ${prop.value}`)

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView/PropertiesPanelContent/OverviewPane.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView/PropertiesPanelContent/OverviewPane.tsx
@@ -127,7 +127,7 @@ export default function OverviewPane({
         {relTypes && visibleRelationshipKeys.length !== 0 && (
           <div>
             <PaneBodySectionHeader
-              title={'Relationship Types'}
+              title={'Relationship types'}
               numOfElementsVisible={visibleRelationshipKeys.length}
               totalNumOfElements={totalNumOfRelTypes}
             />

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView/__snapshots__/VisualizationView.test.tsx.snap
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView/__snapshots__/VisualizationView.test.tsx.snap
@@ -140,7 +140,7 @@ exports[`Visualization renders with result and escapes any HTML 1`] = `
       </div>
       <div
         class="sc-hiCibw nXgZj"
-        title="Collapse the Node Properties display"
+        title="Collapse the node properties display"
       >
         <svg
           aria-hidden="true"

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/DefaultPanelContent/DefaultDetailsPane.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/DefaultPanelContent/DefaultDetailsPane.tsx
@@ -60,7 +60,7 @@ export function DefaultDetailsPane({
     <>
       <PaneHeader>
         <PaneTitle>
-          <span>{`${upperFirst(vizItem.type)} Properties`}</span>
+          <span>{`${upperFirst(vizItem.type)} properties`}</span>
           <ClipboardCopier
             textToCopy={allItemProperties
               .map(prop => `${prop.key}: ${prop.value}`)

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/DefaultPanelContent/DefaultOverviewPane.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/DefaultPanelContent/DefaultOverviewPane.tsx
@@ -138,7 +138,7 @@ function DefaultOverviewPane({
         {relTypes && visibleRelationshipKeys.length !== 0 && (
           <div>
             <PaneBodySectionHeader
-              title={'Relationship Types'}
+              title={'Relationship types'}
               numOfElementsVisible={visibleRelationshipKeys.length}
               totalNumOfElements={totalNumOfRelTypes}
             />

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/NodeInspectorPanel.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/NodeInspectorPanel.tsx
@@ -90,8 +90,8 @@ export class NodeInspectorPanel extends Component<NodeInspectorPanelProps> {
           onClick={toggleExpanded}
           title={
             expanded
-              ? 'Collapse the Node Properties display'
-              : 'Expand the Node Properties display'
+              ? 'Collapse the node properties display'
+              : 'Expand the node properties display'
           }
         >
           {expanded ? <ChevronRightIcon /> : <ChevronLeftIcon />}

--- a/src/neo4j-arc/package.json
+++ b/src/neo4j-arc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo4j-devtools/arc",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "main": "dist/neo4j-arc.js",
   "author": "Neo4j Inc.",
   "license": "GPL-3.0",


### PR DESCRIPTION
<img width="308" alt="Screenshot 2022-08-08 at 14 52 37" src="https://user-images.githubusercontent.com/26452483/183438487-dd661ae6-a6ba-40e3-ba6f-9a2bbc57ea15.png">
<img width="306" alt="Screenshot 2022-08-08 at 14 55 50" src="https://user-images.githubusercontent.com/26452483/183438498-fcb216b4-ea0d-464d-ab4f-36b629f6c903.png">
<img width="403" alt="Screenshot 2022-08-08 at 14 56 52" src="https://user-images.githubusercontent.com/26452483/183438509-20230efa-ed58-4740-8045-a2a56a4fbc7f.png">

There are some UI consistencies between title-case and sentence-case. This PR unifies some of them to sentence-case according to what designers agreed with.

<img width="302" alt="Screenshot 2022-08-08 at 15 14 23" src="https://user-images.githubusercontent.com/26452483/183438972-143ee6b3-f3be-4749-aa70-e20148039f57.png">
<img width="323" alt="Screenshot 2022-08-08 at 15 14 43" src="https://user-images.githubusercontent.com/26452483/183438991-354e91b5-dea0-4a42-b78e-f443d4d13065.png">
<img width="331" alt="Screenshot 2022-08-08 at 15 22 23" src="https://user-images.githubusercontent.com/26452483/183441981-7a2968a4-b54f-44f5-b033-f0a7db94b180.png">
<img width="307" alt="Screenshot 2022-08-08 at 15 29 04" src="https://user-images.githubusercontent.com/26452483/183442000-b06f5893-dd14-41ac-a8c8-7dcddd3a6a07.png">

