### PR TITLE
Fixing broken link

### DIFF
--- a/docs/modules/ROOT/pages/operations/dbms-connection.adoc
+++ b/docs/modules/ROOT/pages/operations/dbms-connection.adoc
@@ -14,7 +14,7 @@ image:home-screen.png[]
 [[uri-scheme]]
 == Connection URI schemes
 
-Neo4j Browser requires a connection to a Neo4j DBMS via the link:https://7687.org/[Bolt Protocol^] using the link:{neo4j-docs-base-uri}/javascript-manual/current/[Neo4j JavaScript Driver^] to execute Cypher queries.
+Neo4j Browser requires a connection to a Neo4j DBMS via the link:https://7687.org/[Bolt Protocol^] using the https://neo4j.com/docs/javascript-manual/current/[Neo4j JavaScript Driver^] to execute Cypher queries.
 
 Neo4j Browser supports the following connection URI schemes:
 


### PR DESCRIPTION
`{neo4j-docs-base-uri}` doesn't seem to be working correctly, so I'm reverting the link to the regular format.