### PR TITLE
Ensure node expansion runs against the correct database

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/VisualizationView/VisualizationView.tsx
+++ b/src/browser/modules/Stream/CypherFrame/VisualizationView/VisualizationView.tsx
@@ -26,30 +26,30 @@ import { Bus } from 'suber'
 
 import { GraphModel, GraphVisualizer } from 'neo4j-arc/graph-visualization'
 
-import { StyledVisContainer } from './VisualizationView.styled'
 import { resultHasTruncatedFields } from 'browser/modules/Stream/CypherFrame/helpers'
-import bolt from 'services/bolt/bolt'
 import {
   BasicNode,
   BasicNodesAndRels,
-  BasicRelationship
+  BasicRelationship,
+  deepEquals
 } from 'neo4j-arc/common'
+import bolt from 'services/bolt/bolt'
 import { NEO4J_BROWSER_USER_ACTION_QUERY } from 'services/bolt/txMetadata'
-import { deepEquals } from 'neo4j-arc/common'
 import { GlobalState } from 'shared/globalState'
 import { ROUTED_CYPHER_READ_REQUEST } from 'shared/modules/cypher/cypherDuck'
+import {
+  getNodePropertiesExpandedByDefault,
+  setNodePropertiesExpandedByDefault
+} from 'shared/modules/frames/framesDuck'
 import * as grassActions from 'shared/modules/grass/grassDuck'
 import {
   getMaxFieldItems,
   shouldShowWheelZoomInfo,
   update as updateSettings
 } from 'shared/modules/settings/settingsDuck'
-import {
-  getNodePropertiesExpandedByDefault,
-  setNodePropertiesExpandedByDefault
-} from 'shared/modules/frames/framesDuck'
 import { DetailsPane } from './PropertiesPanelContent/DetailsPane'
 import OverviewPane from './PropertiesPanelContent/OverviewPane'
+import { StyledVisContainer } from './VisualizationView.styled'
 
 type VisualizationState = {
   updated: number
@@ -198,7 +198,11 @@ LIMIT ${maxNewNeighbours}`
       this.props.bus &&
         this.props.bus.self(
           ROUTED_CYPHER_READ_REQUEST,
-          { query: query, queryType: NEO4J_BROWSER_USER_ACTION_QUERY },
+          {
+            query: query,
+            queryType: NEO4J_BROWSER_USER_ACTION_QUERY,
+            useDb: this.props.result.summary.database.name
+          },
           (response: any) => {
             if (!response.success) {
               reject(new Error())
@@ -246,7 +250,8 @@ LIMIT ${maxNewNeighbours}`
           {
             query,
             params: { existingNodeIds, newNodeIds },
-            queryType: NEO4J_BROWSER_USER_ACTION_QUERY
+            queryType: NEO4J_BROWSER_USER_ACTION_QUERY,
+            useDb: this.props.result.summary.database.name
           },
           (response: any) => {
             if (!response.success) {


### PR DESCRIPTION
Using the `database` field on the result ensures that the right database is used for node expansion, even if the query dynamically switched database, for example like this:

```
:use neo4j
USE movies MATCH (n) RETURN n;
```