### PR TITLE
SSO papercuts (more logs & make downloading them easier)

### DIFF
--- a/src/browser/modules/Stream/Auth/ConnectForm.tsx
+++ b/src/browser/modules/Stream/Auth/ConnectForm.tsx
@@ -391,7 +391,7 @@ export default function ConnectForm(props: ConnectFormProps): JSX.Element {
           ))}
         {props.authenticationMethod === SSO &&
           !SSOLoading &&
-          (SSOError || SSORedirectError || true) && (
+          (SSOError || SSORedirectError) && (
             <>
               <StyledSSOError>
                 <StyledCypherErrorMessage>ERROR</StyledCypherErrorMessage>

--- a/src/browser/modules/Stream/Auth/ConnectForm.tsx
+++ b/src/browser/modules/Stream/Auth/ConnectForm.tsx
@@ -391,14 +391,16 @@ export default function ConnectForm(props: ConnectFormProps): JSX.Element {
           ))}
         {props.authenticationMethod === SSO &&
           !SSOLoading &&
-          (SSOError || SSORedirectError) && (
-            <StyledSSOError>
-              <StyledCypherErrorMessage>ERROR</StyledCypherErrorMessage>
-              <div>{SSOError || SSORedirectError}</div>
+          (SSOError || SSORedirectError || true) && (
+            <>
+              <StyledSSOError>
+                <StyledCypherErrorMessage>ERROR</StyledCypherErrorMessage>
+                <div>{SSOError || SSORedirectError}</div>
+              </StyledSSOError>
               <StyledSSOLogDownload onClick={downloadAuthLogs}>
-                Download logs
+                Download browser SSO logs
               </StyledSSOLogDownload>
-            </StyledSSOError>
+            </>
           )}
 
         {props.connecting

--- a/src/browser/modules/Stream/Auth/styled.tsx
+++ b/src/browser/modules/Stream/Auth/styled.tsx
@@ -152,9 +152,27 @@ export const StyledDbsRow = styled.li``
 export const StyledFormContainer = styled.div`
   display: flex;
 `
-export const StyledSSOLogDownload = styled.a`
+export const StyledSSOLogDownload = styled.button`
+  color: ${props => props.theme.primaryButtonText};
+  background-color: ${props => props.theme.primary};
+  border: 1px solid ${props => props.theme.primary};
+  font-family: ${props => props.theme.primaryFontFamily};
+  padding: 6px 18px;
+  font-weight: 600;
+  font-size: 14px;
+  text-align: center;
+  vertical-align: middle;
   cursor: pointer;
+  border-radius: 4px;
+  line-height: 20px;
+
+  &:hover {
+    background-color: ${props => props.theme.primary50};
+    color: ${props => props.theme.secondaryButtonTextHover};
+    border: 1px solid ${props => props.theme.primary50};
+  }
 `
+
 export const StyledSSOButtonContainer = styled.div`
   margin-bottom: 12px;
 `
@@ -162,4 +180,5 @@ export const StyledSSOError = styled.div`
   margin-top: 30px;
   padding: 3px;
   white-space: pre-line;
+  display: flex;
 `


### PR DESCRIPTION
In the past the "download logs" button was only text with "cursor pointer" so it wasn't clear it was clickable. I now make it into a button specifying which logs will get downloaded.
<img width="325" alt="CleanShot 2023-07-28 at 09 28 35@2x" src="https://github.com/neo4j/neo4j-browser/assets/10564538/0c25ff5e-61e7-4b4a-9f19-f8271f581891">

I've also added a few more logs to make debugging easier.