### PR TITLE
Visualizer zooms to fit after initial render is default behaviour

### DIFF
--- a/e2e_tests/integration/viz.spec.ts
+++ b/e2e_tests/integration/viz.spec.ts
@@ -154,6 +154,10 @@ describe('Viz rendering', () => {
       parseSpecialCharSequences: false
     })
 
+    const zoomOutButton = cy.get(`[aria-label="zoom-out"]`)
+    zoomOutButton.click({ force: true })
+    cy.wait(1000)
+
     // Check that zoom in button increases the size of the node in the graph view
     cy.get('svg')
       .find(`[aria-label^="graph-node"]`)
@@ -164,7 +168,7 @@ describe('Viz rendering', () => {
 
         const zoomInButton = cy.get(`[aria-label="zoom-in"]`)
         zoomInButton.click()
-
+        cy.wait(1000)
         cy.get('svg')
           .find(`[aria-label^="graph-node"]`)
           .then($el => $el[0].getBoundingClientRect().width)
@@ -198,7 +202,7 @@ describe('Viz rendering', () => {
     // Enter fullscreen
     cy.get('article').find(`[title='Fullscreen']`).click()
     cy.get(`#svg-vis`).trigger('wheel', { deltaY: 3000 })
-    
+
     cy.get(`[aria-label="zoom-out"]`).should('be.disabled')
 
     // Leave fullscreen

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView/VisualizationView.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView/VisualizationView.tsx
@@ -301,6 +301,7 @@ LIMIT ${maxNewNeighbours}`
           DetailsPaneOverride={DetailsPane}
           OverviewPaneOverride={OverviewPane}
           useGeneratedDefaultColors={false}
+          initialZoomToFit={true}
         />
       </StyledVisContainer>
     )

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/Graph.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/Graph.tsx
@@ -144,9 +144,7 @@ export class Graph extends React.Component<GraphProps, GraphState> {
     this.visualization.resize(isFullscreen, !!wheelZoomRequiresModKey)
     if (initialZoomToFit) {
       this.visualization.endInitCallback = () => {
-        setTimeout(() => {
-          this.visualization?.zoomByType(ZoomType.FIT)
-        }, 150)
+        this.visualization?.zoomByType(ZoomType.FIT)
       }
     }
     this.visualization.init()


### PR DESCRIPTION
Adds a wait until the initial graph render is done and then zooms to fit the graph. The wait is because of the initial wiggle of the nodes, if we do not wait the zoom to fit can get the incorrect scale.