### PR TITLE
Add autocomplete to password fields

### DIFF
--- a/src/browser/modules/Stream/Auth/ChangePasswordForm.tsx
+++ b/src/browser/modules/Stream/Auth/ChangePasswordForm.tsx
@@ -136,7 +136,8 @@ export default class ChangePasswordForm extends Component<any, State> {
                         onChange: this.onExistingPasswordChange,
                         value: this.state.password,
                         ref: (ref: any) => setRefForIndex(0, ref),
-                        disabled: isLoading
+                        disabled: isLoading,
+                        autoComplete: 'off'
                       })}
                     />
                   </StyledConnectionFormEntry>
@@ -153,7 +154,8 @@ export default class ChangePasswordForm extends Component<any, State> {
                       setRef: (ref: any) => setRefForIndex(indexStart, ref),
                       disabled: isLoading,
                       isRevealed: this.state.revealNewPassword,
-                      toggleReveal: this.togglePasswordRevealed
+                      toggleReveal: this.togglePasswordRevealed,
+                      autoComplete: 'new-password'
                     })}
                   />
                   &nbsp;OR&nbsp;&nbsp;
@@ -174,7 +176,8 @@ export default class ChangePasswordForm extends Component<any, State> {
                       setRef: (ref: any) => setRefForIndex(indexStart + 1, ref),
                       disabled: isLoading,
                       isRevealed: this.state.revealNewPassword,
-                      toggleReveal: this.togglePasswordRevealed
+                      toggleReveal: this.togglePasswordRevealed,
+                      autoComplete: 'new-password'
                     })}
                   />
                 </StyledConnectionFormEntry>

--- a/src/browser/modules/Stream/Auth/ConnectForm.tsx
+++ b/src/browser/modules/Stream/Auth/ConnectForm.tsx
@@ -233,6 +233,7 @@ export default function ConnectForm(props: ConnectFormProps): JSX.Element {
                 onChange={props.onPasswordChange}
                 defaultValue={props.password}
                 type="password"
+                autoComplete="off"
               />
             </StyledConnectionLabel>
           </StyledConnectionFormEntry>


### PR DESCRIPTION
The best practice is to use autocomplete="off" for password fields and autocomplete="new-password" for new password fields. As described here: [https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#the_autocomplete_attribute_and_login_fields](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#the_autocomplete_attribute_and_login_fields
)