### PR TITLE
CALL dbms.listQueries() is not supported in 5

### DIFF
--- a/src/shared/modules/favorites/staticScripts.ts
+++ b/src/shared/modules/favorites/staticScripts.ts
@@ -166,7 +166,7 @@ REQUIRE n.<propertyKey> IS UNIQUE`,
   {
     folder: 'procedures',
     content: '// List running queries\nCALL dbms.listQueries()',
-    versionRange: '>=3'
+    versionRange: '>=3 <5'
   },
   {
     folder: 'procedures',


### PR DESCRIPTION
so removed from scripts when above 5.

<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

