### PR TITLE
Change validate connection query

### DIFF
--- a/src/shared/services/bolt/boltConnection.ts
+++ b/src/shared/services/bolt/boltConnection.ts
@@ -101,7 +101,7 @@ export const validateConnection = (
       //Can be any query, is used use to validate the connection and to get an error code if user has expired crdentails for example.
       //This query works for version 4.3 and above. For older versions, use the fallback function.
       session
-        .readTransaction(tx => tx.run('SHOW PROCEDURES LIMIT 1'), {
+        .readTransaction(tx => tx.run('SHOW PROCEDURES'), {
           metadata: backgroundTxMetadata.txMetadata
         })
         .then(() => {

--- a/src/shared/services/bolt/boltConnection.ts
+++ b/src/shared/services/bolt/boltConnection.ts
@@ -101,7 +101,7 @@ export const validateConnection = (
       //Can be any query, is used use to validate the connection and to get an error code if user has expired crdentails for example.
       //This query works for version 4.3 and above. For older versions, use the fallback function.
       session
-        .readTransaction(tx => tx.run('SHOW PROCEDURES'), {
+        .readTransaction(tx => tx.run('SHOW DATABASES'), {
           metadata: backgroundTxMetadata.txMetadata
         })
         .then(() => {


### PR DESCRIPTION
Limit 1 is not supported on show procedures which results in a different error than expected. Using no limit can return many rows which is unnecessary. Show databases should (hopefully) be better in most cases