### PR TITLE
Align documentation by allowing Graph export in JSON & CSV formats

### DIFF
--- a/e2e_tests/integration/data-export.spec.ts
+++ b/e2e_tests/integration/data-export.spec.ts
@@ -42,7 +42,7 @@ describe('Data export', () => {
       cy.executeCommand('MATCH (n:ExportTest) DETACH DELETE n')
     })
     const tests = [
-      { panel: 'Visualization', expected: ['PNG', 'SVG'] },
+      { panel: 'Visualization', expected: ['CSV', 'JSON', 'PNG', 'SVG'] },
       {
         panel: 'Plan',
         expected: [

--- a/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
+++ b/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
@@ -177,9 +177,12 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
     const textDownloadEnabled = () =>
       this.getRecords().length > 0 &&
       this.state.openView &&
-      [ViewTypes.TEXT, ViewTypes.TABLE, ViewTypes.CODE].includes(
-        this.state.openView
-      )
+      [
+        ViewTypes.TEXT,
+        ViewTypes.TABLE,
+        ViewTypes.CODE,
+        ViewTypes.VISUALIZATION
+      ].includes(this.state.openView)
     const graphicsDownloadEnabled = () =>
       this.visElement &&
       this.state.openView &&
@@ -190,8 +193,6 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
       { name: 'JSON', download: this.exportJSON }
     ]
     const downloadGraphics = [
-      { name: 'CSV', download: this.exportCSV },
-      { name: 'JSON', download: this.exportJSON },
       { name: 'PNG', download: this.exportPNG },
       { name: 'SVG', download: this.exportSVG }
     ]

--- a/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
+++ b/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
@@ -190,6 +190,8 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
       { name: 'JSON', download: this.exportJSON }
     ]
     const downloadGraphics = [
+      { name: 'CSV', download: this.exportCSV },
+      { name: 'JSON', download: this.exportJSON },
       { name: 'PNG', download: this.exportPNG },
       { name: 'SVG', download: this.exportSVG }
     ]


### PR DESCRIPTION
<!--
BEFORE YOU SUBMIT make sure you've done the following:
[ ] Done your work in a personal fork of the original repository
[ ] Created a branch with a useful name
[ ] Include unit tests if appropriate (obviously not necessary for documentation changes)
[ ] Made sure the unit and e2e tests all pass
[ ] Read and signed our [CLA](https://neo4j.com/developer/cla) (the test will fail if you haven't done so)
[ ] Added a short explanation of what you've done and included a relevant screen shot if possible

More details on contributing can be found in CONTRIBUTING.md in the root of this repository. Thank you for your time and interest in the Neo4j Browser! 
-->

This PR aligns graph export behavior with [what's being documented](https://neo4j.com/docs/browser-manual/current/operations/export-results/), i.e. exporting in JSON and CSV

<img width="887" alt="page" src="https://github.com/neo4j/neo4j-browser/assets/16126939/8070aa42-000e-4a60-8845-ea7046532e9a">

We like the feature of JSON export very much, because our research needs it a lot. Thanks a lot for developing this option, folks!

PS: I have also signed the CLA (jack20220723@gmail.com, QubitPi). Please let me know if I can help with anything else