### PR TITLE
Avoid running `SHOW ALIASES` to show only non-composite aliases in database dropdown

### DIFF
--- a/src/browser/modules/DBMSInfo/DBMSInfo.tsx
+++ b/src/browser/modules/DBMSInfo/DBMSInfo.tsx
@@ -42,8 +42,7 @@ import {
   forceCount,
   getCountAutomaticRefreshLoading,
   getCountAutomaticRefreshEnabled,
-  getUniqueDatabases,
-  getAliases
+  getUniqueDatbases
 } from 'shared/modules/dbMeta/dbMetaDuck'
 import { getGraphStyleData } from 'shared/modules/grass/grassDuck'
 import { Button } from '@neo4j-ndl/react'
@@ -74,14 +73,7 @@ export function DBMSInfo(props: any): JSX.Element {
     nodes,
     relationships
   } = props.meta
-  const {
-    user,
-    onItemClick,
-    onDbSelect,
-    useDb,
-    uniqueDatabases = [],
-    aliases
-  } = props
+  const { user, onItemClick, onDbSelect, useDb, uniqueDatabases = [] } = props
 
   return (
     <Drawer id="db-drawer">
@@ -89,7 +81,6 @@ export function DBMSInfo(props: any): JSX.Element {
       <DrawerBody>
         <DatabaseSelector
           uniqueDatabases={uniqueDatabases}
-          aliases={aliases}
           selectedDb={useDb ?? ''}
           onChange={onDbSelect}
         />
@@ -150,8 +141,7 @@ const mapStateToProps = (state: any) => {
   const countAutoRefreshing = getCountAutomaticRefreshEnabled(state)
   const countLoading = getCountAutomaticRefreshLoading(state)
 
-  const uniqueDatabases = getUniqueDatabases(state)
-  const aliases = getAliases(state)
+  const uniqueDatabases = getUniqueDatbases(state)
 
   return {
     graphStyleData: getGraphStyleData(state),
@@ -159,7 +149,6 @@ const mapStateToProps = (state: any) => {
     user: getCurrentUser(state),
     useDb,
     uniqueDatabases,
-    aliases,
     countAutoRefreshing,
     countLoading
   }

--- a/src/browser/modules/DBMSInfo/DatabaseSelector.test.tsx
+++ b/src/browser/modules/DBMSInfo/DatabaseSelector.test.tsx
@@ -45,11 +45,7 @@ describe('DatabaseSelector', () => {
 
     // When
     const { container } = render(
-      <DatabaseSelector
-        selectedDb=""
-        uniqueDatabases={databases}
-        aliases={[]}
-      />
+      <DatabaseSelector selectedDb="" uniqueDatabases={databases} />
     )
 
     // Then
@@ -62,11 +58,7 @@ describe('DatabaseSelector', () => {
 
     // When
     const { getByDisplayValue, queryByDisplayValue, rerender } = render(
-      <DatabaseSelector
-        uniqueDatabases={databases}
-        selectedDb={selected}
-        aliases={[]}
-      />
+      <DatabaseSelector uniqueDatabases={databases} selectedDb={selected} />
     )
 
     // Then
@@ -76,11 +68,7 @@ describe('DatabaseSelector', () => {
     // When
     selected = 'molly'
     rerender(
-      <DatabaseSelector
-        uniqueDatabases={databases}
-        selectedDb={selected}
-        aliases={[]}
-      />
+      <DatabaseSelector uniqueDatabases={databases} selectedDb={selected} />
     )
 
     // Then
@@ -90,11 +78,7 @@ describe('DatabaseSelector', () => {
     // When
     selected = ''
     rerender(
-      <DatabaseSelector
-        uniqueDatabases={databases}
-        selectedDb={selected}
-        aliases={[]}
-      />
+      <DatabaseSelector uniqueDatabases={databases} selectedDb={selected} />
     )
 
     // Then select db text should be shown
@@ -113,7 +97,6 @@ describe('DatabaseSelector', () => {
         uniqueDatabases={databases}
         selectedDb=""
         onChange={onChange}
-        aliases={[]}
       />
     )
     const select = getByTestId(testId)
@@ -143,7 +126,6 @@ describe('DatabaseSelector', () => {
         selectedDb=""
         uniqueDatabases={databases}
         onChange={onChange}
-        aliases={[]}
       />
     )
     const select = getByTestId(testId)

--- a/src/browser/modules/DBMSInfo/DatabaseSelector.tsx
+++ b/src/browser/modules/DBMSInfo/DatabaseSelector.tsx
@@ -26,7 +26,7 @@ import {
   DrawerSubHeader
 } from 'browser-components/drawer/drawer-styled'
 import { escapeCypherIdentifier } from 'services/utils'
-import { Alias, Database } from 'shared/modules/dbMeta/dbMetaDuck'
+import { Database } from 'shared/modules/dbMeta/dbMetaDuck'
 
 const Select = styled.select`
   width: 100%;
@@ -43,12 +43,10 @@ type DatabaseSelectorProps = {
   uniqueDatabases?: Database[]
   selectedDb: string
   onChange?: (dbName: string) => void
-  aliases: Alias[]
 }
 export const DatabaseSelector = ({
   uniqueDatabases = [],
   selectedDb,
-  aliases,
   onChange = () => undefined
 }: DatabaseSelectorProps): JSX.Element | null => {
   if (uniqueDatabases.length === 0) {
@@ -66,23 +64,15 @@ export const DatabaseSelector = ({
     uniqueDatabases.find(db => db.home) ||
     uniqueDatabases.find(db => db.default)
 
-  const aliasList = aliases.flatMap(alias => {
-    const aliasedDb = uniqueDatabases.find(db => db.name === alias.database)
-
-    // Don't show composite aliases since they can't be queried directly
-    if (alias.composite) {
-      return []
-    }
-
-    if (aliasedDb === undefined) {
-      return []
-    }
-
-    return {
-      name: alias.name,
-      status: aliasedDb.status
-    }
-  })
+  const aliasList = uniqueDatabases.flatMap(db =>
+    db.aliases
+      ? db.aliases.map(alias => ({
+          databaseName: db.name,
+          name: alias,
+          status: db.status
+        }))
+      : []
+  )
 
   const databasesAndAliases = [...aliasList, ...uniqueDatabases].sort((a, b) =>
     a.name.localeCompare(b.name)

--- a/src/browser/modules/DBMSInfo/DatabaseSelector.tsx
+++ b/src/browser/modules/DBMSInfo/DatabaseSelector.tsx
@@ -66,11 +66,22 @@ export const DatabaseSelector = ({
 
   const aliasList = uniqueDatabases.flatMap(db =>
     db.aliases
-      ? db.aliases.map(alias => ({
-          databaseName: db.name,
-          name: alias,
-          status: db.status
-        }))
+      ? db.aliases
+          .map(alias => ({
+            databaseName: db.name,
+            name: alias,
+            status: db.status
+          }))
+          .filter(
+            // If the alias points to a composite database and the alias is listed as
+            // one of the constituents, we don't want to show it as it's not directly queryable
+            alias =>
+              !uniqueDatabases.some(
+                db =>
+                  db.type === 'composite' &&
+                  db.constituents?.includes(alias.name)
+              )
+          )
       : []
   )
 

--- a/src/shared/modules/dbMeta/__snapshots__/dbMetaDuck.test.ts.snap
+++ b/src/shared/modules/dbMeta/__snapshots__/dbMetaDuck.test.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`hydrating state can CLEAR to reset state 1`] = `
 Object {
-  "aliases": Array [],
   "countAutomaticRefresh": Object {
     "enabled": true,
     "loading": false,
@@ -70,7 +69,6 @@ Object {
 
 exports[`hydrating state should merge inital state and state on load 1`] = `
 Object {
-  "aliases": Array [],
   "countAutomaticRefresh": Object {
     "enabled": true,
     "loading": false,

--- a/src/shared/modules/dbMeta/dbMetaDuck.ts
+++ b/src/shared/modules/dbMeta/dbMetaDuck.ts
@@ -206,7 +206,6 @@ export const initialState = {
     storeSize: null
   },
   databases: [],
-  aliases: [],
   serverConfigDone: false,
   settings: initialClientSettings,
   countAutomaticRefresh: {
@@ -230,14 +229,6 @@ export type Database = {
   status: string
 }
 
-export const ALIAS_COMPOSITE_FIELD_FIRST_VERSION = '5.11.0'
-export type Alias = {
-  name: string
-  database: string
-  location: string
-  composite?: string | null // introduced in neo4j 5.11
-}
-
 // Selectors
 export function findDatabaseByNameOrAlias(
   state: GlobalState,
@@ -258,7 +249,7 @@ export function findDatabaseByNameOrAlias(
   )
 }
 
-export function getUniqueDatabases(state: GlobalState): Database[] {
+export function getUniqueDatbases(state: GlobalState): Database[] {
   const uniqueDatabaseNames = uniq(
     state[NAME].databases.map((db: Database) => db.name)
   )
@@ -344,10 +335,6 @@ export const getMetricsPrefix = (state: GlobalState): string =>
 
 export const getDatabases = (state: any): Database[] =>
   (state[NAME] || initialState).databases
-
-export const getAliases = (state: any): null | Alias[] =>
-  (state[NAME] || initialState).aliases
-
 export const getActiveDbName = (state: any) =>
   ((state[NAME] || {}).settings || {})['dbms.active_database']
 

--- a/src/shared/modules/dbMeta/dbMetaDuck.ts
+++ b/src/shared/modules/dbMeta/dbMetaDuck.ts
@@ -17,19 +17,19 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+import { uniq } from 'lodash-es'
+import { QueryResult } from 'neo4j-driver'
+import { SemVer, coerce, gte } from 'semver'
+import { isConfigValFalsy } from 'services/bolt/boltHelpers'
+import { GlobalState } from 'shared/globalState'
+import { APP_START } from 'shared/modules/app/appDuck'
+import { FIRST_MULTI_DB_SUPPORT } from '../features/versionedFeatures'
 import {
+  extractServerInfo,
   extractTrialStatus,
   extractTrialStatusOld,
   versionHasEditorHistorySetting
 } from './utils'
-import { isConfigValFalsy } from 'services/bolt/boltHelpers'
-import { GlobalState } from 'shared/globalState'
-import { APP_START } from 'shared/modules/app/appDuck'
-import { extractServerInfo } from './utils'
-import { coerce, SemVer, gte } from 'semver'
-import { QueryResult } from 'neo4j-driver'
-import { uniq } from 'lodash-es'
-import { FIRST_MULTI_DB_SUPPORT } from '../features/versionedFeatures'
 
 export const UPDATE_META = 'meta/UPDATE_META'
 export const PARSE_META = 'meta/PARSE_META'
@@ -226,6 +226,7 @@ export type Database = {
   home?: boolean // introduced in neo4j 4.3
   aliases?: string[] // introduced in neo4j 4.4
   type?: 'system' | 'composite' | 'standard' // introduced in neo4j 5
+  constituents?: string[] // introduced in neo4j 5
   status: string
 }
 

--- a/src/shared/modules/dbMeta/dbMetaEpics.ts
+++ b/src/shared/modules/dbMeta/dbMetaEpics.ts
@@ -135,27 +135,6 @@ async function databaseList(store: any) {
   } catch {}
 }
 
-async function aliasList(store: any) {
-  try {
-    const hasMultidb = supportsMultiDb(store.getState())
-    if (!hasMultidb) {
-      return
-    }
-
-    const res = await bolt.backgroundWorkerlessRoutedRead(
-      'SHOW ALIASES FOR DATABASE',
-      { useDb: SYSTEM_DB },
-      store
-    )
-
-    if (!res) return
-
-    const aliases = res.records.map((record: any) => record.toObject())
-
-    store.dispatch(update({ aliases }))
-  } catch {}
-}
-
 async function getLabelsAndTypes(store: any) {
   const db = getCurrentDatabase(store.getState())
 
@@ -416,8 +395,7 @@ async function pollDbMeta(store: any) {
   await Promise.all([
     getFunctionsAndProcedures(store),
     clusterRole(store),
-    databaseList(store),
-    aliasList(store)
+    databaseList(store)
   ])
 }
 


### PR DESCRIPTION
It's problematic to run `SHOW ALIASES` as it requires privileges to run, we can figure out if a alias is a composite alias without this. 