### PR TITLE
improve sysinfo frame consistency

### DIFF
--- a/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.test.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.test.tsx
@@ -28,19 +28,19 @@ import reducers from 'project-root/src/shared/rootReducer'
 import { Database } from 'shared/modules/dbMeta/dbMetaDuck'
 import { Frame } from 'shared/modules/frames/framesDuck'
 
-const baseProps = {
+const baseProps: SysInfoFrameProps = {
   databases: [],
   bus: { self: () => undefined } as unknown as Bus,
   frame: {} as Frame,
   hasMultiDbSupport: true,
   isConnected: true,
   isEnterprise: true,
-  useDb: 'neo4j',
   isFullscreen: false,
   isCollapsed: false,
   isOnCluster: true,
   namespacesEnabled: false,
-  metricsPrefix: 'neo4j'
+  metricsPrefix: 'neo4j',
+  rerunWithDb: () => undefined
 }
 
 const mountWithStore = (props: Partial<SysInfoFrameProps>) => {

--- a/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/SysInfoFrame.tsx
@@ -84,7 +84,6 @@ export type SysInfoFrameProps = {
   hasMultiDbSupport: boolean
   isConnected: boolean
   isEnterprise: boolean
-  fallbackDb: string | null
   isFullscreen: boolean
   isCollapsed: boolean
   isOnCluster: boolean

--- a/src/browser/modules/Stream/SysInfoFrame/styled.tsx
+++ b/src/browser/modules/Stream/SysInfoFrame/styled.tsx
@@ -4,3 +4,9 @@ export const InlineError = styled.span`
   color: ${props => props.theme.error};
   padding-left: 15px;
 `
+
+export const SpinnerContainer = styled.div`
+  margin: 20px 0 20px 0;
+  width: 100%;
+  text-align: center;
+`

--- a/src/shared/services/commandInterpreterHelper.ts
+++ b/src/shared/services/commandInterpreterHelper.ts
@@ -391,8 +391,8 @@ const availableCommands = [
       if (db && isSystemOrCompositeDb(db)) {
         put(
           frames.add({
-            useDb,
             ...action,
+            useDb: db.name,
             type: 'error',
             error: UnsupportedError(
               'The :sysinfo command is not supported while using the system or a composite database.'
@@ -402,8 +402,8 @@ const availableCommands = [
       } else {
         put(
           frames.add({
-            useDb,
             ...action,
+            useDb: db?.name,
             type: 'sysinfo'
           })
         )


### PR DESCRIPTION
Sysinfo would always run against the currently active database, leading to confusion on which database the stats came from. This PR makes it clear which database the stats come from, even if sysinfo was run before the database list was loaded