### PR TITLE
Make sure fit to graph always work

### DIFF
--- a/src/neo4j-arc/cypher-language-support/cypher-editor/CypherEditor.tsx
+++ b/src/neo4j-arc/cypher-language-support/cypher-editor/CypherEditor.tsx
@@ -99,9 +99,18 @@ export class CypherEditor extends React.Component<
     currentHistoryIndex: UNRUN_CMD_HISTORY_INDEX,
     draft: ''
   }
-
+  resizeObserver: ResizeObserver
   editor?: monaco.editor.IStandaloneCodeEditor
   container?: HTMLElement
+
+  constructor(props: CypherEditorProps) {
+    super(props)
+    this.resizeObserver = new ResizeObserver(() => {
+      window.requestAnimationFrame(() => {
+        this.editor?.layout()
+      })
+    })
+  }
 
   static defaultProps = cypherEditorDefaultProps
 
@@ -383,13 +392,7 @@ export class CypherEditor extends React.Component<
       this.resize(this.props.isFullscreen)
     )
 
-    const resizeObserver = new ResizeObserver(() => {
-      // Wrapped in requestAnimationFrame to avoid the error "ResizeObserver loop limit exceeded"
-      window.requestAnimationFrame(() => {
-        this.editor?.layout()
-      })
-    })
-    resizeObserver.observe(this.container)
+    this.resizeObserver.observe(this.container)
 
     /*
      * This moves the the command palette widget out of of the overflow-guard div where overlay widgets
@@ -443,5 +446,6 @@ export class CypherEditor extends React.Component<
   componentWillUnmount = (): void => {
     this.editor?.dispose()
     this.debouncedUpdateCode?.cancel()
+    this.resizeObserver.disconnect()
   }
 }

--- a/src/neo4j-arc/cypher-language-support/cypher-editor/CypherEditor.tsx
+++ b/src/neo4j-arc/cypher-language-support/cypher-editor/CypherEditor.tsx
@@ -105,6 +105,8 @@ export class CypherEditor extends React.Component<
 
   constructor(props: CypherEditorProps) {
     super(props)
+
+    // Wrapped in requestAnimationFrame to avoid the error "ResizeObserver loop limit exceeded"
     this.resizeObserver = new ResizeObserver(() => {
       window.requestAnimationFrame(() => {
         this.editor?.layout()

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/Graph.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/Graph.tsx
@@ -83,7 +83,6 @@ export class Graph extends React.Component<GraphProps, GraphState> {
   wrapperElement: React.RefObject<HTMLDivElement>
   wrapperResizeObserver: ResizeObserver
   visualization: Visualization | null = null
-  onResize: () => void
 
   constructor(props: GraphProps) {
     super(props)
@@ -94,14 +93,6 @@ export class Graph extends React.Component<GraphProps, GraphState> {
     }
     this.svgElement = React.createRef()
     this.wrapperElement = React.createRef()
-    this.onResize = (() => {
-      if (this.visualization) {
-        this.visualization.resize(
-          this.props.isFullscreen,
-          !!this.props.wheelZoomRequiresModKey
-        )
-      }
-    }).bind(this)
   }
 
   componentDidMount(): void {
@@ -184,6 +175,9 @@ export class Graph extends React.Component<GraphProps, GraphState> {
     }
 
     this.wrapperResizeObserver = new ResizeObserver((entries, observer) => {
+      if (!this.visualization) {
+        return
+      }
       this.visualization.resize(
         this.props.isFullscreen,
         !!this.props.wheelZoomRequiresModKey

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/Graph.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/Graph.tsx
@@ -81,6 +81,7 @@ type GraphState = {
 export class Graph extends React.Component<GraphProps, GraphState> {
   svgElement: React.RefObject<SVGSVGElement>
   visualization: Visualization | null = null
+  onResize: () => void
 
   constructor(props: GraphProps) {
     super(props)
@@ -90,6 +91,14 @@ export class Graph extends React.Component<GraphProps, GraphState> {
       displayingWheelZoomInfoMessage: false
     }
     this.svgElement = React.createRef()
+    this.onResize = (() => {
+      if (this.visualization) {
+        this.visualization.resize(
+          this.props.isFullscreen,
+          !!this.props.wheelZoomRequiresModKey
+        )
+      }
+    }).bind(this)
   }
 
   componentDidMount(): void {
@@ -170,6 +179,8 @@ export class Graph extends React.Component<GraphProps, GraphState> {
     if (assignVisElement) {
       assignVisElement(this.svgElement.current, this.visualization)
     }
+
+    window.addEventListener('resize', this.onResize, false)
   }
 
   componentDidUpdate(prevProps: GraphProps): void {
@@ -183,6 +194,10 @@ export class Graph extends React.Component<GraphProps, GraphState> {
     if (this.props.styleVersion !== prevProps.styleVersion) {
       this.visualization?.init()
     }
+  }
+
+  componentWillUnmount(): void {
+    window.removeEventListener('resize', this.onResize, false)
   }
 
   handleZoomEvent = (limitsReached: ZoomLimitsReached): void => {

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/Graph.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/Graph.tsx
@@ -95,11 +95,8 @@ export class Graph extends React.Component<GraphProps, GraphState> {
     this.svgElement = React.createRef()
     this.wrapperElement = React.createRef()
 
-    this.wrapperResizeObserver = new ResizeObserver((_entries, _observer) => {
-      if (!this.visualization) {
-        return
-      }
-      this.visualization.resize(
+    this.wrapperResizeObserver = new ResizeObserver(() => {
+      this.visualization?.resize(
         this.props.isFullscreen,
         !!this.props.wheelZoomRequiresModKey
       )

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/Graph.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/Graph.tsx
@@ -48,6 +48,7 @@ import {
 import { Visualization } from './visualization/Visualization'
 import { WheelZoomInfoOverlay } from './WheelZoomInfoOverlay'
 import { StyledSvgWrapper, StyledZoomButton, StyledZoomHolder } from './styled'
+import { ResizeObserver } from '@juggle/resize-observer'
 
 export type GraphProps = {
   isFullscreen: boolean
@@ -93,6 +94,16 @@ export class Graph extends React.Component<GraphProps, GraphState> {
     }
     this.svgElement = React.createRef()
     this.wrapperElement = React.createRef()
+
+    this.wrapperResizeObserver = new ResizeObserver((_entries, _observer) => {
+      if (!this.visualization) {
+        return
+      }
+      this.visualization.resize(
+        this.props.isFullscreen,
+        !!this.props.wheelZoomRequiresModKey
+      )
+    })
   }
 
   componentDidMount(): void {
@@ -173,16 +184,6 @@ export class Graph extends React.Component<GraphProps, GraphState> {
     if (assignVisElement) {
       assignVisElement(this.svgElement.current, this.visualization)
     }
-
-    this.wrapperResizeObserver = new ResizeObserver((entries, observer) => {
-      if (!this.visualization) {
-        return
-      }
-      this.visualization.resize(
-        this.props.isFullscreen,
-        !!this.props.wheelZoomRequiresModKey
-      )
-    })
 
     this.wrapperResizeObserver.observe(this.svgElement.current)
   }


### PR DESCRIPTION
Add resize observer to visualizer to make sure zoom to fit works when window/container changes size.
