### PR TITLE
fix position of stylers

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/VisualizationView/PropertiesPanelContent/StyleableNodeLabel.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView/PropertiesPanelContent/StyleableNodeLabel.tsx
@@ -54,6 +54,7 @@ export function StyleableNodeLabel({
       pinned
       key={selectedLabel.label}
       wide
+      position="top center"
       trigger={
         <StyledLabelChip
           style={{

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView/PropertiesPanelContent/StyleableNodeLabel.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView/PropertiesPanelContent/StyleableNodeLabel.tsx
@@ -51,10 +51,10 @@ export function StyleableNodeLabel({
     <Popup
       on="click"
       basic
-      pinned
       key={selectedLabel.label}
       wide
-      position="top center"
+      position="left center"
+      offset={[0, 0]}
       trigger={
         <StyledLabelChip
           style={{

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView/PropertiesPanelContent/StyleableRelType.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView/PropertiesPanelContent/StyleableRelType.tsx
@@ -40,9 +40,9 @@ export function StyleableRelType({
     <Popup
       on="click"
       basic
-      pinned
       key={selectedRelType.relType}
-      position="top center"
+      position="left center"
+      offset={[0, 0]}
       trigger={
         <StyledRelationshipChip
           style={{

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView/PropertiesPanelContent/StyleableRelType.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView/PropertiesPanelContent/StyleableRelType.tsx
@@ -42,6 +42,7 @@ export function StyleableRelType({
       basic
       pinned
       key={selectedRelType.relType}
+      position="top center"
       trigger={
         <StyledRelationshipChip
           style={{


### PR DESCRIPTION
When semantic-ui-react was updated the default position for the popup changed to left center. We can't easily make it appear over the element anymore. I think this change might be good enough.

![Screenshot 2023-03-16 at 14 59 28](https://user-images.githubusercontent.com/7382555/225640718-f2446f7a-723f-43ab-8ac1-171242e9c082.png)
