### PR TITLE
Fix bug where the editors autocomplete could not be closed with the escape key

### DIFF
--- a/src/browser/modules/Editor/MainEditor.tsx
+++ b/src/browser/modules/Editor/MainEditor.tsx
@@ -287,7 +287,10 @@ export function MainEditor({
               onExecute={createRunCommandFunction(commandSources.editor)}
               ref={editorRef}
               additionalCommands={{
-                [KeyCode.Escape]: toggleFullscreen
+                [KeyCode.Escape]: {
+                  handler: toggleFullscreen,
+                  context: '!suggestWidgetVisible && !findWidgetVisible'
+                }
               }}
               useDb={useDb}
               sendCypherQuery={(text: string) =>

--- a/src/browser/modules/Frame/FrameEditor.tsx
+++ b/src/browser/modules/Frame/FrameEditor.tsx
@@ -198,7 +198,10 @@ function FrameEditor({
               onExecute={run}
               ref={editorRef}
               additionalCommands={{
-                [KeyCode.Escape]: fullscreenToggle
+                [KeyCode.Escape]: {
+                  handler: fullscreenToggle,
+                  context: '!suggestWidgetVisible && !findWidgetVisible'
+                }
               }}
               useDb={frame.useDb}
               value={editorValue}

--- a/src/neo4j-arc/cypher-language-support/cypher-editor/CypherEditor.tsx
+++ b/src/neo4j-arc/cypher-language-support/cypher-editor/CypherEditor.tsx
@@ -67,7 +67,10 @@ type CypherEditorDefaultProps = {
   onExecute?: (value: string) => void
   sendCypherQuery: (query: string) => Promise<QueryResult>
   additionalCommands: Partial<
-    Record<monaco.KeyCode, monaco.editor.ICommandHandler>
+    Record<
+      monaco.KeyCode,
+      { handler: monaco.editor.ICommandHandler; context?: string }
+    >
   >
   tabIndex?: number
   useDb: null | string
@@ -401,17 +404,20 @@ export class CypherEditor extends React.Component<
       this.props.onDisplayHelpKeys
     )
 
-    this.editor.addCommand(KeyCode.Escape, () => {
-      this.wrapperRef.current?.focus()
-    })
+    this.editor.addCommand(
+      KeyCode.Escape,
+      () => {
+        this.wrapperRef.current?.focus()
+      },
+      '!suggestWidgetVisible && !findWidgetVisible'
+    )
 
     keys(this.props.additionalCommands).forEach(key => {
       const command = this.props.additionalCommands[key]
       if (!command) {
         return
       }
-
-      this?.editor?.addCommand(key, command)
+      this?.editor?.addCommand(key, command.handler, command.context)
     })
 
     this.onContentUpdate()

--- a/src/neo4j-arc/package.json
+++ b/src/neo4j-arc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neo4j-devtools/arc",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "main": "dist/neo4j-arc.js",
   "author": "Neo4j Inc.",
   "license": "GPL-3.0",


### PR DESCRIPTION
When previously adding the possibility to add custom commands for keycodes in the editor the ability to close the editor autocomplete broke. This makes sure the standard escape commands (which blurs) is not active while the autocomplete is visible.