### PR TITLE
Remove credentails from connection form if they should not be stored.

### DIFF
--- a/src/browser/modules/Stream/Auth/ConnectionForm.tsx
+++ b/src/browser/modules/Stream/Auth/ConnectionForm.tsx
@@ -141,6 +141,12 @@ export class ConnectionForm extends Component<any, ConnectionFormState> {
       },
       (res: any) => {
         if (res.success) {
+          //If credentials should not be stored, remove them from form
+          if (!this.props.storeCredentials)
+            this.setState({
+              username: '',
+              password: ''
+            })
           doneFn()
           this.saveAndStart()
         } else {


### PR DESCRIPTION
Currently, credentials are only removed from local storage on disconnect but the old frame used to connect still saves them in its state. This PR clears the username and password from the connection form state on a successful connection.