### PR TITLE
Remove deprecated procedures

### DIFF
--- a/e2e_tests/integration/schema-frame.spec.ts
+++ b/e2e_tests/integration/schema-frame.spec.ts
@@ -103,9 +103,26 @@ describe('Schema Frame', () => {
       cy.executeCommand(':clear')
       cy.executeCommand(':schema')
 
-      cy.get('[data-testid="frameContents"]')
-        .should('contain', 'Constraints')
-        .and('contain', ':SchemaTest')
+      if (Cypress.config('serverVersion') >= 4.2) {
+        // Headers
+        cy.get('[data-testid="frameContents"]')
+          .should('contain', 'Constraint Name')
+          .and('contain', 'Type')
+          .and('contain', 'EntityType')
+          .and('contain', 'LabelsOrTypes')
+          .and('contain', 'Properties')
+
+        // Constraint info
+        cy.get('[data-testid="frameContents"]')
+          .should('contain', 'UNIQUENESS')
+          .and('contain', 'NODE')
+          .and('contain', '"SchemaTest"')
+          .and('contain', '"prop1"')
+      } else {
+        cy.get('[data-testid="frameContents"]')
+          .should('contain', 'Constraints')
+          .and('contain', ':SchemaTest')
+      }
     })
   })
 })

--- a/src/browser/modules/Stream/SchemaFrame.test.tsx
+++ b/src/browser/modules/Stream/SchemaFrame.test.tsx
@@ -48,6 +48,71 @@ test('SchemaFrame renders empty for Neo4j >= 4.0', () => {
   expect(container).toMatchSnapshot()
 })
 
+test('SchemaFrame renders results for Neo4j >= 4.2', () => {
+  const indexResult = {
+    success: true,
+    result: {
+      records: [
+        {
+          _fields: [
+            'INDEX ON :Movie(released)',
+            'Movie',
+            ['released'],
+            'ONLINE',
+            'node_label_property',
+            {
+              version: '2.0',
+              key: 'lucene+native'
+            }
+          ],
+          keys: [
+            'description',
+            'label',
+            'properties',
+            'state',
+            'type',
+            'provider'
+          ]
+        }
+      ]
+    }
+  }
+  const firstIndexRecord: any = indexResult.result.records[0]
+  firstIndexRecord.get = (key: any) =>
+    firstIndexRecord._fields[firstIndexRecord.keys.indexOf(key)]
+
+  const constraintResult = {
+    success: true,
+    result: {
+      records: [
+        {
+          keys: ['name', 'type', 'entityType', 'labelsOrTypes', 'properties'],
+          _fields: [
+            'constraint_550b2518',
+            'UNIQUE',
+            'node',
+            ['Movie'],
+            ['released']
+          ]
+        }
+      ]
+    }
+  }
+  const firstConstraintRecord: any = constraintResult.result.records[0]
+  firstConstraintRecord.get = (key: any) =>
+    firstConstraintRecord._fields[firstConstraintRecord.keys.indexOf(key)]
+
+  const { container } = renderWithRedux(
+    <SchemaFrame
+      indexes={indexResult}
+      constraints={constraintResult}
+      neo4jVersion={'4.2.1'}
+    />
+  )
+
+  expect(container).toMatchSnapshot()
+})
+
 test('SchemaFrame renders results for Neo4j < 4.0', () => {
   const indexResult = {
     success: true,

--- a/src/browser/modules/Stream/SchemaFrame.tsx
+++ b/src/browser/modules/Stream/SchemaFrame.tsx
@@ -21,7 +21,7 @@ import { replace, toUpper } from 'lodash-es'
 import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import { withBus } from 'react-suber'
-import semver from 'semver'
+import semver, { SemVer } from 'semver'
 import { v4 } from 'uuid'
 
 import Slide from '../Carousel/Slide'
@@ -36,11 +36,11 @@ import Directives from 'browser-components/Directives'
 import { GlobalState } from 'project-root/src/shared/globalState'
 import { NEO4J_BROWSER_USER_ACTION_QUERY } from 'services/bolt/txMetadata'
 import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
-import { getRawVersion } from 'shared/modules/dbMeta/dbMetaDuck'
+import { getSemanticVersion } from 'shared/modules/dbMeta/dbMetaDuck'
 
 type IndexesProps = {
   indexes: any
-  neo4jVersion: string | null
+  neo4jVersion: SemVer | null
 }
 const Indexes = ({ indexes, neo4jVersion }: IndexesProps) => {
   if (
@@ -192,7 +192,7 @@ export class SchemaFrame extends Component<any, SchemaFrameState> {
     }
   }
 
-  fetchData(neo4jVersion: string) {
+  fetchData(neo4jVersion: SemVer) {
     if (this.props.bus) {
       // Indexes
       this.props.bus.self(
@@ -282,7 +282,7 @@ const Frame = (props: any) => {
 }
 
 const mapStateToProps = (state: GlobalState) => ({
-  neo4jVersion: getRawVersion(state)
+  neo4jVersion: getSemanticVersion(state)
 })
 
 export default withBus(connect(mapStateToProps, null)(Frame))

--- a/src/browser/modules/Stream/SchemaFrame.tsx
+++ b/src/browser/modules/Stream/SchemaFrame.tsx
@@ -101,19 +101,12 @@ const Constraints = ({
   let header = []
 
   if (semver.valid(neo4jVersion) && semver.satisfies(neo4jVersion, '<4.2.*')) {
+    header = ['Constraints']
+
     rows = constraints.map((constraint: any) => [
       replace(constraint.description, 'CONSTRAINT', '')
     ])
-    header = ['Constraints']
   } else {
-    rows = constraints.map((constraint: any) => [
-      constraint.name,
-      constraint.type,
-      constraint.entityType,
-      JSON.stringify(constraint.labelsOrTypes, null, 2),
-      JSON.stringify(constraint.properties, null, 2)
-    ])
-
     header = [
       'Constraint Name',
       'Type',
@@ -121,6 +114,14 @@ const Constraints = ({
       'LabelsOrTypes',
       'Properties'
     ]
+
+    rows = constraints.map((constraint: any) => [
+      constraint.name,
+      constraint.type,
+      constraint.entityType,
+      JSON.stringify(constraint.labelsOrTypes, null, 2),
+      JSON.stringify(constraint.properties, null, 2)
+    ])
   }
 
   return (

--- a/src/browser/modules/Stream/__snapshots__/SchemaFrame.test.tsx.snap
+++ b/src/browser/modules/Stream/__snapshots__/SchemaFrame.test.tsx.snap
@@ -43,7 +43,27 @@ exports[`SchemaFrame renders empty 1`] = `
               <th
                 class="sc-iUKqMP heOYnT table-header"
               >
-                Constraints
+                Constraint Name
+              </th>
+              <th
+                class="sc-iUKqMP heOYnT table-header"
+              >
+                Type
+              </th>
+              <th
+                class="sc-iUKqMP heOYnT table-header"
+              >
+                EntityType
+              </th>
+              <th
+                class="sc-iUKqMP heOYnT table-header"
+              >
+                LabelsOrTypes
+              </th>
+              <th
+                class="sc-iUKqMP heOYnT table-header"
+              >
+                Properties
               </th>
             </tr>
           </thead>
@@ -56,6 +76,18 @@ exports[`SchemaFrame renders empty 1`] = `
               >
                 None
               </td>
+              <td
+                class="sc-iAKWXU gkvwcC table-properties"
+              />
+              <td
+                class="sc-iAKWXU gkvwcC table-properties"
+              />
+              <td
+                class="sc-iAKWXU gkvwcC table-properties"
+              />
+              <td
+                class="sc-iAKWXU gkvwcC table-properties"
+              />
             </tr>
           </tbody>
         </table>
@@ -173,7 +205,27 @@ exports[`SchemaFrame renders empty for Neo4j >= 4.0 1`] = `
               <th
                 class="sc-iUKqMP heOYnT table-header"
               >
-                Constraints
+                Constraint Name
+              </th>
+              <th
+                class="sc-iUKqMP heOYnT table-header"
+              >
+                Type
+              </th>
+              <th
+                class="sc-iUKqMP heOYnT table-header"
+              >
+                EntityType
+              </th>
+              <th
+                class="sc-iUKqMP heOYnT table-header"
+              >
+                LabelsOrTypes
+              </th>
+              <th
+                class="sc-iUKqMP heOYnT table-header"
+              >
+                Properties
               </th>
             </tr>
           </thead>
@@ -186,6 +238,18 @@ exports[`SchemaFrame renders empty for Neo4j >= 4.0 1`] = `
               >
                 None
               </td>
+              <td
+                class="sc-iAKWXU gkvwcC table-properties"
+              />
+              <td
+                class="sc-iAKWXU gkvwcC table-properties"
+              />
+              <td
+                class="sc-iAKWXU gkvwcC table-properties"
+              />
+              <td
+                class="sc-iAKWXU gkvwcC table-properties"
+              />
             </tr>
           </tbody>
         </table>
@@ -267,6 +331,186 @@ exports[`SchemaFrame renders results for Neo4j < 4.0 1`] = `
                 class="sc-iAKWXU gkvwcC table-properties"
               >
                  ON ( book:Book ) ASSERT book.isbn IS UNIQUE
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <br />
+        <p
+          class="lead"
+        >
+          Execute the following command to visualize what's related, and how
+        </p>
+        <figure>
+          <pre
+            class="code runnable"
+          >
+            <i
+              class="fa fa-play-circle-o"
+              style="padding-right:4px"
+            />
+            CALL db.schema.visualization
+          </pre>
+        </figure>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`SchemaFrame renders results for Neo4j >= 4.2 1`] = `
+<div>
+  <div
+    style="width: 100%;"
+  >
+    <div>
+      <div
+        class="sc-iwjdpV EPaYX"
+      >
+        <table
+          class="sc-jcFjpl emSDdK"
+          data-testid="schemaFrameIndexesTable"
+        >
+          <thead>
+            <tr>
+              <th
+                class="sc-iUKqMP heOYnT table-header"
+              >
+                Index Name
+              </th>
+              <th
+                class="sc-iUKqMP heOYnT table-header"
+              >
+                Type
+              </th>
+              <th
+                class="sc-iUKqMP heOYnT table-header"
+              >
+                Uniqueness
+              </th>
+              <th
+                class="sc-iUKqMP heOYnT table-header"
+              >
+                EntityType
+              </th>
+              <th
+                class="sc-iUKqMP heOYnT table-header"
+              >
+                LabelsOrTypes
+              </th>
+              <th
+                class="sc-iUKqMP heOYnT table-header"
+              >
+                Properties
+              </th>
+              <th
+                class="sc-iUKqMP heOYnT table-header"
+              >
+                State
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              class="sc-caiLqq icfFcF table-row"
+            >
+              <td
+                class="sc-iAKWXU gkvwcC table-properties"
+              />
+              <td
+                class="sc-iAKWXU gkvwcC table-properties"
+              >
+                node_label_property
+              </td>
+              <td
+                class="sc-iAKWXU gkvwcC table-properties"
+              />
+              <td
+                class="sc-iAKWXU gkvwcC table-properties"
+              />
+              <td
+                class="sc-iAKWXU gkvwcC table-properties"
+              />
+              <td
+                class="sc-iAKWXU gkvwcC table-properties"
+              >
+                [
+  "released"
+]
+              </td>
+              <td
+                class="sc-iAKWXU gkvwcC table-properties"
+              >
+                ONLINE
+              </td>
+            </tr>
+          </tbody>
+        </table>
+        <table
+          class="sc-jcFjpl emSDdK"
+          data-testid="schemaFrameConstraintsTable"
+        >
+          <thead>
+            <tr>
+              <th
+                class="sc-iUKqMP heOYnT table-header"
+              >
+                Constraint Name
+              </th>
+              <th
+                class="sc-iUKqMP heOYnT table-header"
+              >
+                Type
+              </th>
+              <th
+                class="sc-iUKqMP heOYnT table-header"
+              >
+                EntityType
+              </th>
+              <th
+                class="sc-iUKqMP heOYnT table-header"
+              >
+                LabelsOrTypes
+              </th>
+              <th
+                class="sc-iUKqMP heOYnT table-header"
+              >
+                Properties
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              class="sc-caiLqq icfFcF table-row"
+            >
+              <td
+                class="sc-iAKWXU gkvwcC table-properties"
+              >
+                constraint_550b2518
+              </td>
+              <td
+                class="sc-iAKWXU gkvwcC table-properties"
+              >
+                UNIQUE
+              </td>
+              <td
+                class="sc-iAKWXU gkvwcC table-properties"
+              >
+                node
+              </td>
+              <td
+                class="sc-iAKWXU gkvwcC table-properties"
+              >
+                [
+  "Movie"
+]
+              </td>
+              <td
+                class="sc-iAKWXU gkvwcC table-properties"
+              >
+                [
+  "released"
+]
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
db.indexes() and db.constraints() have been deprecated in Neo4j 4.2 and will be removed in a future release. This pr replaces calls to those procedures with SHOW INDEXES and SHOW CONSTRAINTS. 
