### PR TITLE
Add missing space to params help text

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/ErrorsView/MissingParamsTemplateLink.tsx
+++ b/src/browser/modules/Stream/CypherFrame/ErrorsView/MissingParamsTemplateLink.tsx
@@ -91,7 +91,7 @@ export const MissingParamsTemplateLink = ({
           'Set editor content with template to be used for setting the missing parameters'
         }
       >
-        :params{'{'}
+        :params{' {'}
         <StyledSpecifyParamsText>specify params</StyledSpecifyParamsText>
         {'}'}
       </StyledParamsTemplateClickableArea>


### PR DESCRIPTION
Before:
![Screenshot 2023-03-23 at 17 29 14](https://user-images.githubusercontent.com/7382555/227270991-e6783b72-9cfb-4e8c-b980-ccd19e1a4eef.png)


After:
![Screenshot 2023-03-23 at 17 28 38](https://user-images.githubusercontent.com/7382555/227271012-0a0f9378-289e-48ba-8d5b-b3b6c0e696c1.png)


