### PR TITLE
Separate metadata count query

### DIFF
--- a/src/browser/components/TabNavigation/Navigation.tsx
+++ b/src/browser/components/TabNavigation/Navigation.tsx
@@ -66,13 +66,15 @@ interface NavigationState {
   transitionState: DrawerTransitionState
   closingDrawerName: string | null
   guideWidth: number
+  isResizing: boolean
 }
 
 class Navigation extends Component<NavigationProps, NavigationState> {
   state: NavigationState = {
     transitionState: this.props.selectedDrawerName ? Open : Closed,
     closingDrawerName: null,
-    guideWidth: LARGE_DRAWER_WIDTH
+    guideWidth: LARGE_DRAWER_WIDTH,
+    isResizing: false
   }
 
   componentDidUpdate(
@@ -180,10 +182,10 @@ class Navigation extends Component<NavigationProps, NavigationState> {
     const drawerWidth = guideDrawerSelected
       ? this.state.guideWidth
       : STANDARD_DRAWER_WIDTH
-    const useFullWidth =
+    const isOpenOrOpening =
       this.state.transitionState === Open ||
       this.state.transitionState === Opening
-    const width = useFullWidth ? drawerWidth : 0
+    const width = isOpenOrOpening ? drawerWidth : 0
 
     return (
       <StyledSidebar>
@@ -192,32 +194,43 @@ class Navigation extends Component<NavigationProps, NavigationState> {
           <StyledBottomNav>{bottomNavItemsList}</StyledBottomNav>
         </StyledTabsWrapper>
 
-        <Resizable
-          minWidth={guideDrawerSelected ? STANDARD_DRAWER_WIDTH : 0}
-          maxWidth={'70vw'}
-          size={{ width: width, height: '100%' }}
-          onResizeStop={(_e, _direction, _ref, d) => {
-            this.setState({ guideWidth: this.state.guideWidth + d.width })
+        <StyledDrawer
+          onTransitionEnd={this.onTransitionEnd}
+          style={{
+            width: this.state.isResizing ? 'unset' : width
           }}
-          enable={{
-            top: false,
-            right: guideDrawerSelected,
-            bottom: false,
-            left: false,
-            topRight: false,
-            bottomRight: false,
-            bottomLeft: false,
-            topLeft: false
-          }}
-          style={{ zIndex: 100 }}
         >
-          <StyledDrawer onTransitionEnd={this.onTransitionEnd}>
+          <Resizable
+            minWidth={guideDrawerSelected ? STANDARD_DRAWER_WIDTH : 0}
+            maxWidth={'70vw'}
+            size={{ width: width, height: '100%' }}
+            onResizeStart={() => {
+              this.setState({ isResizing: true })
+            }}
+            onResizeStop={(_e, _direction, _ref, d) => {
+              this.setState({
+                guideWidth: this.state.guideWidth + d.width,
+                isResizing: false
+              })
+            }}
+            enable={{
+              top: false,
+              right: guideDrawerSelected,
+              bottom: false,
+              left: false,
+              topRight: false,
+              bottomRight: false,
+              bottomLeft: false,
+              topLeft: false
+            }}
+            style={{ zIndex: 100 }}
+          >
             {drawerIsVisible &&
               getContentToShow(
                 this.props.selectedDrawerName || this.state.closingDrawerName
               )}
-          </StyledDrawer>
-        </Resizable>
+          </Resizable>
+        </StyledDrawer>
       </StyledSidebar>
     )
   }

--- a/src/browser/modules/DBMSInfo/DBMSInfo.tsx
+++ b/src/browser/modules/DBMSInfo/DBMSInfo.tsx
@@ -97,7 +97,7 @@ export function DBMSInfo(props: any): JSX.Element {
               loading={props.countLoading}
               onClick={() => props.forceCount()}
             >
-              Manually refresh counts
+              Refresh counts
             </Button>
           </>
         )}

--- a/src/browser/modules/DBMSInfo/DBMSInfo.tsx
+++ b/src/browser/modules/DBMSInfo/DBMSInfo.tsx
@@ -87,10 +87,9 @@ export function DBMSInfo(props: any): JSX.Element {
         {!props.countAutoRefreshing && (
           <>
             <p>
-              The automatic refresh of the node and relationship counts has been
-              disabled due to long loading times.{' '}
+              Automatic updates of node and relationship counts have been disabled for performance reasons, likely due to{' '}
               <DrawerExternalLink href="https://neo4j.com/docs/cypher-manual/current/access-control/limitations/#access-control-limitations-db-operations">
-                Read more here.
+                RBAC configuration.
               </DrawerExternalLink>
             </p>
             <Button

--- a/src/browser/modules/DBMSInfo/DBMSInfo.tsx
+++ b/src/browser/modules/DBMSInfo/DBMSInfo.tsx
@@ -41,7 +41,7 @@ import { getCurrentUser } from 'shared/modules/currentUser/currentUserDuck'
 import {
   forceCount,
   getCountAutomaticRefreshLoading,
-  getCountAutomaticRefreshStatus,
+  getCountAutomaticRefreshEnabled,
   getDatabases
 } from 'shared/modules/dbMeta/dbMetaDuck'
 import { getGraphStyleData } from 'shared/modules/grass/grassDuck'
@@ -87,7 +87,8 @@ export function DBMSInfo(props: any): JSX.Element {
         {!props.countAutoRefreshing && (
           <>
             <p>
-              Automatic updates of node and relationship counts have been disabled for performance reasons, likely due to{' '}
+              Automatic updates of node and relationship counts have been
+              disabled for performance reasons, likely due to{' '}
               <DrawerExternalLink href="https://neo4j.com/docs/cypher-manual/current/access-control/limitations/#access-control-limitations-db-operations">
                 RBAC configuration.
               </DrawerExternalLink>
@@ -138,7 +139,7 @@ export function DBMSInfo(props: any): JSX.Element {
 const mapStateToProps = (state: any) => {
   const useDb = getUseDb(state)
   const databases = getDatabases(state)
-  const countAutoRefreshing = getCountAutomaticRefreshStatus(state)
+  const countAutoRefreshing = getCountAutomaticRefreshEnabled(state)
   const countLoading = getCountAutomaticRefreshLoading(state)
   return {
     graphStyleData: getGraphStyleData(state),

--- a/src/browser/modules/DBMSInfo/DBMSInfo.tsx
+++ b/src/browser/modules/DBMSInfo/DBMSInfo.tsx
@@ -28,6 +28,7 @@ import { UserDetails } from './UserDetails'
 import {
   Drawer,
   DrawerBody,
+  DrawerExternalLink,
   DrawerHeader
 } from 'browser-components/drawer/drawer-styled'
 import {
@@ -37,8 +38,14 @@ import {
 } from 'shared/modules/commands/commandsDuck'
 import { getUseDb } from 'shared/modules/connections/connectionsDuck'
 import { getCurrentUser } from 'shared/modules/currentUser/currentUserDuck'
-import { getDatabases } from 'shared/modules/dbMeta/dbMetaDuck'
+import {
+  forceCount,
+  getCountAutomaticRefreshLoading,
+  getCountAutomaticRefreshStatus,
+  getDatabases
+} from 'shared/modules/dbMeta/dbMetaDuck'
 import { getGraphStyleData } from 'shared/modules/grass/grassDuck'
+import { Button } from '@neo4j-ndl/react'
 
 export function DBMSInfo(props: any): JSX.Element {
   const moreStep = 50
@@ -77,6 +84,23 @@ export function DBMSInfo(props: any): JSX.Element {
           selectedDb={useDb}
           onChange={onDbSelect}
         />
+        {!props.countAutoRefreshing && (
+          <>
+            <p>
+              The automatic refresh of the node and relationship counts has been
+              disabled due to long loading times.{' '}
+              <DrawerExternalLink href="https://neo4j.com/docs/cypher-manual/current/access-control/limitations/#access-control-limitations-db-operations">
+                Read more here.
+              </DrawerExternalLink>
+            </p>
+            <Button
+              loading={props.countLoading}
+              onClick={() => props.forceCount()}
+            >
+              Manually refresh counts
+            </Button>
+          </>
+        )}
         <LabelItems
           count={nodes}
           labels={labels.slice(0, maxLabelsCount)}
@@ -115,12 +139,16 @@ export function DBMSInfo(props: any): JSX.Element {
 const mapStateToProps = (state: any) => {
   const useDb = getUseDb(state)
   const databases = getDatabases(state)
+  const countAutoRefreshing = getCountAutomaticRefreshStatus(state)
+  const countLoading = getCountAutomaticRefreshLoading(state)
   return {
     graphStyleData: getGraphStyleData(state),
     meta: state.meta,
     user: getCurrentUser(state),
     useDb,
-    databases
+    databases,
+    countAutoRefreshing,
+    countLoading
   }
 }
 const mapDispatchToProps = (dispatch: any, ownProps: any) => {
@@ -128,6 +156,9 @@ const mapDispatchToProps = (dispatch: any, ownProps: any) => {
     onItemClick: (cmd: any) => {
       const action = executeCommand(cmd, { source: commandSources.button })
       ownProps.bus.send(action.type, action)
+    },
+    forceCount: () => {
+      dispatch(forceCount())
     },
     onDbSelect: (dbName: any) =>
       dispatch(executeCommand(`:${useDbCommand} ${dbName || ''}`), {

--- a/src/shared/modules/dbMeta/__snapshots__/dbMetaDuck.test.ts.snap
+++ b/src/shared/modules/dbMeta/__snapshots__/dbMetaDuck.test.ts.snap
@@ -2,6 +2,10 @@
 
 exports[`hydrating state can CLEAR to reset state 1`] = `
 Object {
+  "countAutomaticRefresh": Object {
+    "enabled": true,
+    "loading": false,
+  },
   "databases": Array [],
   "functions": Array [],
   "labels": Array [],
@@ -62,6 +66,10 @@ Object {
 
 exports[`hydrating state should merge inital state and state on load 1`] = `
 Object {
+  "countAutomaticRefresh": Object {
+    "enabled": true,
+    "loading": false,
+  },
   "databases": Array [],
   "foo": "bar",
   "functions": Array [],

--- a/src/shared/modules/dbMeta/dbMetaDuck.ts
+++ b/src/shared/modules/dbMeta/dbMetaDuck.ts
@@ -289,7 +289,7 @@ export const getClusterRoleForDb = (state: GlobalState, activeDb: string) => {
   }
 }
 
-export const getCountAutomaticRefreshStatus = (state: GlobalState): boolean => {
+export const getCondAutomaticRefreshEnabled = (state: GlobalState): boolean => {
   return state[NAME].countAutomaticRefresh.enabled
 }
 

--- a/src/shared/modules/dbMeta/dbMetaDuck.ts
+++ b/src/shared/modules/dbMeta/dbMetaDuck.ts
@@ -31,12 +31,16 @@ export const UPDATE_SETTINGS = 'meta/UPDATE_SETTINGS'
 export const CLEAR_META = 'meta/CLEAR'
 export const FORCE_FETCH = 'meta/FORCE_FETCH'
 export const DB_META_DONE = 'meta/DB_META_DONE'
+export const DB_META_COUNT_DONE = 'meta/DB_META_COUNT_DONE'
+export const DB_META_FORCE_COUNT = 'meta/DB_FORCE_COUNT'
+export const UPDATE_COUNT_AUTOMATIC_REFRESH =
+  'meta/UPDATE_COUNT_AUTOMATIC_REFRESH'
 
 export const SYSTEM_DB = 'system'
 export const VERSION_FOR_EDITOR_HISTORY_SETTING = '4.3.0'
 export const VERSION_FOR_CLUSTER_ROLE_IN_SHOW_DB = '4.3.0'
 
-export const metaQuery = `
+export const metaTypesQuery = `
 CALL db.labels() YIELD label
 RETURN {name:'labels', data:COLLECT(label)[..1000]} AS result
 UNION ALL
@@ -45,7 +49,9 @@ RETURN {name:'relationshipTypes', data:COLLECT(relationshipType)[..1000]} AS res
 UNION ALL
 CALL db.propertyKeys() YIELD propertyKey
 RETURN {name:'propertyKeys', data:COLLECT(propertyKey)[..1000]} AS result
-UNION ALL
+`
+
+export const metaCountQuery = `
 MATCH () RETURN { name:'nodes', data:count(*) } AS result
 UNION ALL
 MATCH ()-[]->() RETURN { name:'relationships', data: count(*)} AS result
@@ -57,6 +63,12 @@ export const serverInfoQuery =
 export function fetchMetaData() {
   return {
     type: FORCE_FETCH
+  }
+}
+
+export function forceCount() {
+  return {
+    type: DB_META_FORCE_COUNT
   }
 }
 
@@ -79,6 +91,16 @@ export const updateServerInfo = (res: any) => {
   return {
     ...extrated,
     type: UPDATE_SERVER
+  }
+}
+
+export const updateCountAutomaticRefresh = (countAutomaticRefresh: {
+  enabled?: boolean
+  loading?: boolean
+}) => {
+  return {
+    type: UPDATE_COUNT_AUTOMATIC_REFRESH,
+    countAutomaticRefresh
   }
 }
 
@@ -136,7 +158,11 @@ export const initialState = {
   },
   databases: [],
   serverConfigDone: false,
-  settings: initialClientSettings
+  settings: initialClientSettings,
+  countAutomaticRefresh: {
+    enabled: true,
+    loading: false
+  }
 }
 
 export type Database = {
@@ -263,6 +289,16 @@ export const getClusterRoleForDb = (state: GlobalState, activeDb: string) => {
   }
 }
 
+export const getCountAutomaticRefreshStatus = (state: GlobalState): boolean => {
+  return state[NAME].countAutomaticRefresh.enabled
+}
+
+export const getCountAutomaticRefreshLoading = (
+  state: GlobalState
+): boolean => {
+  return state[NAME].countAutomaticRefresh.loading
+}
+
 // Reducers
 const dbMetaReducer = (
   state = initialState,
@@ -274,6 +310,18 @@ const dbMetaReducer = (
     case UPDATE_META:
       const { type, ...rest } = action
       return { ...state, ...rest }
+    case UPDATE_COUNT_AUTOMATIC_REFRESH:
+      console.log(
+        'UPDATE_COUNT_AUTOMATIC_REFRESH',
+        action.countAutomaticRefresh
+      )
+      return {
+        ...state,
+        countAutomaticRefresh: {
+          ...state.countAutomaticRefresh,
+          ...action.countAutomaticRefresh
+        }
+      }
     case UPDATE_SERVER:
       const { type: serverType, ...serverRest } = action
       const serverState: any = {}

--- a/src/shared/modules/dbMeta/dbMetaDuck.ts
+++ b/src/shared/modules/dbMeta/dbMetaDuck.ts
@@ -289,7 +289,9 @@ export const getClusterRoleForDb = (state: GlobalState, activeDb: string) => {
   }
 }
 
-export const getCondAutomaticRefreshEnabled = (state: GlobalState): boolean => {
+export const getCountAutomaticRefreshEnabled = (
+  state: GlobalState
+): boolean => {
   return state[NAME].countAutomaticRefresh.enabled
 }
 

--- a/src/shared/modules/dbMeta/dbMetaDuck.ts
+++ b/src/shared/modules/dbMeta/dbMetaDuck.ts
@@ -311,10 +311,6 @@ const dbMetaReducer = (
       const { type, ...rest } = action
       return { ...state, ...rest }
     case UPDATE_COUNT_AUTOMATIC_REFRESH:
-      console.log(
-        'UPDATE_COUNT_AUTOMATIC_REFRESH',
-        action.countAutomaticRefresh
-      )
       return {
         ...state,
         countAutomaticRefresh: {

--- a/src/shared/modules/dbMeta/dbMetaEpics.ts
+++ b/src/shared/modules/dbMeta/dbMetaEpics.ts
@@ -40,7 +40,7 @@ import {
   VERSION_FOR_CLUSTER_ROLE_IN_SHOW_DB,
   isOnCluster,
   updateCountAutomaticRefresh,
-  getCondAutomaticRefreshEnabled,
+  getCountAutomaticRefreshEnabled,
   DB_META_FORCE_COUNT,
   DB_META_COUNT_DONE,
   metaCountQuery
@@ -86,7 +86,7 @@ import {
 import { isInt, Record } from 'neo4j-driver'
 import semver, { gte, SemVer } from 'semver'
 import { triggerCredentialsTimeout } from '../credentialsPolicy/credentialsPolicyDuck'
-
+getCountAutomaticRefreshEnabled
 async function databaseList(store: any) {
   try {
     const supportsMultiDb = await bolt.hasMultiDbSupport()
@@ -371,14 +371,14 @@ export const dbMetaEpic = (some$: any, store: any) =>
 export const dbCountEpic = (some$: any, store: any) =>
   some$
     .ofType(DB_META_DONE)
-    .filter(() => getCondAutomaticRefreshEnabled(store.getState()))
+    .filter(() => getCountAutomaticRefreshEnabled(store.getState()))
     .merge(some$.ofType(DB_META_FORCE_COUNT))
     .throttle(() => some$.ofType(DB_META_COUNT_DONE))
     .mergeMap(() =>
       Rx.Observable.fromPromise<void>(
         new Promise(async resolve => {
           store.dispatch(updateCountAutomaticRefresh({ loading: true }))
-          if (getCondAutomaticRefreshEnabled(store.getState())) {
+          if (getCountAutomaticRefreshEnabled(store.getState())) {
             const startTime = performance.now()
             await getNodeAndRelationshipCounts(store)
             const timeTaken = performance.now() - startTime

--- a/src/shared/modules/dbMeta/dbMetaEpics.ts
+++ b/src/shared/modules/dbMeta/dbMetaEpics.ts
@@ -40,7 +40,7 @@ import {
   VERSION_FOR_CLUSTER_ROLE_IN_SHOW_DB,
   isOnCluster,
   updateCountAutomaticRefresh,
-  getCountAutomaticRefreshStatus,
+  getCondAutomaticRefreshEnabled,
   DB_META_FORCE_COUNT,
   DB_META_COUNT_DONE,
   metaCountQuery
@@ -371,14 +371,14 @@ export const dbMetaEpic = (some$: any, store: any) =>
 export const dbCountEpic = (some$: any, store: any) =>
   some$
     .ofType(DB_META_DONE)
-    .filter(() => getCountAutomaticRefreshStatus(store.getState()))
+    .filter(() => getCondAutomaticRefreshEnabled(store.getState()))
     .merge(some$.ofType(DB_META_FORCE_COUNT))
     .throttle(() => some$.ofType(DB_META_COUNT_DONE))
     .mergeMap(() =>
       Rx.Observable.fromPromise<void>(
         new Promise(async resolve => {
           store.dispatch(updateCountAutomaticRefresh({ loading: true }))
-          if (getCountAutomaticRefreshStatus(store.getState())) {
+          if (getCondAutomaticRefreshEnabled(store.getState())) {
             const startTime = performance.now()
             await getNodeAndRelationshipCounts(store)
             const timeTaken = performance.now() - startTime

--- a/src/shared/modules/dbMeta/dbMetaEpics.ts
+++ b/src/shared/modules/dbMeta/dbMetaEpics.ts
@@ -35,10 +35,15 @@ import {
   DB_META_DONE,
   FORCE_FETCH,
   SYSTEM_DB,
-  metaQuery,
+  metaTypesQuery,
   serverInfoQuery,
   VERSION_FOR_CLUSTER_ROLE_IN_SHOW_DB,
-  isOnCluster
+  isOnCluster,
+  updateCountAutomaticRefresh,
+  getCountAutomaticRefreshStatus,
+  DB_META_FORCE_COUNT,
+  DB_META_COUNT_DONE,
+  metaCountQuery
 } from './dbMetaDuck'
 import {
   ClientSettings,
@@ -70,8 +75,7 @@ import {
   setAuthEnabled,
   setRetainCredentials,
   updateConnection,
-  useDb,
-  getConnectedHost
+  useDb
 } from 'shared/modules/connections/connectionsDuck'
 import { clearHistory } from 'shared/modules/history/historyDuck'
 import { backgroundTxMetadata } from 'shared/services/bolt/txMetadata'
@@ -82,7 +86,6 @@ import {
 import { isInt, Record } from 'neo4j-driver'
 import semver, { gte, SemVer } from 'semver'
 import { triggerCredentialsTimeout } from '../credentialsPolicy/credentialsPolicyDuck'
-import { isNonRoutingScheme } from 'services/boltscheme.utils'
 
 async function databaseList(store: any) {
   try {
@@ -127,7 +130,7 @@ async function getLabelsAndTypes(store: any) {
   // Not system db, try and fetch meta data
   try {
     const res = await bolt.routedReadTransaction(
-      metaQuery,
+      metaTypesQuery,
       {},
       {
         onLostConnection: onLostConnection(store.dispatch),
@@ -135,18 +138,48 @@ async function getLabelsAndTypes(store: any) {
       }
     )
     if (res && res.records && res.records.length !== 0) {
-      const [
-        rawLabels,
-        rawRelTypes,
-        rawProperties,
-        rawNodeCount,
-        rawRelationshipCount
-      ] = res.records.map((r: Record) => r.get(0).data)
+      const [rawLabels, rawRelTypes, rawProperties] = res.records.map(
+        (r: Record) => r.get(0).data
+      )
 
       const compareMetaItems = (a: any, b: any) => (a < b ? -1 : a > b ? 1 : 0)
       const labels = rawLabels.sort(compareMetaItems)
       const relationshipTypes = rawRelTypes.sort(compareMetaItems)
       const properties = rawProperties.sort(compareMetaItems)
+
+      store.dispatch(
+        update({
+          labels,
+          properties,
+          relationshipTypes
+        })
+      )
+    }
+  } catch {}
+}
+
+async function getNodeAndRelationshipCounts(store: any) {
+  const db = getUseDb(store.getState())
+
+  // System db, do nothing
+  if (db === SYSTEM_DB) {
+    return
+  }
+
+  // Not system db, try and fetch meta data
+  try {
+    const res = await bolt.routedReadTransaction(
+      metaCountQuery,
+      {},
+      {
+        onLostConnection: onLostConnection(store.dispatch),
+        ...backgroundTxMetadata
+      }
+    )
+    if (res && res.records && res.records.length !== 0) {
+      const [rawNodeCount, rawRelationshipCount] = res.records.map(
+        (r: Record) => r.get(0).data
+      )
 
       const neo4jIntegerToNumber = (r: any) =>
         isInt(r) ? r.toNumber() || 0 : r || 0
@@ -155,10 +188,7 @@ async function getLabelsAndTypes(store: any) {
       const relationships = neo4jIntegerToNumber(rawRelationshipCount)
       store.dispatch(
         update({
-          labels,
           nodes,
-          properties,
-          relationshipTypes,
           relationships
         })
       )
@@ -338,6 +368,35 @@ export const dbMetaEpic = (some$: any, store: any) =>
         .do(() => switchToRequestedDb(store))
         .mapTo({ type: DB_META_DONE })
     )
+export const dbCountEpic = (some$: any, store: any) =>
+  some$
+    .ofType(DB_META_DONE)
+    .filter(() => getCountAutomaticRefreshStatus(store.getState()))
+    .merge(some$.ofType(DB_META_FORCE_COUNT))
+    .throttle(() => some$.ofType(DB_META_COUNT_DONE))
+    .mergeMap(() =>
+      Rx.Observable.fromPromise<void>(
+        new Promise(async resolve => {
+          store.dispatch(updateCountAutomaticRefresh({ loading: true }))
+          if (getCountAutomaticRefreshStatus(store.getState())) {
+            const startTime = performance.now()
+            await getNodeAndRelationshipCounts(store)
+            const timeTaken = performance.now() - startTime
+
+            if (timeTaken > 2000) {
+              console.log('turn off auto refresh')
+              store.dispatch(updateCountAutomaticRefresh({ enabled: false }))
+            }
+          } else {
+            await getNodeAndRelationshipCounts(store)
+          }
+
+          store.dispatch(updateCountAutomaticRefresh({ loading: false }))
+          resolve()
+        })
+      )
+    )
+    .mapTo({ type: DB_META_COUNT_DONE })
 
 export const serverConfigEpic = (some$: any, store: any) =>
   some$

--- a/src/shared/modules/dbMeta/dbMetaEpics.ts
+++ b/src/shared/modules/dbMeta/dbMetaEpics.ts
@@ -384,7 +384,6 @@ export const dbCountEpic = (some$: any, store: any) =>
             const timeTaken = performance.now() - startTime
 
             if (timeTaken > 2000) {
-              console.log('turn off auto refresh')
               store.dispatch(updateCountAutomaticRefresh({ enabled: false }))
             }
           } else {

--- a/src/shared/rootEpic.ts
+++ b/src/shared/rootEpic.ts
@@ -58,6 +58,7 @@ import {
 import {
   clearMetaOnDisconnectEpic,
   dbMetaEpic,
+  dbCountEpic,
   serverConfigEpic
 } from './modules/dbMeta/dbMetaEpics'
 import {
@@ -113,6 +114,7 @@ export default combineEpics(
   startupConnectionFailEpic,
   detectActiveConnectionChangeEpic,
   dbMetaEpic,
+  dbCountEpic,
   serverConfigEpic,
   clearMetaOnDisconnectEpic,
   cancelRequestEpic,


### PR DESCRIPTION
Suppose the metadata count query takes a long time then switch off the automatic refresh for that data and display a warning in the sidebar.  It also fixes the transitions when opening/closing the sidebar.

![Screenshot 2022-10-24 at 10 08 30](https://user-images.githubusercontent.com/7382555/197487206-558235ee-071c-447d-943c-e39e30f393de.png)
