### PR TITLE
Fix relationship stylings not getting applied 

### DIFF
--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/visualization/Visualization.ts
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/visualization/Visualization.ts
@@ -234,6 +234,7 @@ export class Visualization {
     )
 
     this.forceSimulation.updateRelationships(this.graph)
+    this.render()
   }
 
   zoomByType = (zoomType: ZoomType): void => {

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/visualization/Visualization.ts
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/visualization/Visualization.ts
@@ -234,6 +234,9 @@ export class Visualization {
     )
 
     this.forceSimulation.updateRelationships(this.graph)
+    // The onGraphChange handler does only repaint relationship color
+    // not width and caption. We work around that by doing an aditional full
+    // render to get the new stylings
     this.render()
   }
 

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/visualization/Visualization.ts
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/visualization/Visualization.ts
@@ -234,9 +234,11 @@ export class Visualization {
     )
 
     this.forceSimulation.updateRelationships(this.graph)
-    // The onGraphChange handler does only repaint relationship color
-    // not width and caption. We work around that by doing an aditional full
-    // render to get the new stylings
+   // The onGraphChange handler does only repaint relationship color
+    // not width and caption, since it requires taking into account surrounding data
+    // since the arrows have different bending depending on how the nodes are 
+    // connected. We work around that by doing an additional full render to get the 
+// new stylings
     this.render()
   }
 


### PR DESCRIPTION
The graph change handler did not repaint updated shaft widths or captions. The simplest change is to just call another tick on the visualization since the normal render will update with the new width/caption!