### PR TITLE
Transaction error new code & update caniuse to get rid of warning

### DIFF
--- a/src/shared/services/cypherErrorsHelper.ts
+++ b/src/shared/services/cypherErrorsHelper.ts
@@ -8,7 +8,8 @@ export const isNoDbAccessError = ({ code, message }: BrowserError): boolean =>
   /Database access is not allowed/i.test(message)
 
 const isCallInTransactionError = ({ code, message }: BrowserError) =>
-  code === 'Neo.DatabaseError.Statement.ExecutionFailed' &&
+  (code === 'Neo.DatabaseError.Statement.ExecutionFailed' ||
+    code === 'Neo.DatabaseError.Transaction.TransactionStartFailed') &&
   /in an implicit transaction/.test(message)
 
 const isPeriodicCommitError = ({ code, message }: BrowserError) =>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4323,14 +4323,9 @@ camelize@^1.0.0:
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
-caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30001131:
-  version "1.0.30001285"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001285.tgz"
-
-caniuse-lite@^1.0.30000823, caniuse-lite@^1.0.30000844:
-  version "1.0.30001442"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz#40337f1cf3be7c637b061e2f78582dc1daec0614"
-  integrity sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==
+caniuse-lite@^1.0.30000792, caniuse-lite@^1.0.30000805, caniuse-lite@^1.0.30000823, caniuse-lite@^1.0.30000844, caniuse-lite@^1.0.30001131:
+  version "1.0.30001494"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001494.tgz"
 
 canvg@^3.0.7:
   version "3.0.7"


### PR DESCRIPTION
The error code for transaction was changed, so we we're no longer showing the hint about `:auto`

<img width="882" alt="image" src="https://github.com/neo4j/neo4j-browser/assets/10564538/a79bcbd7-a301-4af9-8980-fa8f1d3729c6">
