### PR TITLE
Release GQL Errors and Notifications support

### DIFF
--- a/src/browser/modules/Stream/CypherFrame/ErrorsView/ErrorsView.test.tsx
+++ b/src/browser/modules/Stream/CypherFrame/ErrorsView/ErrorsView.test.tsx
@@ -38,8 +38,7 @@ const mount = (props: Partial<ErrorsViewProps>, state?: any) => {
     params: {},
     executeCmd: jest.fn(),
     setEditorContent: jest.fn(),
-    neo4jVersion: null,
-    gqlErrorsEnabled: true
+    neo4jVersion: null
   }
 
   const combinedProps = {
@@ -118,9 +117,6 @@ describe('ErrorsView', () => {
         server: {
           version: '5.26.0'
         }
-      },
-      settings: {
-        enableGqlErrorsAndNotifications: true
       }
     }
 
@@ -161,9 +157,6 @@ describe('ErrorsView', () => {
         server: {
           version: '5.26.0'
         }
-      },
-      settings: {
-        enableGqlErrorsAndNotifications: true
       }
     }
 

--- a/src/browser/modules/Stream/CypherFrame/ErrorsView/ErrorsView.tsx
+++ b/src/browser/modules/Stream/CypherFrame/ErrorsView/ErrorsView.tsx
@@ -57,14 +57,12 @@ import {
 import { BrowserError } from 'services/exceptions'
 import { deepEquals } from 'neo4j-arc/common'
 import { getSemanticVersion } from 'shared/modules/dbMeta/dbMetaDuck'
-import { gte, SemVer } from 'semver'
+import { SemVer } from 'semver'
 import {
   formatError,
   formatErrorGqlStatusObject,
   hasPopulatedGqlFields
 } from '../errorUtils'
-import { FIRST_GQL_ERRORS_SUPPORT } from 'shared/modules/features/versionedFeatures'
-import { shouldShowGqlErrorsAndNotifications } from 'shared/modules/settings/settingsDuck'
 
 export type ErrorsViewProps = {
   result: BrowserRequestResult
@@ -74,7 +72,6 @@ export type ErrorsViewProps = {
   executeCmd: (cmd: string) => void
   setEditorContent: (cmd: string) => void
   depth?: number
-  gqlErrorsEnabled: boolean
 }
 
 class ErrorsViewComponent extends Component<ErrorsViewProps> {
@@ -92,8 +89,7 @@ class ErrorsViewComponent extends Component<ErrorsViewProps> {
       executeCmd,
       setEditorContent,
       neo4jVersion,
-      depth = 0,
-      gqlErrorsEnabled
+      depth = 0
     } = this.props
 
     const error = this.props.result as BrowserError
@@ -101,10 +97,9 @@ class ErrorsViewComponent extends Component<ErrorsViewProps> {
       return null
     }
 
-    const formattedError =
-      gqlErrorsEnabled && hasPopulatedGqlFields(error)
-        ? formatErrorGqlStatusObject(error)
-        : formatError(error)
+    const formattedError = hasPopulatedGqlFields(error)
+      ? formatErrorGqlStatusObject(error)
+      : formatError(error)
 
     if (!formattedError?.title) {
       return null
@@ -176,18 +171,9 @@ class ErrorsViewComponent extends Component<ErrorsViewProps> {
   }
 }
 
-const gqlErrorsEnabled = (state: GlobalState): boolean => {
-  const featureEnabled = shouldShowGqlErrorsAndNotifications(state)
-  const version = getSemanticVersion(state)
-  return version
-    ? featureEnabled && gte(version, FIRST_GQL_ERRORS_SUPPORT)
-    : false
-}
-
 const mapStateToProps = (state: GlobalState) => ({
   params: getParams(state),
-  neo4jVersion: getSemanticVersion(state),
-  gqlErrorsEnabled: gqlErrorsEnabled(state)
+  neo4jVersion: getSemanticVersion(state)
 })
 
 const mapDispatchToProps = (

--- a/src/browser/modules/Stream/CypherFrame/WarningsView.test.tsx
+++ b/src/browser/modules/Stream/CypherFrame/WarningsView.test.tsx
@@ -36,8 +36,7 @@ const withProvider = (store: any, children: any) => {
 const mount = (props: DeepPartial<WarningsViewProps>, state?: any) => {
   const defaultProps: WarningsViewProps = {
     result: null,
-    bus: createBus(),
-    gqlWarningsEnabled: false
+    bus: createBus()
   }
 
   const combinedProps = {
@@ -141,9 +140,6 @@ describe('WarningsView', () => {
         server: {
           version: '5.23.0'
         }
-      },
-      settings: {
-        enableGqlErrorsAndNotifications: true
       }
     }
 
@@ -237,9 +233,6 @@ describe('WarningsView', () => {
         server: {
           version: '5.23.0'
         }
-      },
-      settings: {
-        enableGqlErrorsAndNotifications: true
       }
     }
 

--- a/src/browser/modules/Stream/CypherFrame/gqlStatusUtils.ts
+++ b/src/browser/modules/Stream/CypherFrame/gqlStatusUtils.ts
@@ -31,7 +31,7 @@ const formatPropertyFromStatusDescripton = (
 ): string | undefined => {
   const matches =
     gqlStatusDescription?.match(
-      /^(?:error|info|warn):\s(.+?)(?:\.(.+?))?\.?$/
+      /^(?:(?:error|info|warn):\s)?(.+?)(?:\.(.+?))?\.?$/s
     ) ?? []
 
   return matches[index] === undefined

--- a/src/browser/modules/Stream/CypherFrame/warningUtilts.ts
+++ b/src/browser/modules/Stream/CypherFrame/warningUtilts.ts
@@ -75,6 +75,18 @@ const mapNotificationsToFormattedNotifications = (
 
 const SEVERITY_LEVELS = ['ERROR', 'WARNING', 'INFORMATION']
 
+export const hasPopulatedGqlFields = (
+  resultSummary: Partial<ResultSummary>
+): resultSummary is Partial<ResultSummary> & {
+  gqlStatusObjects: GqlStatusObject[]
+  notifications: Notification[]
+} => {
+  return (
+    'gqlStatusObjects' in resultSummary &&
+    resultSummary.gqlStatusObjects !== undefined
+  )
+}
+
 export const formatSummaryFromNotifications = (
   resultSummary?: Partial<ResultSummary>
 ): FormattedNotification[] => {

--- a/src/shared/modules/features/versionedFeatures.ts
+++ b/src/shared/modules/features/versionedFeatures.ts
@@ -32,9 +32,6 @@ export const FIRST_MULTI_DB_SUPPORT = NEO4J_4_0
 // compatible bolt server.
 export const FIRST_NO_MULTI_DB_SUPPORT = '3.4.0'
 
-export const FIRST_GQL_NOTIFICATIONS_SUPPORT = '5.23.0'
-export const FIRST_GQL_ERRORS_SUPPORT = '5.26.0'
-
 export const getShowCurrentUserProcedure = (serverVersion: string) => {
   const serverVersionGuessed = guessSemverVersion(serverVersion)
 

--- a/src/shared/modules/settings/settingsDuck.ts
+++ b/src/shared/modules/settings/settingsDuck.ts
@@ -94,8 +94,6 @@ export const getAllowUserStats = (state: GlobalState): boolean =>
   state[NAME].allowUserStats ?? initialState.allowUserStats
 export const shouldShowWheelZoomInfo = (state: GlobalState) =>
   state[NAME].showWheelZoomInfo
-export const shouldShowGqlErrorsAndNotifications = (state: any) =>
-  state[NAME].enableGqlErrorsAndNotifications
 
 // Ideally the string | number types would be only numbers
 // but they're saved as strings in the settings component


### PR DESCRIPTION
Finalisation of https://github.com/neo4j/neo4j-browser/pull/1989 where GQL Errors and Notifications were first introduced to Browser.

This PR removes the feature toggle for GQL Errors and Notifications, making it available by default.

There is one small change to the regex that parses the errors and notifications to fix a formatting issue picked up in final testing for backfilled errors/notifications on 4.4 databases.