### PR TITLE
Fix maximum call stack size exceeded for csv export

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
+++ b/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
@@ -427,11 +427,10 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
     const firstRecord = records[0]
     const keys = firstRecord?.length > 0 ? firstRecord.keys : []
 
-    const exportdataRaw = [keys]
-    exportdataRaw.push(
+    const exportData = stringifyResultArray(csvFormat, [
+      keys,
       ...(records.map(record => recordToStringArray(record)) as any)
-    )
-    const exportData = stringifyResultArray(csvFormat, exportdataRaw)
+    ])
     const data = exportData.slice()
     const csv = CSVSerializer(data.shift())
     csv.appendRows(data)

--- a/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
+++ b/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
@@ -427,10 +427,10 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
     const firstRecord = records[0]
     const keys = firstRecord?.length > 0 ? firstRecord.keys : []
 
-    const exportData = stringifyResultArray(csvFormat, [
-      keys,
-      ...(records.map(record => recordToStringArray(record)) as any)
-    ])
+    const exportData = stringifyResultArray(
+      csvFormat,
+      [keys].concat(records.map(record => recordToStringArray(record)))
+    )
     const data = exportData.slice()
     const csv = CSVSerializer(data.shift())
     csv.appendRows(data)


### PR DESCRIPTION
If the user exports a result that is very long (over 100 000 rows) Browser crashes with the error  Maximum call stack size exceeded. This fix updates the code to avoid adding calls to the stack. 

