### PR TITLE
Add localhost preview-as-default rollout service

### DIFF
--- a/src/browser/index.tsx
+++ b/src/browser/index.tsx
@@ -23,14 +23,16 @@ import ReactDOM from 'react-dom'
 import AppInit, { setupSentry } from './AppInit'
 import './init'
 import { navigateToPreview } from './modules/Stream/StartPreviewFrame'
+import { optedInByLocalhost } from 'browser-services/preview-optin-service'
 
 setupSentry()
+
 ;(async () => {
-  const doesPreferQuery = localStorage.getItem('prefersOldBrowser') === 'false'
+  const optedInToPreview = optedInByLocalhost()
   try {
     const response = await fetch('./preview/manifest.json')
     if (response.status === 200) {
-      if (doesPreferQuery) {
+      if (optedInToPreview) {
         navigateToPreview()
       } else {
         localStorage.setItem('previewAvailable', 'true')

--- a/src/browser/services/preview-optin-service.ts
+++ b/src/browser/services/preview-optin-service.ts
@@ -1,0 +1,12 @@
+const notOptedOutOfPreview = (): boolean => {
+  const prefersOldBrowser = localStorage.getItem('prefersOldBrowser')
+  const doesPreferQuery = prefersOldBrowser === 'false'
+
+  return doesPreferQuery || prefersOldBrowser === null
+}
+
+export const optedInByLocalhost = (): boolean => {
+  console.log('notOptedOutOfPreview', notOptedOutOfPreview())
+  console.log('window.location.hostname', window.location.hostname)
+  return notOptedOutOfPreview() && window.location.hostname === 'localhost'
+}

--- a/src/browser/services/preview-optin-service.ts
+++ b/src/browser/services/preview-optin-service.ts
@@ -6,7 +6,5 @@ const notOptedOutOfPreview = (): boolean => {
 }
 
 export const optedInByLocalhost = (): boolean => {
-  console.log('notOptedOutOfPreview', notOptedOutOfPreview())
-  console.log('window.location.hostname', window.location.hostname)
   return notOptedOutOfPreview() && window.location.hostname === 'localhost'
 }


### PR DESCRIPTION
We wish to execute a controlled rollout of the new Browser as the default experience.

This change will opt in all users on **localhost** by default, excluding those who have previously opted in and then reverted to the old Browser.