### PR TITLE
fix ascii table crash on empty array or object

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/helpers.test.ts
+++ b/src/browser/modules/Stream/CypherFrame/helpers.test.ts
@@ -556,6 +556,12 @@ describe('helpers', () => {
       // Then
       expect(res).toEqual([])
     })
+    test('recordToStringArray handles record with empty object and array', () => {
+      const records = [new Record(['"x"', '"y"', '[]', '{}'], [[], {}, [], {}])]
+      const res = records.map(record => recordToStringArray(record))
+      expect(res).toEqual([['[]', '{}', '[]', '{}']])
+    })
+
     test('recordToStringArray handles regular records', () => {
       // Given
       const start = new (neo4j.types.Node as any)(1, ['X'], { x: 1 })

--- a/src/browser/modules/Stream/CypherFrame/helpers.ts
+++ b/src/browser/modules/Stream/CypherFrame/helpers.ts
@@ -428,9 +428,10 @@ function isNeo4jValue(value: any) {
 }
 
 export const recordToStringArray = (record: Record): string[] => {
+  console.log('record', record)
   const recursiveStringify = (value: CypherDataType): string => {
     if (Array.isArray(value)) {
-      if (value.length === 0) return ''
+      if (value.length === 0) return '[]'
       return `[${value.map(v => recursiveStringify(v)).join(', ')}]`
     }
 
@@ -441,7 +442,7 @@ export const recordToStringArray = (record: Record): string[] => {
 
     // We have nodes, relationships, paths and cypher maps left.
     const entries = Object.entries(value)
-    if (entries.length === 0) return ''
+    if (entries.length === 0) return '{}'
 
     if (
       value instanceof Node ||

--- a/src/browser/modules/Stream/CypherFrame/helpers.ts
+++ b/src/browser/modules/Stream/CypherFrame/helpers.ts
@@ -428,7 +428,6 @@ function isNeo4jValue(value: any) {
 }
 
 export const recordToStringArray = (record: Record): string[] => {
-  console.log('record', record)
   const recursiveStringify = (value: CypherDataType): string => {
     if (Array.isArray(value)) {
       if (value.length === 0) return '[]'


### PR DESCRIPTION
The ascii table currently shows empty arrays or objects as ''. This PR changes this to [] and {} respectively. This also fixes a crash where ascii-data-table does not work with empty strings.