### PR TITLE
Updates sso e2e tests workflow action to use v2 compose command

### DIFF
--- a/.github/workflows/pr-sso-tests.yml
+++ b/.github/workflows/pr-sso-tests.yml
@@ -23,7 +23,7 @@ jobs:
       - run: sudo apt-get -y install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
       - name: Setup Keycloak and Neo4j
         working-directory: ./docker/sso-keycloak
-        run: docker-compose -f docker-compose.yml up -d --remove-orphans
+        run: docker compose -f docker-compose.yml up -d --remove-orphans
       - name: Wait for Keycloak and Neo4j config containers to finish
         run: sleep 90
       - run: npx serve -l 8080 dist & npm run wait-on-neo4j && yarn wait-on-dev


### PR DESCRIPTION
https://docs.docker.com/compose/releases/migrate/#what-are-the-differences-between-compose-v1-and-compose-v2

GitHub has deprecated the v1 compose command, `docker-compose`, so the pipeline fails to bootup the requisite containers for the SSO e2e tests.

This PR updates the command from v1 to v2, `docker compose`.