### PR TITLE
ensure right protocol is used for http reachablity check

### DIFF
--- a/src/browser/modules/Stream/Auth/ConnectForm.tsx
+++ b/src/browser/modules/Stream/Auth/ConnectForm.tsx
@@ -175,7 +175,7 @@ export default function ConnectForm(props: ConnectFormProps): JSX.Element {
 
   async function reachabilityCheck(url: string) {
     setReachablityState('loading')
-    const res = await httpReachabilityCheck(`http://${stripScheme(url)}`)
+    const res = await httpReachabilityCheck(`//${stripScheme(url)}`)
 
     // Being reachable by http is not a requirement (you could have some really odd network setup)
     // But if it doesn't work though, it is likely the connection will time out which can take a while


### PR DESCRIPTION
Using a [protocol relative URL](https://en.wikipedia.org/wiki/URL#prurl), we can ensure that HTTPS is used when appropriate.  Easiest way to test this is to use `yarn starts` to get Browser running with a self signed certificate