### PR TITLE
removing triple quotes from csv exports

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
+++ b/src/browser/modules/Stream/CypherFrame/CypherFrame.tsx
@@ -429,7 +429,7 @@ export class CypherFrame extends Component<CypherFrameProps, CypherFrameState> {
 
     const exportData = stringifyResultArray(
       csvFormat,
-      [keys].concat(records.map(record => recordToStringArray(record)))
+      [keys].concat(records.map(record => recordToStringArray(record, true)))
     )
     const data = exportData.slice()
     const csv = CSVSerializer(data.shift())

--- a/src/browser/modules/Stream/CypherFrame/helpers.test.ts
+++ b/src/browser/modules/Stream/CypherFrame/helpers.test.ts
@@ -648,6 +648,31 @@ describe('helpers', () => {
       // Then
       expect(res).toEqual([['"P1M2DT3.000000004S"']])
     })
+
+    test('recordToStringArray handles strings correctly when double quotes are disabled', () => {
+      const records = [
+        new Record(
+          ['x', 'y', 'n', 'z', '{}'],
+          [
+            'xRecord',
+            neo4j.int(10),
+            new neo4j.types.Duration(1, 2, 3, 4),
+            new (neo4j.types.Node as any)('1', ['Person'], { prop1: 'prop1' }),
+            {}
+          ]
+        )
+      ]
+      const res = records.map(record => recordToStringArray(record, true))
+      expect(res).toEqual([
+        [
+          'xRecord',
+          '10',
+          'P1M2DT3.000000004S',
+          '(:Person {prop1: prop1})',
+          '{}'
+        ]
+      ])
+    })
   })
 
   describe('recordToJSONMapper', () => {

--- a/src/browser/modules/Stream/CypherFrame/helpers.ts
+++ b/src/browser/modules/Stream/CypherFrame/helpers.ts
@@ -35,7 +35,7 @@ import neo4j, { Node, Path, Record, Relationship } from 'neo4j-driver'
 import bolt from 'services/bolt/bolt'
 import { recursivelyExtractGraphItems } from 'services/bolt/boltMappings'
 import { stringModifier } from 'services/bolt/cypherTypesFormatting'
-import { stringifyMod, unescapeDoubleQuotesForDisplay } from 'services/utils'
+import { stringifyMod } from 'services/utils'
 import * as viewTypes from 'shared/modules/frames/frameViewTypes'
 import { BrowserRequestResult } from 'shared/modules/requests/requestsDuck'
 
@@ -231,14 +231,13 @@ export const initialView = (props: any, state: any = {}) => {
  */
 export const stringifyResultArray = (
   formatter = stringModifier,
-  arr: any[] = [],
-  unescapeDoubleQuotes = false
+  arr: any[] = []
 ) => {
   return arr.map(col => {
     if (!col) return col
     return col.map((fVal: any) => {
       const res = stringifyMod(fVal, formatter)
-      return unescapeDoubleQuotes ? unescapeDoubleQuotesForDisplay(res) : res
+      return res
     })
   })
 }
@@ -423,7 +422,10 @@ function isNeo4jValue(value: any) {
   }
 }
 
-export const recordToStringArray = (record: Record): string[] => {
+export const recordToStringArray = (
+  record: Record,
+  discardDoubleQuotes?: boolean
+): string[] => {
   const recursiveStringify = (value: CypherDataType): string => {
     if (Array.isArray(value)) {
       if (value.length === 0) return '[]'
@@ -432,7 +434,13 @@ export const recordToStringArray = (record: Record): string[] => {
 
     if (isCypherPropertyType(value)) {
       //Note: later we should use propertyToString here but needs to be updated to show year in durations.
-      return stringifyMod(value, stringModifier, true)
+      return stringifyMod(
+        value,
+        (v: any) => stringModifier(v, discardDoubleQuotes),
+        true,
+        false,
+        discardDoubleQuotes
+      )
     }
 
     // We have nodes, relationships, paths and cypher maps left.

--- a/src/shared/services/bolt/cypherTypesFormatting.ts
+++ b/src/shared/services/bolt/cypherTypesFormatting.ts
@@ -19,7 +19,10 @@ export const csvFormat = (anything: any) => {
   return undefined
 }
 
-export const stringModifier = (anything: any) => {
+export const stringModifier = (
+  anything: any,
+  discardDoubleQuotes?: boolean
+) => {
   if (typeof anything === 'number') {
     return numberFormat(anything)
   }
@@ -30,7 +33,9 @@ export const stringModifier = (anything: any) => {
     return spacialFormat(anything)
   }
   if (isTemporalType(anything)) {
-    return `"${anything.toString()}"`
+    return discardDoubleQuotes
+      ? anything.toString()
+      : `"${anything.toString()}"`
   }
   return undefined
 }

--- a/src/shared/services/utils.ts
+++ b/src/shared/services/utils.ts
@@ -307,7 +307,8 @@ export const stringifyMod = (
   value: any,
   modFn: any = null,
   pretty: boolean | number = false,
-  skipOpeningIndentation = false
+  skipOpeningIndentation = false,
+  discardDoubleQuotes = false
 ): string => {
   const prettyLevel = isNumber(pretty) ? pretty : +pretty
   const nextPrettyLevel = prettyLevel ? prettyLevel + 1 : false
@@ -386,7 +387,9 @@ export const stringifyMod = (
       )}${newLine}${endIndentation}}`
     }
   }
-  return `${indentation}"${value.toString().replace(escRE, escFunc)}"`
+  return discardDoubleQuotes
+    ? `${indentation}${value.toString().replace(escRE, escFunc)}`
+    : `${indentation}"${value.toString().replace(escRE, escFunc)}"`
 }
 
 export const unescapeDoubleQuotesForDisplay = (str: any) =>


### PR DESCRIPTION
This pull request is to remove triple quotes from the csv export of statements. 

Before, exported csv:
```
n.types,n.point,n.cuteness,n.duration2,n.birthDate,n.cool,n.time,n.name,n
"[""Ground"", ""Psychic""]","point({srid:7203, x:3, y:0})",10.3,"""P0M0DT91.123456789S""","""2023-04-28""",true,"""12:50:35.556000000+01:00""","""Baltoy""","(:Query_graph {duration: ""P0M14DT58320S"",types: [""Ground"", ""Psychic""],level: 1,cool: true,cuteness: 10.3,name: ""Baltoy"",duration2: ""P0M0DT91.123456789S"",time: ""12:50:35.556000000+01:00"",birthDate: ""2023-04-28"",point: point({srid:7203, x:3, y:0})})"
```

After with this pr changes, exported csv:
```
n.types,n.point,n.cuteness,n.duration2,n.birthDate,n.cool,n.time,n.name,n
"[Ground, Psychic]","point({srid:7203, x:3, y:0})",10.3,P0M0DT91.123456789S,2023-04-28,true,12:50:35.556000000+01:00,Baltoy,"(:Query_graph {duration: P0M14DT58320S,types: [Ground, Psychic],level: 1,cool: true,cuteness: 10.3,name: Baltoy,duration2: P0M0DT91.123456789S,time: 12:50:35.556000000+01:00,birthDate: 2023-04-28,point: point({srid:7203, x:3, y:0})})"
```

Please see the following doc for csv quote requirements: https://www.ietf.org/rfc/rfc4180.txt