### PR TITLE
Expand completion detail by default

### DIFF
--- a/src/neo4j-arc/cypher-language-support/cypher-editor/CypherEditor.tsx
+++ b/src/neo4j-arc/cypher-language-support/cypher-editor/CypherEditor.tsx
@@ -361,6 +361,12 @@ export class CypherEditor extends React.Component<
       tabIndex: this.props.tabIndex
     })
 
+    // Set the details to be visible by default
+    this.editor
+      .getContribution('editor.contrib.suggestController')
+      // @ts-ignore this is an internal API
+      ?.widget?.value?._setDetailsVisible(true)
+
     const { KeyCode, KeyMod } = monaco
     if (this.props.onExecute) {
       this.editor.addCommand(


### PR DESCRIPTION
Before the signature of the function could make the method name unreadable:
![CleanShot 2023-09-12 at 07 57 02](https://github.com/neo4j/neo4j-browser/assets/10564538/19142ec9-ae79-4e6c-866f-ed0eb0b2a31f)

After we expand the completion by default:
![CleanShot 2023-09-12 at 07 56 09](https://github.com/neo4j/neo4j-browser/assets/10564538/f37d6a29-9fa1-4387-a8fc-e5069a8419e4)
