### PR TITLE
bugfix missing tooltip on fa icons

### DIFF
--- a/src/browser/components/icons/IconContainer.tsx
+++ b/src/browser/components/icons/IconContainer.tsx
@@ -92,6 +92,7 @@ export const IconContainer = (props: IconContainerProps): JSX.Element => {
   ) : (
     <StyledIconWrapper
       {...rest}
+      title={title}
       style={{ fontSize: fontSize, lineHeight: 'inherit' }}
     />
   )


### PR DESCRIPTION
Tooltip was missing on question icon in sysinfo frame, now it works again.

<img width="760" alt="Screenshot 2022-09-15 at 11 03 04" src="https://user-images.githubusercontent.com/11065688/190402239-23b4992b-4691-4518-8e00-b0559c11d11f.png">

<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

