### PR TITLE
Don't prevent setting parameters on composite databases

### DIFF
--- a/src/shared/modules/commands/helpers/params.ts
+++ b/src/shared/modules/commands/helpers/params.ts
@@ -78,15 +78,13 @@ export const getParamName = (input: any) => {
 export const handleParamsCommand = async (
   action: any,
   put: any,
-  onUnsupportedDatabase: boolean
+  onSystemDatabase: boolean
 ): Promise<{
   result: any
   type: string
 }> => {
-  if (onUnsupportedDatabase) {
-    throw new Error(
-      'Parameters cannot be declared when using system or composite database.'
-    )
+  if (onSystemDatabase) {
+    throw new Error('Parameters cannot be declared when using system database.')
   }
   const strippedCmd = action.cmd.substr(1)
   const parts = splitStringOnFirst(strippedCmd, /\s/)

--- a/src/shared/services/commandInterpreterHelper.ts
+++ b/src/shared/services/commandInterpreterHelper.ts
@@ -156,8 +156,8 @@ const availableCommands = [
     match: (cmd: any) => /^params?\s/.test(cmd),
     exec(action: any, put: any, store: any) {
       const currDb = getCurrentDatabase(store.getState())
-      const onUnsupportedDb = Boolean(currDb && isSystemOrCompositeDb(currDb))
-      return handleParamsCommand(action, put, onUnsupportedDb)
+      const onSystemDb = currDb?.name === SYSTEM_DB
+      return handleParamsCommand(action, put, onSystemDb)
         .then(res => {
           const params =
             res.type === 'param' ? res.result : getParams(store.getState())


### PR DESCRIPTION
Given that a `RETURN` statement should not do any graph operations, defining your parameters on a composite db is not a problem. So let's not prevent users from doing so.