### PR TITLE
Replace empty string with placeholder string in column header generation

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/RelatableView/__snapshots__/relatable-view.test.tsx.snap
+++ b/src/browser/modules/Stream/CypherFrame/RelatableView/__snapshots__/relatable-view.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`RelatableViews RelatableView does not crash if key is empty string 1`] 
               colspan="1"
               role="columnheader"
             >
-              ``
+              \`\`
             </th>
           </tr>
         </thead>

--- a/src/browser/modules/Stream/CypherFrame/RelatableView/__snapshots__/relatable-view.test.tsx.snap
+++ b/src/browser/modules/Stream/CypherFrame/RelatableView/__snapshots__/relatable-view.test.tsx.snap
@@ -14,6 +14,78 @@ exports[`RelatableViews RelatableView displays bodyMessage if no rows 1`] = `
 </div>
 `;
 
+exports[`RelatableViews RelatableView does not crash if key is empty string 1`] = `
+<div>
+  <div
+    class="sc-brSvTw iHVSPL"
+  >
+    <div
+      class="sc-ctqQKy hgjWJZ relatable"
+    >
+      <table
+        class="ui basic table relatable__table "
+        role="table"
+      >
+        <thead
+          class=""
+        >
+          <tr
+            class="relatable__table-row relatable__table-header-row"
+            role="row"
+          >
+            <th
+              class="collapsing relatable__table-cell relatable__table-header-cell relatable__table-header-actions-cell"
+            >
+              <span
+                class="relatable__table-row-actions"
+              />
+            </th>
+            <th
+              class="relatable__table-cell relatable__table-header-cell"
+              colspan="1"
+              role="columnheader"
+            >
+              ''
+            </th>
+          </tr>
+        </thead>
+        <tbody
+          class=""
+        >
+          <tr
+            class="relatable__table-row relatable__table-body-row "
+            role="row"
+          >
+            <td
+              class="relatable__table-cell relatable__table-body-cell relatable__table-row-actions-cell"
+            >
+              <div
+                class="ui label relatable__table-row-number"
+              >
+                1
+              </div>
+              <span
+                class="relatable__table-row-actions"
+              />
+            </td>
+            <td
+              class="relatable__table-cell relatable__table-body-cell"
+              role="cell"
+            >
+              <span
+                class="sc-evcjhq kRdrLI"
+              >
+                "String value"
+              </span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`RelatableViews RelatableView does not display bodyMessage if rows, and escapes HTML 1`] = `
 <div>
   <div

--- a/src/browser/modules/Stream/CypherFrame/RelatableView/__snapshots__/relatable-view.test.tsx.snap
+++ b/src/browser/modules/Stream/CypherFrame/RelatableView/__snapshots__/relatable-view.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`RelatableViews RelatableView does not crash if key is empty string 1`] 
               colspan="1"
               role="columnheader"
             >
-              ''
+              ``
             </th>
           </tr>
         </thead>

--- a/src/browser/modules/Stream/CypherFrame/RelatableView/relatable-view.test.tsx
+++ b/src/browser/modules/Stream/CypherFrame/RelatableView/relatable-view.test.tsx
@@ -66,6 +66,25 @@ describe('RelatableViews', () => {
       // Then
       expect(container).toMatchSnapshot()
     })
+
+    test('does not crash if key is empty string', () => {
+      const value = 'String value'
+      const result = {
+        records: [{ keys: [``], _fields: [value], get: () => value }] as any,
+        summary: {
+          resultAvailableAfter: neo4j.int(5),
+          resultConsumedAfter: neo4j.int(5)
+        } as any
+      }
+
+      // When
+      const { container } = render(
+        <RelatableView result={result} maxFieldItems={1000} maxRows={1000} />
+      )
+
+      // Then
+      expect(container).toMatchSnapshot()
+    })
   })
   describe('TableStatusbar', () => {
     test('displays no statusBarMessage', () => {

--- a/src/browser/modules/Stream/CypherFrame/RelatableView/relatable-view.tsx
+++ b/src/browser/modules/Stream/CypherFrame/RelatableView/relatable-view.tsx
@@ -94,9 +94,8 @@ export function RelatableViewComponent({
 
 function getColumns(records: Record[], maxFieldItems: number) {
   const keys = get(head(records), 'keys', [])
-
   return map(keys, key => ({
-    Header: key,
+    Header: key !== '' ? key : "''",
     accessor: (record: Record) => {
       const fieldItem = record.get(key)
 

--- a/src/browser/modules/Stream/CypherFrame/RelatableView/relatable-view.tsx
+++ b/src/browser/modules/Stream/CypherFrame/RelatableView/relatable-view.tsx
@@ -95,7 +95,7 @@ export function RelatableViewComponent({
 function getColumns(records: Record[], maxFieldItems: number) {
   const keys = get(head(records), 'keys', [])
   return map(keys, key => ({
-    Header: key !== '' ? key : "''",
+    Header: key !== '' ? key : '``',
     accessor: (record: Record) => {
       const fieldItem = record.get(key)
 


### PR DESCRIPTION
This fixes the following issue:
https://github.com/neo4j/neo4j-browser/issues/1761

Does so by checking for empty string and replace it with a string that contains two quotation marks.
The queries in the original issue do not cause a browser crash now.

However, the following query still fails:
```
RETURN 'test' AS ``, 'test2' AS `''`
```
Giving the error:
`Duplicate columns were found with ids: "''" in the columns array above`
Which is caused by `` being mapped to `''` so there is a collision in the column keys.

So the fix is not completely satisfactory since a user can still generate a crash by giving weird input queries. 

