### PR TITLE
Fix bug where visualizations were unable to load neighbours/relationships in a cluster environment

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/VisualizationView/VisualizationView.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView/VisualizationView.tsx
@@ -37,7 +37,7 @@ import {
 import { NEO4J_BROWSER_USER_ACTION_QUERY } from 'services/bolt/txMetadata'
 import { deepEquals } from 'neo4j-arc/common'
 import { GlobalState } from 'shared/globalState'
-import { CYPHER_REQUEST } from 'shared/modules/cypher/cypherDuck'
+import { ROUTED_CYPHER_READ_REQUEST } from 'shared/modules/cypher/cypherDuck'
 import * as grassActions from 'shared/modules/grass/grassDuck'
 import {
   getMaxFieldItems,
@@ -197,7 +197,7 @@ LIMIT ${maxNewNeighbours}`
     return new Promise((resolve, reject) => {
       this.props.bus &&
         this.props.bus.self(
-          CYPHER_REQUEST,
+          ROUTED_CYPHER_READ_REQUEST,
           { query: query, queryType: NEO4J_BROWSER_USER_ACTION_QUERY },
           (response: any) => {
             if (!response.success) {
@@ -242,7 +242,7 @@ LIMIT ${maxNewNeighbours}`
     return new Promise(resolve => {
       this.props.bus &&
         this.props.bus.self(
-          CYPHER_REQUEST,
+          ROUTED_CYPHER_READ_REQUEST,
           {
             query,
             params: { existingNodeIds, newNodeIds },

--- a/src/shared/rootEpic.ts
+++ b/src/shared/rootEpic.ts
@@ -53,7 +53,8 @@ import {
   clusterCypherRequestEpic,
   cypherRequestEpic,
   handleForcePasswordChangeEpic,
-  routedCypherRequestEpic
+  routedCypherReadRequestEpic,
+  routedCypherWriteRequestEpic
 } from './modules/cypher/cypherDuck'
 import {
   clearMetaOnDisconnectEpic,
@@ -122,7 +123,8 @@ export default combineEpics(
   injectDiscoveryEpic,
   populateEditorFromUrlEpic,
   adHocCypherRequestEpic,
-  routedCypherRequestEpic,
+  routedCypherReadRequestEpic,
+  routedCypherWriteRequestEpic,
   cypherRequestEpic,
   clusterCypherRequestEpic,
   clearLocalstorageEpic,


### PR DESCRIPTION
A client was experiencing an issue expanding a node's neighbours and relationships due to routing being disabled on the requests that these functions were executing.

In this change, we are updating the functions in the vizualization component to use routed requests to query for a node's relationships and neighbours.