### PR TITLE
Update sitemap version in playbooks

### DIFF
--- a/docs/preview.yml
+++ b/docs/preview.yml
@@ -25,7 +25,7 @@ urls:
 antora:
   extensions:
   - require: "@neo4j-antora/antora-modify-sitemaps"
-    sitemap_version: '4.4'
+    sitemap_version: '5'
     sitemap_loc_version: 'current'
     move_sitemaps_to_components: true
 

--- a/docs/publish.yml
+++ b/docs/publish.yml
@@ -26,7 +26,7 @@ urls:
 antora:
   extensions:
   - require: "@neo4j-antora/antora-modify-sitemaps"
-    sitemap_version: '4.4'
+    sitemap_version: '5'
     sitemap_loc_version: 'current'
     move_sitemaps_to_components: true
 


### PR DESCRIPTION
For the docs, the value of `sitemap_version` in the playbooks needs to be updated to match the version in `antora.yml` in order to generate and publish a valid sitemap for SEO.