### PR TITLE
NodeDrag by Petra Schanz on behalf of DB Systel GmbH

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,16 @@ CYPRESS_BASE_URL=<url to reach the browser to test> (default http://localhost:80
 ```
 
 Example: `CYPRESS_E2E_TEST_ENV="local" CYPRESS_BASE_URL=http://localhost:30000 cypress open --env server=4.2`
+
+## Import svg-File with node positions
+This fork implements the feature requested here: https://github.com/neo4j/neo4j-browser/issues/858
+and was written by petra.schanz@deutschebahn.com
+
+Svgs exported by neo4j contain the positions of the drawn nodes.
+If you show the same nodes in the neo4j-browser you can use the new upload-button 
+(below the zoom buttons because this is all about visualization) and upload your svg:
+The nodes will be dragged automatically to the positions shown in the svg. 
+You can interact with them and use them as you are used to.
+
+If you need to re-import the database data you should set a uuid before exporting the svg and after importing the data
+by using something along "MATCH (n) SET n.uuid = n.myEternalAndUniqeAttribute RETURN n"

--- a/src/browser/modules/Frame/FrameEditor.tsx
+++ b/src/browser/modules/Frame/FrameEditor.tsx
@@ -27,7 +27,8 @@ import { isMac } from 'neo4j-arc/common'
 import {
   SaveFavoriteIcon,
   RunIcon,
-  StopIcon
+  StopIcon,
+  RightArrowIcon
 } from 'browser-components/icons/LegacyIcons'
 
 import { MAIN_WRAPPER_DOM_ID } from '../App/App'

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/Graph.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/Graph.tsx
@@ -49,6 +49,7 @@ import { Visualization } from './visualization/Visualization'
 import { WheelZoomInfoOverlay } from './WheelZoomInfoOverlay'
 import { StyledSvgWrapper, StyledZoomButton, StyledZoomHolder } from './styled'
 import { ResizeObserver } from '@juggle/resize-observer'
+import SvgUploadButton from './SvgUploadButton'
 
 export type GraphProps = {
   isFullscreen: boolean
@@ -299,6 +300,9 @@ export class Graph extends React.Component<GraphProps, GraphState> {
             onClick={this.zoomToFitClicked}
           >
             <ZoomToFitIcon large={isFullscreen} />
+          </StyledZoomButton>
+          <StyledZoomButton aria-label={'upload-node-positions'}>
+            <SvgUploadButton visualization={this.visualization} />
           </StyledZoomButton>
         </StyledZoomHolder>
         {wheelZoomInfoMessageEnabled && displayingWheelZoomInfoMessage && (

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/SvgUploadButton.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/SvgUploadButton.tsx
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Neo4j is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * This component was written by petra.schanz@deutschebahn.com
+ */
+import React, { ChangeEvent, useState } from 'react'
+
+import { RightArrowIcon } from '../../../../../src/browser/components/icons/LegacyIcons'
+
+import { createPortal } from 'react-dom'
+import { NodeModel } from '../../models/Node'
+
+function SvgUploadButton(props: any): JSX.Element {
+  const [showDialog, setShowDialog] = useState(false)
+
+  const togglePopup = () => {
+    setShowDialog(!showDialog)
+  }
+
+  function extractSvgGElements(svgString: string) {
+    if (
+      !svgString ||
+      !svgString.startsWith('<svg') ||
+      !svgString.endsWith('</svg>') ||
+      svgString.indexOf('<style') > -1 ||
+      svgString.indexOf('<script') > -1
+    ) {
+      alert('Sorry, this is not a valid neo4j-svg file')
+      return []
+    }
+    const svgFragment = document.createDocumentFragment()
+    const svgContainer = document.createElement('div')
+    svgContainer.innerHTML = svgString
+    svgFragment.appendChild(svgContainer)
+    const gElements = svgFragment.querySelector('g.layer.nodes')?.children
+    return gElements
+  }
+
+  function extractSvgGElementAttributes(gElement: SVGGElement) {
+    const classes = gElement
+      ?.getAttribute('class')
+      ?.split(' ')
+      .filter((cl: string) => cl.startsWith('uuid_'))
+    const uuid = classes && classes.length ? classes[0].split('_')[1] : ''
+    const nodeId = gElement?.getAttribute('aria-label')?.split('graph-node')[1]
+    const transform = gElement
+      ?.getAttribute('transform')
+      ?.split('(')[1]
+      ?.split(',')
+    return { uuid, nodeId, transform }
+  }
+
+  const changeHandler: any = (event: ChangeEvent) => {
+    const reader = new FileReader()
+
+    reader.onload = async event => {
+      const gElements = extractSvgGElements(
+        event?.target?.result ? (event.target.result as string) : ''
+      )
+      const graphModel = props.visualization.getGraph()
+
+      if (!gElements) {
+        alert('Sorry, this is not a valid neo4j-svg-File')
+        return
+      }
+
+      Array.prototype.forEach.call(gElements, (gElement: SVGGElement): void => {
+        const { uuid, nodeId, transform } =
+          extractSvgGElementAttributes(gElement)
+
+        if (!nodeId || !transform) {
+          return
+        }
+
+        const myNode = uuid
+          ? graphModel.findNodeByUuid(uuid)
+          : graphModel.findNode(nodeId)
+
+        if (!myNode) {
+          return
+        }
+
+        myNode.moveNodePosition(
+          parseFloat(transform[0]),
+          parseFloat(transform[1].split(')')[0])
+        )
+        graphModel.updateNode(myNode)
+      })
+      props.visualization.updateNodePositions()
+    }
+    reader.readAsText((event?.target as any)?.files[0])
+  }
+
+  return (
+    <>
+      <button title="Upload node positions" onClick={() => togglePopup()}>
+        <RightArrowIcon />
+      </button>
+      {createPortal(
+        <div
+          id="uploadDialogContainer"
+          onClick={() => togglePopup()}
+          style={{
+            position: 'absolute',
+            width: showDialog ? '100vw' : '0',
+            height: '100vh',
+            backgroundColor: 'rgba(0,0,0,0.5)',
+            left: '0',
+            top: '0',
+            zIndex: 10
+          }}
+        >
+          <dialog
+            open={showDialog}
+            style={{
+              padding: '10px',
+              borderRadius: '5px',
+              top: '30vh',
+              margin: '0 auto'
+            }}
+          >
+            <form>
+              <p>Upload a formerly exported svg here.</p>
+              <p>
+                All known nodes will be dragged to the position marked in the
+                svg
+              </p>
+              <br />
+              <input
+                type="file"
+                id="upload_file_input"
+                accept=".svg"
+                onChange={event => changeHandler(event)}
+              />
+            </form>
+          </dialog>
+        </div>,
+        document.body
+      )}
+    </>
+  )
+}
+
+export default SvgUploadButton

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/visualization/Visualization.ts
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/Graph/visualization/Visualization.ts
@@ -48,6 +48,7 @@ import {
 } from './renderers/init'
 import { nodeMenuRenderer } from './renderers/menu'
 import { ZoomLimitsReached, ZoomType } from '../../../types'
+import { mapRelationships } from '../../../utils/mapper'
 
 type MeasureSizeFn = () => { width: number; height: number }
 
@@ -196,8 +197,13 @@ export class Visualization {
       .selectAll<SVGGElement, NodeModel>('g.node')
       .data(nodes, d => d.id)
       .join('g')
-      .attr('class', 'node')
+      .attr('class', d =>
+        d.propertyMap.hasOwnProperty('uuid')
+          ? 'node uuid_' + d.propertyMap.uuid.replace(/[^a-z0-9]/gi, '')
+          : 'node'
+      )
       .attr('aria-label', d => `graph-node${d.id}`)
+      .attr('transform', d => `translate(${d.x}, ${d.y})`)
       .call(nodeEventHandlers, this.trigger, this.forceSimulation.simulation)
       .classed('selected', node => node.selected)
 
@@ -234,11 +240,11 @@ export class Visualization {
     )
 
     this.forceSimulation.updateRelationships(this.graph)
-   // The onGraphChange handler does only repaint relationship color
+    // The onGraphChange handler does only repaint relationship color
     // not width and caption, since it requires taking into account surrounding data
-    // since the arrows have different bending depending on how the nodes are 
-    // connected. We work around that by doing an additional full render to get the 
-// new stylings
+    // since the arrows have different bending depending on how the nodes are
+    // connected. We work around that by doing an additional full render to get the
+    // new stylings
     this.render()
   }
 
@@ -396,5 +402,14 @@ export class Visualization {
         size.height
       ].join(' ')
     )
+  }
+
+  updateNodePositions(): void {
+    this.updateNodes()
+    this.updateRelationships()
+  }
+
+  public getGraph(): GraphModel {
+    return this.graph
   }
 }

--- a/src/neo4j-arc/graph-visualization/models/Graph.ts
+++ b/src/neo4j-arc/graph-visualization/models/Graph.ts
@@ -42,6 +42,7 @@ export class GraphModel {
     this.addInternalRelationships = this.addInternalRelationships.bind(this)
     this.pruneInternalRelationships = this.pruneInternalRelationships.bind(this)
     this.findNode = this.findNode.bind(this)
+    this.findNodeByUuid = this.findNodeByUuid.bind(this)
     this.findNodeNeighbourIds = this.findNodeNeighbourIds.bind(this)
     this.findRelationship = this.findRelationship.bind(this)
     this.findAllRelationshipToNode = this.findAllRelationshipToNode.bind(this)
@@ -171,6 +172,15 @@ export class GraphModel {
 
   findNode(id: string): NodeModel {
     return this.nodeMap[id]
+  }
+
+  findNodeByUuid = function (
+    this: GraphModel,
+    uuid: string
+  ): NodeModel | undefined {
+    return Object.values(this.nodeMap).find(
+      obj => obj.propertyMap.uuid.replace(/[^a-z0-9]/gi, '') === uuid
+    )
   }
 
   findNodeNeighbourIds(id: string): string[] {

--- a/src/neo4j-arc/graph-visualization/models/Node.ts
+++ b/src/neo4j-arc/graph-visualization/models/Node.ts
@@ -93,4 +93,12 @@ export class NodeModel {
       .relationships()
       .some(rel => rel.source === this || rel.target === this)
   }
+
+  moveNodePosition(x: number, y: number): void {
+    // added by petra.schanz@deutschebahn.com
+    this.x = x
+    this.y = y
+    this.fx = x // by setting the f attrs we lock the node
+    this.fy = y // by setting the f attrs we lock the node
+  }
 }


### PR DESCRIPTION
This fork implements the feature requested here: [https://github.com/neo4j/neo4j-browser/issues/858](https://github.com/neo4j/neo4j-browser/issues/858) and was written by petra.schanz@deutschebahn.com on behalf of DB Systel GmbH.

Svgs exported by neo4j contain the positions of the drawn nodes. If you show the same nodes in the neo4j-browser you can use the new upload-button (below the zoom buttons because this is all about visualization) and upload your svg: The nodes will be dragged automatically to the positions shown in the svg. You can interact with them and use them as you are used to.

If you need to re-import the database data you should set a uuid before exporting the svg and after importing the data by using something along "MATCH (n) SET n.uuid = n.myEternalAndUniqeAttribute RETURN n"

![tempsnip](https://github.com/neo4j/neo4j-browser/assets/122791942/a000270c-ebf4-4e3f-a757-60ae68a597be)
