### PR TITLE
Reset expandedNodeMap when Graph is reset

### DIFF
--- a/src/neo4j-arc/graph-visualization/models/Graph.ts
+++ b/src/neo4j-arc/graph-visualization/models/Graph.ts
@@ -203,6 +203,7 @@ export class GraphModel {
     this._nodes = []
     this.relationshipMap = {}
     this._relationships = []
+    this.expandedNodeMap = {}
   }
 }
 


### PR DESCRIPTION
<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

When we [reset a Graph](https://github.com/neo4j/neo4j-browser/blob/master/src/neo4j-arc/graph-visualization/models/Graph.ts#L201), we see that the `expandedNodeMap` was not reset. We think we should clear all instance variables while resetting the graph. So this PR adds the reset to the `expandedNodeMap`