### PR TITLE
Fix leader incorrectly reporting role cluster role in sidebar 

### DIFF
--- a/src/browser/modules/DBMSInfo/DatabaseKernelInfo.tsx
+++ b/src/browser/modules/DBMSInfo/DatabaseKernelInfo.tsx
@@ -41,13 +41,13 @@ import {
 } from 'shared/modules/commands/commandsDuck'
 import {
   Database,
-  getClusterRoleForDb,
   getDatabases,
   getEdition,
   getStoreSize,
   getRawVersion
 } from 'shared/modules/dbMeta/dbMetaDuck'
 import { getUsedDbName } from 'shared/modules/features/versionedFeatures'
+import { getClusterRoleForCurrentDb } from 'shared/utils/selectors'
 
 type DatabaseKernelInfo = {
   role: any
@@ -133,13 +133,12 @@ export const DatabaseKernelInfo = ({
 }
 
 const mapStateToProps = (state: any) => {
-  const dbName = getUsedDbName(state)
   return {
     version: getRawVersion(state),
     edition: getEdition(state),
-    dbName,
+    dbName: getUsedDbName(state),
     storeSize: getStoreSize(state),
-    role: getClusterRoleForDb(state, dbName),
+    role: getClusterRoleForCurrentDb(state),
     databases: getDatabases(state)
   }
 }

--- a/src/shared/modules/dbMeta/dbMetaDuck.ts
+++ b/src/shared/modules/dbMeta/dbMetaDuck.ts
@@ -309,17 +309,6 @@ export const isOnCluster = (state: GlobalState): boolean => {
     return hasProcedure(state, 'dbms.cluster.overview')
   }
 }
-export const getClusterRoleForDb = (state: GlobalState, activeDb: string) => {
-  const version = getSemanticVersion(state)
-  if (!version) return false
-
-  if (gte(version, VERSION_FOR_CLUSTER_ROLE_IN_SHOW_DB)) {
-    return getDatabases(state).find(database => database.name === activeDb)
-      ?.role
-  } else {
-    return state[NAME].role
-  }
-}
 
 export const getCountAutomaticRefreshEnabled = (
   state: GlobalState

--- a/src/shared/utils/selectors.ts
+++ b/src/shared/utils/selectors.ts
@@ -1,19 +1,25 @@
+import { gte } from 'semver'
+import { stripScheme } from 'services/boltscheme.utils'
 import { GlobalState } from 'shared/globalState'
 import { inDesktop } from 'shared/modules/app/appDuck'
 import {
+  getConnectedHost,
   getUseDb,
   isConnected,
-  isConnectedAuraHost,
-  useDb
+  isConnectedAuraHost
 } from 'shared/modules/connections/connectionsDuck'
 import {
   Database,
   findDatabaseByNameOrAlias,
   getAllowOutgoingConnections,
   getClientsAllowTelemetry,
+  getDatabases,
+  getSemanticVersion,
   isServerConfigDone,
+  NAME,
   shouldAllowOutgoingConnections,
-  SYSTEM_DB
+  SYSTEM_DB,
+  VERSION_FOR_CLUSTER_ROLE_IN_SHOW_DB
 } from 'shared/modules/dbMeta/dbMetaDuck'
 import {
   getAllowCrashReports,
@@ -36,6 +42,30 @@ export function getCurrentDatabase(state: GlobalState): Database | null {
 
 export function isSystemOrCompositeDb(db: Database): boolean {
   return db?.name === SYSTEM_DB || db?.type === 'composite'
+}
+
+export const getClusterRoleForCurrentDb = (state: GlobalState) => {
+  const version = getSemanticVersion(state)
+  if (!version) return null
+
+  if (gte(version, VERSION_FOR_CLUSTER_ROLE_IN_SHOW_DB)) {
+    // In a cluster setup, there are many databases with the same name, often one per member
+    // So our "cluster role" is the role we have on the database that lives
+    // at the adress we're connected to
+    const dbName = getUseDb(state)
+    const host = getConnectedHost(state)
+    if (dbName && host) {
+      const databases = getDatabases(state)
+      const currentDb = databases
+        .filter(db => db.address === stripScheme(host))
+        .find(database => database.name === dbName)
+      return currentDb?.role
+    } else {
+      return null
+    }
+  } else {
+    return state[NAME].role
+  }
 }
 
 export type TelemetrySettingSource =


### PR DESCRIPTION
We get the role from SHOW DATABASES, but it we pick the wrong item in the list since it shows one entry per cluster instance.

Tested on (with both bolt&neo4j schemes):
- 5.0 CORE
- 5.0 Read replica
- 4.4 leader
- 4.4 follower
- 4.4 read replica
- 4.4 Standalone