### PR TITLE
Migrate upload-artifact action to v4 and update cypress dependent packages

### DIFF
--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -45,7 +45,7 @@ jobs:
       - run: yarn e2e --env server=${{ matrix.neo4j-version }},browser-password=password,edition=${{ matrix.neo4j-edition }}
       - name: Upload test screenshots
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-screenshots-${{ matrix.neo4j-version }}-${{ matrix.neo4j-edition }}
           path: |

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -39,7 +39,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: sudo apt-get update
-      - run: sudo apt-get -y install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+      - run: sudo apt-get -y install libgtk2.0-0t64 libgtk-3-0t64 libgbm-dev libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth xvfb
       - run: npx serve -l 8080 dist & npm run wait-on-neo4j && yarn wait-on-dev
       - run: echo "Servers ready!"
       - run: yarn e2e --env server=${{ matrix.neo4j-version }},browser-password=password,edition=${{ matrix.neo4j-edition }}

--- a/.github/workflows/pr-sso-tests.yml
+++ b/.github/workflows/pr-sso-tests.yml
@@ -20,7 +20,7 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn build
       - run: sudo apt-get update
-      - run: sudo apt-get -y install libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+      - run: sudo apt-get -y install libgtk2.0-0t64 libgtk-3-0t64 libgbm-dev libnotify-dev libnss3 libxss1 libasound2t64 libxtst6 xauth xvfb
       - name: Setup Keycloak and Neo4j
         working-directory: ./docker/sso-keycloak
         run: docker compose -f docker-compose.yml up -d --remove-orphans

--- a/.github/workflows/pr-sso-tests.yml
+++ b/.github/workflows/pr-sso-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - run: yarn e2e-sso
       - name: Upload test screenshots
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-screenshots-sso
           path: |


### PR DESCRIPTION
V3 of the upload/download artifact actions have been deprecated, and removed since January 25th https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

This PR migrates to v4.

It doesn't seem necessary to make any additional changes outlined in the migration guide https://github.com/actions/upload-artifact/blob/main/docs/MIGRATION.md here, since it doesn't look like we were previously mutating uploaded artifacts from different runs.

We are also updating some packages that cypress is dependent on in the image, see https://docs.cypress.io/app/get-started/install-cypress#UbuntuDebian

ubuntu-latest resolves to 24.04 https://github.com/actions/runner-images?tab=readme-ov-file#available-images