### PR TITLE
Replace deprecated procedure for checking connection

### DIFF
--- a/src/shared/services/bolt/boltConnection.ts
+++ b/src/shared/services/bolt/boltConnection.ts
@@ -69,7 +69,7 @@ export const validateConnection = (
       })
       const txFn = buildTxFunctionByMode(session)
       txFn &&
-        txFn(tx => tx.run('CALL db.indexes()'), {
+        txFn(tx => tx.run('CALL db.info()'), {
           metadata: backgroundTxMetadata.txMetadata
         })
           .then(() => {

--- a/src/shared/services/bolt/boltConnection.ts
+++ b/src/shared/services/bolt/boltConnection.ts
@@ -59,26 +59,25 @@ const validateConnectionFallback = (
     defaultAccessMode: neo4j.session.READ,
     database: multiDbSupport ? 'system' : undefined
   })
-  const txFn = buildTxFunctionByMode(session)
-  txFn &&
-    txFn(tx => tx.run('CALL db.indexes()'), {
+  session
+    .readTransaction(tx => tx.run('CALL db.indexes()'), {
       metadata: backgroundTxMetadata.txMetadata
     })
-      .then(() => {
-        session.close()
+    .then(() => {
+      session.close()
+      res(driver)
+    })
+    .catch((e: { code: string; message: string }) => {
+      session.close()
+      // Only invalidate the connection if not available
+      // or not authed
+      // or credentials have expired
+      if (!e.code || isBoltConnectionErrorCode(e.code)) {
+        rej(e)
+      } else {
         res(driver)
-      })
-      .catch((e: { code: string; message: string }) => {
-        session.close()
-        // Only invalidate the connection if not available
-        // or not authed
-        // or credentials have expired
-        if (!e.code || isBoltConnectionErrorCode(e.code)) {
-          rej(e)
-        } else {
-          res(driver)
-        }
-      })
+      }
+    })
 }
 
 export const validateConnection = (
@@ -99,28 +98,29 @@ export const validateConnection = (
         defaultAccessMode: neo4j.session.READ,
         database: multiDbSupport ? 'system' : undefined
       })
-      const txFn = buildTxFunctionByMode(session)
-      txFn &&
-        txFn(tx => tx.run('SHOW PROCEDURES LIMIT 1'), {
+      //Can be any query, is used use to validate the connection and to get an error code if user has expired crdentails for example.
+      //This query works for version 4.3 and above. For older versions, use the fallback function.
+      session
+        .readTransaction(tx => tx.run('SHOW PROCEDURES LIMIT 1'), {
           metadata: backgroundTxMetadata.txMetadata
         })
-          .then(() => {
-            session.close()
-            res(driver)
-          })
-          .catch((e: { code: string; message: string }) => {
-            session.close()
-            // Only invalidate the connection if not available
-            // or not authed
-            // or credentials have expired
-            if (!e.code || isBoltConnectionErrorCode(e.code)) {
-              rej(e)
-            } else {
-              // if connection could not be validated using SHOW PROCEDURES then try using
-              // CALL db.indexes()
-              validateConnectionFallback(driver, res, rej, multiDbSupport)
-            }
-          })
+        .then(() => {
+          session.close()
+          res(driver)
+        })
+        .catch((e: { code: string; message: string }) => {
+          session.close()
+          // Only invalidate the connection if not available
+          // or not authed
+          // or credentials have expired
+          if (!e.code || isBoltConnectionErrorCode(e.code)) {
+            rej(e)
+          } else {
+            // if connection could not be validated using SHOW PROCEDURES then try using CALL db.indexes()
+            //Remove this fallback function when we drop support for older versions and replace with "res(driver)".
+            validateConnectionFallback(driver, res, rej, multiDbSupport)
+          }
+        })
     })
     .catch(rej)
 }


### PR DESCRIPTION
db.indexes() was used to check the connection to the database but was deprecated in neo4j 4.2 and will be removed in a future version. SHOW PROCEDURES seems to accomplish the same thing and is not deprecated