### PR TITLE
manually marking the version to support calver zero-padded versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "neo4j-browser",
-  "version": "2025.1.0",
+  "version": "2025.01.0",
   "description": "Neo4j Browser is the general purpose user interface for working with Neo4j. Query, visualize, administer and monitor the database.",
   "neo4jDesktop": {
     "apiVersion": "^1.4.0"

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.neo4j.client</groupId>
   <artifactId>neo4j-browser</artifactId>
-  <version>2025.1.0</version>
+  <version>2025.01.0</version>
   <name>Neo4j - Browser</name>
   <description>Graph database client.</description>
   <url>https://github.com/neo4j/neo4j</url>


### PR DESCRIPTION
## Description

Next Neo4j release will have the version `2025.01.0`. In order to maintain the consistency between desktop and the browser, and since `npm version` is only supporting semver versioning, this pr aims to manually change the version to `2025.01.0`.
