### PR TITLE
Updates force password change flow to use Cypher first, falling back to dbms function call

### DIFF
--- a/src/browser/modules/Stream/Auth/ConnectionFormController.tsx
+++ b/src/browser/modules/Stream/Auth/ConnectionFormController.tsx
@@ -47,8 +47,10 @@ import {
   setActiveConnection,
   updateConnection
 } from 'shared/modules/connections/connectionsDuck'
-import { AuthenticationMethod } from 'shared/modules/connections/connectionsDuck'
-import { FORCE_CHANGE_PASSWORD } from 'shared/modules/cypher/cypherDuck'
+import {
+  AuthenticationMethod,
+  FORCE_CHANGE_PASSWORD
+} from 'shared/modules/connections/connectionsDuck'
 import { shouldRetainConnectionCredentials } from 'shared/modules/dbMeta/dbMetaDuck'
 import { CONNECTION_ID } from 'shared/modules/discovery/discoveryDuck'
 import { fetchBrowserDiscoveryDataFromUrl } from 'shared/modules/discovery/discoveryHelpers'

--- a/src/shared/modules/connections/connectionsDuck.test.ts
+++ b/src/shared/modules/connections/connectionsDuck.test.ts
@@ -507,7 +507,6 @@ describe('handleForcePasswordChangeEpic', () => {
   const mockSessionClose = jest.fn()
 
   const mockDriver = {
-    supportsMultiDb: () => true,
     session: jest.fn().mockReturnValue({
       close: mockSessionClose
     }),
@@ -709,7 +708,7 @@ describe('handleForcePasswordChangeEpic', () => {
               query: 'CALL dbms.security.changePassword($password)'
             }),
             expect.anything(),
-            { database: 'system' }
+            undefined
           )
 
           expect(currentAction).toEqual(
@@ -724,45 +723,6 @@ describe('handleForcePasswordChangeEpic', () => {
 
           expect(mockDriver.close).toHaveBeenCalledTimes(1)
           expect(mockSessionClose).toHaveBeenCalledTimes(2)
-        } catch (e) {
-          reject(e)
-        }
-      })
-    })
-
-    // When
-    epicMiddleware.replaceEpic(connections.handleForcePasswordChangeEpic)
-    store.clearActions()
-    store.dispatch(action)
-
-    // Return
-    return p
-  })
-
-  test('handleForcePasswordChangeEpic does not execute against system database when unavailable', () => {
-    // Given
-    ;(bolt.directConnect as jest.Mock).mockClear()
-    ;(bolt.directConnect as jest.Mock).mockResolvedValue({
-      supportsMultiDb: () => false,
-      close: () => true
-    })
-
-    const p = new Promise<void>((resolve, reject) => {
-      bus.take($$responseChannel, currentAction => {
-        // Then
-        const actions = store.getActions()
-
-        try {
-          expect(actions).toEqual([action, currentAction])
-
-          expect(executePasswordResetQuerySpy).toHaveBeenCalledWith(
-            expect.anything(),
-            expect.anything(),
-            expect.anything(),
-            undefined
-          )
-
-          resolve()
         } catch (e) {
           reject(e)
         }

--- a/src/shared/modules/connections/connectionsDuck.test.ts
+++ b/src/shared/modules/connections/connectionsDuck.test.ts
@@ -476,6 +476,7 @@ describe('handleForcePasswordChangeEpic', () => {
 
   const $$responseChannel = 'test-channel'
   const action = {
+    host: 'bolt://localhost:7687',
     type: connections.FORCE_CHANGE_PASSWORD,
     password: 'changeme',
     newPassword: 'password1',
@@ -524,9 +525,8 @@ describe('handleForcePasswordChangeEpic', () => {
 
   test('handleForcePasswordChangeEpic resolves with an error if directConnect fails', () => {
     // Given
-    ;(bolt.directConnect as jest.Mock).mockRejectedValue(
-      new Error('An error occurred.')
-    )
+    const message = 'An error occurred.'
+    ;(bolt.directConnect as jest.Mock).mockRejectedValue(new Error(message))
 
     const p = new Promise<void>((resolve, reject) => {
       bus.take($$responseChannel, currentAction => {
@@ -541,19 +541,18 @@ describe('handleForcePasswordChangeEpic', () => {
 
           expect(executePasswordResetQuerySpy).not.toHaveBeenCalled()
 
-          expect(currentAction).toEqual(
-            expect.objectContaining({
-              error: expect.objectContaining({
-                message: 'An error occurred.'
-              }),
-              success: false,
-              type: $$responseChannel
-            })
-          )
+          expect(currentAction).toEqual({
+            error: expect.objectContaining({
+              message
+            }),
+            success: false,
+            type: $$responseChannel
+          })
 
           resolve()
 
           expect(mockDriver.close).not.toHaveBeenCalled()
+          expect(mockSessionClose).not.toHaveBeenCalled()
         } catch (e) {
           reject(e)
         }
@@ -596,13 +595,11 @@ describe('handleForcePasswordChangeEpic', () => {
             { database: 'system' }
           )
 
-          expect(currentAction).toEqual(
-            expect.objectContaining({
-              result: expect.anything(),
-              success: true,
-              type: $$responseChannel
-            })
-          )
+          expect(currentAction).toEqual({
+            result: { meta: 'bolt://localhost:7687' },
+            success: true,
+            type: $$responseChannel
+          })
 
           resolve()
 
@@ -625,10 +622,9 @@ describe('handleForcePasswordChangeEpic', () => {
 
   test('handleForcePasswordChangeEpic resolves with an error if cypher query fails', () => {
     // Given
+    const message = 'A password must be at least 8 characters.'
     mockSessionExecuteWrite
-      .mockRejectedValueOnce(
-        new Error('A password must be at least 8 characters.')
-      )
+      .mockRejectedValueOnce(new Error(message))
       .mockResolvedValue(true)
 
     const p = new Promise<void>((resolve, reject) => {
@@ -644,15 +640,13 @@ describe('handleForcePasswordChangeEpic', () => {
 
           expect(executePasswordResetQuerySpy).toHaveBeenCalledTimes(1)
 
-          expect(currentAction).toEqual(
-            expect.objectContaining({
-              error: expect.objectContaining({
-                message: 'A password must be at least 8 characters.'
-              }),
-              success: false,
-              type: $$responseChannel
-            })
-          )
+          expect(currentAction).toEqual({
+            error: expect.objectContaining({
+              message
+            }),
+            success: false,
+            type: $$responseChannel
+          })
 
           resolve()
 
@@ -702,13 +696,11 @@ describe('handleForcePasswordChangeEpic', () => {
             undefined
           )
 
-          expect(currentAction).toEqual(
-            expect.objectContaining({
-              result: expect.anything(),
-              success: true,
-              type: $$responseChannel
-            })
-          )
+          expect(currentAction).toEqual({
+            result: { meta: 'bolt://localhost:7687' },
+            success: true,
+            type: $$responseChannel
+          })
 
           resolve()
 
@@ -731,9 +723,10 @@ describe('handleForcePasswordChangeEpic', () => {
 
   test('handleForcePasswordChangeEpic resolves with an error if dbms function call fails', () => {
     // Given
+    const message = 'A password must be at least 8 characters.'
     mockSessionExecuteWrite
       .mockRejectedValueOnce(new MultiDatabaseNotSupportedError())
-      .mockRejectedValue(new Error('A password must be at least 8 characters.'))
+      .mockRejectedValue(new Error(message))
 
     const p = new Promise<void>((resolve, reject) => {
       bus.take($$responseChannel, currentAction => {
@@ -748,15 +741,13 @@ describe('handleForcePasswordChangeEpic', () => {
 
           expect(executePasswordResetQuerySpy).toHaveBeenCalledTimes(2)
 
-          expect(currentAction).toEqual(
-            expect.objectContaining({
-              error: expect.objectContaining({
-                message: 'A password must be at least 8 characters.'
-              }),
-              success: false,
-              type: $$responseChannel
-            })
-          )
+          expect(currentAction).toEqual({
+            error: expect.objectContaining({
+              message
+            }),
+            success: false,
+            type: $$responseChannel
+          })
 
           resolve()
 

--- a/src/shared/modules/connections/connectionsDuck.ts
+++ b/src/shared/modules/connections/connectionsDuck.ts
@@ -958,10 +958,8 @@ export const handleForcePasswordChangeEpic = (some$: any) =>
             )
             .then(async driver => {
               try {
-                const supportsMultiDb = await driver.supportsMultiDb()
-
                 const res = await forceResetPasswordQueryHelper
-                  .executeAlterCurrentUserQuery(driver, action, supportsMultiDb)
+                  .executeAlterCurrentUserQuery(driver, action)
                   .then((res: any) => {
                     resolve({
                       type: action.$$responseChannel,
@@ -981,11 +979,7 @@ export const handleForcePasswordChangeEpic = (some$: any) =>
                     /(Invalid input 'A': expected <init>)/.test(res.message)
                   ) {
                     await forceResetPasswordQueryHelper
-                      .executeCallChangePasswordQuery(
-                        driver,
-                        action,
-                        supportsMultiDb
-                      )
+                      .executeCallChangePasswordQuery(driver, action)
                       .then((res: any) => {
                         resolve({
                           type: action.$$responseChannel,

--- a/src/shared/modules/connections/forceResetPasswordQueryHelper.ts
+++ b/src/shared/modules/connections/forceResetPasswordQueryHelper.ts
@@ -43,8 +43,7 @@ export default {
    */
   executeAlterCurrentUserQuery: function (
     driver: Driver,
-    action: Connection & { newPassword: string },
-    supportsMultiDb: boolean
+    action: Connection & { newPassword: string }
   ): Promise<void> {
     const payload = {
       query: 'ALTER CURRENT USER SET PASSWORD FROM $oldPw TO $newPw',
@@ -58,7 +57,7 @@ export default {
       driver,
       payload,
       userActionTxMetadata.txMetadata,
-      supportsMultiDb ? { database: SYSTEM_DB } : undefined
+      { database: SYSTEM_DB }
     )
   },
   /**
@@ -67,8 +66,7 @@ export default {
    */
   executeCallChangePasswordQuery: function (
     driver: Driver,
-    action: { newPassword: string },
-    supportsMultiDb: boolean
+    action: { newPassword: string }
   ): Promise<void> {
     const payload = {
       query: 'CALL dbms.security.changePassword($password)',
@@ -79,7 +77,7 @@ export default {
       driver,
       payload,
       userActionTxMetadata.txMetadata,
-      supportsMultiDb ? { database: SYSTEM_DB } : undefined
+      undefined
     )
   }
 }

--- a/src/shared/modules/connections/forceResetPasswordQueryHelper.ts
+++ b/src/shared/modules/connections/forceResetPasswordQueryHelper.ts
@@ -1,0 +1,85 @@
+import neo4j from 'neo4j-driver'
+import { Driver } from 'neo4j-driver'
+import { userActionTxMetadata } from 'services/bolt/txMetadata'
+import { Connection } from './connectionsDuck'
+import { SYSTEM_DB } from '../dbMeta/dbMetaDuck'
+import { buildTxFunctionByMode } from 'services/bolt/boltHelpers'
+
+export default {
+  executePasswordResetQuery: async (
+    driver: Driver,
+    action: {
+      query: string
+      parameters: { oldPw: string; newPw: string } | { password: string }
+    },
+    metadata: { type: string; app: string },
+    useDb = {}
+  ): Promise<void> => {
+    const session = driver.session({
+      defaultAccessMode: neo4j.session.WRITE,
+      ...useDb
+    })
+
+    const txFn = buildTxFunctionByMode(session)
+
+    txFn &&
+      (await txFn(
+        async (tx: { run: (input: string, parameters: unknown) => unknown }) =>
+          await tx.run(action.query, action.parameters),
+        {
+          metadata
+        }
+      )
+        .catch(e => {
+          throw e
+        })
+        .finally(() => {
+          session.close()
+        }))
+  },
+  /**
+   * Executes a query to change the user's password using Cypher available
+   * on Neo4j versions since 4.0
+   */
+  executeAlterCurrentUserQuery: function (
+    driver: Driver,
+    action: Connection & { newPassword: string },
+    supportsMultiDb: boolean
+  ): Promise<void> {
+    const payload = {
+      query: 'ALTER CURRENT USER SET PASSWORD FROM $oldPw TO $newPw',
+      parameters: {
+        oldPw: action.password,
+        newPw: action.newPassword
+      }
+    }
+
+    return this.executePasswordResetQuery(
+      driver,
+      payload,
+      userActionTxMetadata.txMetadata,
+      supportsMultiDb ? { database: SYSTEM_DB } : undefined
+    )
+  },
+  /**
+   * Executes a query to change the user's password using legacy DBMS function
+   * for versions of Neo4j older than 4.0
+   */
+  executeCallChangePasswordQuery: function (
+    driver: Driver,
+    action: { newPassword: string },
+    supportsMultiDb: boolean
+  ): Promise<void> {
+    const payload = {
+      query: 'CALL dbms.security.changePassword($password)',
+      parameters: { password: action.newPassword }
+    }
+
+    return this.executePasswordResetQuery(
+      driver,
+      payload,
+      userActionTxMetadata.txMetadata,
+      supportsMultiDb ? { database: SYSTEM_DB } : undefined
+    )
+  }
+}

--- a/src/shared/modules/features/versionedFeatures.ts
+++ b/src/shared/modules/features/versionedFeatures.ts
@@ -99,28 +99,6 @@ export const getDefaultBoltScheme = (serverVersion: string | null) => {
   return pre4
 }
 
-export const changeUserPasswordQuery = (
-  serverVersion: string,
-  oldPw: any,
-  newPw: any
-) => {
-  const pre4 = {
-    query: 'CALL dbms.security.changePassword($password)',
-    parameters: { password: newPw }
-  }
-  const semverVersion = guessSemverVersion(serverVersion)
-  if (!semver.valid(semverVersion)) {
-    return pre4
-  }
-  if (semverVersion && semver.gte(semverVersion, NEO4J_4_0)) {
-    return {
-      query: 'ALTER CURRENT USER SET PASSWORD FROM $oldPw TO $newPw',
-      parameters: { oldPw, newPw }
-    }
-  }
-  return pre4
-}
-
 export const driverDatabaseSelection = (state: GlobalState, database: any) => {
   const pre4 = undefined
   const serverVersion = guessSemverVersion(getRawVersion(state))

--- a/src/shared/rootEpic.ts
+++ b/src/shared/rootEpic.ts
@@ -31,6 +31,7 @@ import {
   detectActiveConnectionChangeEpic,
   disconnectEpic,
   disconnectSuccessEpic,
+  handleForcePasswordChangeEpic,
   initialSwitchConnectionFailEpic,
   retainCredentialsSettingsEpic,
   silentDisconnectEpic,
@@ -52,7 +53,6 @@ import {
   adHocCypherRequestEpic,
   clusterCypherRequestEpic,
   cypherRequestEpic,
-  handleForcePasswordChangeEpic,
   routedCypherReadRequestEpic,
   routedCypherWriteRequestEpic
 } from './modules/cypher/cypherDuck'

--- a/src/shared/services/bolt/globalDrivers.ts
+++ b/src/shared/services/bolt/globalDrivers.ts
@@ -62,7 +62,7 @@ export const buildGlobalDriversObject = async (
         opts,
         () => {}
       )
-      routed && (await routed.verifyConnectivity())
+      routed && (await routed.verifyConnectivity({ database: 'system' }))
       routingSupported = true
     } catch (e) {
       if (e && isError(e)) {


### PR DESCRIPTION
This PR updates the force password change flow that users go through when their password requires resetting upon login. 

Currently, the flow will use the app's detected version to determine whether to use the dbms function call if the app is on a version lower than 4.0, otherwise it will use the Cypher query.

This is problematic since the server's version will not be in state if this is a first login attempt, so it will try and query the database to get the server version.

Only the user is not authorized to query the database, because their password requires a reset.. so we cannot use the server version to accurately determine which version of the query to use.

If we still don't have a version at this point, we fallback to using a function on the driver to determine if there is multidb support - if there is then we use the Cypher query, otherwise we will use the dbms function call.

If, for whatever reason, the server is running >4.0 and multidb returns false, the legacy query is used, and will fail since it does not exist.

In this refactored approach, we no longer attempt to determine the version, and simply attempt to execute the Cypher query, falling back to the dbms function call if a specific error is encountered executing the Cypher - a much more straightforward approach, with less margin of error.

There is also a small update in the bolt service to target the system database when verifying connectivity.

This will resolve a problem some users encounter upon logging in when the default `neo4j` database is unavailable.. deleted or otherwise.

**Repro**
- Run a version 3 server
- Drop the default neo4j database
- Create a user requiring a password change`CALL dbms.security.createUser('user', 'changeme', true)`
- Log in as this user - you will be prompted to change your password - change the password
- You should be able to log in successfully
---
- Run a version >4.0 server
- Drop the default neo4j database
- Create a user requiring a password change `CREATE USER user IF NOT EXISTS SET PASSWORD 'changeme' CHANGE REQUIRED`
- Log in as this user - you will be prompted to change your password - change the password
- You should be able to log in successfully