### PR TITLE
Fix sysinfo: in 5.0 settings metrics.namespaces.enabled is removed

### DIFF
--- a/e2e_tests/integration/sysinfo-command.spec.ts
+++ b/e2e_tests/integration/sysinfo-command.spec.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2002-2021 "Neo4j,"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { isEnterpriseEdition } from '../support/utils'
+
+describe(':sysinfo command', () => {
+  before(function () {
+    cy.visit(Cypress.config('url')).title().should('include', 'Neo4j Browser')
+    cy.wait(3000)
+    cy.ensureConnection()
+  })
+  beforeEach(() => {
+    cy.executeCommand(':clear')
+  })
+
+  if (isEnterpriseEdition()) {
+    if (Cypress.config('serverVersion') >= 4.0) {
+      it('sysinfo shows store size', () => {
+        cy.executeCommand(':sysinfo')
+
+        cy.get('[data-testid="Database"]').should('not.have.text', '-')
+      })
+    }
+
+    it('sysinfo shows Id allocation', () => {
+      cy.executeCommand(
+        'CREATE (a:TestLabel)-[:CONNECTS]->(b:TestLabel) RETURN a, b'
+      )
+
+      cy.executeCommand(':sysinfo')
+
+      cy.get('[data-testid="Relationship Type ID"]').should(
+        'not.have.text',
+        '-'
+      )
+
+      // Clear
+      cy.executeCommand('MATCH (a:TestLabel) DETACH DELETE a')
+    })
+  }
+})

--- a/src/browser/components/Tables.tsx
+++ b/src/browser/components/Tables.tsx
@@ -109,7 +109,9 @@ export const SysInfoTableEntry = ({
   return mappedValue || !optional ? (
     <StyledTr>
       <StyledTdKey>{label}</StyledTdKey>
-      <StyledTd>{mappedValue || missingValuePlaceholder}</StyledTd>
+      <StyledTd data-testid={label}>
+        {mappedValue || missingValuePlaceholder}
+      </StyledTd>
     </StyledTr>
   ) : null
 }

--- a/src/shared/modules/dbMeta/dbMetaDuck.ts
+++ b/src/shared/modules/dbMeta/dbMetaDuck.ts
@@ -116,7 +116,7 @@ export const initialClientSettings: ClientSettings = {
   retainEditorHistory: false, // default is true, but set to false until settings read
   allowTelemetry: true, // default is true. Renamed to client.allow_telemetry after 5.0
   authEnabled: true, // default is true
-  metricsNamespacesEnabled: false, // default is false, Renamed to server.metrics.namespaces.enabled after 5.0
+  metricsNamespacesEnabled: false, // pre 5.0: default is false, from and after 5.0: settings removed, always true
   metricsPrefix: 'neo4j' // default is 'neo4j', Renamed to server.metrics.prefix after 5.0
 }
 // Initial state

--- a/src/shared/modules/dbMeta/dbMetaEpics.test.ts
+++ b/src/shared/modules/dbMeta/dbMetaEpics.test.ts
@@ -20,6 +20,7 @@
 
 import { cleanupSettings } from './dbMetaEpics'
 import { ClientSettings } from './dbMetaDuck'
+import { SemVer } from 'semver'
 
 const defaultSettings: ClientSettings = {
   allowOutgoingConnections: true,
@@ -30,7 +31,7 @@ const defaultSettings: ClientSettings = {
   retainEditorHistory: true,
   allowTelemetry: true,
   authEnabled: true,
-  metricsNamespacesEnabled: false,
+  metricsNamespacesEnabled: true,
   metricsPrefix: 'neo4j'
 }
 
@@ -58,22 +59,25 @@ describe('cleanupSettings', () => {
       retainEditorHistory: true,
       allowTelemetry: true,
       authEnabled: true,
-      metricsNamespacesEnabled: false,
+      metricsNamespacesEnabled: true,
       metricsPrefix: 'neo4j4j'
     }
 
-    const newSettings = cleanupSettings(rawSettings)
+    const newSettings = cleanupSettings(rawSettings, null)
 
     expect(newSettings).toEqual(expectedSettings)
   })
   test('default values', () => {
-    const newSettings = cleanupSettings({})
+    const newSettings = cleanupSettings({}, null)
     expect(newSettings).toEqual(defaultSettings)
   })
   test('browser.allow_outgoing_connections="false"', () => {
-    const newSettings = cleanupSettings({
-      'browser.allow_outgoing_connections': 'false'
-    })
+    const newSettings = cleanupSettings(
+      {
+        'browser.allow_outgoing_connections': 'false'
+      },
+      null
+    )
     const expectedSettings = {
       ...defaultSettings,
       allowOutgoingConnections: false
@@ -81,9 +85,12 @@ describe('cleanupSettings', () => {
     expect(newSettings).toEqual(expectedSettings)
   })
   test('browser.allow_outgoing_connections="true"', () => {
-    const newSettings = cleanupSettings({
-      'browser.allow_outgoing_connections': 'true'
-    })
+    const newSettings = cleanupSettings(
+      {
+        'browser.allow_outgoing_connections': 'true'
+      },
+      null
+    )
     const expectedSettings: ClientSettings = {
       ...defaultSettings,
       allowOutgoingConnections: true
@@ -91,7 +98,10 @@ describe('cleanupSettings', () => {
     expect(newSettings).toEqual(expectedSettings)
   })
   test('clients.allow_telemetry="false"', () => {
-    const newSettings = cleanupSettings({ 'clients.allow_telemetry': 'false' })
+    const newSettings = cleanupSettings(
+      { 'clients.allow_telemetry': 'false' },
+      null
+    )
     const expectedSettings: ClientSettings = {
       ...defaultSettings,
       allowTelemetry: false
@@ -99,7 +109,10 @@ describe('cleanupSettings', () => {
     expect(newSettings).toEqual(expectedSettings)
   })
   test('client.allow_telemetry="false"', () => {
-    const newSettings = cleanupSettings({ 'client.allow_telemetry': 'false' })
+    const newSettings = cleanupSettings(
+      { 'client.allow_telemetry': 'false' },
+      null
+    )
     const expectedSettings: ClientSettings = {
       ...defaultSettings,
       allowTelemetry: false
@@ -107,10 +120,32 @@ describe('cleanupSettings', () => {
     expect(newSettings).toEqual(expectedSettings)
   })
   test('server.metrics.prefix=""', () => {
-    const newSettings = cleanupSettings({ 'server.metrics.prefix': '' })
+    const newSettings = cleanupSettings({ 'server.metrics.prefix': '' }, null)
     const expectedSettings: ClientSettings = {
       ...defaultSettings,
       metricsPrefix: ''
+    }
+    expect(newSettings).toEqual(expectedSettings)
+  })
+  test('metricsNamespacesEnabled should be default false in 4.0', () => {
+    const newSettings = cleanupSettings(
+      { 'server.metrics.namespaces.enabled': '' },
+      new SemVer('4.0.0')
+    )
+    const expectedSettings: ClientSettings = {
+      ...defaultSettings,
+      metricsNamespacesEnabled: false
+    }
+    expect(newSettings).toEqual(expectedSettings)
+  })
+  test('metricsNamespacesEnabled should be default true in 5.0', () => {
+    const newSettings = cleanupSettings(
+      { 'server.metrics.namespaces.enabled': '' },
+      new SemVer('5.0.0')
+    )
+    const expectedSettings: ClientSettings = {
+      ...defaultSettings,
+      metricsNamespacesEnabled: true
     }
     expect(newSettings).toEqual(expectedSettings)
   })


### PR DESCRIPTION
...and always true

<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

