### PR TITLE
fix bug where element-id shows incorrectly in table

### DIFF
--- a/e2e_tests/integration/types.spec.ts
+++ b/e2e_tests/integration/types.spec.ts
@@ -145,6 +145,7 @@ describe('Types in Browser', () => {
       cy.get('[data-testid="vizInspector"]')
         .should('contain', 'P11M2DT2H19')
         .and('contain', 'srid:4326')
+        .and('contain', 'elementId')
     })
     it('renders types in paths in viz correctly', () => {
       cy.executeCommand(':clear')

--- a/src/browser/modules/Stream/CypherFrame/AsciiView.tsx
+++ b/src/browser/modules/Stream/CypherFrame/AsciiView.tsx
@@ -43,7 +43,6 @@ import { shallowEquals } from 'services/utils'
 import { GlobalState } from 'shared/globalState'
 import { BrowserRequestResult } from 'shared/modules/requests/requestsDuck'
 import { getMaxFieldItems } from 'shared/modules/settings/settingsDuck'
-import { Record } from 'neo4j-driver'
 
 interface BaseAsciiViewComponentProps {
   result: BrowserRequestResult

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView/PropertiesPanelContent/DetailsPane.test.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView/PropertiesPanelContent/DetailsPane.test.tsx
@@ -55,6 +55,7 @@ describe('<DetailsPane />', () => {
           type: type,
           item: {
             id: 'abc',
+            elementId: 'abc',
             labels,
             propertyList
           }
@@ -65,6 +66,7 @@ describe('<DetailsPane />', () => {
           type: type,
           item: {
             id: 'abc',
+            elementId: 'abc',
             type: 'abc2',
             propertyList
           }

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView/PropertiesPanelContent/DetailsPane.test.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView/PropertiesPanelContent/DetailsPane.test.tsx
@@ -86,8 +86,8 @@ describe('<DetailsPane />', () => {
 
     expect(screen.getByRole('button', { name: 'Show all' })).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Show 2 more' })
-    ).toBeInTheDocument() // id is added to list of properties so only showing 999
+      screen.getByRole('button', { name: 'Show 3 more' })
+    ).toBeInTheDocument() // id & elementId is added to list of properties so only showing 998
     expect(screen.queryByText('prop1000')).not.toBeInTheDocument()
 
     const showAllButton = screen.getByText('Show all')
@@ -119,7 +119,7 @@ describe('<DetailsPane />', () => {
       screen.queryByRole('button', { name: 'Show all' })
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Show 2 more' })
+      screen.getByRole('button', { name: 'Show 3 more' })
     ).toBeInTheDocument()
   })
 })

--- a/src/browser/modules/Stream/CypherFrame/VisualizationView/PropertiesPanelContent/DetailsPane.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView/PropertiesPanelContent/DetailsPane.tsx
@@ -41,9 +41,16 @@ export function DetailsPane({
     value: `${vizItem.item.id}`,
     type: 'String'
   }
-  const allItemProperties = [idProperty, ...vizItem.item.propertyList].sort(
-    (a, b) => (a.key < b.key ? -1 : 1)
-  )
+  const elementIdProperty = {
+    key: '<elementId>',
+    value: `${vizItem.item.elementId}`,
+    type: 'String'
+  }
+  const allItemProperties = [
+    idProperty,
+    elementIdProperty,
+    ...vizItem.item.propertyList
+  ].sort((a, b) => (a.key < b.key ? -1 : 1))
   const visibleItemProperties = allItemProperties.slice(0, maxPropertiesCount)
 
   const handleMorePropertiesClick = (numMore: number) => {

--- a/src/neo4j-arc/common/components/PropertiesTable/PropertiesTable.test.tsx
+++ b/src/neo4j-arc/common/components/PropertiesTable/PropertiesTable.test.tsx
@@ -51,6 +51,7 @@ describe('<DetailsPane />', () => {
           type: type,
           item: {
             id: 'abc',
+            elementId: 'abc',
             labels,
             propertyList
           }
@@ -61,6 +62,7 @@ describe('<DetailsPane />', () => {
           type: type,
           item: {
             id: 'abc',
+            elementId: 'abc',
             type: 'abc2',
             propertyList
           }

--- a/src/neo4j-arc/common/types/arcTypes.ts
+++ b/src/neo4j-arc/common/types/arcTypes.ts
@@ -19,12 +19,14 @@
  */
 export type BasicNode = {
   id: string
+  elementId: string
   labels: string[]
   properties: Record<string, string>
   propertyTypes: Record<string, string>
 }
 export type BasicRelationship = {
   id: string
+  elementId: string
   startNodeId: string
   endNodeId: string
   type: string

--- a/src/neo4j-arc/common/utils/driverUtils.ts
+++ b/src/neo4j-arc/common/utils/driverUtils.ts
@@ -117,6 +117,7 @@ export const extractUniqueNodesAndRels = (
   const nodes = Array.from(nodeMap.values()).map(item => {
     return {
       id: item.identity.toString(),
+      elementId: item.elementId,
       labels: item.labels,
       properties: mapObjectValues(item.properties, propertyToString),
       propertyTypes: mapObjectValues(
@@ -142,6 +143,7 @@ export const extractUniqueNodesAndRels = (
     .map(item => {
       return {
         id: item.identity.toString(),
+        elementId: item.elementId,
         startNodeId: item.start.toString(),
         endNodeId: item.end.toString(),
         type: item.type,

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/DefaultPanelContent/DefaultDetailsPane.test.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/DefaultPanelContent/DefaultDetailsPane.test.tsx
@@ -59,7 +59,7 @@ describe('<DetailsPane />', () => {
           type: type,
           item: {
             id: 'abc',
-            elementId: 'abc',
+            elementId: 'elementId',
             labels,
             propertyList
           }
@@ -70,7 +70,7 @@ describe('<DetailsPane />', () => {
           type: type,
           item: {
             id: 'abc',
-            elementId: 'abc',
+            elementId: 'elementId',
             type: 'abc2',
             propertyList
           }
@@ -90,8 +90,8 @@ describe('<DetailsPane />', () => {
 
     expect(screen.getByRole('button', { name: 'Show all' })).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Show 2 more' })
-    ).toBeInTheDocument() // id is added to list of properties so only showing 999
+      screen.getByRole('button', { name: 'Show 3 more' })
+    ).toBeInTheDocument() // id & elementId is added to list of properties so only showing 998
     expect(screen.queryByText('prop1000')).not.toBeInTheDocument()
 
     const showAllButton = screen.getByText('Show all')
@@ -123,7 +123,7 @@ describe('<DetailsPane />', () => {
       screen.queryByRole('button', { name: 'Show all' })
     ).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Show 2 more' })
+      screen.getByRole('button', { name: 'Show 3 more' })
     ).toBeInTheDocument()
   })
 })

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/DefaultPanelContent/DefaultDetailsPane.test.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/DefaultPanelContent/DefaultDetailsPane.test.tsx
@@ -59,6 +59,7 @@ describe('<DetailsPane />', () => {
           type: type,
           item: {
             id: 'abc',
+            elementId: 'abc',
             labels,
             propertyList
           }
@@ -69,6 +70,7 @@ describe('<DetailsPane />', () => {
           type: type,
           item: {
             id: 'abc',
+            elementId: 'abc',
             type: 'abc2',
             propertyList
           }

--- a/src/neo4j-arc/graph-visualization/GraphVisualizer/DefaultPanelContent/DefaultDetailsPane.tsx
+++ b/src/neo4j-arc/graph-visualization/GraphVisualizer/DefaultPanelContent/DefaultDetailsPane.tsx
@@ -47,9 +47,16 @@ export function DefaultDetailsPane({
     value: `${vizItem.item.id}`,
     type: 'String'
   }
-  const allItemProperties = [idProperty, ...vizItem.item.propertyList].sort(
-    (a, b) => (a.key < b.key ? -1 : 1)
-  )
+  const elementIdProperty = {
+    key: '<element-id>',
+    value: `${vizItem.item.elementId}`,
+    type: 'String'
+  }
+  const allItemProperties = [
+    idProperty,
+    elementIdProperty,
+    ...vizItem.item.propertyList
+  ].sort((a, b) => (a.key < b.key ? -1 : 1))
   const visibleItemProperties = allItemProperties.slice(0, maxPropertiesCount)
 
   const handleMorePropertiesClick = (numMore: number) => {

--- a/src/neo4j-arc/graph-visualization/models/Node.ts
+++ b/src/neo4j-arc/graph-visualization/models/Node.ts
@@ -30,6 +30,7 @@ export type NodeCaptionLine = {
 
 export class NodeModel {
   id: string
+  elementId: string
   labels: string[]
   propertyList: VizItemProperty[]
   propertyMap: NodeProperties
@@ -55,7 +56,8 @@ export class NodeModel {
     id: string,
     labels: string[],
     properties: NodeProperties,
-    propertyTypes: Record<string, string>
+    propertyTypes: Record<string, string>,
+    elementId: string
   ) {
     this.id = id
     this.labels = labels
@@ -76,6 +78,7 @@ export class NodeModel {
     this.y = 0
     this.hoverFixed = false
     this.initialPositionCalculated = false
+    this.elementId = elementId
   }
 
   toJSON(): NodeProperties {

--- a/src/neo4j-arc/graph-visualization/models/Relationship.ts
+++ b/src/neo4j-arc/graph-visualization/models/Relationship.ts
@@ -26,6 +26,7 @@ import { NodeModel } from './Node'
 export type RelationshipCaptionLayout = 'internal' | 'external'
 export class RelationshipModel {
   id: string
+  elementId: string
   propertyList: VizItemProperty[]
   propertyMap: Record<string, string>
   source: NodeModel
@@ -52,7 +53,8 @@ export class RelationshipModel {
     target: NodeModel,
     type: string,
     properties: Record<string, string>,
-    propertyTypes: Record<string, string>
+    propertyTypes: Record<string, string>,
+    elementId: string
   ) {
     this.id = id
     this.source = source
@@ -73,6 +75,8 @@ export class RelationshipModel {
     this.captionHeight = 0
     this.captionLayout = 'internal'
     this.centreDistance = 0
+
+    this.elementId = elementId
   }
 
   toJSON(): Record<string, string> {

--- a/src/neo4j-arc/graph-visualization/types.ts
+++ b/src/neo4j-arc/graph-visualization/types.ts
@@ -30,7 +30,7 @@ export type VizItem =
 
 export type NodeItem = {
   type: 'node'
-  item: Pick<NodeModel, 'id' | 'labels' | 'propertyList'>
+  item: Pick<NodeModel, 'id' | 'elementId' | 'labels' | 'propertyList'>
 }
 
 type ContextMenuItem = {
@@ -49,7 +49,7 @@ type StatusItem = {
 
 export type RelationshipItem = {
   type: 'relationship'
-  item: Pick<RelationshipModel, 'id' | 'type' | 'propertyList'>
+  item: Pick<RelationshipModel, 'id' | 'elementId' | 'type' | 'propertyList'>
 }
 
 type CanvasItem = {

--- a/src/neo4j-arc/graph-visualization/utils/mapper.ts
+++ b/src/neo4j-arc/graph-visualization/utils/mapper.ts
@@ -46,7 +46,8 @@ export function mapNodes(nodes: BasicNode[]): NodeModel[] {
         node.id,
         node.labels,
         mapProperties(node.properties),
-        node.propertyTypes
+        node.propertyTypes,
+        node.elementId
       )
   )
 }
@@ -64,7 +65,8 @@ export function mapRelationships(
       target,
       rel.type,
       mapProperties(rel.properties),
-      rel.propertyTypes
+      rel.propertyTypes,
+      rel.elementId
     )
   })
 }

--- a/src/shared/services/bolt/boltMappings.ts
+++ b/src/shared/services/bolt/boltMappings.ts
@@ -252,6 +252,7 @@ export function extractNodesAndRelationshipsFromRecordsForOldVis(
   const nodes = rawNodes.map(item => {
     return {
       id: item.identity.toString(),
+      elementId: item.elementId,
       labels: item.labels,
       properties: itemIntToString(item.properties, converters),
       propertyTypes: Object.entries(item.properties).reduce(
@@ -274,6 +275,8 @@ export function extractNodesAndRelationshipsFromRecordsForOldVis(
   relationships = relationships.map(item => {
     return {
       id: item.identity.toString(),
+      elementId: item.elementId,
+      // end node element ID?
       startNodeId: item.start.toString(),
       endNodeId: item.end.toString(),
       type: item.type,
@@ -427,7 +430,8 @@ export const applyGraphTypes = (
         return new types[className](
           applyGraphTypes(tmpItem.identity, types),
           tmpItem.labels,
-          applyGraphTypes(tmpItem.properties, types)
+          applyGraphTypes(tmpItem.properties, types),
+          tmpItem.elementId
         )
       case 'Relationship':
         return new types[className](
@@ -435,7 +439,10 @@ export const applyGraphTypes = (
           applyGraphTypes(item.start, types),
           applyGraphTypes(item.end, types),
           item.type,
-          applyGraphTypes(item.properties, types)
+          applyGraphTypes(item.properties, types),
+          tmpItem.elementId,
+          tmpItem.startNodeElementId,
+          tmpItem.endNodeElementId
         )
       case 'PathSegment':
         return new types[className](

--- a/src/shared/services/bolt/boltMappings.ts
+++ b/src/shared/services/bolt/boltMappings.ts
@@ -276,7 +276,6 @@ export function extractNodesAndRelationshipsFromRecordsForOldVis(
     return {
       id: item.identity.toString(),
       elementId: item.elementId,
-      // end node element ID?
       startNodeId: item.start.toString(),
       endNodeId: item.end.toString(),
       type: item.type,


### PR DESCRIPTION
Before (notice the element ids are just old ids but as strings):
![CleanShot 2023-11-06 at 14 14 39](https://github.com/neo4j/neo4j-browser/assets/10564538/dadcd1f1-b442-4b88-92bf-858c867f4bdc)


After:
![CleanShot 2023-11-06 at 14 13 55](https://github.com/neo4j/neo4j-browser/assets/10564538/0fe52601-c5d0-4cd7-b80d-d88198a76280)


Also adds it to the node properties panel here:
![CleanShot 2023-11-06 at 14 13 19](https://github.com/neo4j/neo4j-browser/assets/10564538/b18cdcbd-ea09-4e98-a5c0-4a2040a28f09)
